### PR TITLE
Foundation work: hook system, ToolResult, cancellation, AgentPause, SQLite + FTS5, session resume

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,6 +567,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fancy-regex"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,6 +587,12 @@ dependencies = [
  "bit-set",
  "regex",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "filedescriptor"
@@ -792,6 +810,15 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
+dependencies = [
+ "hashbrown 0.16.1",
+]
 
 [[package]]
 name = "heck"
@@ -1217,6 +1244,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "line-clipping"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1560,6 +1598,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "portable-atomic"
@@ -1912,6 +1956,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsqlite-vfs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
+dependencies = [
+ "bitflags 2.11.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+ "sqlite-wasm-rs",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2217,6 +2286,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b2c760607300407ddeaee518acf28c795661b7108c75421303dbefb237d3a36"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2322,6 +2403,19 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2529,6 +2623,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]
@@ -2780,6 +2875,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2806,10 +2907,13 @@ dependencies = [
  "futures-util",
  "ratatui",
  "reqwest",
+ "rusqlite",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "toml",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,9 +44,14 @@ chrono = { version = "0.4", features = ["serde"] }
 
 # UUID for session IDs
 uuid = { version = "1", features = ["v4"] }
+tokio-util = { version = "0.7.18", features = ["rt"] }
+rusqlite = { version = "0.39.0", features = ["bundled"] }
 
 [profile.release]
 opt-level = "z"    # optimize for size
 lto = true
 codegen-units = 1
 strip = true
+
+[dev-dependencies]
+tempfile = "3.27.0"

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -2,9 +2,11 @@ use std::sync::Arc;
 
 use crate::config::Config;
 use crate::context::ContextManager;
+use crate::hooks::safety::SafetyHook;
 use crate::hooks::skills::SkillsHook;
 use crate::hooks::{HookRegistry, ToolCallDecision};
 use crate::memory::SessionStore;
+use crate::pause::PauseSender;
 use crate::prompt_builder::PromptBuilder;
 use crate::provider::openai::OpenAIProvider;
 use crate::provider::{LLMProvider, Message, StreamEvent};
@@ -13,6 +15,7 @@ use crate::tools::{ToolRegistry, ToolResult};
 use anyhow::Result;
 use serde_json::Value;
 use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 /// The core agent — orchestrates the LLM, tools, hooks, and state.
@@ -30,19 +33,34 @@ pub struct Agent {
     hooks: Arc<HookRegistry>,
     session_id: String,
     turns: u32,
+    /// Per-turn cancellation token. `cancel_current_turn()` fires it; the
+    /// next call to `run_prompt` / `run_prompt_stream` swaps in a fresh token
+    /// so cancel applies to the in-flight turn only, not future ones.
+    turn_cancel: CancellationToken,
 }
 
 impl Agent {
     /// Construct an Agent with no caller-supplied hooks. Built-in hooks (skills
     /// injection, etc.) are still registered.
     pub fn new(config: &Config) -> Self {
-        Self::with_hooks(config, HookRegistry::new())
+        Self::with_hooks_and_pause(config, HookRegistry::new(), None)
     }
 
-    /// Construct an Agent with a caller-supplied hook registry. Built-in hooks
-    /// (currently: skills) are registered into it before it's wrapped in Arc.
-    /// Fires `session_start` is up to the caller — see `start_session`.
-    pub fn with_hooks(config: &Config, mut hooks: HookRegistry) -> Self {
+    /// Construct with caller-supplied hooks and no interactive pause channel.
+    /// The TUI uses `with_hooks_and_pause` to wire one up.
+    pub fn with_hooks(config: &Config, hooks: HookRegistry) -> Self {
+        Self::with_hooks_and_pause(config, hooks, None)
+    }
+
+    /// Construct an Agent with a caller-supplied hook registry and an optional
+    /// pause emitter. Built-ins (skills, safety) are registered into the
+    /// registry; if a pause emitter is provided, `SafetyHook` is wired up to
+    /// route blocks through it as `AgentPause::SafetyApproval`.
+    pub fn with_hooks_and_pause(
+        config: &Config,
+        mut hooks: HookRegistry,
+        pause_tx: Option<PauseSender>,
+    ) -> Self {
         let api_key = config
             .api_key()
             .expect("No API key configured. Set VULCAN_API_KEY or add api_key to config.toml");
@@ -66,6 +84,18 @@ impl Agent {
         // Built-in hook: surface available skills to the LLM via BeforePrompt.
         hooks.register(Arc::new(SkillsHook::new(skills.clone())));
 
+        // Built-in hook: block dangerous shell invocations unless yolo_mode is on.
+        // Skipped entirely (not even registered as observe-only) when yolo_mode
+        // is true — keeps the no-op path zero-cost. With a pause emitter
+        // wired up, blocks become interactive prompts.
+        if !config.tools.yolo_mode {
+            let safety = match pause_tx {
+                Some(tx) => SafetyHook::with_pause_emitter(tx),
+                None => SafetyHook::new(),
+            };
+            hooks.register(Arc::new(safety));
+        }
+
         Self {
             provider,
             tools,
@@ -76,11 +106,21 @@ impl Agent {
             hooks: Arc::new(hooks),
             session_id,
             turns: 0,
+            turn_cancel: CancellationToken::new(),
         }
     }
 
     pub fn session_id(&self) -> &str {
         &self.session_id
+    }
+
+    /// Cancel the currently-running turn. Safe to call from any thread.
+    /// After cancellation fires, the in-flight tool/LLM/hook futures get
+    /// dropped (with `kill_on_drop` semantics where applicable) and the
+    /// agent loop exits cleanly. The next `run_prompt` call swaps in a
+    /// fresh token, so this only affects the current turn.
+    pub fn cancel_current_turn(&self) {
+        self.turn_cancel.cancel();
     }
 
     /// Fires `session_start` on all hook handlers. Call once after construction
@@ -98,15 +138,21 @@ impl Agent {
     /// Run a one-shot prompt (no TUI). Gathers context, calls LLM, dispatches
     /// tools, returns result. Honors all hook events.
     pub async fn run_prompt(&mut self, input: &str) -> Result<String> {
+        // Fresh token for this turn — calling cancel_current_turn between
+        // turns shouldn't affect the next one.
+        self.turn_cancel = CancellationToken::new();
+        let cancel = self.turn_cancel.clone();
+
         let system = self.prompt_builder.build_system_prompt(&self.tools);
         let tool_defs = self.tools.definitions();
         let mut messages = vec![Message::System { content: system }];
 
-        if let Some(session_id) = self.memory.last_session_id() {
-            if let Some(history) = self.memory.load_history(&session_id)? {
-                for msg in history {
-                    messages.push(msg);
-                }
+        // Load history for *this* agent's session — set by `resume_session` or
+        // `continue_last_session`; defaults to a fresh UUID so a new agent has
+        // empty history.
+        if let Some(history) = self.memory.load_history(&self.session_id)? {
+            for msg in history {
+                messages.push(msg);
             }
         }
 
@@ -129,12 +175,16 @@ impl Agent {
                 ];
             }
 
+            if cancel.is_cancelled() {
+                return Ok("Cancelled".to_string());
+            }
+
             // ── BeforePrompt: handlers may inject extra messages. Injections
             // are transient — they go on the wire but don't persist into the
             // conversation history we save to memory.
-            let outgoing = self.hooks.apply_before_prompt(&messages).await;
+            let outgoing = self.hooks.apply_before_prompt(&messages, cancel.clone()).await;
 
-            let response = self.provider.chat(&outgoing, &tool_defs).await?;
+            let response = self.provider.chat(&outgoing, &tool_defs, cancel.clone()).await?;
 
             if let Some(usage) = &response.usage {
                 self.context
@@ -149,8 +199,9 @@ impl Agent {
 
                 for tc in tool_calls {
                     tracing::info!("Executing tool: {} (call {})", tc.function.name, tc.id);
-                    let final_result =
-                        self.dispatch_tool(&tc.function.name, &tc.function.arguments).await;
+                    let final_result = self
+                        .dispatch_tool(&tc.function.name, &tc.function.arguments, cancel.clone())
+                        .await;
                     messages.push(Message::Tool {
                         tool_call_id: tc.id.clone(),
                         content: final_result,
@@ -160,7 +211,7 @@ impl Agent {
                 let text = response.content.unwrap_or_default();
 
                 // ── BeforeAgentEnd: a handler may force the loop to continue.
-                if let Some(instruction) = self.hooks.before_agent_end(&text).await {
+                if let Some(instruction) = self.hooks.before_agent_end(&text, cancel.clone()).await {
                     messages.push(Message::Assistant {
                         content: Some(text.clone()),
                         tool_calls: None,
@@ -169,7 +220,7 @@ impl Agent {
                     continue;
                 }
 
-                self.memory.save_messages(&messages)?;
+                self.memory.save_messages(&self.session_id, &messages)?;
                 self.turns = self.turns.saturating_add(1);
                 if iteration >= 5 {
                     self.skills.try_auto_create(input, &text)?;
@@ -188,15 +239,17 @@ impl Agent {
         input: &str,
         ui_tx: mpsc::UnboundedSender<StreamEvent>,
     ) -> Result<String> {
+        // Fresh per-turn cancel token (see run_prompt).
+        self.turn_cancel = CancellationToken::new();
+        let cancel = self.turn_cancel.clone();
+
         let system = self.prompt_builder.build_system_prompt(&self.tools);
         let tool_defs = self.tools.definitions();
         let mut messages = vec![Message::System { content: system }];
 
-        if let Some(session_id) = self.memory.last_session_id() {
-            if let Some(history) = self.memory.load_history(&session_id)? {
-                for msg in history {
-                    messages.push(msg);
-                }
+        if let Some(history) = self.memory.load_history(&self.session_id)? {
+            for msg in history {
+                messages.push(msg);
             }
         }
 
@@ -207,8 +260,18 @@ impl Agent {
         let mut full_response = String::new();
 
         for iteration in 0..10 {
+            if cancel.is_cancelled() {
+                let _ = ui_tx.send(StreamEvent::Done(crate::provider::ChatResponse {
+                    content: Some("Cancelled".into()),
+                    tool_calls: None,
+                    usage: None,
+                    finish_reason: Some("cancelled".into()),
+                }));
+                return Ok("Cancelled".to_string());
+            }
+
             // ── BeforePrompt (transient — see run_prompt for rationale).
-            let outgoing = self.hooks.apply_before_prompt(&messages).await;
+            let outgoing = self.hooks.apply_before_prompt(&messages, cancel.clone()).await;
 
             let (inner_tx, mut inner_rx) = mpsc::unbounded_channel::<StreamEvent>();
             let (priv_tx, mut priv_rx) = mpsc::unbounded_channel::<StreamEvent>();
@@ -232,7 +295,7 @@ impl Agent {
             });
 
             self.provider
-                .chat_stream(&outgoing, &tool_defs, inner_tx)
+                .chat_stream(&outgoing, &tool_defs, inner_tx, cancel.clone())
                 .await?;
 
             let mut final_response: Option<crate::provider::ChatResponse> = None;
@@ -266,8 +329,9 @@ impl Agent {
 
                 for tc in tool_calls {
                     tracing::info!("Executing tool: {} (call {})", tc.function.name, tc.id);
-                    let final_result =
-                        self.dispatch_tool(&tc.function.name, &tc.function.arguments).await;
+                    let final_result = self
+                        .dispatch_tool(&tc.function.name, &tc.function.arguments, cancel.clone())
+                        .await;
                     messages.push(Message::Tool {
                         tool_call_id: tc.id.clone(),
                         content: final_result,
@@ -275,7 +339,7 @@ impl Agent {
                 }
             } else {
                 // ── BeforeAgentEnd
-                if let Some(instruction) = self.hooks.before_agent_end(&full_response).await {
+                if let Some(instruction) = self.hooks.before_agent_end(&full_response, cancel.clone()).await {
                     messages.push(Message::Assistant {
                         content: Some(full_response.clone()),
                         tool_calls: None,
@@ -284,7 +348,7 @@ impl Agent {
                     continue;
                 }
 
-                self.memory.save_messages(&messages)?;
+                self.memory.save_messages(&self.session_id, &messages)?;
                 self.turns = self.turns.saturating_add(1);
                 if iteration >= 5 {
                     self.skills.try_auto_create(input, &full_response)?;
@@ -302,31 +366,51 @@ impl Agent {
         Ok("Agent reached maximum iteration limit.".to_string())
     }
 
-    /// Resume a previous session by ID
-    pub async fn resume_session(&mut self, session_id: &str) -> Result<()> {
-        let history = self.memory.load_history(session_id)?.unwrap_or_default();
-
-        if history.is_empty() {
-            eprintln!("No session found with ID: {session_id}");
-            return Ok(());
-        }
-
-        println!(
-            "Resumed session {session_id} ({} messages)",
+    /// Resume a previous session by ID. Swaps `self.session_id` to the
+    /// requested one; subsequent `run_prompt[_stream]` calls load and append
+    /// to that session's history. Errors if the session doesn't exist.
+    pub fn resume_session(&mut self, session_id: &str) -> Result<()> {
+        let history = self
+            .memory
+            .load_history(session_id)?
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {session_id}"))?;
+        self.session_id = session_id.to_string();
+        tracing::info!(
+            "resumed session {session_id} ({} messages)",
             history.len()
         );
         Ok(())
+    }
+
+    /// Resume the most recently active session. Errors if there are no
+    /// sessions on disk.
+    pub fn continue_last_session(&mut self) -> Result<()> {
+        match self.memory.last_session_id() {
+            Some(id) => self.resume_session(&id),
+            None => anyhow::bail!("No previous session to resume"),
+        }
+    }
+
+    /// Borrow the underlying `SessionStore`. Used by the TUI's `/search`
+    /// command and the `vulcan search` CLI subcommand to run FTS queries.
+    pub fn memory(&self) -> &crate::memory::SessionStore {
+        &self.memory
     }
 
     /// Dispatch a single tool call, running BeforeToolCall + AfterToolCall
     /// hooks around it. Returns the result flattened to the `String` payload
     /// expected by `Message::Tool` (media references inlined as `[media: ...]`
     /// markers). Hooks see the full `ToolResult`.
-    async fn dispatch_tool(&self, name: &str, raw_args: &str) -> String {
+    async fn dispatch_tool(
+        &self,
+        name: &str,
+        raw_args: &str,
+        cancel: CancellationToken,
+    ) -> String {
         let parsed_args: Value = serde_json::from_str(raw_args).unwrap_or(Value::Null);
 
         let (effective_args_str, blocked) =
-            match self.hooks.before_tool_call(name, &parsed_args).await {
+            match self.hooks.before_tool_call(name, &parsed_args, cancel.clone()).await {
                 ToolCallDecision::Continue => (raw_args.to_string(), None),
                 ToolCallDecision::Block(reason) => (raw_args.to_string(), Some(reason)),
                 ToolCallDecision::ReplaceArgs(new_args) => (
@@ -338,13 +422,13 @@ impl Agent {
         let raw_result: ToolResult = if let Some(reason) = blocked {
             ToolResult::err(format!("Blocked: {reason}"))
         } else {
-            match self.tools.execute(name, &effective_args_str).await {
+            match self.tools.execute(name, &effective_args_str, cancel.clone()).await {
                 Ok(r) => r,
                 Err(e) => ToolResult::err(format!("Error: {e}")),
             }
         };
 
-        let final_result = match self.hooks.after_tool_call(name, &raw_result).await {
+        let final_result = match self.hooks.after_tool_call(name, &raw_result, cancel.clone()).await {
             Some(replaced) => replaced,
             None => raw_result,
         };

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,6 +6,12 @@ use clap::{Parser, Subcommand};
 pub struct Cli {
     #[command(subcommand)]
     pub command: Option<Command>,
+
+    /// Resume the most recent session. Applies to `chat` (default) and
+    /// `prompt` subcommands. Ignored for `session` (which already targets a
+    /// specific ID) and `search`.
+    #[arg(long, global = true)]
+    pub r#continue: bool,
 }
 
 #[derive(Subcommand, Debug)]
@@ -17,9 +23,17 @@ pub enum Command {
         /// The prompt text to send to the agent
         text: String,
     },
-    /// Resume a previous session by ID
+    /// Resume a previous session by ID (interactive TUI)
     Session {
         /// Session ID to resume
         id: String,
+    },
+    /// Full-text search across all saved sessions
+    Search {
+        /// FTS5 query (matches against message content)
+        query: String,
+        /// Max results to return
+        #[arg(long, default_value_t = 10)]
+        limit: usize,
     },
 }

--- a/src/hooks/audit.rs
+++ b/src/hooks/audit.rs
@@ -9,6 +9,7 @@ use std::sync::{Arc, Mutex};
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use serde_json::Value;
+use tokio_util::sync::CancellationToken;
 
 use crate::tools::ToolResult;
 
@@ -70,7 +71,12 @@ impl HookHandler for AuditHook {
         1
     }
 
-    async fn before_tool_call(&self, tool: &str, args: &Value) -> Result<HookOutcome> {
+    async fn before_tool_call(
+        &self,
+        tool: &str,
+        args: &Value,
+        _cancel: CancellationToken,
+    ) -> Result<HookOutcome> {
         let detail = args.to_string();
         self.push(AuditEntry {
             time: Utc::now(),
@@ -81,7 +87,12 @@ impl HookHandler for AuditHook {
         Ok(HookOutcome::Continue)
     }
 
-    async fn after_tool_call(&self, tool: &str, result: &ToolResult) -> Result<HookOutcome> {
+    async fn after_tool_call(
+        &self,
+        tool: &str,
+        result: &ToolResult,
+        _cancel: CancellationToken,
+    ) -> Result<HookOutcome> {
         let kind = if result.is_error {
             AuditKind::Err
         } else {

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -12,11 +12,13 @@ use std::time::Duration;
 use anyhow::Result;
 use serde_json::Value;
 use tokio::time::timeout;
+use tokio_util::sync::CancellationToken;
 
 use crate::provider::Message;
 use crate::tools::ToolResult;
 
 pub mod audit;
+pub mod safety;
 pub mod skills;
 
 /// Where injected messages land in the outgoing prompt. Only honored by
@@ -77,19 +79,37 @@ pub trait HookHandler: Send + Sync {
         50
     }
 
-    async fn before_prompt(&self, _messages: &[Message]) -> Result<HookOutcome> {
+    async fn before_prompt(
+        &self,
+        _messages: &[Message],
+        _cancel: CancellationToken,
+    ) -> Result<HookOutcome> {
         Ok(HookOutcome::Continue)
     }
 
-    async fn before_tool_call(&self, _tool: &str, _args: &Value) -> Result<HookOutcome> {
+    async fn before_tool_call(
+        &self,
+        _tool: &str,
+        _args: &Value,
+        _cancel: CancellationToken,
+    ) -> Result<HookOutcome> {
         Ok(HookOutcome::Continue)
     }
 
-    async fn after_tool_call(&self, _tool: &str, _result: &ToolResult) -> Result<HookOutcome> {
+    async fn after_tool_call(
+        &self,
+        _tool: &str,
+        _result: &ToolResult,
+        _cancel: CancellationToken,
+    ) -> Result<HookOutcome> {
         Ok(HookOutcome::Continue)
     }
 
-    async fn before_agent_end(&self, _final_response: &str) -> Result<HookOutcome> {
+    async fn before_agent_end(
+        &self,
+        _final_response: &str,
+        _cancel: CancellationToken,
+    ) -> Result<HookOutcome> {
         Ok(HookOutcome::Continue)
     }
 
@@ -131,12 +151,16 @@ impl HookRegistry {
     /// all injections applied at their requested positions. The input slice is
     /// not mutated — injections are transient and never persist into
     /// conversation history.
-    pub async fn apply_before_prompt(&self, messages: &[Message]) -> Vec<Message> {
+    pub async fn apply_before_prompt(
+        &self,
+        messages: &[Message],
+        cancel: CancellationToken,
+    ) -> Vec<Message> {
         let mut after_system: Vec<Message> = Vec::new();
         let mut appended: Vec<Message> = Vec::new();
 
         for h in &self.handlers {
-            match self.run(h, h.before_prompt(messages)).await {
+            match self.run(h, h.before_prompt(messages, cancel.clone())).await {
                 Some(HookOutcome::InjectMessages {
                     messages: msgs,
                     position,
@@ -183,9 +207,14 @@ impl HookRegistry {
     }
 
     /// Emit BeforeToolCall. First non-Continue outcome wins.
-    pub async fn before_tool_call(&self, tool: &str, args: &Value) -> ToolCallDecision {
+    pub async fn before_tool_call(
+        &self,
+        tool: &str,
+        args: &Value,
+        cancel: CancellationToken,
+    ) -> ToolCallDecision {
         for h in &self.handlers {
-            match self.run(h, h.before_tool_call(tool, args)).await {
+            match self.run(h, h.before_tool_call(tool, args, cancel.clone())).await {
                 Some(HookOutcome::Block { reason }) => {
                     tracing::info!("hook {} blocked tool {tool}: {reason}", h.name());
                     return ToolCallDecision::Block(reason);
@@ -208,9 +237,14 @@ impl HookRegistry {
     }
 
     /// Emit AfterToolCall. First ReplaceResult wins; otherwise None.
-    pub async fn after_tool_call(&self, tool: &str, result: &ToolResult) -> Option<ToolResult> {
+    pub async fn after_tool_call(
+        &self,
+        tool: &str,
+        result: &ToolResult,
+        cancel: CancellationToken,
+    ) -> Option<ToolResult> {
         for h in &self.handlers {
-            match self.run(h, h.after_tool_call(tool, result)).await {
+            match self.run(h, h.after_tool_call(tool, result, cancel.clone())).await {
                 Some(HookOutcome::ReplaceResult(new)) => {
                     tracing::info!("hook {} replaced result for {tool}", h.name());
                     return Some(new);
@@ -230,9 +264,13 @@ impl HookRegistry {
 
     /// Emit BeforeAgentEnd. First ForceContinue wins; returned instruction is
     /// appended as a user turn and the loop continues.
-    pub async fn before_agent_end(&self, response: &str) -> Option<String> {
+    pub async fn before_agent_end(
+        &self,
+        response: &str,
+        cancel: CancellationToken,
+    ) -> Option<String> {
         for h in &self.handlers {
-            match self.run(h, h.before_agent_end(response)).await {
+            match self.run(h, h.before_agent_end(response, cancel.clone())).await {
                 Some(HookOutcome::ForceContinue { instruction }) => {
                     tracing::info!("hook {} forced continue", h.name());
                     return Some(instruction);

--- a/src/hooks/safety.rs
+++ b/src/hooks/safety.rs
@@ -1,0 +1,297 @@
+//! Built-in BeforeToolCall hook that blocks dangerous shell invocations.
+//!
+//! Replaces the binary `yolo_mode` flag with structured pattern matching plus
+//! a per-session approval cache. When the cache approves a command, that
+//! exact command is allowed for the rest of the session — proving long-lived
+//! `Agent` lets stateful handlers carry approvals across turns.
+//!
+//! Scope of v1: shell commands only. The patterns are hard-coded; user
+//! customization will land when there's demand. See Linear YYC-26.
+
+use std::collections::HashSet;
+use std::sync::Mutex;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde_json::Value;
+use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
+
+use crate::pause::{AgentPause, AgentResume, PauseKind, PauseSender};
+
+use super::{HookHandler, HookOutcome};
+
+pub struct SafetyHook {
+    approved: Mutex<HashSet<String>>,
+    pause_tx: Option<PauseSender>,
+}
+
+impl SafetyHook {
+    /// Construct without an interactive pause channel. Blocked commands stay
+    /// blocked — there's no path back to the user. Suitable for CLI one-shot.
+    pub fn new() -> Self {
+        Self {
+            approved: Mutex::new(HashSet::new()),
+            pause_tx: None,
+        }
+    }
+
+    /// Construct with a pause channel. When a dangerous command is matched,
+    /// the hook emits an `AgentPause::SafetyApproval` and awaits the user's
+    /// response before deciding to block or allow.
+    pub fn with_pause_emitter(pause_tx: PauseSender) -> Self {
+        Self {
+            approved: Mutex::new(HashSet::new()),
+            pause_tx: Some(pause_tx),
+        }
+    }
+
+    /// Add a command to the per-session approval cache. Future invocations of
+    /// the *exact same* command in this session will bypass the safety check.
+    /// Public so the TUI can pre-seed approvals if it ever wants to.
+    pub fn approve(&self, command: &str) {
+        if let Ok(mut set) = self.approved.lock() {
+            set.insert(command.to_string());
+        }
+    }
+
+    fn is_approved(&self, command: &str) -> bool {
+        self.approved
+            .lock()
+            .map(|s| s.contains(command))
+            .unwrap_or(false)
+    }
+}
+
+impl Default for SafetyHook {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl HookHandler for SafetyHook {
+    fn name(&self) -> &str {
+        "safety-gate"
+    }
+
+    fn priority(&self) -> i32 {
+        // Run before audit so blocked calls don't appear as "started" in the log.
+        // Audit hook is priority 1; we go priority 0.
+        0
+    }
+
+    async fn before_tool_call(
+        &self,
+        tool: &str,
+        args: &Value,
+        cancel: CancellationToken,
+    ) -> Result<HookOutcome> {
+        if tool != "bash" {
+            return Ok(HookOutcome::Continue);
+        }
+
+        let command = match args.get("command").and_then(|v| v.as_str()) {
+            Some(c) => c,
+            None => return Ok(HookOutcome::Continue),
+        };
+
+        let reason = match match_dangerous(command) {
+            Some(r) => r,
+            None => return Ok(HookOutcome::Continue),
+        };
+
+        if self.is_approved(command) {
+            tracing::info!("safety-gate: '{command}' approved earlier this session, allowing");
+            return Ok(HookOutcome::Continue);
+        }
+
+        // If a pause emitter is wired up, ask the user. Otherwise fall back to
+        // a hard block (CLI one-shot path).
+        if let Some(tx) = &self.pause_tx {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            let pause = AgentPause {
+                kind: PauseKind::SafetyApproval {
+                    tool: tool.to_string(),
+                    command: command.to_string(),
+                    reason: reason.to_string(),
+                },
+                reply: reply_tx,
+            };
+
+            if tx.send(pause).await.is_err() {
+                // Consumer is gone. Fall back to block.
+                tracing::warn!("safety-gate: pause consumer dropped, falling back to block");
+                return Ok(HookOutcome::Block {
+                    reason: format!("{reason} (no approval consumer available)"),
+                });
+            }
+
+            let resume = tokio::select! {
+                biased;
+                _ = cancel.cancelled() => {
+                    return Ok(HookOutcome::Block {
+                        reason: "Cancelled while awaiting approval".to_string(),
+                    });
+                }
+                r = reply_rx => r,
+            };
+
+            return Ok(match resume {
+                Ok(AgentResume::Allow) => HookOutcome::Continue,
+                Ok(AgentResume::AllowAndRemember) => {
+                    self.approve(command);
+                    HookOutcome::Continue
+                }
+                Ok(AgentResume::Deny) => HookOutcome::Block {
+                    reason: format!("{reason} (user denied)"),
+                },
+                Ok(AgentResume::DenyWithReason(r)) => HookOutcome::Block { reason: r },
+                Err(_) => HookOutcome::Block {
+                    reason: format!("{reason} (approval channel closed)"),
+                },
+            });
+        }
+
+        tracing::warn!("safety-gate blocked bash command: {reason} ({command})");
+        Ok(HookOutcome::Block {
+            reason: format!("{reason}. If you really need this, ask the user to approve."),
+        })
+    }
+}
+
+/// Returns the human-readable block reason for known-dangerous shell patterns,
+/// or `None` if the command looks fine.
+fn match_dangerous(command: &str) -> Option<&'static str> {
+    let c = command;
+
+    if c.contains("rm -rf /")
+        || c.contains("rm -rf ~")
+        || c.contains("rm -rf $HOME")
+        || c.contains("rm -rf ${HOME}")
+    {
+        return Some("destructive recursive remove of root or home directory");
+    }
+
+    if c.contains("dd if=") {
+        return Some("low-level disk operation (dd)");
+    }
+
+    if c.contains("mkfs") {
+        return Some("filesystem format command (mkfs)");
+    }
+
+    if c.contains("chmod -R 777") || c.contains("chmod 777 /") {
+        return Some("overly permissive recursive chmod 777");
+    }
+
+    if c.contains(":(){") {
+        return Some("possible fork bomb pattern");
+    }
+
+    if (c.contains("git push --force") || c.contains("git push -f ") || c.ends_with("git push -f"))
+        && !c.contains("--force-with-lease")
+    {
+        return Some("force push (consider --force-with-lease)");
+    }
+
+    if (c.contains("curl ") || c.contains("wget "))
+        && (c.contains("| bash") || c.contains("| sh") || c.contains("|bash") || c.contains("|sh"))
+    {
+        return Some("pipe-to-shell from network (curl|bash / wget|sh)");
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blocks_dangerous_commands() {
+        assert!(match_dangerous("rm -rf /").is_some());
+        assert!(match_dangerous("rm -rf ~").is_some());
+        assert!(match_dangerous("dd if=/dev/zero of=/dev/sda").is_some());
+        assert!(match_dangerous("mkfs.ext4 /dev/sda1").is_some());
+        assert!(match_dangerous("chmod -R 777 /etc").is_some());
+        assert!(match_dangerous(":(){ :|:& };:").is_some());
+        assert!(match_dangerous("git push --force origin main").is_some());
+        assert!(match_dangerous("curl https://x.com/install.sh | bash").is_some());
+    }
+
+    #[test]
+    fn allows_safe_commands() {
+        assert!(match_dangerous("ls -la").is_none());
+        assert!(match_dangerous("rm -rf node_modules").is_none());
+        assert!(match_dangerous("git push origin main").is_none());
+        assert!(match_dangerous("git push --force-with-lease").is_none());
+        assert!(match_dangerous("cargo build").is_none());
+    }
+
+    #[tokio::test]
+    async fn pause_path_routes_through_emitter() {
+        use crate::pause::{AgentResume, PauseKind};
+
+        let (tx, mut rx) = crate::pause::channel(4);
+        let hook = SafetyHook::with_pause_emitter(tx);
+        let dangerous = "rm -rf /";
+        let args = serde_json::json!({ "command": dangerous });
+        let cancel = CancellationToken::new();
+
+        // Start the hook call in a background task — it will block awaiting
+        // the user's response on the oneshot reply channel.
+        let hook_arc = std::sync::Arc::new(hook);
+        let h = hook_arc.clone();
+        let c = cancel.clone();
+        let task = tokio::spawn(async move {
+            h.before_tool_call("bash", &args, c).await
+        });
+
+        // Simulate the TUI consuming the pause and sending AllowAndRemember.
+        let pause = rx.recv().await.expect("pause should arrive");
+        match &pause.kind {
+            PauseKind::SafetyApproval { command, .. } => assert_eq!(command, dangerous),
+            other => panic!("expected SafetyApproval, got {other:?}"),
+        }
+        pause.reply.send(AgentResume::AllowAndRemember).expect("reply ok");
+
+        // Hook should now resolve to Continue.
+        let outcome = task.await.expect("task ok").expect("hook ok");
+        assert!(matches!(outcome, HookOutcome::Continue));
+
+        // And the command should now be in the approval cache.
+        assert!(hook_arc.is_approved(dangerous));
+    }
+
+    #[tokio::test]
+    async fn approval_cache_bypasses_block() {
+        let hook = SafetyHook::new();
+        let dangerous = "rm -rf /";
+        let args = serde_json::json!({ "command": dangerous });
+        let cancel = CancellationToken::new();
+
+        // First call blocks
+        match hook
+            .before_tool_call("bash", &args, cancel.clone())
+            .await
+            .unwrap()
+        {
+            HookOutcome::Block { .. } => {}
+            other => panic!("expected Block, got {other:?}"),
+        }
+
+        // Approve it
+        hook.approve(dangerous);
+
+        // Second call passes
+        match hook
+            .before_tool_call("bash", &args, cancel.clone())
+            .await
+            .unwrap()
+        {
+            HookOutcome::Continue => {}
+            other => panic!("expected Continue, got {other:?}"),
+        }
+    }
+}

--- a/src/hooks/skills.rs
+++ b/src/hooks/skills.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use async_trait::async_trait;
+use tokio_util::sync::CancellationToken;
 
 use crate::provider::Message;
 use crate::skills::SkillRegistry;
@@ -34,7 +35,11 @@ impl HookHandler for SkillsHook {
         10
     }
 
-    async fn before_prompt(&self, _messages: &[Message]) -> Result<HookOutcome> {
+    async fn before_prompt(
+        &self,
+        _messages: &[Message],
+        _cancel: CancellationToken,
+    ) -> Result<HookOutcome> {
         if self.skills.is_empty() {
             return Ok(HookOutcome::Continue);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod context;
 pub mod hooks;
 pub mod memory;
+pub mod pause;
 pub mod platform;
 pub mod prompt_builder;
 pub mod provider;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 use clap::Parser;
+use tracing_subscriber::EnvFilter;
 use vulcan::cli::{Cli, Command};
 use vulcan::config::Config;
-use vulcan::tui::run_tui;
-use tracing_subscriber::EnvFilter;
+use vulcan::tui::{ResumeTarget, run_tui};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -11,21 +11,45 @@ async fn main() -> anyhow::Result<()> {
 
     match cli.command {
         None | Some(Command::Chat) => {
-            // TUI mode: log to a file so tracing output doesn't splat into the TUI
             init_tui_logging();
-            run_tui(&config).await?;
+            let resume = if cli.r#continue {
+                ResumeTarget::Last
+            } else {
+                ResumeTarget::None
+            };
+            run_tui(&config, resume).await?;
         }
         Some(Command::Prompt { text }) => {
-            // One-shot mode: log to stderr (visible while waiting)
             init_cli_logging();
             let mut agent = vulcan::agent::Agent::new(&config);
+            if cli.r#continue {
+                agent.continue_last_session()?;
+            }
             let response = agent.run_prompt(&text).await?;
             println!("{response}");
         }
         Some(Command::Session { id }) => {
+            init_tui_logging();
+            run_tui(&config, ResumeTarget::Specific(id)).await?;
+        }
+        Some(Command::Search { query, limit }) => {
             init_cli_logging();
-            let mut agent = vulcan::agent::Agent::new(&config);
-            agent.resume_session(&id).await?;
+            let store = vulcan::memory::SessionStore::new();
+            let hits = store.search_messages(&query, limit)?;
+            if hits.is_empty() {
+                println!("No matches.");
+            } else {
+                for h in hits {
+                    let preview: String = h.content.chars().take(120).collect();
+                    println!(
+                        "[{}…] {} (score {:.2})\n  {}\n",
+                        &h.session_id[..8],
+                        h.role,
+                        h.score,
+                        preview.replace('\n', " ")
+                    );
+                }
+            }
         }
     }
 
@@ -49,7 +73,6 @@ fn init_tui_logging() {
     let log_path = log_dir.join("vulcan.log");
 
     let file = std::fs::File::create(&log_path).unwrap_or_else(|_| {
-        // Fallback: /dev/null
         std::fs::File::open("/dev/null").unwrap()
     });
 
@@ -61,6 +84,5 @@ fn init_tui_logging() {
         .with_ansi(false)
         .init();
 
-    // Also print a note to stderr before the TUI takes over
     eprintln!("Vulcan TUI starting... logs → {log_path:?}");
 }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,124 +1,485 @@
-use crate::provider::Message;
+//! Persistent session storage backed by SQLite (with FTS5 for cross-session
+//! search).
+//!
+//! Schema:
+//! - `sessions(id PK, created_at, last_active)`
+//! - `messages(id PK AUTOINCREMENT, session_id FK, position, role, content,
+//!    tool_call_id, tool_calls_json, created_at)` indexed on `(session_id, position)`
+//! - `messages_fts` — external-content FTS5 over `messages.content`, kept in
+//!    sync via insert/update/delete triggers.
+//!
+//! The JSONL format used previously is gone; old data under
+//! `~/.vulcan/sessions/*.jsonl` is left in place but not read. Migration is a
+//! manual one-off if it ever matters (see Linear YYC-14).
+
+use std::sync::Mutex;
+
 use anyhow::{Context, Result};
 use chrono::Utc;
-use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use rusqlite::{Connection, OptionalExtension, params};
 
-/// Persistent session storage using JSONL files
+use crate::provider::{Message, ToolCall};
+
+const SCHEMA: &str = r#"
+PRAGMA foreign_keys = ON;
+PRAGMA journal_mode = WAL;
+
+CREATE TABLE IF NOT EXISTS sessions (
+    id          TEXT PRIMARY KEY,
+    created_at  INTEGER NOT NULL,
+    last_active INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS messages (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id      TEXT NOT NULL,
+    position        INTEGER NOT NULL,
+    role            TEXT NOT NULL,
+    content         TEXT,
+    tool_call_id    TEXT,
+    tool_calls_json TEXT,
+    created_at      INTEGER NOT NULL,
+    FOREIGN KEY(session_id) REFERENCES sessions(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_messages_session ON messages(session_id, position);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5(
+    content,
+    content='messages',
+    content_rowid='id'
+);
+
+CREATE TRIGGER IF NOT EXISTS messages_ai AFTER INSERT ON messages BEGIN
+    INSERT INTO messages_fts(rowid, content) VALUES (new.id, COALESCE(new.content, ''));
+END;
+
+CREATE TRIGGER IF NOT EXISTS messages_ad AFTER DELETE ON messages BEGIN
+    INSERT INTO messages_fts(messages_fts, rowid, content) VALUES('delete', old.id, COALESCE(old.content, ''));
+END;
+
+CREATE TRIGGER IF NOT EXISTS messages_au AFTER UPDATE ON messages BEGIN
+    INSERT INTO messages_fts(messages_fts, rowid, content) VALUES('delete', old.id, COALESCE(old.content, ''));
+    INSERT INTO messages_fts(rowid, content) VALUES (new.id, COALESCE(new.content, ''));
+END;
+"#;
+
 pub struct SessionStore {
-    sessions_dir: PathBuf,
+    conn: Mutex<Connection>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-pub struct SessionMeta {
+/// One row from a full-text search. Score is the BM25 rank (lower = better
+/// per FTS5 conventions).
+#[derive(Debug, Clone)]
+pub struct SearchHit {
+    pub session_id: String,
+    pub position: i64,
+    pub role: String,
+    pub content: String,
+    pub created_at: i64,
+    pub score: f64,
+}
+
+#[derive(Debug, Clone)]
+pub struct SessionSummary {
     pub id: String,
-    pub created_at: String,
-    pub updated_at: String,
+    pub created_at: i64,
+    pub last_active: i64,
     pub message_count: usize,
-    pub title: Option<String>,
 }
 
 impl SessionStore {
+    /// Open (or create) the session store at `~/.vulcan/sessions.db`. Panics
+    /// on fatal DB initialization errors — matches the existing pattern in
+    /// `Agent::new` (api key, provider).
     pub fn new() -> Self {
-        let dir = crate::config::vulcan_home().join("sessions");
+        let dir = crate::config::vulcan_home();
         std::fs::create_dir_all(&dir).ok();
-        Self { sessions_dir: dir }
+        let path = dir.join("sessions.db");
+
+        let conn = Connection::open(&path)
+            .unwrap_or_else(|e| panic!("Failed to open session DB at {}: {e}", path.display()));
+
+        conn.execute_batch(SCHEMA)
+            .unwrap_or_else(|e| panic!("Failed to initialize session DB schema: {e}"));
+
+        Self {
+            conn: Mutex::new(conn),
+        }
     }
 
-    /// Get the most recent session ID, if any
+    /// Most recently active session, by `last_active`. `None` if there are no
+    /// sessions yet.
     pub fn last_session_id(&self) -> Option<String> {
-        let mut entries: Vec<_> = std::fs::read_dir(&self.sessions_dir)
-            .ok()?
-            .filter_map(|e| e.ok())
-            .filter(|e| e.path().extension().map_or(false, |ext| ext == "jsonl"))
-            .filter_map(|e| {
-                let meta = e.path().with_extension("json");
-                let created = std::fs::metadata(&meta)
-                    .and_then(|m| m.created())
-                    .ok()?;
-                Some((e.path(), created))
-            })
-            .collect();
-
-        entries.sort_by(|a, b| b.1.cmp(&a.1));
-        entries
-            .first()
-            .map(|(path, _)| {
-                path.file_stem()
-                    .and_then(|s| s.to_str())
-                    .unwrap_or("")
-                    .to_string()
-            })
+        let conn = self.conn.lock().ok()?;
+        conn.query_row(
+            "SELECT id FROM sessions ORDER BY last_active DESC LIMIT 1",
+            [],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .ok()
+        .flatten()
     }
 
-    /// Load message history for a session
+    /// Load all messages for `session_id` in the order they were saved.
+    /// Returns `Ok(None)` if the session doesn't exist.
     pub fn load_history(&self, session_id: &str) -> Result<Option<Vec<Message>>> {
-        let path = self.sessions_dir.join(format!("{session_id}.jsonl"));
-        if !path.exists() {
+        let conn = self.conn.lock().map_err(|_| anyhow::anyhow!("session DB poisoned"))?;
+
+        let exists: bool = conn
+            .query_row(
+                "SELECT 1 FROM sessions WHERE id = ?1",
+                params![session_id],
+                |_| Ok(true),
+            )
+            .optional()
+            .context("Failed to check session existence")?
+            .unwrap_or(false);
+        if !exists {
             return Ok(None);
         }
 
-        let content = std::fs::read_to_string(&path)
-            .with_context(|| format!("Failed to read session {session_id}"))?;
+        let mut stmt = conn.prepare(
+            "SELECT role, content, tool_call_id, tool_calls_json
+             FROM messages
+             WHERE session_id = ?1
+             ORDER BY position ASC",
+        )?;
 
-        let messages: Vec<Message> = content
-            .lines()
-            .filter_map(|line| serde_json::from_str(line).ok())
-            .collect();
+        let rows = stmt.query_map(params![session_id], |row| {
+            let role: String = row.get(0)?;
+            let content: Option<String> = row.get(1)?;
+            let tool_call_id: Option<String> = row.get(2)?;
+            let tool_calls_json: Option<String> = row.get(3)?;
+            Ok((role, content, tool_call_id, tool_calls_json))
+        })?;
+
+        let mut messages = Vec::new();
+        for row in rows {
+            let (role, content, tool_call_id, tool_calls_json) = row?;
+            let msg = decode_message(&role, content, tool_call_id, tool_calls_json)?;
+            messages.push(msg);
+        }
 
         Ok(Some(messages))
     }
 
-    /// Save messages to session history
-    pub fn save_messages(&self, messages: &[Message]) -> Result<String> {
-        let session_id = self.last_session_id().unwrap_or_else(|| {
-            uuid::Uuid::new_v4().to_string()
-        });
+    /// Save the full message history for `session_id`. The session row is
+    /// upserted (`last_active` bumped); existing messages for the session are
+    /// deleted and replaced with `messages` — full-snapshot semantics matching
+    /// the per-prompt save the agent emits.
+    pub fn save_messages(&self, session_id: &str, messages: &[Message]) -> Result<()> {
+        let now = Utc::now().timestamp();
 
-        let path = self.sessions_dir.join(format!("{session_id}.jsonl"));
+        let mut conn = self
+            .conn
+            .lock()
+            .map_err(|_| anyhow::anyhow!("session DB poisoned"))?;
+        let tx = conn.transaction()?;
 
-        let saved_count = if path.exists() {
-            let existing = std::fs::read_to_string(&path)?;
-            existing.lines().count()
-        } else {
-            0
-        };
+        // Upsert the session row.
+        tx.execute(
+            "INSERT INTO sessions (id, created_at, last_active)
+             VALUES (?1, ?2, ?2)
+             ON CONFLICT(id) DO UPDATE SET last_active = excluded.last_active",
+            params![session_id, now],
+        )?;
 
-        // Write out the full history
-        let mut file = std::fs::File::create(&path)?;
-        for msg in messages {
-            let line = serde_json::to_string(msg)?;
-            writeln!(file, "{line}")?;
+        // Replace all messages for this session — full snapshot semantics.
+        tx.execute(
+            "DELETE FROM messages WHERE session_id = ?1",
+            params![session_id],
+        )?;
+
+        for (idx, msg) in messages.iter().enumerate() {
+            let (role, content, tool_call_id, tool_calls_json) = encode_message(msg)?;
+            tx.execute(
+                "INSERT INTO messages
+                 (session_id, position, role, content, tool_call_id, tool_calls_json, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                params![
+                    session_id,
+                    idx as i64,
+                    role,
+                    content,
+                    tool_call_id,
+                    tool_calls_json,
+                    now,
+                ],
+            )?;
         }
 
-        // Write meta
-        let meta = SessionMeta {
-            id: session_id.clone(),
-            created_at: if saved_count == 0 {
-                Utc::now().to_rfc3339()
-            } else {
-                // Read existing meta
-                Self::read_meta(&self.sessions_dir, &session_id)
-                    .unwrap_or_else(|| Utc::now().to_rfc3339())
-            },
-            updated_at: Utc::now().to_rfc3339(),
-            message_count: messages.len(),
-            title: None,
-        };
-
-        let meta_path = self.sessions_dir.join(format!("{session_id}.json"));
-        std::fs::write(&meta_path, serde_json::to_string_pretty(&meta)?)?;
-
-        Ok(session_id)
+        tx.commit()?;
+        Ok(())
     }
 
-    fn read_meta(dir: &PathBuf, id: &str) -> Option<String> {
-        let path = dir.join(format!("{id}.json"));
-        let meta: SessionMeta =
-            serde_json::from_str(&std::fs::read_to_string(path).ok()?).ok()?;
-        Some(meta.created_at)
+    /// Most-recent-first list of saved sessions, capped at `limit`.
+    pub fn list_sessions(&self, limit: usize) -> Result<Vec<SessionSummary>> {
+        let conn = self.conn.lock().map_err(|_| anyhow::anyhow!("session DB poisoned"))?;
+
+        let mut stmt = conn.prepare(
+            "SELECT s.id, s.created_at, s.last_active,
+                    (SELECT COUNT(*) FROM messages m WHERE m.session_id = s.id) AS msg_count
+             FROM sessions s
+             ORDER BY s.last_active DESC
+             LIMIT ?1",
+        )?;
+
+        let rows = stmt.query_map(params![limit as i64], |row| {
+            Ok(SessionSummary {
+                id: row.get(0)?,
+                created_at: row.get(1)?,
+                last_active: row.get(2)?,
+                message_count: row.get::<_, i64>(3)? as usize,
+            })
+        })?;
+
+        let mut summaries = Vec::new();
+        for row in rows {
+            summaries.push(row?);
+        }
+        Ok(summaries)
+    }
+
+    /// Full-text search across every saved message. Returns the top `limit`
+    /// hits ranked by BM25.
+    pub fn search_messages(&self, query: &str, limit: usize) -> Result<Vec<SearchHit>> {
+        let conn = self.conn.lock().map_err(|_| anyhow::anyhow!("session DB poisoned"))?;
+
+        let mut stmt = conn.prepare(
+            "SELECT m.session_id, m.position, m.role, m.content, m.created_at, bm25(messages_fts) AS score
+             FROM messages_fts
+             JOIN messages m ON m.id = messages_fts.rowid
+             WHERE messages_fts MATCH ?1
+             ORDER BY score
+             LIMIT ?2",
+        )?;
+
+        let rows = stmt.query_map(params![query, limit as i64], |row| {
+            Ok(SearchHit {
+                session_id: row.get(0)?,
+                position: row.get(1)?,
+                role: row.get(2)?,
+                content: row.get::<_, Option<String>>(3)?.unwrap_or_default(),
+                created_at: row.get(4)?,
+                score: row.get(5)?,
+            })
+        })?;
+
+        let mut hits = Vec::new();
+        for row in rows {
+            hits.push(row?);
+        }
+        Ok(hits)
     }
 }
 
-// Helper for the write! macro in save_messages
-use std::io::Write;
+impl Default for SessionStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn encode_message(
+    msg: &Message,
+) -> Result<(&'static str, Option<String>, Option<String>, Option<String>)> {
+    Ok(match msg {
+        Message::System { content } => ("system", Some(content.clone()), None, None),
+        Message::User { content } => ("user", Some(content.clone()), None, None),
+        Message::Assistant {
+            content,
+            tool_calls,
+        } => {
+            let tool_calls_json = match tool_calls {
+                Some(tcs) => Some(serde_json::to_string(tcs).context("encode tool_calls")?),
+                None => None,
+            };
+            ("assistant", content.clone(), None, tool_calls_json)
+        }
+        Message::Tool {
+            tool_call_id,
+            content,
+        } => (
+            "tool",
+            Some(content.clone()),
+            Some(tool_call_id.clone()),
+            None,
+        ),
+    })
+}
+
+fn decode_message(
+    role: &str,
+    content: Option<String>,
+    tool_call_id: Option<String>,
+    tool_calls_json: Option<String>,
+) -> Result<Message> {
+    Ok(match role {
+        "system" => Message::System {
+            content: content.unwrap_or_default(),
+        },
+        "user" => Message::User {
+            content: content.unwrap_or_default(),
+        },
+        "assistant" => {
+            let tool_calls = match tool_calls_json {
+                Some(s) => Some(serde_json::from_str::<Vec<ToolCall>>(&s).context("decode tool_calls")?),
+                None => None,
+            };
+            Message::Assistant {
+                content,
+                tool_calls,
+            }
+        }
+        "tool" => Message::Tool {
+            tool_call_id: tool_call_id.unwrap_or_default(),
+            content: content.unwrap_or_default(),
+        },
+        other => anyhow::bail!("unknown role in DB: {other}"),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn store_in(dir: &TempDir) -> SessionStore {
+        // Bypass `new()` so we don't write into ~/.vulcan during tests.
+        let path = dir.path().join("sessions.db");
+        let conn = Connection::open(&path).unwrap();
+        conn.execute_batch(SCHEMA).unwrap();
+        SessionStore {
+            conn: Mutex::new(conn),
+        }
+    }
+
+    #[test]
+    fn round_trip_messages() {
+        let dir = TempDir::new().unwrap();
+        let store = store_in(&dir);
+        let session_id = uuid::Uuid::new_v4().to_string();
+
+        let messages = vec![
+            Message::System {
+                content: "you are a helpful agent".into(),
+            },
+            Message::User {
+                content: "what is rust?".into(),
+            },
+            Message::Assistant {
+                content: Some("a systems language with strong types".into()),
+                tool_calls: None,
+            },
+        ];
+
+        store.save_messages(&session_id, &messages).unwrap();
+        let loaded = store.load_history(&session_id).unwrap().unwrap();
+        assert_eq!(loaded.len(), 3);
+        match &loaded[1] {
+            Message::User { content } => assert_eq!(content, "what is rust?"),
+            other => panic!("expected User, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn last_session_id_returns_most_recent() {
+        let dir = TempDir::new().unwrap();
+        let store = store_in(&dir);
+        let id = uuid::Uuid::new_v4().to_string();
+
+        store
+            .save_messages(
+                &id,
+                &[Message::User {
+                    content: "first".into(),
+                }],
+            )
+            .unwrap();
+        assert_eq!(store.last_session_id(), Some(id));
+    }
+
+    #[test]
+    fn list_sessions_returns_summaries_in_recency_order() {
+        let dir = TempDir::new().unwrap();
+        let store = store_in(&dir);
+        let s1 = uuid::Uuid::new_v4().to_string();
+        let s2 = uuid::Uuid::new_v4().to_string();
+
+        store
+            .save_messages(&s1, &[Message::User { content: "a".into() }])
+            .unwrap();
+        // Sleep 1s would make this deterministic, but the second save bumps
+        // last_active beyond the first's wall-clock-second granularity in
+        // practice. Make it explicit by saving twice with different content.
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        store
+            .save_messages(&s2, &[Message::User { content: "b".into() }])
+            .unwrap();
+
+        let summaries = store.list_sessions(10).unwrap();
+        assert_eq!(summaries.len(), 2);
+        assert_eq!(summaries[0].id, s2, "most recent should come first");
+        assert_eq!(summaries[1].id, s1);
+        assert_eq!(summaries[0].message_count, 1);
+    }
+
+    #[test]
+    fn fts_search_finds_content() {
+        let dir = TempDir::new().unwrap();
+        let store = store_in(&dir);
+        let session_id = uuid::Uuid::new_v4().to_string();
+
+        store
+            .save_messages(
+                &session_id,
+                &[
+                    Message::User {
+                        content: "the quick brown fox jumps over the lazy dog".into(),
+                    },
+                    Message::User {
+                        content: "lorem ipsum dolor sit amet".into(),
+                    },
+                ],
+            )
+            .unwrap();
+
+        let hits = store.search_messages("brown fox", 10).unwrap();
+        assert!(
+            hits.iter().any(|h| h.content.contains("brown fox")),
+            "expected fox hit, got {hits:?}"
+        );
+    }
+
+    #[test]
+    fn assistant_with_tool_calls_round_trips() {
+        let dir = TempDir::new().unwrap();
+        let store = store_in(&dir);
+        let id = uuid::Uuid::new_v4().to_string();
+
+        let messages = vec![Message::Assistant {
+            content: None,
+            tool_calls: Some(vec![ToolCall {
+                id: "call_1".into(),
+                call_type: "function".into(),
+                function: crate::provider::ToolCallFunction {
+                    name: "bash".into(),
+                    arguments: r#"{"command":"ls"}"#.into(),
+                },
+            }]),
+        }];
+
+        store.save_messages(&id, &messages).unwrap();
+        let loaded = store.load_history(&id).unwrap().unwrap();
+
+        match &loaded[0] {
+            Message::Assistant { tool_calls, .. } => {
+                let tcs = tool_calls.as_ref().expect("tool calls present");
+                assert_eq!(tcs.len(), 1);
+                assert_eq!(tcs[0].function.name, "bash");
+            }
+            other => panic!("expected Assistant, got {other:?}"),
+        }
+    }
+}

--- a/src/pause.rs
+++ b/src/pause.rs
@@ -1,0 +1,71 @@
+//! Generic agent-paused-awaiting-user-input mechanism.
+//!
+//! Several features need to pause the agent loop mid-flight and wait for a
+//! user decision before continuing — safety-gate approval, granular tool-arg
+//! confirmation, skill-save prompts, ambiguity resolution. Rather than each
+//! feature inventing its own channel + UI surface, all such interruptions
+//! flow through one type: an `AgentPause` is emitted, the consumer (TUI)
+//! renders an appropriate prompt, and a response is delivered back via the
+//! pause's `oneshot` reply channel.
+//!
+//! When the agent has no pause emitter wired up (CLI one-shot mode, or any
+//! caller that doesn't want interactive prompts), hooks fall back to their
+//! pre-pause behavior — typically: reject conservatively. See
+//! [`SafetyHook`](crate::hooks::safety::SafetyHook) for the canonical example.
+
+use serde_json::Value;
+use tokio::sync::oneshot;
+
+/// One pause emission: what's being asked, plus a reply channel.
+#[derive(Debug)]
+pub struct AgentPause {
+    pub kind: PauseKind,
+    pub reply: oneshot::Sender<AgentResume>,
+}
+
+/// What the agent is asking the user.
+#[derive(Debug)]
+pub enum PauseKind {
+    /// A `SafetyHook` matched a dangerous shell command and wants the user
+    /// to choose: allow once, allow + remember for the session, or deny.
+    SafetyApproval {
+        tool: String,
+        command: String,
+        reason: String,
+    },
+    /// A tool is about to run with these args; confirm before dispatching.
+    /// (Replacement for the binary `yolo_mode` flag at granular scope.)
+    ToolArgConfirm {
+        tool: String,
+        args: Value,
+        summary: String,
+    },
+    /// "I noticed you used N+ tools to do X, save this as a skill?"
+    SkillSave {
+        suggested_name: String,
+        body: String,
+    },
+}
+
+/// The user's decision.
+#[derive(Debug, Clone)]
+pub enum AgentResume {
+    /// Allow this single instance.
+    Allow,
+    /// Allow this instance and remember for the rest of the session. Hooks
+    /// decide what "remember" means (e.g. `SafetyHook` adds the command to
+    /// its approval cache).
+    AllowAndRemember,
+    /// Deny — hook returns its default `Block` outcome.
+    Deny,
+    /// Deny with a reason that gets surfaced to the LLM as the block reason.
+    DenyWithReason(String),
+}
+
+pub type PauseSender = tokio::sync::mpsc::Sender<AgentPause>;
+pub type PauseReceiver = tokio::sync::mpsc::Receiver<AgentPause>;
+
+/// Convenience constructor for callers wiring up the channel.
+pub fn channel(buffer: usize) -> (PauseSender, PauseReceiver) {
+    tokio::sync::mpsc::channel(buffer)
+}

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -144,19 +144,23 @@ pub enum StreamEvent {
 /// A provider capable of chatting with an LLM
 #[async_trait::async_trait]
 pub trait LLMProvider: Send + Sync {
-    /// Send a chat request and get a buffered response (for CLI mode)
+    /// Send a chat request and get a buffered response (for CLI mode).
+    /// Race against `cancel.cancelled()`; on cancel, drop the in-flight HTTP
+    /// request and return an `Err` (the agent loop translates this).
     async fn chat(
         &self,
         messages: &[Message],
         tools: &[ToolDefinition],
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<ChatResponse>;
 
-    /// Send a chat request and stream response events through a channel (for TUI mode)
+    /// Send a chat request and stream response events through a channel (for TUI mode).
     async fn chat_stream(
         &self,
         messages: &[Message],
         tools: &[ToolDefinition],
         tx: mpsc::UnboundedSender<StreamEvent>,
+        cancel: tokio_util::sync::CancellationToken,
     ) -> Result<()>;
 
     /// Get the model's context window size

--- a/src/provider/openai.rs
+++ b/src/provider/openai.rs
@@ -4,6 +4,7 @@ use reqwest::Client;
 use serde_json::{json, Value};
 use std::time::Duration;
 use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
 
 /// OpenAI-compatible provider (works with OpenRouter, Anthropic, Ollama, etc.)
 pub struct OpenAIProvider {
@@ -164,9 +165,16 @@ impl LLMProvider for OpenAIProvider {
         &self,
         messages: &[Message],
         tools: &[ToolDefinition],
+        cancel: CancellationToken,
     ) -> Result<ChatResponse> {
-        let response = self.do_request(messages, tools).await?;
-        let bytes = response.bytes().await.context("Failed to read response body")?;
+        let bytes = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => anyhow::bail!("Cancelled"),
+            res = async {
+                let response = self.do_request(messages, tools).await?;
+                response.bytes().await.context("Failed to read response body")
+            } => res?,
+        };
         let text = String::from_utf8_lossy(&bytes);
 
         let mut content = String::new();
@@ -192,8 +200,13 @@ impl LLMProvider for OpenAIProvider {
         messages: &[Message],
         tools: &[ToolDefinition],
         tx: mpsc::UnboundedSender<StreamEvent>,
+        cancel: CancellationToken,
     ) -> Result<()> {
-        let response = self.do_request(messages, tools).await?;
+        let response = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => anyhow::bail!("Cancelled"),
+            res = self.do_request(messages, tools) => res?,
+        };
 
         let mut content = String::new();
         let mut tool_calls: Vec<ToolCall> = Vec::new();
@@ -205,7 +218,15 @@ impl LLMProvider for OpenAIProvider {
         let mut buf = String::new();
 
         use futures_util::StreamExt;
-        while let Some(chunk_result) = stream.next().await {
+        loop {
+            let chunk_result = tokio::select! {
+                biased;
+                _ = cancel.cancelled() => anyhow::bail!("Cancelled"),
+                next = stream.next() => match next {
+                    Some(r) => r,
+                    None => break,
+                },
+            };
             let chunk = chunk_result.context("Failed to read stream chunk")?;
             let chunk_str = String::from_utf8_lossy(&chunk);
             buf.push_str(&chunk_str);

--- a/src/tools/file.rs
+++ b/src/tools/file.rs
@@ -3,6 +3,7 @@ use crate::tools::{Tool, ToolResult};
 use anyhow::Result;
 use async_trait::async_trait;
 use serde_json::{json, Value};
+use tokio_util::sync::CancellationToken;
 
 pub struct ReadFile;
 
@@ -25,7 +26,7 @@ impl Tool for ReadFile {
             "required": ["path"]
         })
     }
-    async fn call(&self, params: Value) -> Result<ToolResult> {
+    async fn call(&self, params: Value, _cancel: CancellationToken) -> Result<ToolResult> {
         let path = params["path"].as_str().ok_or_else(|| anyhow::anyhow!("path required"))?;
         let offset = params["offset"].as_i64().unwrap_or(1);
         let limit = params["limit"].as_i64().unwrap_or(500);
@@ -75,7 +76,7 @@ impl Tool for WriteFile {
             "required": ["path", "content"]
         })
     }
-    async fn call(&self, params: Value) -> Result<ToolResult> {
+    async fn call(&self, params: Value, _cancel: CancellationToken) -> Result<ToolResult> {
         let path = params["path"].as_str().ok_or_else(|| anyhow::anyhow!("path required"))?;
         let content = params["content"].as_str().unwrap_or("");
 
@@ -112,7 +113,7 @@ impl Tool for SearchFiles {
             "required": ["pattern"]
         })
     }
-    async fn call(&self, params: Value) -> Result<ToolResult> {
+    async fn call(&self, params: Value, _cancel: CancellationToken) -> Result<ToolResult> {
         let pattern = params["pattern"].as_str().ok_or_else(|| anyhow::anyhow!("pattern required"))?;
         let path = params["path"].as_str().unwrap_or(".");
         let limit = params["limit"].as_i64().unwrap_or(20);
@@ -166,7 +167,7 @@ impl Tool for PatchFile {
             "required": ["path", "old_string", "new_string"]
         })
     }
-    async fn call(&self, params: Value) -> Result<ToolResult> {
+    async fn call(&self, params: Value, _cancel: CancellationToken) -> Result<ToolResult> {
         let path = params["path"].as_str().ok_or_else(|| anyhow::anyhow!("path required"))?;
         let old = params["old_string"].as_str().ok_or_else(|| anyhow::anyhow!("old_string required"))?;
         let new = params["new_string"].as_str().unwrap_or("");

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -3,6 +3,7 @@ use anyhow::Result;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
 
 /// Canonical tool return type — the wire format between `Tool::call`, the
 /// agent loop, and `AfterToolCall` hooks.
@@ -55,7 +56,11 @@ pub trait Tool: Send + Sync {
     fn name(&self) -> &str;
     fn description(&self) -> &str;
     fn schema(&self) -> Value;
-    async fn call(&self, params: Value) -> Result<ToolResult>;
+    /// Execute the tool. The `cancel` token fires when the user requests
+    /// cancellation; impls should race their work against `cancel.cancelled()`
+    /// (or rely on `kill_on_drop` for child processes) and return
+    /// `ToolResult::err("Cancelled")` on cancel.
+    async fn call(&self, params: Value, cancel: CancellationToken) -> Result<ToolResult>;
 }
 
 pub mod file;
@@ -102,7 +107,12 @@ impl ToolRegistry {
     }
 
     /// Execute a tool by name with JSON arguments.
-    pub async fn execute(&self, name: &str, arguments: &str) -> Result<ToolResult> {
+    pub async fn execute(
+        &self,
+        name: &str,
+        arguments: &str,
+        cancel: CancellationToken,
+    ) -> Result<ToolResult> {
         let tool = self
             .tools
             .get(name)
@@ -111,6 +121,6 @@ impl ToolRegistry {
         let params: Value = serde_json::from_str(arguments)
             .map_err(|e| anyhow::anyhow!("Failed to parse arguments for {name}: {e}"))?;
 
-        tool.call(params).await
+        tool.call(params, cancel).await
     }
 }

--- a/src/tools/shell.rs
+++ b/src/tools/shell.rs
@@ -2,6 +2,7 @@ use crate::tools::{Tool, ToolResult};
 use anyhow::Result;
 use async_trait::async_trait;
 use serde_json::{json, Value};
+use tokio_util::sync::CancellationToken;
 
 pub struct BashTool;
 
@@ -24,24 +25,32 @@ impl Tool for BashTool {
             "required": ["command"]
         })
     }
-    async fn call(&self, params: Value) -> Result<ToolResult> {
+    async fn call(&self, params: Value, cancel: CancellationToken) -> Result<ToolResult> {
         let command = params["command"].as_str().ok_or_else(|| anyhow::anyhow!("command required"))?;
         let timeout = params["timeout"].as_i64().unwrap_or(60);
         let workdir = params["workdir"].as_str();
 
         let mut cmd = tokio::process::Command::new("bash");
         cmd.arg("-c").arg(command);
+        // kill_on_drop: when the future is dropped (cancel races) the child
+        // process is killed instead of orphaned.
+        cmd.kill_on_drop(true);
 
         if let Some(dir) = workdir {
             cmd.current_dir(dir);
         }
 
-        let output = tokio::time::timeout(
-            std::time::Duration::from_secs(timeout as u64),
-            cmd.output(),
-        )
-        .await
-        .map_err(|_| anyhow::anyhow!("Command timed out after {timeout}s"))??;
+        let output = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => {
+                return Ok(ToolResult::err("Cancelled"));
+            }
+            res = tokio::time::timeout(
+                std::time::Duration::from_secs(timeout as u64),
+                cmd.output(),
+            ) => res
+                .map_err(|_| anyhow::anyhow!("Command timed out after {timeout}s"))??,
+        };
 
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);

--- a/src/tools/web.rs
+++ b/src/tools/web.rs
@@ -2,6 +2,7 @@ use crate::tools::{Tool, ToolResult};
 use anyhow::Result;
 use async_trait::async_trait;
 use serde_json::{json, Value};
+use tokio_util::sync::CancellationToken;
 
 pub struct WebSearch;
 
@@ -22,7 +23,7 @@ impl Tool for WebSearch {
             "required": ["query"]
         })
     }
-    async fn call(&self, params: Value) -> Result<ToolResult> {
+    async fn call(&self, params: Value, cancel: CancellationToken) -> Result<ToolResult> {
         let query = params["query"].as_str().ok_or_else(|| anyhow::anyhow!("query required"))?;
 
         // Use DuckDuckGo's lite version for simple scraping
@@ -31,8 +32,14 @@ impl Tool for WebSearch {
             .user_agent("vulcan/0.1 (AI agent; personal use)")
             .build()?;
 
-        let response = client.get(&url).send().await?;
-        let html = response.text().await?;
+        let html = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => return Ok(ToolResult::err("Cancelled")),
+            res = async {
+                let response = client.get(&url).send().await?;
+                response.text().await
+            } => res?,
+        };
 
         // Simple extraction of result links from DuckDuckGo HTML
         let results = extract_ddg_results(&html);
@@ -134,7 +141,7 @@ impl Tool for WebFetch {
             "required": ["url"]
         })
     }
-    async fn call(&self, params: Value) -> Result<ToolResult> {
+    async fn call(&self, params: Value, cancel: CancellationToken) -> Result<ToolResult> {
         let url = params["url"].as_str().ok_or_else(|| anyhow::anyhow!("url required"))?;
 
         let client = reqwest::Client::builder()
@@ -142,21 +149,19 @@ impl Tool for WebFetch {
             .timeout(std::time::Duration::from_secs(30))
             .build()?;
 
-        let response = client.get(url).send().await?;
-        let status = response.status();
-
-        if !status.is_success() {
-            return Err(anyhow::anyhow!("HTTP {status} fetching {url}"));
-        }
-
-        // Check content type — if it's text/html we can extract
-        let _content_type = response
-            .headers()
-            .get("content-type")
-            .and_then(|v| v.to_str().ok())
-            .unwrap_or("");
-
-        let body = response.text().await?;
+        let (status, body) = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => return Ok(ToolResult::err("Cancelled")),
+            res = async {
+                let response = client.get(url).send().await?;
+                let status = response.status();
+                if !status.is_success() {
+                    return Err(anyhow::anyhow!("HTTP {status} fetching {url}"));
+                }
+                let body = response.text().await?;
+                Ok::<_, anyhow::Error>((status, body))
+            } => res?,
+        };
 
         // Trim page content
         let text = html_to_text(&body);

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -16,6 +16,7 @@ use crate::agent::Agent;
 use crate::config::Config;
 use crate::hooks::HookRegistry;
 use crate::hooks::audit::AuditHook;
+use crate::pause::{self, AgentResume, PauseKind};
 use crate::provider::StreamEvent;
 
 pub mod markdown;
@@ -27,6 +28,17 @@ pub mod widgets;
 use state::{AppState, ChatMessage, ChatRole};
 use theme::{Palette, body};
 use views::{View, render_view};
+
+/// What session, if any, the TUI should load on startup.
+#[derive(Debug, Clone)]
+pub enum ResumeTarget {
+    /// Start fresh — new session, empty history.
+    None,
+    /// Resume the most recently active session.
+    Last,
+    /// Resume a specific session by ID.
+    Specific(String),
+}
 
 enum KeyEv {
     Press(Event),
@@ -46,7 +58,12 @@ const SLASH_COMMANDS: &[SlashCommand] = &[
     SlashCommand { name: "clear", description: "Clear message history" },
     SlashCommand { name: "view", description: "Cycle to next view (or 1-5)" },
     SlashCommand { name: "reasoning", description: "Toggle reasoning trace" },
+    SlashCommand { name: "search", description: "Search past sessions: /search <query>" },
 ];
+
+fn short_id(id: &str) -> String {
+    id.chars().take(8).collect()
+}
 
 fn filter_commands(prefix: &str) -> Vec<&'static SlashCommand> {
     if prefix.is_empty() {
@@ -83,7 +100,7 @@ fn complete_slash(prefix: &str) -> Option<String> {
     }
 }
 
-pub async fn run_tui(config: &Config) -> Result<()> {
+pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
     let mut terminal = init_terminal()?;
 
     // keyboard
@@ -112,9 +129,36 @@ pub async fn run_tui(config: &Config) -> Result<()> {
     let (audit_hook, audit_buf) = AuditHook::new(200);
     hook_reg.register(audit_hook);
 
+    // ── AgentPause channel: when SafetyHook (or future hooks) needs user
+    // input mid-loop, it sends an AgentPause; the main TUI loop renders an
+    // overlay and routes the response back via the pause's oneshot reply.
+    let (pause_tx, mut pause_rx) = pause::channel(8);
+
     // ── Long-lived agent: one per TUI session, shared across prompts so
     // hook handlers' state (audit log, rate limits, etc.) survives turns.
-    let agent = Arc::new(Mutex::new(Agent::with_hooks(config, hook_reg)));
+    let agent = Arc::new(Mutex::new(Agent::with_hooks_and_pause(
+        config,
+        hook_reg,
+        Some(pause_tx),
+    )));
+
+    // ── Apply resume target if any. Errors here are non-fatal — we report
+    // and start fresh.
+    let resume_note = {
+        let mut a = agent.lock().await;
+        match resume {
+            ResumeTarget::None => None,
+            ResumeTarget::Last => match a.continue_last_session() {
+                Ok(()) => Some(format!("Resumed last session ({})", short_id(a.session_id()))),
+                Err(e) => Some(format!("Could not resume last session: {e}")),
+            },
+            ResumeTarget::Specific(id) => match a.resume_session(&id) {
+                Ok(()) => Some(format!("Resumed session {}", short_id(&id))),
+                Err(e) => Some(format!("Could not resume session: {e}")),
+            },
+        }
+    };
+
     {
         let a = agent.lock().await;
         a.start_session().await;
@@ -125,6 +169,13 @@ pub async fn run_tui(config: &Config) -> Result<()> {
         config.provider.max_context as u32,
     );
     app.audit_log = Some(audit_buf);
+
+    if let Some(note) = resume_note {
+        app.messages.push(ChatMessage {
+            role: ChatRole::System,
+            content: note,
+        });
+    }
 
     let mut exit = false;
     let mut pending_quit = false;
@@ -169,11 +220,60 @@ pub async fn run_tui(config: &Config) -> Result<()> {
         })?;
 
         tokio::select! {
+            pause = pause_rx.recv() => {
+                if let Some(p) = pause {
+                    let summary = match &p.kind {
+                        PauseKind::SafetyApproval { command, reason, .. } => {
+                            format!("Safety: {reason}\n  $ {command}\n  [a]llow once, [r]emember & allow, [d]eny")
+                        }
+                        PauseKind::ToolArgConfirm { tool, summary, .. } => {
+                            format!("Confirm tool '{tool}': {summary}\n  [a]llow once, [r]emember & allow, [d]eny")
+                        }
+                        PauseKind::SkillSave { suggested_name, .. } => {
+                            format!("Save this as a skill named '{suggested_name}'?\n  [a]llow once, [d]eny")
+                        }
+                    };
+                    app.messages.push(ChatMessage {
+                        role: ChatRole::System,
+                        content: format!("⏸  Agent paused — {summary}"),
+                    });
+                    app.pending_pause = Some(p);
+                }
+                continue;
+            }
             ev = key_rx.recv() => {
                 match ev {
                     Some(KeyEv::Press(event)) => {
                         if let Event::Key(key) = event {
                             if key.kind == KeyEventKind::Press {
+                                // ── If a pause is active, intercept the keys that
+                                // dispatch a response. Anything else falls through
+                                // to normal handling so the user can still scroll, etc.
+                                if app.pending_pause.is_some() {
+                                    let resume = match key.code {
+                                        KeyCode::Char('a') | KeyCode::Char('A') => Some(AgentResume::Allow),
+                                        KeyCode::Char('r') | KeyCode::Char('R') => Some(AgentResume::AllowAndRemember),
+                                        KeyCode::Char('d') | KeyCode::Char('D') | KeyCode::Esc => Some(AgentResume::Deny),
+                                        _ => None,
+                                    };
+                                    if let Some(r) = resume {
+                                        if let Some(p) = app.pending_pause.take() {
+                                            let label = match &r {
+                                                AgentResume::Allow => "allowed (once)",
+                                                AgentResume::AllowAndRemember => "allowed (remembered)",
+                                                AgentResume::Deny => "denied",
+                                                AgentResume::DenyWithReason(_) => "denied",
+                                            };
+                                            let _ = p.reply.send(r);
+                                            app.messages.push(ChatMessage {
+                                                role: ChatRole::System,
+                                                content: format!("▶  Resumed — {label}"),
+                                            });
+                                        }
+                                        continue;
+                                    }
+                                }
+
                                 // ── view switching: Ctrl+1..5
                                 if key.modifiers.contains(KeyModifiers::CONTROL) {
                                     match key.code {
@@ -190,6 +290,18 @@ pub async fn run_tui(config: &Config) -> Result<()> {
                                         KeyCode::Char('c') => {
                                             if pending_quit {
                                                 exit = true;
+                                            } else if app.thinking {
+                                                // Turn in flight: single Ctrl+C cancels it.
+                                                // Double Ctrl+C still exits (pending_quit path).
+                                                let a = agent.clone();
+                                                tokio::spawn(async move {
+                                                    a.lock().await.cancel_current_turn();
+                                                });
+                                                app.messages.push(ChatMessage {
+                                                    role: ChatRole::System,
+                                                    content: "Cancelling current turn… (Ctrl+C again to quit)".into(),
+                                                });
+                                                pending_quit = true;
                                             } else {
                                                 pending_quit = true;
                                                 app.messages.push(ChatMessage {
@@ -253,6 +365,42 @@ pub async fn run_tui(config: &Config) -> Result<()> {
                                                                 app.view = v;
                                                             }
                                                         }
+                                                        continue;
+                                                    }
+                                                    s if s.starts_with("search ") => {
+                                                        let query = s[7..].trim();
+                                                        if query.is_empty() {
+                                                            app.messages.push(ChatMessage {
+                                                                role: ChatRole::System,
+                                                                content: "Usage: /search <query>".into(),
+                                                            });
+                                                            continue;
+                                                        }
+                                                        let hits = {
+                                                            let a = agent.lock().await;
+                                                            a.memory().search_messages(query, 10)
+                                                        };
+                                                        let report = match hits {
+                                                            Ok(hs) if hs.is_empty() => format!("No matches for '{query}'"),
+                                                            Ok(hs) => {
+                                                                let mut out = format!("Search '{query}' — {} hit(s):", hs.len());
+                                                                for h in hs {
+                                                                    let preview: String = h.content.chars().take(100).collect();
+                                                                    out.push_str(&format!(
+                                                                        "\n  [{}] {} — {}",
+                                                                        short_id(&h.session_id),
+                                                                        h.role,
+                                                                        preview.replace('\n', " ")
+                                                                    ));
+                                                                }
+                                                                out
+                                                            }
+                                                            Err(e) => format!("Search failed: {e}"),
+                                                        };
+                                                        app.messages.push(ChatMessage {
+                                                            role: ChatRole::System,
+                                                            content: report,
+                                                        });
                                                         continue;
                                                     }
                                                     _ => {

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -83,6 +83,11 @@ pub struct AppState {
     /// falls back to demo data so the design still looks alive on first launch.
     pub audit_log: Option<AuditBuffer>,
 
+    /// When the agent emits an `AgentPause`, the TUI parks it here. Render
+    /// shows an overlay; key handler intercepts Y/A/N keys and consumes the
+    /// pause via `take()` to send the reply.
+    pub pending_pause: Option<crate::pause::AgentPause>,
+
     cursor: Cell<(u16, u16)>,
     pub model_label: String,
     pub token_used: u32,
@@ -107,6 +112,7 @@ impl AppState {
             tree: demo_tree(),
 
             audit_log: None,
+            pending_pause: None,
 
             cursor: Cell::new((0, 0)),
             model_label,


### PR DESCRIPTION
This branch captures the session's foundation work that wasn't yet
broken into per-issue branches when the Graphite workflow was adopted.
Subsequent work (YYC-43+) will use one branch per Linear issue.

Closes:
  YYC-25  Hooks foundation (5-event Pi-style extension surface)
  YYC-29  Skills-as-hook refactor
  YYC-30  Tool::call returns ToolResult { output, media, is_error }
  YYC-26  Safety-gate BeforeToolCall hook
  YYC-28  Hooks design doc in ~/wiki
  YYC-33  Cancellation tokens through tools, hooks, providers, agent
  YYC-32  AgentPause mechanism (SafetyHook first consumer)
  YYC-14  SQLite session store with FTS5 search
  YYC-15  Session resume + cross-session FTS search

New deps: tokio-util 0.7.18, rusqlite 0.39.0, tempfile 3.27.0 (all latest stable).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>