### PR TITLE
Pass reasoning_content through for thinking-mode models (DeepSeek V4)

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -195,6 +195,7 @@ impl Agent {
                 messages.push(Message::Assistant {
                     content: response.content.clone(),
                     tool_calls: Some(tool_calls.clone()),
+                    reasoning_content: response.reasoning_content.clone(),
                 });
 
                 for tc in tool_calls {
@@ -209,12 +210,14 @@ impl Agent {
                 }
             } else {
                 let text = response.content.unwrap_or_default();
+                let reasoning = response.reasoning_content.clone();
 
                 // ── BeforeAgentEnd: a handler may force the loop to continue.
                 if let Some(instruction) = self.hooks.before_agent_end(&text, cancel.clone()).await {
                     messages.push(Message::Assistant {
                         content: Some(text.clone()),
                         tool_calls: None,
+                        reasoning_content: reasoning,
                     });
                     messages.push(Message::User { content: instruction });
                     continue;
@@ -266,6 +269,7 @@ impl Agent {
                     tool_calls: None,
                     usage: None,
                     finish_reason: Some("cancelled".into()),
+                    reasoning_content: None,
                 }));
                 return Ok("Cancelled".to_string());
             }
@@ -325,6 +329,7 @@ impl Agent {
                 messages.push(Message::Assistant {
                     content: response.content.clone(),
                     tool_calls: Some(tool_calls.clone()),
+                    reasoning_content: response.reasoning_content.clone(),
                 });
 
                 for tc in tool_calls {
@@ -338,15 +343,26 @@ impl Agent {
                     });
                 }
             } else {
+                let reasoning = response.reasoning_content.clone();
+
                 // ── BeforeAgentEnd
                 if let Some(instruction) = self.hooks.before_agent_end(&full_response, cancel.clone()).await {
                     messages.push(Message::Assistant {
                         content: Some(full_response.clone()),
                         tool_calls: None,
+                        reasoning_content: reasoning,
                     });
                     messages.push(Message::User { content: instruction });
                     continue;
                 }
+
+                // Final assistant turn after the loop ends — save with reasoning
+                // so the next turn can echo it back to thinking-mode models.
+                messages.push(Message::Assistant {
+                    content: Some(full_response.clone()),
+                    tool_calls: None,
+                    reasoning_content: reasoning.clone(),
+                });
 
                 self.memory.save_messages(&self.session_id, &messages)?;
                 self.turns = self.turns.saturating_add(1);
@@ -358,6 +374,7 @@ impl Agent {
                     tool_calls: None,
                     usage: response.usage,
                     finish_reason: response.finish_reason,
+                    reasoning_content: reasoning,
                 }));
                 return Ok(full_response);
             }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -31,14 +31,15 @@ CREATE TABLE IF NOT EXISTS sessions (
 );
 
 CREATE TABLE IF NOT EXISTS messages (
-    id              INTEGER PRIMARY KEY AUTOINCREMENT,
-    session_id      TEXT NOT NULL,
-    position        INTEGER NOT NULL,
-    role            TEXT NOT NULL,
-    content         TEXT,
-    tool_call_id    TEXT,
-    tool_calls_json TEXT,
-    created_at      INTEGER NOT NULL,
+    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id        TEXT NOT NULL,
+    position          INTEGER NOT NULL,
+    role              TEXT NOT NULL,
+    content           TEXT,
+    tool_call_id      TEXT,
+    tool_calls_json   TEXT,
+    reasoning_content TEXT,
+    created_at        INTEGER NOT NULL,
     FOREIGN KEY(session_id) REFERENCES sessions(id) ON DELETE CASCADE
 );
 
@@ -103,6 +104,15 @@ impl SessionStore {
         conn.execute_batch(SCHEMA)
             .unwrap_or_else(|e| panic!("Failed to initialize session DB schema: {e}"));
 
+        // Idempotent migration for DBs that pre-date the reasoning_content
+        // column (YYC-43). SQLite errors on duplicate-column ADD; harmless to
+        // ignore — the column either exists from CREATE TABLE above or this
+        // adds it.
+        let _ = conn.execute(
+            "ALTER TABLE messages ADD COLUMN reasoning_content TEXT",
+            [],
+        );
+
         Self {
             conn: Mutex::new(conn),
         }
@@ -141,7 +151,7 @@ impl SessionStore {
         }
 
         let mut stmt = conn.prepare(
-            "SELECT role, content, tool_call_id, tool_calls_json
+            "SELECT role, content, tool_call_id, tool_calls_json, reasoning_content
              FROM messages
              WHERE session_id = ?1
              ORDER BY position ASC",
@@ -152,13 +162,14 @@ impl SessionStore {
             let content: Option<String> = row.get(1)?;
             let tool_call_id: Option<String> = row.get(2)?;
             let tool_calls_json: Option<String> = row.get(3)?;
-            Ok((role, content, tool_call_id, tool_calls_json))
+            let reasoning_content: Option<String> = row.get(4)?;
+            Ok((role, content, tool_call_id, tool_calls_json, reasoning_content))
         })?;
 
         let mut messages = Vec::new();
         for row in rows {
-            let (role, content, tool_call_id, tool_calls_json) = row?;
-            let msg = decode_message(&role, content, tool_call_id, tool_calls_json)?;
+            let (role, content, tool_call_id, tool_calls_json, reasoning_content) = row?;
+            let msg = decode_message(&role, content, tool_call_id, tool_calls_json, reasoning_content)?;
             messages.push(msg);
         }
 
@@ -193,11 +204,12 @@ impl SessionStore {
         )?;
 
         for (idx, msg) in messages.iter().enumerate() {
-            let (role, content, tool_call_id, tool_calls_json) = encode_message(msg)?;
+            let (role, content, tool_call_id, tool_calls_json, reasoning_content) =
+                encode_message(msg)?;
             tx.execute(
                 "INSERT INTO messages
-                 (session_id, position, role, content, tool_call_id, tool_calls_json, created_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                 (session_id, position, role, content, tool_call_id, tool_calls_json, reasoning_content, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
                 params![
                     session_id,
                     idx as i64,
@@ -205,6 +217,7 @@ impl SessionStore {
                     content,
                     tool_call_id,
                     tool_calls_json,
+                    reasoning_content,
                     now,
                 ],
             )?;
@@ -281,21 +294,34 @@ impl Default for SessionStore {
     }
 }
 
-fn encode_message(
-    msg: &Message,
-) -> Result<(&'static str, Option<String>, Option<String>, Option<String>)> {
+type Encoded = (
+    &'static str,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+);
+
+fn encode_message(msg: &Message) -> Result<Encoded> {
     Ok(match msg {
-        Message::System { content } => ("system", Some(content.clone()), None, None),
-        Message::User { content } => ("user", Some(content.clone()), None, None),
+        Message::System { content } => ("system", Some(content.clone()), None, None, None),
+        Message::User { content } => ("user", Some(content.clone()), None, None, None),
         Message::Assistant {
             content,
             tool_calls,
+            reasoning_content,
         } => {
             let tool_calls_json = match tool_calls {
                 Some(tcs) => Some(serde_json::to_string(tcs).context("encode tool_calls")?),
                 None => None,
             };
-            ("assistant", content.clone(), None, tool_calls_json)
+            (
+                "assistant",
+                content.clone(),
+                None,
+                tool_calls_json,
+                reasoning_content.clone(),
+            )
         }
         Message::Tool {
             tool_call_id,
@@ -304,6 +330,7 @@ fn encode_message(
             "tool",
             Some(content.clone()),
             Some(tool_call_id.clone()),
+            None,
             None,
         ),
     })
@@ -314,6 +341,7 @@ fn decode_message(
     content: Option<String>,
     tool_call_id: Option<String>,
     tool_calls_json: Option<String>,
+    reasoning_content: Option<String>,
 ) -> Result<Message> {
     Ok(match role {
         "system" => Message::System {
@@ -330,6 +358,7 @@ fn decode_message(
             Message::Assistant {
                 content,
                 tool_calls,
+                reasoning_content,
             }
         }
         "tool" => Message::Tool {
@@ -371,6 +400,7 @@ mod tests {
             Message::Assistant {
                 content: Some("a systems language with strong types".into()),
                 tool_calls: None,
+                reasoning_content: None,
             },
         ];
 
@@ -468,6 +498,7 @@ mod tests {
                     arguments: r#"{"command":"ls"}"#.into(),
                 },
             }]),
+            reasoning_content: None,
         }];
 
         store.save_messages(&id, &messages).unwrap();
@@ -479,6 +510,31 @@ mod tests {
                 assert_eq!(tcs.len(), 1);
                 assert_eq!(tcs[0].function.name, "bash");
             }
+            other => panic!("expected Assistant, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reasoning_content_round_trips() {
+        let dir = TempDir::new().unwrap();
+        let store = store_in(&dir);
+        let id = uuid::Uuid::new_v4().to_string();
+
+        let messages = vec![Message::Assistant {
+            content: Some("the answer is 42".into()),
+            tool_calls: None,
+            reasoning_content: Some("First I considered…then I weighed…".into()),
+        }];
+
+        store.save_messages(&id, &messages).unwrap();
+        let loaded = store.load_history(&id).unwrap().unwrap();
+        match &loaded[0] {
+            Message::Assistant {
+                reasoning_content, ..
+            } => assert_eq!(
+                reasoning_content.as_deref(),
+                Some("First I considered…then I weighed…")
+            ),
             other => panic!("expected Assistant, got {other:?}"),
         }
     }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -18,6 +18,11 @@ pub enum Message {
     Assistant {
         content: Option<String>,
         tool_calls: Option<Vec<ToolCall>>,
+        /// Reasoning trace from thinking-mode models (DeepSeek V4 emits this
+        /// as `reasoning_content`). When the conversation continues, the
+        /// provider may require the prior assistant turn's reasoning to be
+        /// echoed back — without it, the API rejects with 400. See YYC-43.
+        reasoning_content: Option<String>,
     },
     Tool {
         tool_call_id: String,
@@ -41,8 +46,12 @@ impl Serialize for Message {
                 s.serialize_field("content", content)?;
                 s.end()
             }
-            Message::Assistant { content, tool_calls } => {
-                let mut s = serializer.serialize_struct("Message", 3)?;
+            Message::Assistant {
+                content,
+                tool_calls,
+                reasoning_content,
+            } => {
+                let mut s = serializer.serialize_struct("Message", 4)?;
                 s.serialize_field("role", "assistant")?;
                 if let Some(c) = content {
                     s.serialize_field("content", c)?;
@@ -51,6 +60,9 @@ impl Serialize for Message {
                 }
                 if let Some(tc) = tool_calls {
                     s.serialize_field("tool_calls", tc)?;
+                }
+                if let Some(rc) = reasoning_content {
+                    s.serialize_field("reasoning_content", rc)?;
                 }
                 s.end()
             }
@@ -76,6 +88,8 @@ impl<'de> Deserialize<'de> for Message {
             tool_call_id: Option<String>,
             #[serde(default)]
             tool_calls: Option<Vec<ToolCall>>,
+            #[serde(default)]
+            reasoning_content: Option<String>,
         }
 
         let data = MessageData::deserialize(deserializer)?;
@@ -89,6 +103,7 @@ impl<'de> Deserialize<'de> for Message {
             "assistant" => Ok(Message::Assistant {
                 content: data.content,
                 tool_calls: data.tool_calls,
+                reasoning_content: data.reasoning_content,
             }),
             "tool" => Ok(Message::Tool {
                 tool_call_id: data.tool_call_id.unwrap_or_default(),
@@ -174,6 +189,9 @@ pub struct ChatResponse {
     pub tool_calls: Option<Vec<ToolCall>>,
     pub usage: Option<Usage>,
     pub finish_reason: Option<String>,
+    /// Reasoning trace from thinking-mode models. Carried through so the
+    /// agent can attach it to the assistant message it appends to history.
+    pub reasoning_content: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/provider/openai.rs
+++ b/src/provider/openai.rs
@@ -79,6 +79,7 @@ impl OpenAIProvider {
     fn parse_line(
         line: &str,
         content: &mut String,
+        reasoning: &mut String,
         tool_calls: &mut Vec<ToolCall>,
         usage: &mut Option<Usage>,
         finish_reason: &mut Option<String>,
@@ -99,6 +100,12 @@ impl OpenAIProvider {
                     if let Some(delta) = choice["delta"].as_object() {
                         if let Some(text) = delta.get("content").and_then(|c| c.as_str()) {
                             content.push_str(text);
+                        }
+                        // DeepSeek-shape reasoning trace. OpenRouter passes
+                        // it through for thinking-mode models; we accumulate
+                        // and echo it back on the next turn (YYC-43).
+                        if let Some(rc) = delta.get("reasoning_content").and_then(|c| c.as_str()) {
+                            reasoning.push_str(rc);
                         }
                         if let Some(tcs) = delta.get("tool_calls").and_then(|c| c.as_array()) {
                             for tc in tcs {
@@ -178,12 +185,20 @@ impl LLMProvider for OpenAIProvider {
         let text = String::from_utf8_lossy(&bytes);
 
         let mut content = String::new();
+        let mut reasoning = String::new();
         let mut tool_calls: Vec<ToolCall> = Vec::new();
         let mut usage: Option<Usage> = None;
         let mut finish_reason: Option<String> = None;
 
         for line in text.lines() {
-            Self::parse_line(line, &mut content, &mut tool_calls, &mut usage, &mut finish_reason);
+            Self::parse_line(
+                line,
+                &mut content,
+                &mut reasoning,
+                &mut tool_calls,
+                &mut usage,
+                &mut finish_reason,
+            );
         }
 
         Ok(ChatResponse {
@@ -191,6 +206,7 @@ impl LLMProvider for OpenAIProvider {
             tool_calls: Some(tool_calls).filter(|c| !c.is_empty()),
             usage,
             finish_reason,
+            reasoning_content: Some(reasoning).filter(|r| !r.is_empty()),
         })
     }
 
@@ -209,6 +225,7 @@ impl LLMProvider for OpenAIProvider {
         };
 
         let mut content = String::new();
+        let mut reasoning = String::new();
         let mut tool_calls: Vec<ToolCall> = Vec::new();
         let mut usage: Option<Usage> = None;
         let mut finish_reason: Option<String> = None;
@@ -237,7 +254,14 @@ impl LLMProvider for OpenAIProvider {
                 buf = buf[newline + 1..].to_string();
 
                 let prev_len = content.len();
-                Self::parse_line(&line, &mut content, &mut tool_calls, &mut usage, &mut finish_reason);
+                Self::parse_line(
+                    &line,
+                    &mut content,
+                    &mut reasoning,
+                    &mut tool_calls,
+                    &mut usage,
+                    &mut finish_reason,
+                );
 
                 // If content grew, send the delta through the channel
                 if content.len() > prev_len {
@@ -253,6 +277,7 @@ impl LLMProvider for OpenAIProvider {
             tool_calls: Some(tool_calls).filter(|c| !c.is_empty()),
             usage,
             finish_reason,
+            reasoning_content: Some(reasoning).filter(|r| !r.is_empty()),
         };
 
         let _ = tx.send(StreamEvent::Done(response));


### PR DESCRIPTION
Thinking-mode models emit a reasoning trace (DeepSeek/OpenRouter via
'reasoning_content'). When the conversation continues — especially
after a tool call — providers may require the prior assistant turn's
reasoning to be echoed back, otherwise the next request fails 400.

Vulcan's SSE parser previously dropped this field and Message::Assistant
didn't model it, breaking DeepSeek V4 (the default config model) the
moment a tool call landed.

Changes:
- Message::Assistant gains 'reasoning_content: Option<String>' (Serialize
  emits it as 'reasoning_content' when Some; Deserialize reads it back).
- ChatResponse carries 'reasoning_content' so the agent can attach the
  trace to the assistant message it pushes to history.
- OpenAI provider's parse_line accumulates 'delta.reasoning_content'
  alongside 'delta.content'. Both 'chat' and 'chat_stream' return it.
- Agent loop (run_prompt and run_prompt_stream) pulls 'reasoning_content'
  from each ChatResponse onto every Message::Assistant it appends —
  including the final post-loop assistant turn in the streaming path,
  which previously wasn't pushed at all.
- SQLite schema gains a 'reasoning_content TEXT' column on messages with
  an idempotent ALTER TABLE for pre-existing DBs. encode/decode functions
  thread it through.

Out of scope (separate issues when needed):
- OpenAI o1/o3 hidden reasoning (opaque 'reasoning.id' echo, different
  shape).
- Anthropic extended thinking (signed 'thinking' blocks, lives behind
  /v1/messages, requires a native Anthropic provider).

Tests: 10/10 (added 'reasoning_content_round_trips').

Closes YYC-43.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>