### PR TITLE
Display reasoning_content / thinking trace in the TUI

### DIFF
--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -148,6 +148,10 @@ pub struct ToolFunction {
 pub enum StreamEvent {
     /// A chunk of text content
     Text(String),
+    /// A chunk of reasoning trace from a thinking-mode model (DeepSeek
+    /// `reasoning_content`). Sent as it arrives so the UI can render the
+    /// model "thinking" rather than blocking on the wait. See YYC-47.
+    Reasoning(String),
     /// A tool call was received (name + arguments-so-far)
     ToolCallStart { id: String, name: String },
     /// The stream is complete (with optional final ChatResponse)

--- a/src/provider/openai.rs
+++ b/src/provider/openai.rs
@@ -253,7 +253,8 @@ impl LLMProvider for OpenAIProvider {
                 let line = buf[..newline].to_string();
                 buf = buf[newline + 1..].to_string();
 
-                let prev_len = content.len();
+                let prev_content_len = content.len();
+                let prev_reasoning_len = reasoning.len();
                 Self::parse_line(
                     &line,
                     &mut content,
@@ -263,10 +264,14 @@ impl LLMProvider for OpenAIProvider {
                     &mut finish_reason,
                 );
 
-                // If content grew, send the delta through the channel
-                if content.len() > prev_len {
-                    let delta = &content[prev_len..];
+                // Send any new content/reasoning deltas through the channel.
+                if content.len() > prev_content_len {
+                    let delta = &content[prev_content_len..];
                     let _ = tx.send(StreamEvent::Text(delta.to_string()));
+                }
+                if reasoning.len() > prev_reasoning_len {
+                    let delta = &reasoning[prev_reasoning_len..];
+                    let _ = tx.send(StreamEvent::Reasoning(delta.to_string()));
                 }
             }
         }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -174,7 +174,41 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
         app.messages.push(ChatMessage {
             role: ChatRole::System,
             content: note,
+            reasoning: String::new(),
         });
+
+        // Hydrate prior turns into the chat panel so resumed sessions show their
+        // history, not a blank screen. Tool turns are skipped (audit log surfaces
+        // tool activity separately).
+        let history = {
+            let a = agent.lock().await;
+            a.memory().load_history(a.session_id()).ok().flatten()
+        };
+        if let Some(msgs) = history {
+            for msg in msgs {
+                use crate::provider::Message;
+                match msg {
+                    Message::User { content } => {
+                        app.messages.push(ChatMessage::new(ChatRole::User, content));
+                    }
+                    Message::System { content } => {
+                        app.messages.push(ChatMessage::new(ChatRole::System, content));
+                    }
+                    Message::Assistant {
+                        content,
+                        reasoning_content,
+                        ..
+                    } => {
+                        app.messages.push(ChatMessage {
+                            role: ChatRole::Agent,
+                            content: content.unwrap_or_default(),
+                            reasoning: reasoning_content.unwrap_or_default(),
+                        });
+                    }
+                    Message::Tool { .. } => {} // skip — audit log shows tool activity
+                }
+            }
+        }
     }
 
     let mut exit = false;
@@ -236,6 +270,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                     app.messages.push(ChatMessage {
                         role: ChatRole::System,
                         content: format!("⏸  Agent paused — {summary}"),
+                        reasoning: String::new(),
                     });
                     app.pending_pause = Some(p);
                 }
@@ -268,6 +303,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                             app.messages.push(ChatMessage {
                                                 role: ChatRole::System,
                                                 content: format!("▶  Resumed — {label}"),
+                                                reasoning: String::new(),
                                             });
                                         }
                                         continue;
@@ -300,6 +336,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                                 app.messages.push(ChatMessage {
                                                     role: ChatRole::System,
                                                     content: "Cancelling current turn… (Ctrl+C again to quit)".into(),
+                                                    reasoning: String::new(),
                                                 });
                                                 pending_quit = true;
                                             } else {
@@ -307,6 +344,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                                 app.messages.push(ChatMessage {
                                                     role: ChatRole::System,
                                                     content: "Press Ctrl+C again to quit, or any key to cancel.".into(),
+                                                    reasoning: String::new(),
                                                 });
                                             }
                                             continue;
@@ -333,7 +371,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                                             help.push_str(&format!("\n  /{:<10}  {}", cmd.name, cmd.description));
                                                         }
                                                         help.push_str("\n\nKeys:\n  Ctrl+1..5  switch view (1=stack 2=split 3=tiled 4=tree 5=floor)\n  Ctrl+R     toggle reasoning trace\n  Tab        complete slash command");
-                                                        app.messages.push(ChatMessage { role: ChatRole::System, content: help });
+                                                        app.messages.push(ChatMessage { role: ChatRole::System, content: help, ..Default::default() });
                                                         continue;
                                                     }
                                                     "clear" => {
@@ -345,6 +383,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                                         app.messages.push(ChatMessage {
                                                             role: ChatRole::System,
                                                             content: format!("Reasoning trace: {}", if app.show_reasoning { "on" } else { "off" }),
+                                                            reasoning: String::new(),
                                                         });
                                                         continue;
                                                     }
@@ -373,6 +412,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                                             app.messages.push(ChatMessage {
                                                                 role: ChatRole::System,
                                                                 content: "Usage: /search <query>".into(),
+                                                                reasoning: String::new(),
                                                             });
                                                             continue;
                                                         }
@@ -400,6 +440,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                                         app.messages.push(ChatMessage {
                                                             role: ChatRole::System,
                                                             content: report,
+                                                            reasoning: String::new(),
                                                         });
                                                         continue;
                                                     }
@@ -407,14 +448,15 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                                         app.messages.push(ChatMessage {
                                                             role: ChatRole::System,
                                                             content: format!("Unknown command: {msg}. Try /help"),
+                                                            reasoning: String::new(),
                                                         });
                                                         continue;
                                                     }
                                                 }
                                             }
 
-                                            app.messages.push(ChatMessage { role: ChatRole::User, content: msg.clone() });
-                                            app.messages.push(ChatMessage { role: ChatRole::Agent, content: String::new() });
+                                            app.messages.push(ChatMessage { role: ChatRole::User, content: msg.clone(), ..Default::default() });
+                                            app.messages.push(ChatMessage { role: ChatRole::Agent, content: String::new(), ..Default::default() });
                                             app.thinking = true;
                                             app.scroll = 0;
 
@@ -465,6 +507,16 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                         if let Some(last) = app.messages.last_mut() {
                             if matches!(last.role, ChatRole::Agent) {
                                 last.content.push_str(&chunk);
+                            }
+                        }
+                    }
+                    Some(StreamEvent::Reasoning(chunk)) => {
+                        // Per-token reasoning trace from thinking-mode models.
+                        // Append to the current agent message's reasoning buffer
+                        // so the renderer can show it as the model thinks.
+                        if let Some(last) = app.messages.last_mut() {
+                            if matches!(last.role, ChatRole::Agent) {
+                                last.reasoning.push_str(&chunk);
                             }
                         }
                     }

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -8,17 +8,32 @@ use crate::hooks::audit::{AuditBuffer, AuditKind};
 use super::theme::Palette;
 use super::views::{DiffKind, DiffLine, View};
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub enum ChatRole {
     User,
+    #[default]
     Agent,
     System,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ChatMessage {
     pub role: ChatRole,
     pub content: String,
+    /// Reasoning trace for thinking-mode models (`Message::Assistant.reasoning_content`).
+    /// Populated for agent messages from streaming `StreamEvent::Reasoning` deltas
+    /// and from session-resume hydration. Empty for everything else.
+    pub reasoning: String,
+}
+
+impl ChatMessage {
+    pub fn new(role: ChatRole, content: impl Into<String>) -> Self {
+        Self {
+            role,
+            content: content.into(),
+            reasoning: String::new(),
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/tui/views.rs
+++ b/src/tui/views.rs
@@ -96,9 +96,23 @@ fn build_chat_lines(app: &AppState, show_reasoning: bool, dense: bool) -> Vec<Li
             ChatRole::System => ("system", Palette::YELLOW),
         };
         out.push(message_header(role_label, accent, None));
+
+        // Reasoning trace from a thinking-mode model, when present and toggle is on.
+        // Rendered before the agent's content so the visual order matches the
+        // model's natural output (think → answer).
+        if show_reasoning && matches!(m.role, ChatRole::Agent) && !m.reasoning.is_empty() {
+            for l in super::widgets::reasoning_lines(&m.reasoning, false) {
+                out.push(l);
+            }
+        }
+
         if matches!(m.role, ChatRole::Agent) && m.content.is_empty() {
+            // Streaming and content hasn't started yet — show "thinking…" hint.
+            // If reasoning is already streaming above, this still tells the user
+            // they're waiting on the answer (not lost).
+            let label = if m.reasoning.is_empty() { "▎ Thinking…" } else { "▎ Answering…" };
             out.push(Line::from(Span::styled(
-                "▎ Thinking…",
+                label,
                 Style::default().fg(Palette::MUTED).add_modifier(Modifier::SLOW_BLINK),
             )));
         } else {
@@ -111,20 +125,6 @@ fn build_chat_lines(app: &AppState, show_reasoning: bool, dense: bool) -> Vec<Li
             }
         }
         if !dense || i + 1 == app.messages.len() {
-            out.push(Line::from(""));
-        }
-
-        // After the very first agent message, optionally inject a reasoning trace.
-        if show_reasoning
-            && matches!(m.role, ChatRole::Agent)
-            && i == app.messages.iter().position(|x| matches!(x.role, ChatRole::Agent)).unwrap_or(0)
-        {
-            for l in super::widgets::reasoning_lines(
-                "Three services share AuthMiddleware. Gateway is upstream — refactor it last.",
-                false,
-            ) {
-                out.push(l);
-            }
             out.push(Line::from(""));
         }
     }


### PR DESCRIPTION
YYC-43 plumbed reasoning_content end-to-end (provider → agent → SQLite)
so thinking-mode models work, but the user couldn't see the trace.
'app.show_reasoning' was just toggling demo placeholders.

Stream events:
- New StreamEvent::Reasoning(String) variant for per-token reasoning
  deltas.
- chat_stream now sends Reasoning events alongside Text events whenever
  the reasoning accumulator grows. UI sees the model thinking instead
  of staring at empty space.

State:
- ChatMessage gains a 'reasoning: String' field.
- ChatRole and ChatMessage derive Default so existing struct literals
  can use ..Default::default() (introduced via a sweep).
- ChatMessage::new(role, content) constructor for new sites.
- TUI stream handler appends Reasoning chunks to the current agent
  message's reasoning buffer.

Resume hydration:
- When a session is resumed, the TUI now loads message history from
  SessionStore and pushes a ChatMessage per turn. Assistant messages
  carry their reasoning_content into ChatMessage.reasoning. Tool turns
  are skipped (audit log surfaces those separately).

Rendering:
- build_chat_lines renders each agent message's actual reasoning
  (not the old hardcoded demo string) before the content, dimmed via
  widgets::reasoning_lines. Toggling Ctrl+R or /reasoning hides it.
- Streaming UX: 'Thinking…' label while content is empty and reasoning
  is empty; switches to 'Answering…' once reasoning has started but
  content hasn't.

Out of scope:
- Decorative reasoning blocks in TiledMesh / TreeOfThought views still
  use hardcoded strings — those are visual-design demo data, separate
  cleanup if/when those views graduate.
- OpenAI o1/o3 hidden reasoning + Anthropic signed thinking blocks
  (need provider-side work first).

Tests: 10/10 (no new tests — change is rendering and stream-event
plumbing; manual TUI verification recommended once a thinking-mode
model is exercised).

Closes YYC-47.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>