### PR TITLE
Graceful error handling: API retry + cleaner failure modes

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -6,12 +6,15 @@
 type = "openai-compat"
 # Base URL for the API
 base_url = "https://openrouter.ai/api/v1"
-# API key — can also be set via FERRIS_API_KEY env var
+# API key — can also be set via VULCAN_API_KEY env var
 # api_key = "sk-..."
 # Model to use
 model = "deepseek/deepseek-v4-flash"
 # Max context size in tokens
 max_context = 128000
+# Max retries on transient API failures (429, 5xx, network errors).
+# Backoff is exponential with jitter: 1s, 2s, 4s, 8s, 16s.
+max_retries = 4
 
 [tools]
 # Enable dangerous tools (file overwrite, shell exec) without confirmation

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -12,7 +12,7 @@ use crate::provider::openai::OpenAIProvider;
 use crate::provider::{LLMProvider, Message, StreamEvent};
 use crate::skills::SkillRegistry;
 use crate::tools::{ToolRegistry, ToolResult};
-use anyhow::Result;
+use anyhow::{Context, Result};
 use serde_json::Value;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
@@ -42,13 +42,13 @@ pub struct Agent {
 impl Agent {
     /// Construct an Agent with no caller-supplied hooks. Built-in hooks (skills
     /// injection, etc.) are still registered.
-    pub fn new(config: &Config) -> Self {
+    pub fn new(config: &Config) -> Result<Self> {
         Self::with_hooks_and_pause(config, HookRegistry::new(), None)
     }
 
     /// Construct with caller-supplied hooks and no interactive pause channel.
     /// The TUI uses `with_hooks_and_pause` to wire one up.
-    pub fn with_hooks(config: &Config, hooks: HookRegistry) -> Self {
+    pub fn with_hooks(config: &Config, hooks: HookRegistry) -> Result<Self> {
         Self::with_hooks_and_pause(config, hooks, None)
     }
 
@@ -56,14 +56,20 @@ impl Agent {
     /// pause emitter. Built-ins (skills, safety) are registered into the
     /// registry; if a pause emitter is provided, `SafetyHook` is wired up to
     /// route blocks through it as `AgentPause::SafetyApproval`.
+    ///
+    /// Returns `Err` for fatal init failures (missing API key, provider build
+    /// failure). These were previously panics; the caller now decides how to
+    /// surface the error.
     pub fn with_hooks_and_pause(
         config: &Config,
         mut hooks: HookRegistry,
         pause_tx: Option<PauseSender>,
-    ) -> Self {
-        let api_key = config
-            .api_key()
-            .expect("No API key configured. Set VULCAN_API_KEY or add api_key to config.toml");
+    ) -> Result<Self> {
+        let api_key = config.api_key().ok_or_else(|| {
+            anyhow::anyhow!(
+                "No API key configured. Set VULCAN_API_KEY or add api_key to ~/.vulcan/config.toml"
+            )
+        })?;
 
         let provider: Box<dyn LLMProvider> = Box::new(
             OpenAIProvider::new(
@@ -71,8 +77,9 @@ impl Agent {
                 &api_key,
                 &config.provider.model,
                 config.provider.max_context,
+                config.provider.max_retries,
             )
-            .expect("Failed to initialize LLM provider"),
+            .context("Failed to initialize LLM provider")?,
         );
 
         let tools = ToolRegistry::new();
@@ -96,7 +103,7 @@ impl Agent {
             hooks.register(Arc::new(safety));
         }
 
-        Self {
+        Ok(Self {
             provider,
             tools,
             skills,
@@ -107,7 +114,7 @@ impl Agent {
             session_id,
             turns: 0,
             turn_cancel: CancellationToken::new(),
-        }
+        })
     }
 
     pub fn session_id(&self) -> &str {
@@ -424,7 +431,18 @@ impl Agent {
         raw_args: &str,
         cancel: CancellationToken,
     ) -> String {
-        let parsed_args: Value = serde_json::from_str(raw_args).unwrap_or(Value::Null);
+        let parsed_args: Value = match serde_json::from_str(raw_args) {
+            Ok(v) => v,
+            Err(e) => {
+                // Hooks see Null when args are unparseable, but we surface the
+                // structured error to the LLM via `tools.execute` (which also
+                // re-parses) so the agent can self-correct on the next turn.
+                tracing::warn!(
+                    "Tool '{name}' received unparseable JSON args ({e}). Raw: {raw_args}"
+                );
+                Value::Null
+            }
+        };
 
         let (effective_args_str, blocked) =
             match self.hooks.before_tool_call(name, &parsed_args, cancel.clone()).await {

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,6 +43,10 @@ pub struct ProviderConfig {
     /// Max context size in tokens
     #[serde(default = "default_max_context")]
     pub max_context: usize,
+    /// Max retries on transient API failures (429, 5xx, connection errors).
+    /// Backoff is exponential with jitter: 1s, 2s, 4s, 8s, 16s.
+    #[serde(default = "default_max_retries")]
+    pub max_retries: u32,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -73,6 +77,7 @@ impl Default for ProviderConfig {
             api_key: None,
             model: default_model(),
             max_context: default_max_context(),
+            max_retries: default_max_retries(),
         }
     }
 }
@@ -115,6 +120,9 @@ fn default_model() -> String {
 }
 fn default_max_context() -> usize {
     128_000
+}
+fn default_max_retries() -> u32 {
+    4
 }
 fn default_skills_dir() -> PathBuf {
     vulcan_home().join("skills")

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ async fn main() -> anyhow::Result<()> {
         }
         Some(Command::Prompt { text }) => {
             init_cli_logging();
-            let mut agent = vulcan::agent::Agent::new(&config);
+            let mut agent = vulcan::agent::Agent::new(&config)?;
             if cli.r#continue {
                 agent.continue_last_session()?;
             }

--- a/src/provider/openai.rs
+++ b/src/provider/openai.rs
@@ -13,6 +13,7 @@ pub struct OpenAIProvider {
     api_key: String,
     model: String,
     max_context: usize,
+    max_retries: u32,
 }
 
 impl OpenAIProvider {
@@ -21,6 +22,7 @@ impl OpenAIProvider {
         api_key: &str,
         model: &str,
         max_context: usize,
+        max_retries: u32,
     ) -> Result<Self> {
         let client = Client::builder()
             .timeout(Duration::from_secs(300))
@@ -33,6 +35,7 @@ impl OpenAIProvider {
             api_key: api_key.to_string(),
             model: model.to_string(),
             max_context,
+            max_retries,
         })
     }
 
@@ -51,28 +54,85 @@ impl OpenAIProvider {
         body
     }
 
-    /// Make the HTTP request and return the response
-    async fn do_request(&self, messages: &[Message], tools: &[ToolDefinition]) -> Result<reqwest::Response> {
+    /// Make the HTTP request and return the response. Retries up to
+    /// `max_retries` times on transient failures (429, 408, 5xx, network
+    /// errors) with exponential backoff + jitter. Non-retryable errors
+    /// (400, 401, 403, 404, 422) and cancellation pass through immediately.
+    async fn do_request(
+        &self,
+        messages: &[Message],
+        tools: &[ToolDefinition],
+        cancel: &CancellationToken,
+    ) -> Result<reqwest::Response> {
         let url = format!("{}/chat/completions", self.base_url);
         let body = self.build_request(messages, tools);
 
-        let response = self
-            .client
-            .post(&url)
-            .header("Authorization", format!("Bearer {}", self.api_key))
-            .header("Content-Type", "application/json")
-            .json(&body)
-            .send()
-            .await
-            .context("LLM API request failed")?;
+        for attempt in 0..=self.max_retries {
+            if cancel.is_cancelled() {
+                anyhow::bail!("Cancelled");
+            }
 
-        if !response.status().is_success() {
-            let status = response.status();
-            let text = response.text().await.unwrap_or_default();
-            anyhow::bail!("LLM API returned {status}: {text}");
+            if attempt > 0 {
+                let delay = backoff_delay(attempt);
+                tracing::warn!(
+                    "Retrying API request (attempt {}/{}) after {:?}",
+                    attempt,
+                    self.max_retries,
+                    delay
+                );
+                tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => anyhow::bail!("Cancelled"),
+                    _ = tokio::time::sleep(delay) => {},
+                }
+            }
+
+            let send_result = self
+                .client
+                .post(&url)
+                .header("Authorization", format!("Bearer {}", self.api_key))
+                .header("Content-Type", "application/json")
+                .json(&body)
+                .send()
+                .await;
+
+            match send_result {
+                Ok(response) => {
+                    let status = response.status();
+                    if status.is_success() {
+                        return Ok(response);
+                    }
+                    let body_text = response.text().await.unwrap_or_default();
+                    if is_retryable_status(status) && attempt < self.max_retries {
+                        tracing::warn!(
+                            "API returned {} (retryable, attempt {}/{}): {}",
+                            status,
+                            attempt + 1,
+                            self.max_retries,
+                            truncate(&body_text, 200)
+                        );
+                        continue;
+                    }
+                    anyhow::bail!("LLM API returned {status}: {body_text}");
+                }
+                Err(e) => {
+                    // Network/timeout errors are always retryable within budget.
+                    if attempt < self.max_retries {
+                        tracing::warn!(
+                            "Network error (retryable, attempt {}/{}): {}",
+                            attempt + 1,
+                            self.max_retries,
+                            e
+                        );
+                        continue;
+                    }
+                    return Err(anyhow::Error::from(e).context("LLM API request failed"));
+                }
+            }
         }
 
-        Ok(response)
+        // Should be unreachable — the loop body always either returns/bails or continues.
+        anyhow::bail!("LLM API retry budget exhausted")
     }
 
     /// Parse a single SSE data line and accumulate state
@@ -178,7 +238,7 @@ impl LLMProvider for OpenAIProvider {
             biased;
             _ = cancel.cancelled() => anyhow::bail!("Cancelled"),
             res = async {
-                let response = self.do_request(messages, tools).await?;
+                let response = self.do_request(messages, tools, &cancel).await?;
                 response.bytes().await.context("Failed to read response body")
             } => res?,
         };
@@ -221,7 +281,7 @@ impl LLMProvider for OpenAIProvider {
         let response = tokio::select! {
             biased;
             _ = cancel.cancelled() => anyhow::bail!("Cancelled"),
-            res = self.do_request(messages, tools) => res?,
+            res = self.do_request(messages, tools, &cancel) => res?,
         };
 
         let mut content = String::new();
@@ -291,5 +351,84 @@ impl LLMProvider for OpenAIProvider {
 
     fn max_context(&self) -> usize {
         self.max_context
+    }
+}
+
+/// Status codes worth retrying. Excludes auth/permission/validation errors
+/// where retrying just spends more of the budget on a guaranteed failure.
+fn is_retryable_status(status: reqwest::StatusCode) -> bool {
+    matches!(
+        status.as_u16(),
+        408 | 425 | 429 | 500 | 502 | 503 | 504
+    )
+}
+
+/// Exponential backoff with jitter. attempt=1 → ~1s, 2 → ~2s, 3 → ~4s, 4 → ~8s, 5 → ~16s.
+/// Jitter is 0-25% of the base delay, derived from monotonic-ish system time
+/// to avoid synchronized retry storms across multiple in-flight requests.
+fn backoff_delay(attempt: u32) -> Duration {
+    let shift = attempt.saturating_sub(1).min(4);
+    let base_ms: u64 = 1_000_u64 << shift;
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.subsec_nanos() as u64)
+        .unwrap_or(0);
+    let jitter_window = (base_ms / 4).max(1);
+    let jitter_ms = nanos % jitter_window;
+    Duration::from_millis(base_ms + jitter_ms)
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let mut out: String = s.chars().take(max).collect();
+        out.push('…');
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqwest::StatusCode;
+
+    #[test]
+    fn retryable_includes_429_5xx_and_timeouts() {
+        assert!(is_retryable_status(StatusCode::REQUEST_TIMEOUT));
+        assert!(is_retryable_status(StatusCode::TOO_MANY_REQUESTS));
+        assert!(is_retryable_status(StatusCode::INTERNAL_SERVER_ERROR));
+        assert!(is_retryable_status(StatusCode::BAD_GATEWAY));
+        assert!(is_retryable_status(StatusCode::SERVICE_UNAVAILABLE));
+        assert!(is_retryable_status(StatusCode::GATEWAY_TIMEOUT));
+    }
+
+    #[test]
+    fn retryable_excludes_auth_and_validation_errors() {
+        // These mean "your request is wrong" — retrying just burns budget.
+        assert!(!is_retryable_status(StatusCode::BAD_REQUEST));
+        assert!(!is_retryable_status(StatusCode::UNAUTHORIZED));
+        assert!(!is_retryable_status(StatusCode::FORBIDDEN));
+        assert!(!is_retryable_status(StatusCode::NOT_FOUND));
+        assert!(!is_retryable_status(StatusCode::UNPROCESSABLE_ENTITY));
+    }
+
+    #[test]
+    fn backoff_grows_exponentially_within_cap() {
+        let d1 = backoff_delay(1).as_millis();
+        let d2 = backoff_delay(2).as_millis();
+        let d3 = backoff_delay(3).as_millis();
+        let d4 = backoff_delay(4).as_millis();
+        let d5 = backoff_delay(5).as_millis();
+        let d6 = backoff_delay(6).as_millis();
+
+        // Base values: 1000, 2000, 4000, 8000, 16000, 16000 (capped at shift=4).
+        // Jitter is up to 25% of base, so each delay is in [base, base + base/4).
+        assert!((1000..1250).contains(&d1), "got {d1}");
+        assert!((2000..2500).contains(&d2), "got {d2}");
+        assert!((4000..5000).contains(&d3), "got {d3}");
+        assert!((8000..10000).contains(&d4), "got {d4}");
+        assert!((16000..20000).contains(&d5), "got {d5}");
+        assert!((16000..20000).contains(&d6), "got {d6} (should be capped)");
     }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -118,8 +118,11 @@ impl ToolRegistry {
             .get(name)
             .ok_or_else(|| anyhow::anyhow!("Unknown tool: {name}"))?;
 
-        let params: Value = serde_json::from_str(arguments)
-            .map_err(|e| anyhow::anyhow!("Failed to parse arguments for {name}: {e}"))?;
+        let params: Value = serde_json::from_str(arguments).map_err(|e| {
+            // Include the raw args so the LLM can see what it generated and
+            // self-correct on the next turn rather than hallucinating fixes.
+            anyhow::anyhow!("Failed to parse arguments for {name}: {e}. Raw args: {arguments}")
+        })?;
 
         tool.call(params, cancel).await
     }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -136,11 +136,9 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
 
     // ── Long-lived agent: one per TUI session, shared across prompts so
     // hook handlers' state (audit log, rate limits, etc.) survives turns.
-    let agent = Arc::new(Mutex::new(Agent::with_hooks_and_pause(
-        config,
-        hook_reg,
-        Some(pause_tx),
-    )));
+    let agent = Arc::new(Mutex::new(
+        Agent::with_hooks_and_pause(config, hook_reg, Some(pause_tx))?,
+    ));
 
     // ── Apply resume target if any. Errors here are non-fatal — we report
     // and start fresh.


### PR DESCRIPTION
Three buckets:

1. **API retry with exponential backoff.** OpenAIProvider's do_request
   now wraps the HTTP call in a retry loop. Retries on 408, 425, 429,
   500, 502, 503, 504, and on network/timeout errors. Auth/validation
   failures (400, 401, 403, 404, 422) pass through immediately so we
   don't burn budget on guaranteed failures. Backoff is 1s, 2s, 4s, 8s,
   16s with up to 25%% jitter to avoid synchronized retry storms; cancel
   token short-circuits the sleep so Ctrl+C aborts cleanly during a
   retry wait.

2. **Configurable retry budget.** New 'provider.max_retries' (default
   4) in config.toml. Threaded through 'OpenAIProvider::new' so future
   providers inherit the same shape.

3. **Removed unwrap/expect hotspots.**
   - 'Agent::new', 'with_hooks', 'with_hooks_and_pause' now return
     'Result<Self>'. Missing API key surfaces as a clear anyhow error
     ("Set VULCAN_API_KEY or add api_key to ~/.vulcan/config.toml")
     instead of a startup panic. Provider-build failures use '.context()'.
     CLI/TUI callers '?' propagate.
   - 'dispatch_tool' previously did 'serde_json::from_str(raw_args)
     .unwrap_or(Value::Null)' silently. Now logs a warn-level event
     including the raw args when parsing fails; downstream
     'tools.execute' returns a structured error with the raw args, so
     the LLM can self-correct on the next turn.

Tests: 13/13 (added 'retryable_includes_429_5xx_and_timeouts',
'retryable_excludes_auth_and_validation_errors',
'backoff_grows_exponentially_within_cap'). Manual hot-path retry
verification needs a flaky provider; deferred to mock provider work
(YYC-35).

Out of scope:
- Provider error taxonomy and richer user-facing error messages
  (YYC-41) — natural follow-up.
- Structured-output enforcement (YYC-39) — also same code area.

Closes YYC-40.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>