### PR TITLE
Accept and emit both 'reasoning_content' and 'reasoning' field names

### DIFF
--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -51,7 +51,7 @@ impl Serialize for Message {
                 tool_calls,
                 reasoning_content,
             } => {
-                let mut s = serializer.serialize_struct("Message", 4)?;
+                let mut s = serializer.serialize_struct("Message", 5)?;
                 s.serialize_field("role", "assistant")?;
                 if let Some(c) = content {
                     s.serialize_field("content", c)?;
@@ -61,8 +61,13 @@ impl Serialize for Message {
                 if let Some(tc) = tool_calls {
                     s.serialize_field("tool_calls", tc)?;
                 }
+                // Emit both field names. DeepSeek's native API uses
+                // `reasoning_content`; OpenRouter's standardized name is
+                // `reasoning`. Sending both means a tool-using turn against
+                // either path won't fail with "must be passed back" (YYC-63).
                 if let Some(rc) = reasoning_content {
                     s.serialize_field("reasoning_content", rc)?;
+                    s.serialize_field("reasoning", rc)?;
                 }
                 s.end()
             }

--- a/src/provider/openai.rs
+++ b/src/provider/openai.rs
@@ -161,10 +161,15 @@ impl OpenAIProvider {
                         if let Some(text) = delta.get("content").and_then(|c| c.as_str()) {
                             content.push_str(text);
                         }
-                        // DeepSeek-shape reasoning trace. OpenRouter passes
-                        // it through for thinking-mode models; we accumulate
-                        // and echo it back on the next turn (YYC-43).
+                        // Reasoning trace from thinking-mode models. The
+                        // field name varies by proxy — DeepSeek's native API
+                        // uses `reasoning_content`, OpenRouter normalizes to
+                        // `reasoning`. Accept either and merge into one
+                        // accumulator (YYC-63).
                         if let Some(rc) = delta.get("reasoning_content").and_then(|c| c.as_str()) {
+                            reasoning.push_str(rc);
+                        }
+                        if let Some(rc) = delta.get("reasoning").and_then(|c| c.as_str()) {
                             reasoning.push_str(rc);
                         }
                         if let Some(tcs) = delta.get("tool_calls").and_then(|c| c.as_array()) {


### PR DESCRIPTION
Tool-using prompts against the default config (OpenRouter →
DeepSeek V4) failed with:

  "The reasoning_content in the thinking mode must be passed back to
   the API."

Despite YYC-43 plumbing reasoning_content end-to-end. Root cause:
OpenRouter standardizes provider-specific reasoning fields to the
single name 'reasoning' in its SSE responses, while DeepSeek's native
API uses 'reasoning_content'. Vulcan's parser only watched for
'delta.reasoning_content', so on OpenRouter we captured nothing,
echoed nothing, and DeepSeek rejected the next request.

Fix:
- parse_line accepts either 'delta.reasoning_content' or
  'delta.reasoning' and merges into one accumulator. Vendors that
  emit both will safely double-count strings; in practice only one
  of the two is present.
- Message::Assistant Serialize emits BOTH 'reasoning_content' and
  'reasoning' fields when reasoning is Some. Belt-and-suspenders for
  whichever proxy is on the wire.

Tests: 13/13 (existing). Manual verification needs a real run against
OpenRouter; the diagnostic logs added in YYC-57 will confirm reasoning
is now captured (reasoning_len > 0).

Closes YYC-63.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>