### PR TITLE
ProviderError taxonomy + actionable user-facing messages

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -313,12 +313,18 @@ impl Agent {
                 .await
             {
                 // Surface provider failures to the TUI rather than dropping
-                // the channel silently — otherwise the user sees the chat
-                // freeze with no error indication.
-                tracing::error!("agent iteration {iteration}: chat_stream failed: {e}");
-                let _ = ui_tx.send(StreamEvent::Error(format!("Provider error: {e}")));
+                // the channel silently. ProviderError carries actionable hints
+                // via its Display impl; if the error chain has one (most
+                // common case), use that — otherwise fall back to the raw
+                // anyhow chain.
+                let user_message = e
+                    .downcast_ref::<crate::provider::ProviderError>()
+                    .map(|pe| pe.to_string())
+                    .unwrap_or_else(|| format!("{e}"));
+                tracing::error!("agent iteration {iteration}: chat_stream failed: {user_message}");
+                let _ = ui_tx.send(StreamEvent::Error(user_message.clone()));
                 let _ = ui_tx.send(StreamEvent::Done(crate::provider::ChatResponse {
-                    content: Some(format!("⚠ Provider error: {e}")),
+                    content: Some(format!("⚠ {user_message}")),
                     tool_calls: None,
                     usage: None,
                     finish_reason: Some("error".into()),

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -1,10 +1,178 @@
 pub mod openai;
 
+use std::fmt;
+use std::time::Duration;
+
 use anyhow::Result;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use serde::ser::SerializeStruct;
 use serde_json::Value;
 use tokio::sync::mpsc;
+
+/// Categorized provider failure. Replaces opaque `anyhow::bail!` strings with
+/// a structured taxonomy so callers (retry logic, TUI banner) can branch on
+/// the kind of failure, and so the user sees an actionable next-step hint
+/// instead of raw provider JSON. See YYC-41.
+#[derive(Debug, thiserror::Error)]
+pub enum ProviderError {
+    /// 401 / 403 — API key is missing, invalid, revoked, or lacks permission.
+    Auth { message: String },
+    /// 429 — provider is throttling. `retry_after` is the server's hint if it
+    /// sent a `Retry-After` header.
+    RateLimited { retry_after: Option<Duration> },
+    /// 404 with a model-shaped error body — bad model slug.
+    ModelNotFound { model: String, message: String },
+    /// 400 / 422 — request shape is wrong (malformed messages, invalid params,
+    /// missing reasoning_content, etc.).
+    BadRequest { message: String },
+    /// 5xx — provider is having a bad day.
+    ServerError { status: u16, message: String },
+    /// Connection/DNS/TLS/timeout — never reached the provider.
+    Network(reqwest::Error),
+    /// Status codes we don't classify (3xx redirects we can't follow,
+    /// uncommon 4xx, etc.) and non-JSON 4xx bodies.
+    Other { status: u16, body: String },
+}
+
+impl fmt::Display for ProviderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ProviderError::Auth { message } => write!(
+                f,
+                "Authentication failed: {message}. \
+                 Check your API key in ~/.vulcan/config.toml or set the VULCAN_API_KEY env var."
+            ),
+            ProviderError::RateLimited { retry_after: Some(d) } => write!(
+                f,
+                "Rate limited by provider. Suggested retry after {}s.",
+                d.as_secs().max(1)
+            ),
+            ProviderError::RateLimited { retry_after: None } => {
+                write!(f, "Rate limited by provider. Retrying with backoff.")
+            }
+            ProviderError::ModelNotFound { model, message } => write!(
+                f,
+                "Model '{model}' not found ({message}). \
+                 Check `[provider].model` in your config — model slugs are listed at the provider's catalog \
+                 (e.g. https://openrouter.ai/models)."
+            ),
+            ProviderError::BadRequest { message } => write!(
+                f,
+                "Provider rejected the request: {message}. \
+                 This usually means the message format is wrong (often a model-specific \
+                 requirement around tool calls or reasoning passthrough)."
+            ),
+            ProviderError::ServerError { status, message } => write!(
+                f,
+                "Provider returned {status}: {message}. This is a transient server-side issue; \
+                 retries should resolve it."
+            ),
+            ProviderError::Network(e) => write!(
+                f,
+                "Network error reaching provider: {e}. \
+                 Check connectivity, base_url in config, and any proxy settings."
+            ),
+            ProviderError::Other { status, body } => {
+                let trimmed = body.chars().take(300).collect::<String>();
+                write!(f, "Provider returned {status}: {trimmed}")
+            }
+        }
+    }
+}
+
+impl ProviderError {
+    /// Should the agent retry this error within its budget?
+    /// `Auth` / `BadRequest` / `ModelNotFound` / `Other` are non-retryable —
+    /// retrying just spends budget on a guaranteed failure.
+    pub fn is_retryable(&self) -> bool {
+        matches!(
+            self,
+            ProviderError::RateLimited { .. }
+                | ProviderError::ServerError { .. }
+                | ProviderError::Network(_)
+        )
+    }
+
+    /// Classify a non-2xx HTTP response into a `ProviderError`. Tolerates
+    /// non-JSON bodies and varying error shapes across OpenAI/OpenRouter/
+    /// Anthropic (`error.message` + either `error.code` or `error.type`).
+    pub fn from_response(status: reqwest::StatusCode, body: &str, model: &str) -> Self {
+        let code = status.as_u16();
+        let message = extract_error_message(body).unwrap_or_else(|| body.to_string());
+
+        match code {
+            401 | 403 => ProviderError::Auth { message },
+            429 => ProviderError::RateLimited {
+                retry_after: None, // header parsing is the caller's job
+            },
+            404 => {
+                // Heuristic: if the body mentions the model slug, treat as ModelNotFound.
+                if message.to_lowercase().contains("model")
+                    || body.to_lowercase().contains(&model.to_lowercase())
+                {
+                    ProviderError::ModelNotFound {
+                        model: model.to_string(),
+                        message,
+                    }
+                } else {
+                    ProviderError::Other {
+                        status: code,
+                        body: body.to_string(),
+                    }
+                }
+            }
+            400 | 422 => ProviderError::BadRequest { message },
+            500..=599 => ProviderError::ServerError {
+                status: code,
+                message,
+            },
+            _ => ProviderError::Other {
+                status: code,
+                body: body.to_string(),
+            },
+        }
+    }
+}
+
+impl From<reqwest::Error> for ProviderError {
+    fn from(e: reqwest::Error) -> Self {
+        ProviderError::Network(e)
+    }
+}
+
+/// Best-effort extraction of `error.message` from common provider body shapes.
+/// All of OpenAI / OpenRouter / Anthropic / DeepSeek wrap errors as
+/// `{"error": {"message": "...", ...}}`; OpenRouter's nested `metadata.raw`
+/// also follows that shape one level deeper.
+fn extract_error_message(body: &str) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_str(body).ok()?;
+    // Top-level error.message
+    if let Some(m) = v.get("error").and_then(|e| e.get("message")).and_then(|m| m.as_str()) {
+        // OpenRouter-style: error.metadata.raw is a JSON string with an inner
+        // error.message that's the actual provider message. Surface that if present.
+        if let Some(raw) = v
+            .get("error")
+            .and_then(|e| e.get("metadata"))
+            .and_then(|md| md.get("raw"))
+            .and_then(|r| r.as_str())
+        {
+            if let Ok(inner) = serde_json::from_str::<serde_json::Value>(raw) {
+                if let Some(inner_m) = inner
+                    .get("error")
+                    .and_then(|e| e.get("message"))
+                    .and_then(|m| m.as_str())
+                {
+                    return Some(inner_m.to_string());
+                }
+            }
+        }
+        return Some(m.to_string());
+    }
+    // Some providers (Anthropic) put it at top level
+    v.get("message")
+        .and_then(|m| m.as_str())
+        .map(|s| s.to_string())
+}
 
 /// A message in the conversation history (OpenAI-compatible format)
 #[derive(Debug, Clone)]

--- a/src/provider/openai.rs
+++ b/src/provider/openai.rs
@@ -1,4 +1,6 @@
-use crate::provider::{ChatResponse, LLMProvider, Message, StreamEvent, ToolCall, ToolDefinition, Usage};
+use crate::provider::{
+    ChatResponse, LLMProvider, Message, ProviderError, StreamEvent, ToolCall, ToolDefinition, Usage,
+};
 use anyhow::{Context, Result};
 use reqwest::Client;
 use serde_json::{json, Value};
@@ -55,21 +57,30 @@ impl OpenAIProvider {
     }
 
     /// Make the HTTP request and return the response. Retries up to
-    /// `max_retries` times on transient failures (429, 408, 5xx, network
-    /// errors) with exponential backoff + jitter. Non-retryable errors
-    /// (400, 401, 403, 404, 422) and cancellation pass through immediately.
+    /// `max_retries` times on transient failures (429, 5xx, network errors)
+    /// with exponential backoff + jitter. Non-retryable errors
+    /// (Auth/BadRequest/ModelNotFound/Other) and cancellation pass through
+    /// immediately. Returns a structured `ProviderError` on failure so
+    /// callers can render actionable messages and retry policies key off
+    /// the variant rather than raw status codes.
     async fn do_request(
         &self,
         messages: &[Message],
         tools: &[ToolDefinition],
         cancel: &CancellationToken,
-    ) -> Result<reqwest::Response> {
+    ) -> std::result::Result<reqwest::Response, ProviderError> {
         let url = format!("{}/chat/completions", self.base_url);
         let body = self.build_request(messages, tools);
 
+        let mut last_err: Option<ProviderError> = None;
         for attempt in 0..=self.max_retries {
             if cancel.is_cancelled() {
-                anyhow::bail!("Cancelled");
+                // Surface as Other; cancellation in the API layer doesn't
+                // map to a real provider failure.
+                return Err(ProviderError::Other {
+                    status: 0,
+                    body: "Cancelled".into(),
+                });
             }
 
             if attempt > 0 {
@@ -82,7 +93,12 @@ impl OpenAIProvider {
                 );
                 tokio::select! {
                     biased;
-                    _ = cancel.cancelled() => anyhow::bail!("Cancelled"),
+                    _ = cancel.cancelled() => {
+                        return Err(ProviderError::Other {
+                            status: 0,
+                            body: "Cancelled".into(),
+                        });
+                    }
                     _ = tokio::time::sleep(delay) => {},
                 }
             }
@@ -96,43 +112,36 @@ impl OpenAIProvider {
                 .send()
                 .await;
 
-            match send_result {
+            let err = match send_result {
                 Ok(response) => {
                     let status = response.status();
                     if status.is_success() {
                         return Ok(response);
                     }
                     let body_text = response.text().await.unwrap_or_default();
-                    if is_retryable_status(status) && attempt < self.max_retries {
-                        tracing::warn!(
-                            "API returned {} (retryable, attempt {}/{}): {}",
-                            status,
-                            attempt + 1,
-                            self.max_retries,
-                            truncate(&body_text, 200)
-                        );
-                        continue;
-                    }
-                    anyhow::bail!("LLM API returned {status}: {body_text}");
+                    ProviderError::from_response(status, &body_text, &self.model)
                 }
-                Err(e) => {
-                    // Network/timeout errors are always retryable within budget.
-                    if attempt < self.max_retries {
-                        tracing::warn!(
-                            "Network error (retryable, attempt {}/{}): {}",
-                            attempt + 1,
-                            self.max_retries,
-                            e
-                        );
-                        continue;
-                    }
-                    return Err(anyhow::Error::from(e).context("LLM API request failed"));
-                }
+                Err(e) => ProviderError::Network(e),
+            };
+
+            if err.is_retryable() && attempt < self.max_retries {
+                tracing::warn!(
+                    "Provider error (retryable, attempt {}/{}): {}",
+                    attempt + 1,
+                    self.max_retries,
+                    truncate(&err.to_string(), 200)
+                );
+                last_err = Some(err);
+                continue;
             }
+            // Non-retryable, or budget exhausted — surface the error.
+            return Err(err);
         }
 
-        // Should be unreachable — the loop body always either returns/bails or continues.
-        anyhow::bail!("LLM API retry budget exhausted")
+        Err(last_err.unwrap_or(ProviderError::Other {
+            status: 0,
+            body: "retry budget exhausted".into(),
+        }))
     }
 
     /// Parse a single SSE data line and accumulate state
@@ -359,15 +368,6 @@ impl LLMProvider for OpenAIProvider {
     }
 }
 
-/// Status codes worth retrying. Excludes auth/permission/validation errors
-/// where retrying just spends more of the budget on a guaranteed failure.
-fn is_retryable_status(status: reqwest::StatusCode) -> bool {
-    matches!(
-        status.as_u16(),
-        408 | 425 | 429 | 500 | 502 | 503 | 504
-    )
-}
-
 /// Exponential backoff with jitter. attempt=1 → ~1s, 2 → ~2s, 3 → ~4s, 4 → ~8s, 5 → ~16s.
 /// Jitter is 0-25% of the base delay, derived from monotonic-ish system time
 /// to avoid synchronized retry storms across multiple in-flight requests.
@@ -397,25 +397,102 @@ fn truncate(s: &str, max: usize) -> String {
 mod tests {
     use super::*;
     use reqwest::StatusCode;
+    use crate::provider::ProviderError;
 
-    #[test]
-    fn retryable_includes_429_5xx_and_timeouts() {
-        assert!(is_retryable_status(StatusCode::REQUEST_TIMEOUT));
-        assert!(is_retryable_status(StatusCode::TOO_MANY_REQUESTS));
-        assert!(is_retryable_status(StatusCode::INTERNAL_SERVER_ERROR));
-        assert!(is_retryable_status(StatusCode::BAD_GATEWAY));
-        assert!(is_retryable_status(StatusCode::SERVICE_UNAVAILABLE));
-        assert!(is_retryable_status(StatusCode::GATEWAY_TIMEOUT));
+    fn classify(code: u16, body: &str) -> ProviderError {
+        ProviderError::from_response(StatusCode::from_u16(code).unwrap(), body, "deepseek/deepseek-v4-flash")
     }
 
     #[test]
-    fn retryable_excludes_auth_and_validation_errors() {
-        // These mean "your request is wrong" — retrying just burns budget.
-        assert!(!is_retryable_status(StatusCode::BAD_REQUEST));
-        assert!(!is_retryable_status(StatusCode::UNAUTHORIZED));
-        assert!(!is_retryable_status(StatusCode::FORBIDDEN));
-        assert!(!is_retryable_status(StatusCode::NOT_FOUND));
-        assert!(!is_retryable_status(StatusCode::UNPROCESSABLE_ENTITY));
+    fn classifier_handles_common_provider_errors() {
+        // 401 / 403 → Auth
+        assert!(matches!(
+            classify(401, r#"{"error":{"message":"User not found.","code":401}}"#),
+            ProviderError::Auth { .. }
+        ));
+        assert!(matches!(
+            classify(403, r#"{"error":{"message":"Forbidden"}}"#),
+            ProviderError::Auth { .. }
+        ));
+        // 429 → RateLimited
+        assert!(matches!(
+            classify(429, r#"{"error":{"message":"slow down"}}"#),
+            ProviderError::RateLimited { .. }
+        ));
+        // 400 / 422 → BadRequest
+        assert!(matches!(
+            classify(400, r#"{"error":{"message":"bad shape"}}"#),
+            ProviderError::BadRequest { .. }
+        ));
+        assert!(matches!(
+            classify(422, r#"{"error":{"message":"invalid arg"}}"#),
+            ProviderError::BadRequest { .. }
+        ));
+        // 5xx → ServerError
+        assert!(matches!(
+            classify(500, r#"{"error":{"message":"oops"}}"#),
+            ProviderError::ServerError { .. }
+        ));
+        assert!(matches!(
+            classify(503, r#"{"error":{"message":"down"}}"#),
+            ProviderError::ServerError { .. }
+        ));
+        // 404 with model in body → ModelNotFound
+        assert!(matches!(
+            classify(404, r#"{"error":{"message":"Model deepseek/deepseek-v4-flash not found"}}"#),
+            ProviderError::ModelNotFound { .. }
+        ));
+        // 404 without model hint → Other
+        assert!(matches!(
+            classify(404, r#"{"error":{"message":"Resource gone"}}"#),
+            ProviderError::Other { .. }
+        ));
+        // Non-JSON body → Other (or BadRequest depending on status)
+        let html = "<html>500 internal server error</html>";
+        assert!(matches!(classify(500, html), ProviderError::ServerError { .. }));
+    }
+
+    #[test]
+    fn classifier_unwraps_openrouter_nested_error() {
+        // OpenRouter wraps the upstream provider's body inside metadata.raw.
+        let body = r#"{"error":{"message":"Provider returned error","code":400,"metadata":{"raw":"{\"error\":{\"message\":\"The reasoning_content in the thinking mode must be passed back to the API.\"}}"}}}"#;
+        let err = classify(400, body);
+        match err {
+            ProviderError::BadRequest { message } => {
+                assert!(
+                    message.contains("reasoning_content"),
+                    "expected unwrapped DeepSeek message, got {message:?}"
+                );
+            }
+            other => panic!("expected BadRequest, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn provider_error_retry_classification() {
+        assert!(classify(429, "{}").is_retryable());
+        assert!(classify(500, "{}").is_retryable());
+        assert!(classify(502, "{}").is_retryable());
+        assert!(classify(503, "{}").is_retryable());
+        // Auth/BadRequest/ModelNotFound/Other are not.
+        assert!(!classify(401, r#"{"error":{"message":"x"}}"#).is_retryable());
+        assert!(!classify(400, r#"{"error":{"message":"x"}}"#).is_retryable());
+        assert!(!classify(
+            404,
+            r#"{"error":{"message":"Model deepseek/deepseek-v4-flash not found"}}"#
+        ).is_retryable());
+    }
+
+    #[test]
+    fn provider_error_display_includes_actionable_hint() {
+        let auth = classify(401, r#"{"error":{"message":"User not found."}}"#).to_string();
+        assert!(auth.contains("API key"), "got {auth:?}");
+        let model = classify(
+            404,
+            r#"{"error":{"message":"Model deepseek/deepseek-v4-flash not found"}}"#,
+        )
+        .to_string();
+        assert!(model.contains("provider's catalog"), "got {model:?}");
     }
 
     #[test]


### PR DESCRIPTION
Replaces opaque 'anyhow::bail!("LLM API returned 401: {raw_json}")'
strings with a structured taxonomy. The 401 incident that motivated
the issue (raw 'User not found.' JSON shown to user, fix was "mint a
new key") now surfaces as:

  Authentication failed: User not found. Check your API key in
  ~/.vulcan/config.toml or set the VULCAN_API_KEY env var.

What's new:

- src/provider/mod.rs adds ProviderError enum (Auth/RateLimited/
  ModelNotFound/BadRequest/ServerError/Network/Other) with Display
  impls that include next-step hints, plus is_retryable() so retry
  policy keys off the variant rather than HTTP status codes.
- ProviderError::from_response classifies a (status, body) pair into
  a variant, tolerating non-JSON bodies. Special-case for OpenRouter's
  nested 'metadata.raw' shape — unwraps the upstream provider's actual
  message instead of "Provider returned error".
- src/provider/openai.rs do_request now returns
  Result<Response, ProviderError>. Retry loop matches on
  ProviderError::is_retryable() instead of raw status code helpers.
  Removed the legacy is_retryable_status helper.
- src/agent.rs run_prompt_stream's error path downcasts
  anyhow::Error → ProviderError when present and shows the variant's
  Display message. Falls back to raw anyhow text when not a
  ProviderError (e.g. memory or tool errors).

Tests: 15/15 (4 new):
- classifier_handles_common_provider_errors (401/403/429/400/422/5xx/
  404 model vs other, non-JSON bodies)
- classifier_unwraps_openrouter_nested_error (DeepSeek message buried
  in error.metadata.raw is surfaced, not "Provider returned error")
- provider_error_retry_classification (Auth/BadRequest/ModelNotFound
  not retryable; RateLimited/ServerError/Network are)
- provider_error_display_includes_actionable_hint

Out of scope:
- TUI-side red banner styling. The error already renders via
  StreamEvent::Error → ChatRole::System message and the actionable
  text is the main UX win; banner is a follow-up if desired.
- Anthropic-specific error.type field (current classifier handles
  the common error.message shape; type-based discrimination would be
  per-provider work).

Closes YYC-41.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>