### PR TITLE
Make Agent constructors async to fetch catalog inside parent runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2910,6 +2910,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "strsim",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }
 tokio-util = { version = "0.7.18", features = ["rt"] }
 rusqlite = { version = "0.39.0", features = ["bundled"] }
+strsim = "0.11.1"
 
 [profile.release]
 opt-level = "z"    # optimize for size

--- a/config.example.toml
+++ b/config.example.toml
@@ -15,6 +15,12 @@ max_context = 128000
 # Max retries on transient API failures (429, 5xx, network errors).
 # Backoff is exponential with jitter: 1s, 2s, 4s, 8s, 16s.
 max_retries = 4
+# How long to cache the provider's model catalog before re-fetching (hours).
+# Vulcan validates `model` against this catalog at startup and uses its
+# `context_length` to size the LLM context window.
+catalog_cache_ttl_hours = 24
+# Skip the catalog fetch entirely. Useful for offline/testing setups.
+# disable_catalog = false
 
 [tools]
 # Enable dangerous tools (file overwrite, shell exec) without confirmation

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -42,14 +42,14 @@ pub struct Agent {
 impl Agent {
     /// Construct an Agent with no caller-supplied hooks. Built-in hooks (skills
     /// injection, etc.) are still registered.
-    pub fn new(config: &Config) -> Result<Self> {
-        Self::with_hooks_and_pause(config, HookRegistry::new(), None)
+    pub async fn new(config: &Config) -> Result<Self> {
+        Self::with_hooks_and_pause(config, HookRegistry::new(), None).await
     }
 
     /// Construct with caller-supplied hooks and no interactive pause channel.
     /// The TUI uses `with_hooks_and_pause` to wire one up.
-    pub fn with_hooks(config: &Config, hooks: HookRegistry) -> Result<Self> {
-        Self::with_hooks_and_pause(config, hooks, None)
+    pub async fn with_hooks(config: &Config, hooks: HookRegistry) -> Result<Self> {
+        Self::with_hooks_and_pause(config, hooks, None).await
     }
 
     /// Construct an Agent with a caller-supplied hook registry and an optional
@@ -57,10 +57,13 @@ impl Agent {
     /// registry; if a pause emitter is provided, `SafetyHook` is wired up to
     /// route blocks through it as `AgentPause::SafetyApproval`.
     ///
+    /// Async because it fetches the provider's model catalog at startup
+    /// (YYC-64). Catalog-fetch failures are non-fatal — logged and continued
+    /// with config defaults.
+    ///
     /// Returns `Err` for fatal init failures (missing API key, provider build
-    /// failure). These were previously panics; the caller now decides how to
-    /// surface the error.
-    pub fn with_hooks_and_pause(
+    /// failure, or model not found in catalog).
+    pub async fn with_hooks_and_pause(
         config: &Config,
         mut hooks: HookRegistry,
         pause_tx: Option<PauseSender>,
@@ -71,12 +74,62 @@ impl Agent {
             )
         })?;
 
+        // ── Catalog: validate the configured model and (optionally) override
+        // max_context with whatever the catalog says it actually is. Non-fatal:
+        // if the catalog endpoint fails, we log + continue with the configured
+        // values rather than blocking startup over a metadata fetch.
+        let mut effective_max_context = config.provider.max_context;
+        if !config.provider.disable_catalog {
+            match Self::fetch_catalog(config, &api_key).await {
+                Ok(models) => {
+                    let found = models.iter().find(|m| m.id == config.provider.model);
+                    match found {
+                        Some(model_info) => {
+                            if model_info.context_length > 0
+                                && config.provider.max_context == 128_000
+                            {
+                                effective_max_context = model_info.context_length;
+                                tracing::info!(
+                                    "catalog: using context_length={} for {}",
+                                    model_info.context_length,
+                                    model_info.id
+                                );
+                            }
+                        }
+                        None => {
+                            let suggestions = crate::provider::catalog::fuzzy_suggest(
+                                &models,
+                                &config.provider.model,
+                                3,
+                            );
+                            let hint = if suggestions.is_empty() {
+                                String::new()
+                            } else {
+                                format!(" Did you mean: {}?", suggestions.join(", "))
+                            };
+                            anyhow::bail!(
+                                "Model '{}' not found in provider catalog.{} \
+                                 (See `[provider].model` in config.)",
+                                config.provider.model,
+                                hint,
+                            );
+                        }
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "catalog fetch failed (continuing with config defaults): {e}"
+                    );
+                }
+            }
+        }
+
         let provider: Box<dyn LLMProvider> = Box::new(
             OpenAIProvider::new(
                 &config.provider.base_url,
                 &api_key,
                 &config.provider.model,
-                config.provider.max_context,
+                effective_max_context,
                 config.provider.max_retries,
             )
             .context("Failed to initialize LLM provider")?,
@@ -119,6 +172,24 @@ impl Agent {
 
     pub fn session_id(&self) -> &str {
         &self.session_id
+    }
+
+    /// Fetch the provider's model catalog (cached if fresh, otherwise
+    /// HTTP-fetched). Used for startup validation and `max_context`
+    /// auto-population. Runs inside the caller's tokio runtime — the
+    /// constructor is `async` for exactly this reason.
+    async fn fetch_catalog(
+        config: &Config,
+        api_key: &str,
+    ) -> Result<Vec<crate::provider::catalog::ModelInfo>> {
+        use std::time::Duration;
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(15))
+            .build()?;
+        let ttl = Duration::from_secs(config.provider.catalog_cache_ttl_hours * 3600);
+        let catalog =
+            crate::provider::catalog::for_base_url(client, &config.provider.base_url, api_key, ttl);
+        catalog.list_models().await.map_err(Into::into)
     }
 
     /// Test-only constructor that takes a fully-built provider and an empty

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,6 +47,15 @@ pub struct ProviderConfig {
     /// Backoff is exponential with jitter: 1s, 2s, 4s, 8s, 16s.
     #[serde(default = "default_max_retries")]
     pub max_retries: u32,
+    /// How long to cache the provider's `/models` catalog before re-fetching.
+    /// Defaults to 24 hours. Set to 0 to disable caching (always fetch fresh).
+    #[serde(default = "default_catalog_cache_ttl_hours")]
+    pub catalog_cache_ttl_hours: u64,
+    /// Skip catalog fetching at startup. Useful when testing or working
+    /// offline. Errors from missing or unreachable catalogs are non-fatal
+    /// regardless; this just avoids the extra HTTP roundtrip on launch.
+    #[serde(default)]
+    pub disable_catalog: bool,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -78,6 +87,8 @@ impl Default for ProviderConfig {
             model: default_model(),
             max_context: default_max_context(),
             max_retries: default_max_retries(),
+            catalog_cache_ttl_hours: default_catalog_cache_ttl_hours(),
+            disable_catalog: false,
         }
     }
 }
@@ -123,6 +134,9 @@ fn default_max_context() -> usize {
 }
 fn default_max_retries() -> u32 {
     4
+}
+fn default_catalog_cache_ttl_hours() -> u64 {
+    24
 }
 fn default_skills_dir() -> PathBuf {
     vulcan_home().join("skills")

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ async fn main() -> anyhow::Result<()> {
         }
         Some(Command::Prompt { text }) => {
             init_cli_logging();
-            let mut agent = vulcan::agent::Agent::new(&config)?;
+            let mut agent = vulcan::agent::Agent::new(&config).await?;
             if cli.r#continue {
                 agent.continue_last_session()?;
             }

--- a/src/provider/catalog.rs
+++ b/src/provider/catalog.rs
@@ -1,0 +1,437 @@
+//! Provider model catalog: fetches metadata from a provider's `/models`
+//! endpoint and caches it locally so we can validate model selection at
+//! startup, surface helpful "did you mean…" suggestions, and (later) gate
+//! features per-model.
+//!
+//! Supports two shapes:
+//! - **OpenRouter-style** rich catalog (context length, pricing, feature
+//!   flags, top provider underneath the slug).
+//! - **OpenAI-style** sparse catalog (just IDs and ownership).
+//!
+//! See YYC-64.
+
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime};
+
+use anyhow::Result;
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::ProviderError;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelInfo {
+    pub id: String,
+    pub display_name: String,
+    /// Context window in tokens. 0 means unknown.
+    pub context_length: usize,
+    pub pricing: Option<Pricing>,
+    pub features: ModelFeatures,
+    /// E.g. "DeepSeek" under an OpenRouter slug like `deepseek/deepseek-v4-flash`.
+    pub top_provider: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Pricing {
+    pub input_per_token: f64,
+    pub output_per_token: f64,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ModelFeatures {
+    pub tools: bool,
+    pub vision: bool,
+    pub json_mode: bool,
+    pub reasoning: bool,
+}
+
+#[async_trait]
+pub trait ProviderCatalog: Send + Sync {
+    async fn list_models(&self) -> std::result::Result<Vec<ModelInfo>, ProviderError>;
+
+    async fn get_model(
+        &self,
+        id: &str,
+    ) -> std::result::Result<Option<ModelInfo>, ProviderError> {
+        let models = self.list_models().await?;
+        Ok(models.into_iter().find(|m| m.id == id))
+    }
+}
+
+// ─── OpenRouter ─────────────────────────────────────────────────────────────
+
+pub struct OpenRouterCatalog {
+    client: Client,
+    base_url: String,
+    api_key: String,
+    cache_ttl: Duration,
+}
+
+impl OpenRouterCatalog {
+    pub fn new(client: Client, base_url: &str, api_key: &str, cache_ttl: Duration) -> Self {
+        Self {
+            client,
+            base_url: base_url.trim_end_matches('/').to_string(),
+            api_key: api_key.to_string(),
+            cache_ttl,
+        }
+    }
+}
+
+#[async_trait]
+impl ProviderCatalog for OpenRouterCatalog {
+    async fn list_models(&self) -> std::result::Result<Vec<ModelInfo>, ProviderError> {
+        if let Some(cached) = read_cache(&self.base_url, self.cache_ttl) {
+            return Ok(cached);
+        }
+
+        let url = format!("{}/models", self.base_url);
+        let response = self
+            .client
+            .get(&url)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .send()
+            .await?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(ProviderError::from_response(status, &body, ""));
+        }
+
+        let body: Value = response.json().await.map_err(ProviderError::Network)?;
+        let models = parse_openrouter(&body);
+        let _ = write_cache(&self.base_url, &models);
+        Ok(models)
+    }
+}
+
+fn parse_openrouter(body: &Value) -> Vec<ModelInfo> {
+    let arr = match body.get("data").and_then(|v| v.as_array()) {
+        Some(a) => a,
+        None => return Vec::new(),
+    };
+    arr.iter()
+        .filter_map(|m| {
+            let id = m.get("id")?.as_str()?.to_string();
+            let display_name = m
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or(&id)
+                .to_string();
+            let context_length = m
+                .get("context_length")
+                .and_then(|v| v.as_u64())
+                .map(|n| n as usize)
+                .unwrap_or(0);
+            let top_provider = m
+                .get("top_provider")
+                .and_then(|tp| tp.get("name"))
+                .and_then(|v| v.as_str())
+                .map(String::from);
+            // OpenRouter pricing is given as strings like "0.00000028" per token.
+            let pricing = m.get("pricing").and_then(|p| {
+                let inp = p.get("prompt").and_then(|v| v.as_str()).and_then(|s| s.parse::<f64>().ok())?;
+                let out = p
+                    .get("completion")
+                    .and_then(|v| v.as_str())
+                    .and_then(|s| s.parse::<f64>().ok())?;
+                Some(Pricing {
+                    input_per_token: inp,
+                    output_per_token: out,
+                })
+            });
+            // Feature flags via `supported_parameters` array (OpenRouter convention).
+            let supported = m
+                .get("supported_parameters")
+                .and_then(|v| v.as_array())
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|s| s.as_str().map(|s| s.to_string()))
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            let features = ModelFeatures {
+                tools: supported.iter().any(|s| s == "tools" || s == "tool_choice"),
+                json_mode: supported.iter().any(|s| s == "response_format"),
+                vision: m
+                    .get("architecture")
+                    .and_then(|a| a.get("input_modalities"))
+                    .and_then(|v| v.as_array())
+                    .map(|a| a.iter().any(|s| s.as_str() == Some("image")))
+                    .unwrap_or(false),
+                reasoning: m
+                    .get("supported_parameters")
+                    .and_then(|v| v.as_array())
+                    .map(|a| {
+                        a.iter()
+                            .any(|s| s.as_str() == Some("reasoning") || s.as_str() == Some("include_reasoning"))
+                    })
+                    .unwrap_or(false),
+            };
+            Some(ModelInfo {
+                id,
+                display_name,
+                context_length,
+                pricing,
+                features,
+                top_provider,
+            })
+        })
+        .collect()
+}
+
+// ─── OpenAI sparse ─────────────────────────────────────────────────────────
+
+pub struct OpenAICatalog {
+    client: Client,
+    base_url: String,
+    api_key: String,
+    cache_ttl: Duration,
+}
+
+impl OpenAICatalog {
+    pub fn new(client: Client, base_url: &str, api_key: &str, cache_ttl: Duration) -> Self {
+        Self {
+            client,
+            base_url: base_url.trim_end_matches('/').to_string(),
+            api_key: api_key.to_string(),
+            cache_ttl,
+        }
+    }
+}
+
+#[async_trait]
+impl ProviderCatalog for OpenAICatalog {
+    async fn list_models(&self) -> std::result::Result<Vec<ModelInfo>, ProviderError> {
+        if let Some(cached) = read_cache(&self.base_url, self.cache_ttl) {
+            return Ok(cached);
+        }
+        let url = format!("{}/models", self.base_url);
+        let response = self
+            .client
+            .get(&url)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .send()
+            .await?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(ProviderError::from_response(status, &body, ""));
+        }
+        let body: Value = response.json().await.map_err(ProviderError::Network)?;
+        let models: Vec<ModelInfo> = body
+            .get("data")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|m| {
+                        let id = m.get("id")?.as_str()?.to_string();
+                        Some(ModelInfo {
+                            display_name: id.clone(),
+                            id,
+                            context_length: 0,
+                            pricing: None,
+                            features: ModelFeatures::default(),
+                            top_provider: m
+                                .get("owned_by")
+                                .and_then(|v| v.as_str())
+                                .map(String::from),
+                        })
+                    })
+                    .collect::<Vec<ModelInfo>>()
+            })
+            .unwrap_or_default();
+        let _ = write_cache(&self.base_url, &models);
+        Ok(models)
+    }
+}
+
+// ─── Construction ─────────────────────────────────────────────────────────
+
+/// Pick the right catalog for a given base_url. Detects OpenRouter via the
+/// host; everything else falls back to the sparse OpenAI shape (which most
+/// OpenAI-compatible providers also serve).
+pub fn for_base_url(
+    client: Client,
+    base_url: &str,
+    api_key: &str,
+    cache_ttl: Duration,
+) -> Box<dyn ProviderCatalog> {
+    if base_url.contains("openrouter.ai") {
+        Box::new(OpenRouterCatalog::new(client, base_url, api_key, cache_ttl))
+    } else {
+        Box::new(OpenAICatalog::new(client, base_url, api_key, cache_ttl))
+    }
+}
+
+// ─── Cache layer ─────────────────────────────────────────────────────────
+
+#[derive(Serialize, Deserialize)]
+struct CacheFile {
+    fetched_at_unix: u64,
+    models: Vec<ModelInfo>,
+}
+
+fn cache_path(base_url: &str) -> PathBuf {
+    let host = host_slug(base_url);
+    crate::config::vulcan_home()
+        .join("cache")
+        .join(format!("{host}_models.json"))
+}
+
+fn host_slug(base_url: &str) -> String {
+    base_url
+        .replace("https://", "")
+        .replace("http://", "")
+        .replace('/', "_")
+        .replace(':', "_")
+}
+
+fn read_cache(base_url: &str, ttl: Duration) -> Option<Vec<ModelInfo>> {
+    let path = cache_path(base_url);
+    let bytes = std::fs::read(&path).ok()?;
+    let cache: CacheFile = serde_json::from_slice(&bytes).ok()?;
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .ok()?
+        .as_secs();
+    if now.saturating_sub(cache.fetched_at_unix) > ttl.as_secs() {
+        tracing::debug!("catalog cache for {base_url} is stale");
+        return None;
+    }
+    Some(cache.models)
+}
+
+fn write_cache(base_url: &str, models: &[ModelInfo]) -> Result<()> {
+    let path = cache_path(base_url);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)?
+        .as_secs();
+    let cache = CacheFile {
+        fetched_at_unix: now,
+        models: models.to_vec(),
+    };
+    let json = serde_json::to_vec_pretty(&cache)?;
+    std::fs::write(path, json)?;
+    Ok(())
+}
+
+// ─── Validation helper ─────────────────────────────────────────────────────
+
+/// Find the closest model IDs to `target` by Damerau-Levenshtein distance.
+/// Returns up to `limit` candidates ordered by similarity.
+pub fn fuzzy_suggest(models: &[ModelInfo], target: &str, limit: usize) -> Vec<String> {
+    let mut scored: Vec<(usize, &str)> = models
+        .iter()
+        .map(|m| {
+            let d = strsim::damerau_levenshtein(&m.id.to_lowercase(), &target.to_lowercase());
+            (d, m.id.as_str())
+        })
+        .collect();
+    scored.sort_by_key(|(d, _)| *d);
+    scored
+        .into_iter()
+        .take(limit)
+        .map(|(_, id)| id.to_string())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_openrouter_extracts_pricing_and_features() {
+        let body = serde_json::json!({
+            "data": [
+                {
+                    "id": "deepseek/deepseek-v4-flash",
+                    "name": "DeepSeek V4 Flash",
+                    "context_length": 128000,
+                    "pricing": {
+                        "prompt": "0.00000028",
+                        "completion": "0.0000011"
+                    },
+                    "supported_parameters": ["tools", "tool_choice", "response_format", "include_reasoning"],
+                    "architecture": {
+                        "input_modalities": ["text"]
+                    },
+                    "top_provider": { "name": "DeepSeek" }
+                },
+                {
+                    "id": "openai/gpt-4o",
+                    "name": "GPT-4o",
+                    "context_length": 128000,
+                    "pricing": {
+                        "prompt": "0.0000025",
+                        "completion": "0.00001"
+                    },
+                    "supported_parameters": ["tools", "response_format"],
+                    "architecture": {
+                        "input_modalities": ["text", "image"]
+                    },
+                    "top_provider": { "name": "OpenAI" }
+                }
+            ]
+        });
+
+        let models = parse_openrouter(&body);
+        assert_eq!(models.len(), 2);
+
+        let deepseek = &models[0];
+        assert_eq!(deepseek.id, "deepseek/deepseek-v4-flash");
+        assert_eq!(deepseek.context_length, 128000);
+        let pricing = deepseek.pricing.as_ref().unwrap();
+        assert!((pricing.input_per_token - 0.00000028).abs() < f64::EPSILON);
+        assert!(deepseek.features.tools);
+        assert!(deepseek.features.json_mode);
+        assert!(deepseek.features.reasoning);
+        assert!(!deepseek.features.vision);
+        assert_eq!(deepseek.top_provider.as_deref(), Some("DeepSeek"));
+
+        let gpt = &models[1];
+        assert!(gpt.features.tools);
+        assert!(gpt.features.json_mode);
+        assert!(gpt.features.vision); // image modality
+        assert!(!gpt.features.reasoning);
+    }
+
+    #[test]
+    fn fuzzy_suggest_finds_close_matches() {
+        let models = vec![
+            ModelInfo {
+                id: "deepseek/deepseek-v4-flash".into(),
+                display_name: "DeepSeek V4 Flash".into(),
+                context_length: 128000,
+                pricing: None,
+                features: ModelFeatures::default(),
+                top_provider: None,
+            },
+            ModelInfo {
+                id: "deepseek/deepseek-chat".into(),
+                display_name: "DeepSeek Chat".into(),
+                context_length: 32000,
+                pricing: None,
+                features: ModelFeatures::default(),
+                top_provider: None,
+            },
+            ModelInfo {
+                id: "openai/gpt-4o".into(),
+                display_name: "GPT-4o".into(),
+                context_length: 128000,
+                pricing: None,
+                features: ModelFeatures::default(),
+                top_provider: None,
+            },
+        ];
+
+        let suggestions = fuzzy_suggest(&models, "deepseek/deepseek-v4-flsh", 3);
+        // Closest match should be the deepseek-v4-flash slug.
+        assert_eq!(suggestions[0], "deepseek/deepseek-v4-flash");
+    }
+}

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -1,3 +1,4 @@
+pub mod catalog;
 pub mod openai;
 
 #[cfg(test)]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -137,7 +137,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
     // ── Long-lived agent: one per TUI session, shared across prompts so
     // hook handlers' state (audit log, rate limits, etc.) survives turns.
     let agent = Arc::new(Mutex::new(
-        Agent::with_hooks_and_pause(config, hook_reg, Some(pause_tx))?,
+        Agent::with_hooks_and_pause(config, hook_reg, Some(pause_tx)).await?,
     ));
 
     // ── Apply resume target if any. Errors here are non-fatal — we report


### PR DESCRIPTION
The first version called the catalog from a synthetic
'Builder::new_current_thread().build()?' / 'block_on' inside the
already-running '#[tokio::main]' runtime — tokio panics on nested
runtimes:

  thread 'main' panicked at src/agent.rs: Cannot start a runtime
  from within a runtime.

Fix: make Agent::new / with_hooks / with_hooks_and_pause async.
The catalog fetch is now a normal '.await' on the parent runtime.
Callers in main.rs and tui/mod.rs add '.await'. No behaviour change
beyond the fix.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>