### PR TITLE
YYC-39: Tool argument validation + json-mode plumbing + provider debug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ config.toml
 # Local planning artifacts
 .hermes/
 /Private
+/.codex
+/docs/plans

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Vulcan is a pure-Rust personal AI agent (CLI + TUI). The binary is `vulcan`; chat is the default subcommand.
 
+## Github PR flow
+
+- This project uses Graphite for pr stacks and review. Branches should follow linear best practice for best sync between github state and linear
+
 ## Where work is tracked and planned
 
-- **Linear** is the source of truth for tasks. Workspace team **Yycholla**, project **Vulcan — Rust AI Agent** — issues use the `YYC-` prefix. Check existing issues before creating new ones; ask before bulk-creating tickets.
+- **Linear** is the source of truth for tasks. Workspace team **Yycholla**, project **Vulcan — Rust AI Agent** — issues use the `YYC-` prefix. Check existing issues before creating new ones; ask before bulk-creating tickets. Group under an epic issue where possible.
 - **`~/wiki/queries/rust-hermes-plan.md`** is the master vision (Phase 1 → 2 → 3, locked Phase 1 scope, tool trait + provider trait shapes). Anything that contradicts the plan is either an open question or a documentation lag — don't silently diverge.
 - **`~/wiki/queries/`** also holds design docs (e.g. `hooks-design.md` once written) — prefer adding cross-cutting design docs there, not in the repo.
 
@@ -27,6 +31,8 @@ Logging: TUI mode logs to a file (so `tracing` output doesn't splat the screen);
 Config: `~/.vulcan/config.toml` (see `config.example.toml`). API key via `VULCAN_API_KEY` env var or the config file.
 
 ## Architecture worth reading multiple files to understand
+
+Currently features and architecture should be focused on creating an excellent foundation for further features and maintenance.
 
 **The hook system is the foundation surface.** It's the in-tree precursor to the OpenClaw-style plugin architecture in the master plan. Reading order: `src/hooks/mod.rs` → `src/hooks/audit.rs` (reference handler) → `src/hooks/skills.rs` (built-in BeforePrompt) → how `src/agent.rs` wires the five events.
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -21,6 +21,11 @@ max_retries = 4
 catalog_cache_ttl_hours = 24
 # Skip the catalog fetch entirely. Useful for offline/testing setups.
 # disable_catalog = false
+# Provider protocol debug logging:
+# - "off": no extra provider logs
+# - "tool-fallback": log raw assistant content when fallback tool-call parsing is used
+# - "wire": also log request and raw response bodies
+# debug = "off"
 
 [tools]
 # Enable dangerous tools (file overwrite, shell exec) without confirmation

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -79,20 +79,23 @@ impl Agent {
         // if the catalog endpoint fails, we log + continue with the configured
         // values rather than blocking startup over a metadata fetch.
         let mut effective_max_context = config.provider.max_context;
+        let mut supports_json_mode = false;
         if !config.provider.disable_catalog {
             match Self::fetch_catalog(config, &api_key).await {
                 Ok(models) => {
                     let found = models.iter().find(|m| m.id == config.provider.model);
                     match found {
                         Some(model_info) => {
+                            supports_json_mode = model_info.features.json_mode;
                             if model_info.context_length > 0
                                 && config.provider.max_context == 128_000
                             {
                                 effective_max_context = model_info.context_length;
                                 tracing::info!(
-                                    "catalog: using context_length={} for {}",
+                                    "catalog: using context_length={} for {} (json_mode={})",
                                     model_info.context_length,
-                                    model_info.id
+                                    model_info.id,
+                                    supports_json_mode,
                                 );
                             }
                         }
@@ -117,9 +120,7 @@ impl Agent {
                     }
                 }
                 Err(e) => {
-                    tracing::warn!(
-                        "catalog fetch failed (continuing with config defaults): {e}"
-                    );
+                    tracing::warn!("catalog fetch failed (continuing with config defaults): {e}");
                 }
             }
         }
@@ -131,6 +132,8 @@ impl Agent {
                 &config.provider.model,
                 effective_max_context,
                 config.provider.max_retries,
+                supports_json_mode,
+                config.provider.debug,
             )
             .context("Failed to initialize LLM provider")?,
         );
@@ -289,9 +292,15 @@ impl Agent {
             // ── BeforePrompt: handlers may inject extra messages. Injections
             // are transient — they go on the wire but don't persist into the
             // conversation history we save to memory.
-            let outgoing = self.hooks.apply_before_prompt(&messages, cancel.clone()).await;
+            let outgoing = self
+                .hooks
+                .apply_before_prompt(&messages, cancel.clone())
+                .await;
 
-            let response = self.provider.chat(&outgoing, &tool_defs, cancel.clone()).await?;
+            let response = self
+                .provider
+                .chat(&outgoing, &tool_defs, cancel.clone())
+                .await?;
 
             if let Some(usage) = &response.usage {
                 self.context
@@ -320,13 +329,16 @@ impl Agent {
                 let reasoning = response.reasoning_content.clone();
 
                 // ── BeforeAgentEnd: a handler may force the loop to continue.
-                if let Some(instruction) = self.hooks.before_agent_end(&text, cancel.clone()).await {
+                if let Some(instruction) = self.hooks.before_agent_end(&text, cancel.clone()).await
+                {
                     messages.push(Message::Assistant {
                         content: Some(text.clone()),
                         tool_calls: None,
                         reasoning_content: reasoning,
                     });
-                    messages.push(Message::User { content: instruction });
+                    messages.push(Message::User {
+                        content: instruction,
+                    });
                     continue;
                 }
 
@@ -381,10 +393,16 @@ impl Agent {
                 return Ok("Cancelled".to_string());
             }
 
-            tracing::info!("agent iteration {iteration} starting (messages={})", messages.len());
+            tracing::info!(
+                "agent iteration {iteration} starting (messages={})",
+                messages.len()
+            );
 
             // ── BeforePrompt (transient — see run_prompt for rationale).
-            let outgoing = self.hooks.apply_before_prompt(&messages, cancel.clone()).await;
+            let outgoing = self
+                .hooks
+                .apply_before_prompt(&messages, cancel.clone())
+                .await;
 
             let (inner_tx, mut inner_rx) = mpsc::unbounded_channel::<StreamEvent>();
             let (priv_tx, mut priv_rx) = mpsc::unbounded_channel::<StreamEvent>();
@@ -461,7 +479,11 @@ impl Agent {
                 "agent iteration {iteration}: response content_len={}, tool_calls={}, reasoning_len={}",
                 response.content.as_deref().map(|s| s.len()).unwrap_or(0),
                 response.tool_calls.as_ref().map(|t| t.len()).unwrap_or(0),
-                response.reasoning_content.as_deref().map(|s| s.len()).unwrap_or(0),
+                response
+                    .reasoning_content
+                    .as_deref()
+                    .map(|s| s.len())
+                    .unwrap_or(0),
             );
 
             if let Some(text) = &response.content {
@@ -501,13 +523,19 @@ impl Agent {
                 let reasoning = response.reasoning_content.clone();
 
                 // ── BeforeAgentEnd
-                if let Some(instruction) = self.hooks.before_agent_end(&full_response, cancel.clone()).await {
+                if let Some(instruction) = self
+                    .hooks
+                    .before_agent_end(&full_response, cancel.clone())
+                    .await
+                {
                     messages.push(Message::Assistant {
                         content: Some(full_response.clone()),
                         tool_calls: None,
                         reasoning_content: reasoning,
                     });
-                    messages.push(Message::User { content: instruction });
+                    messages.push(Message::User {
+                        content: instruction,
+                    });
                     continue;
                 }
 
@@ -560,10 +588,7 @@ impl Agent {
             .load_history(session_id)?
             .ok_or_else(|| anyhow::anyhow!("Session not found: {session_id}"))?;
         self.session_id = session_id.to_string();
-        tracing::info!(
-            "resumed session {session_id} ({} messages)",
-            history.len()
-        );
+        tracing::info!("resumed session {session_id} ({} messages)", history.len());
         Ok(())
     }
 
@@ -608,26 +633,37 @@ impl Agent {
             }
         };
 
-        let (effective_args_str, blocked) =
-            match self.hooks.before_tool_call(name, &parsed_args, cancel.clone()).await {
-                ToolCallDecision::Continue => (raw_args.to_string(), None),
-                ToolCallDecision::Block(reason) => (raw_args.to_string(), Some(reason)),
-                ToolCallDecision::ReplaceArgs(new_args) => (
-                    serde_json::to_string(&new_args).unwrap_or_else(|_| raw_args.to_string()),
-                    None,
-                ),
-            };
+        let (effective_args_str, blocked) = match self
+            .hooks
+            .before_tool_call(name, &parsed_args, cancel.clone())
+            .await
+        {
+            ToolCallDecision::Continue => (raw_args.to_string(), None),
+            ToolCallDecision::Block(reason) => (raw_args.to_string(), Some(reason)),
+            ToolCallDecision::ReplaceArgs(new_args) => (
+                serde_json::to_string(&new_args).unwrap_or_else(|_| raw_args.to_string()),
+                None,
+            ),
+        };
 
         let raw_result: ToolResult = if let Some(reason) = blocked {
             ToolResult::err(format!("Blocked: {reason}"))
         } else {
-            match self.tools.execute(name, &effective_args_str, cancel.clone()).await {
+            match self
+                .tools
+                .execute(name, &effective_args_str, cancel.clone())
+                .await
+            {
                 Ok(r) => r,
                 Err(e) => ToolResult::err(format!("Error: {e}")),
             }
         };
 
-        match self.hooks.after_tool_call(name, &raw_result, cancel.clone()).await {
+        match self
+            .hooks
+            .after_tool_call(name, &raw_result, cancel.clone())
+            .await
+        {
             Some(replaced) => replaced,
             None => raw_result,
         }
@@ -748,7 +784,11 @@ mod tests {
         assert_eq!(resp, "Read failed but that's fine for the test");
 
         let calls = mock.captured_calls();
-        assert_eq!(calls.len(), 2, "should call provider twice (tool, then final)");
+        assert_eq!(
+            calls.len(),
+            2,
+            "should call provider twice (tool, then final)"
+        );
 
         // Iteration 1's messages should include the tool result.
         let iter1 = &calls[1];
@@ -800,4 +840,5 @@ mod tests {
         // run_prompt's final save_messages would have stored the reasoning;
         // not asserting against the DB to avoid touching ~/.vulcan in tests.
     }
+
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,6 +27,25 @@ pub struct Config {
     pub compaction: CompactionConfig,
 }
 
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum ProviderDebugMode {
+    #[default]
+    Off,
+    ToolFallback,
+    Wire,
+}
+
+impl ProviderDebugMode {
+    pub fn logs_wire(self) -> bool {
+        matches!(self, Self::Wire)
+    }
+
+    pub fn logs_tool_fallback(self) -> bool {
+        matches!(self, Self::ToolFallback | Self::Wire)
+    }
+}
+
 #[derive(Debug, Deserialize, Clone)]
 pub struct ProviderConfig {
     /// Provider type: "openai-compat" (covers OpenRouter, Anthropic, Ollama, etc.)
@@ -56,6 +75,13 @@ pub struct ProviderConfig {
     /// regardless; this just avoids the extra HTTP roundtrip on launch.
     #[serde(default)]
     pub disable_catalog: bool,
+    /// Provider protocol debugging:
+    /// - "off": no extra provider logging
+    /// - "tool-fallback": log raw assistant content when content-shaped tool
+    ///   fallback parsing is used
+    /// - "wire": also log request and raw response bodies
+    #[serde(default)]
+    pub debug: ProviderDebugMode,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -89,6 +115,7 @@ impl Default for ProviderConfig {
             max_retries: default_max_retries(),
             catalog_cache_ttl_hours: default_catalog_cache_ttl_hours(),
             disable_catalog: false,
+            debug: ProviderDebugMode::Off,
         }
     }
 }
@@ -164,8 +191,9 @@ impl Config {
 
         for (label, path) in &candidates {
             if path.exists() {
-                let content = std::fs::read_to_string(path)
-                    .with_context(|| format!("Failed to read config at {label} ({})", path.display()))?;
+                let content = std::fs::read_to_string(path).with_context(|| {
+                    format!("Failed to read config at {label} ({})", path.display())
+                })?;
                 let config: Config =
                     toml::from_str(&content).context("Failed to parse config.toml")?;
                 tracing::info!("Loaded config from {}", path.display());
@@ -185,5 +213,35 @@ impl Config {
         std::env::var("VULCAN_API_KEY")
             .ok()
             .or_else(|| self.provider.api_key.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_debug_mode_parses_from_toml() {
+        let config: Config = toml::from_str(
+            r#"
+[provider]
+debug = "wire"
+"#,
+        )
+        .expect("config should parse");
+
+        assert!(matches!(config.provider.debug, ProviderDebugMode::Wire));
+    }
+
+    #[test]
+    fn provider_debug_mode_helpers_match_expected_scopes() {
+        assert!(!ProviderDebugMode::Off.logs_wire());
+        assert!(!ProviderDebugMode::Off.logs_tool_fallback());
+
+        assert!(!ProviderDebugMode::ToolFallback.logs_wire());
+        assert!(ProviderDebugMode::ToolFallback.logs_tool_fallback());
+
+        assert!(ProviderDebugMode::Wire.logs_wire());
+        assert!(ProviderDebugMode::Wire.logs_tool_fallback());
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -98,9 +98,7 @@ impl ContextManager {
             .iter()
             .map(|m| match m {
                 Message::User { content } => content.clone(),
-                Message::Assistant { content, .. } => {
-                    content.clone().unwrap_or_default()
-                }
+                Message::Assistant { content, .. } => content.clone().unwrap_or_default(),
                 Message::Tool { content, .. } => content.clone(),
                 Message::System { content } => content.clone(),
             })

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -214,7 +214,10 @@ impl HookRegistry {
         cancel: CancellationToken,
     ) -> ToolCallDecision {
         for h in &self.handlers {
-            match self.run(h, h.before_tool_call(tool, args, cancel.clone())).await {
+            match self
+                .run(h, h.before_tool_call(tool, args, cancel.clone()))
+                .await
+            {
                 Some(HookOutcome::Block { reason }) => {
                     tracing::info!("hook {} blocked tool {tool}: {reason}", h.name());
                     return ToolCallDecision::Block(reason);
@@ -244,7 +247,10 @@ impl HookRegistry {
         cancel: CancellationToken,
     ) -> Option<ToolResult> {
         for h in &self.handlers {
-            match self.run(h, h.after_tool_call(tool, result, cancel.clone())).await {
+            match self
+                .run(h, h.after_tool_call(tool, result, cancel.clone()))
+                .await
+            {
                 Some(HookOutcome::ReplaceResult(new)) => {
                     tracing::info!("hook {} replaced result for {tool}", h.name());
                     return Some(new);
@@ -270,7 +276,10 @@ impl HookRegistry {
         cancel: CancellationToken,
     ) -> Option<String> {
         for h in &self.handlers {
-            match self.run(h, h.before_agent_end(response, cancel.clone())).await {
+            match self
+                .run(h, h.before_agent_end(response, cancel.clone()))
+                .await
+            {
                 Some(HookOutcome::ForceContinue { instruction }) => {
                     tracing::info!("hook {} forced continue", h.name());
                     return Some(instruction);
@@ -298,11 +307,7 @@ impl HookRegistry {
 
     pub async fn session_end(&self, session_id: &str, total_turns: u32) {
         for h in &self.handlers {
-            let _ = timeout(
-                self.handler_timeout,
-                h.session_end(session_id, total_turns),
-            )
-            .await;
+            let _ = timeout(self.handler_timeout, h.session_end(session_id, total_turns)).await;
         }
     }
 
@@ -443,8 +448,7 @@ mod tests {
 
     #[tokio::test]
     async fn handler_timeout_does_not_break_loop() {
-        let mut reg =
-            HookRegistry::new().with_timeout(std::time::Duration::from_millis(50));
+        let mut reg = HookRegistry::new().with_timeout(std::time::Duration::from_millis(50));
         // First handler sleeps past the timeout window.
         let slow = Arc::new(
             Probe::new(

--- a/src/hooks/safety.rs
+++ b/src/hooks/safety.rs
@@ -244,9 +244,7 @@ mod tests {
         let hook_arc = std::sync::Arc::new(hook);
         let h = hook_arc.clone();
         let c = cancel.clone();
-        let task = tokio::spawn(async move {
-            h.before_tool_call("bash", &args, c).await
-        });
+        let task = tokio::spawn(async move { h.before_tool_call("bash", &args, c).await });
 
         // Simulate the TUI consuming the pause and sending AllowAndRemember.
         let pause = rx.recv().await.expect("pause should arrive");
@@ -254,7 +252,10 @@ mod tests {
             PauseKind::SafetyApproval { command, .. } => assert_eq!(command, dangerous),
             other => panic!("expected SafetyApproval, got {other:?}"),
         }
-        pause.reply.send(AgentResume::AllowAndRemember).expect("reply ok");
+        pause
+            .reply
+            .send(AgentResume::AllowAndRemember)
+            .expect("reply ok");
 
         // Hook should now resolve to Continue.
         let outcome = task.await.expect("task ok").expect("hook ok");

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,8 +58,7 @@ async fn main() -> anyhow::Result<()> {
 
 /// Log to stderr for CLI/one-shot mode — fine because there's no TUI
 fn init_cli_logging() {
-    let filter = EnvFilter::try_from_env("VULCAN_LOG")
-        .unwrap_or_else(|_| EnvFilter::new("info"));
+    let filter = EnvFilter::try_from_env("VULCAN_LOG").unwrap_or_else(|_| EnvFilter::new("info"));
     tracing_subscriber::fmt()
         .with_env_filter(filter)
         .with_writer(std::io::stderr)
@@ -72,12 +71,10 @@ fn init_tui_logging() {
     std::fs::create_dir_all(&log_dir).ok();
     let log_path = log_dir.join("vulcan.log");
 
-    let file = std::fs::File::create(&log_path).unwrap_or_else(|_| {
-        std::fs::File::open("/dev/null").unwrap()
-    });
+    let file = std::fs::File::create(&log_path)
+        .unwrap_or_else(|_| std::fs::File::open("/dev/null").unwrap());
 
-    let filter = EnvFilter::try_from_env("VULCAN_LOG")
-        .unwrap_or_else(|_| EnvFilter::new("info"));
+    let filter = EnvFilter::try_from_env("VULCAN_LOG").unwrap_or_else(|_| EnvFilter::new("info"));
     tracing_subscriber::fmt()
         .with_env_filter(filter)
         .with_writer(file)

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -3,7 +3,6 @@
 /// This module defines the abstraction for sending and receiving messages
 /// across different platforms. Phase 1 uses the CLI platform (stdin/stdout/TUI).
 /// Phase 2 adds Telegram (teloxide) and Discord (serenity).
-
 use anyhow::Result;
 
 /// A message from a user on any platform

--- a/src/prompt_builder.rs
+++ b/src/prompt_builder.rs
@@ -8,7 +8,7 @@ impl PromptBuilder {
         let tool_section = format!(
             "## Available Tools\n\
              You have access to the following tools. When you need to perform an action, \
-             respond with a `tool_calls` array:\n\n{}\n",
+             call the appropriate tool directly through the tool-calling interface:\n\n{}\n",
             tools
                 .definitions()
                 .iter()
@@ -29,7 +29,31 @@ impl PromptBuilder {
              {tool_section}\n\
              ## Response Format\n\
              Respond naturally. If the user's request doesn't need tools, just answer directly. \
-             When tools are needed, include a `tool_calls` block with the appropriate function calls."
+             When tools are needed, call the tool directly instead of printing a JSON blob or a literal \
+             `tool_calls` block in assistant text. Tool call arguments must be valid JSON matching the tool schema."
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn system_prompt_mentions_json_for_tool_call_mode() {
+        let prompt = PromptBuilder.build_system_prompt(&ToolRegistry::new());
+        assert!(
+            prompt.to_lowercase().contains("json"),
+            "prompt must mention json for providers that require it when json_object mode is enabled: {prompt:?}"
+        );
+    }
+
+    #[test]
+    fn system_prompt_does_not_tell_models_to_print_literal_tool_calls_blocks() {
+        let prompt = PromptBuilder.build_system_prompt(&ToolRegistry::new());
+        assert!(
+            !prompt.contains("include a `tool_calls` block"),
+            "prompt should instruct native tool calling, not literal tool_calls text output: {prompt:?}"
+        );
     }
 }

--- a/src/provider/catalog.rs
+++ b/src/provider/catalog.rs
@@ -51,10 +51,7 @@ pub struct ModelFeatures {
 pub trait ProviderCatalog: Send + Sync {
     async fn list_models(&self) -> std::result::Result<Vec<ModelInfo>, ProviderError>;
 
-    async fn get_model(
-        &self,
-        id: &str,
-    ) -> std::result::Result<Option<ModelInfo>, ProviderError> {
+    async fn get_model(&self, id: &str) -> std::result::Result<Option<ModelInfo>, ProviderError> {
         let models = self.list_models().await?;
         Ok(models.into_iter().find(|m| m.id == id))
     }
@@ -132,7 +129,10 @@ fn parse_openrouter(body: &Value) -> Vec<ModelInfo> {
                 .map(String::from);
             // OpenRouter pricing is given as strings like "0.00000028" per token.
             let pricing = m.get("pricing").and_then(|p| {
-                let inp = p.get("prompt").and_then(|v| v.as_str()).and_then(|s| s.parse::<f64>().ok())?;
+                let inp = p
+                    .get("prompt")
+                    .and_then(|v| v.as_str())
+                    .and_then(|s| s.parse::<f64>().ok())?;
                 let out = p
                     .get("completion")
                     .and_then(|v| v.as_str())
@@ -165,8 +165,10 @@ fn parse_openrouter(body: &Value) -> Vec<ModelInfo> {
                     .get("supported_parameters")
                     .and_then(|v| v.as_array())
                     .map(|a| {
-                        a.iter()
-                            .any(|s| s.as_str() == Some("reasoning") || s.as_str() == Some("include_reasoning"))
+                        a.iter().any(|s| {
+                            s.as_str() == Some("reasoning")
+                                || s.as_str() == Some("include_reasoning")
+                        })
                     })
                     .unwrap_or(false),
             };

--- a/src/provider/mock.rs
+++ b/src/provider/mock.rs
@@ -148,10 +148,7 @@ impl LLMProvider for MockProvider {
         _tools: &[ToolDefinition],
         _cancel: CancellationToken,
     ) -> Result<ChatResponse> {
-        self.captured_calls
-            .lock()
-            .unwrap()
-            .push(messages.to_vec());
+        self.captured_calls.lock().unwrap().push(messages.to_vec());
         let r = self.next_response()?;
         Self::build_chat_response(r)
     }
@@ -163,10 +160,7 @@ impl LLMProvider for MockProvider {
         tx: mpsc::UnboundedSender<StreamEvent>,
         _cancel: CancellationToken,
     ) -> Result<()> {
-        self.captured_calls
-            .lock()
-            .unwrap()
-            .push(messages.to_vec());
+        self.captured_calls.lock().unwrap().push(messages.to_vec());
         let r = self.next_response()?;
 
         match &r {

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -8,8 +8,8 @@ use std::fmt;
 use std::time::Duration;
 
 use anyhow::Result;
-use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use serde::ser::SerializeStruct;
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use serde_json::Value;
 use tokio::sync::mpsc;
 
@@ -46,7 +46,9 @@ impl fmt::Display for ProviderError {
                 "Authentication failed: {message}. \
                  Check your API key in ~/.vulcan/config.toml or set the VULCAN_API_KEY env var."
             ),
-            ProviderError::RateLimited { retry_after: Some(d) } => write!(
+            ProviderError::RateLimited {
+                retry_after: Some(d),
+            } => write!(
                 f,
                 "Rate limited by provider. Suggested retry after {}s.",
                 d.as_secs().max(1)
@@ -151,7 +153,11 @@ impl From<reqwest::Error> for ProviderError {
 fn extract_error_message(body: &str) -> Option<String> {
     let v: serde_json::Value = serde_json::from_str(body).ok()?;
     // Top-level error.message
-    if let Some(m) = v.get("error").and_then(|e| e.get("message")).and_then(|m| m.as_str()) {
+    if let Some(m) = v
+        .get("error")
+        .and_then(|e| e.get("message"))
+        .and_then(|m| m.as_str())
+    {
         // OpenRouter-style: error.metadata.raw is a JSON string with an inner
         // error.message that's the actual provider message. Surface that if present.
         if let Some(raw) = v
@@ -243,7 +249,10 @@ impl Serialize for Message {
                 }
                 s.end()
             }
-            Message::Tool { tool_call_id, content } => {
+            Message::Tool {
+                tool_call_id,
+                content,
+            } => {
                 let mut s = serializer.serialize_struct("Message", 3)?;
                 s.serialize_field("role", "tool")?;
                 s.serialize_field("tool_call_id", tool_call_id)?;

--- a/src/provider/openai.rs
+++ b/src/provider/openai.rs
@@ -1,9 +1,10 @@
+use crate::config::ProviderDebugMode;
 use crate::provider::{
     ChatResponse, LLMProvider, Message, ProviderError, StreamEvent, ToolCall, ToolDefinition, Usage,
 };
 use anyhow::{Context, Result};
 use reqwest::Client;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
@@ -16,6 +17,12 @@ pub struct OpenAIProvider {
     model: String,
     max_context: usize,
     max_retries: u32,
+    /// Capability metadata from the provider catalog. This tells us the model
+    /// can support structured outputs if some future caller explicitly asks
+    /// for them, but normal chat/tool turns do not auto-enable
+    /// `response_format`.
+    _supports_json_mode: bool,
+    debug_mode: ProviderDebugMode,
 }
 
 impl OpenAIProvider {
@@ -25,6 +32,8 @@ impl OpenAIProvider {
         model: &str,
         max_context: usize,
         max_retries: u32,
+        supports_json_mode: bool,
+        debug_mode: ProviderDebugMode,
     ) -> Result<Self> {
         let client = Client::builder()
             .timeout(Duration::from_secs(300))
@@ -38,6 +47,8 @@ impl OpenAIProvider {
             model: model.to_string(),
             max_context,
             max_retries,
+            _supports_json_mode: supports_json_mode,
+            debug_mode,
         })
     }
 
@@ -71,6 +82,15 @@ impl OpenAIProvider {
     ) -> std::result::Result<reqwest::Response, ProviderError> {
         let url = format!("{}/chat/completions", self.base_url);
         let body = self.build_request(messages, tools);
+        if self.debug_mode.logs_wire() {
+            tracing::info!(
+                provider = "openai-compat",
+                model = %self.model,
+                url = %url,
+                request_body = %body,
+                "provider wire request"
+            );
+        }
 
         let mut last_err: Option<ProviderError> = None;
         for attempt in 0..=self.max_retries {
@@ -239,6 +259,241 @@ impl OpenAIProvider {
     }
 }
 
+fn log_tool_fallback_if_enabled(
+    debug_mode: ProviderDebugMode,
+    model: &str,
+    content: &str,
+    finish_reason: Option<&str>,
+    inferred_tool_calls: &[ToolCall],
+) {
+    if !debug_mode.logs_tool_fallback() || inferred_tool_calls.is_empty() {
+        return;
+    }
+
+    let tool_names = inferred_tool_calls
+        .iter()
+        .map(|tc| tc.function.name.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    tracing::info!(
+        provider = "openai-compat",
+        model = %model,
+        finish_reason = finish_reason.unwrap_or(""),
+        inferred_tools = %tool_names,
+        assistant_content = %content,
+        "provider response used content-shaped tool-call fallback"
+    );
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct WireResponseSummary {
+    raw_body: Option<String>,
+    sse_data_lines: usize,
+    has_done_marker: bool,
+    non_sse_preview: Option<String>,
+}
+
+fn summarize_wire_response(raw: &str) -> WireResponseSummary {
+    let mut sse_data_lines = 0;
+    let mut has_done_marker = false;
+    let mut non_sse_lines = Vec::new();
+
+    for line in raw.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if trimmed.starts_with("data: ") {
+            sse_data_lines += 1;
+            if trimmed == "data: [DONE]" {
+                has_done_marker = true;
+            }
+        } else {
+            non_sse_lines.push(trimmed.to_string());
+        }
+    }
+
+    if sse_data_lines > 0 {
+        let preview =
+            (!non_sse_lines.is_empty()).then(|| truncate(&non_sse_lines.join("\n"), 2_000));
+        WireResponseSummary {
+            raw_body: None,
+            sse_data_lines,
+            has_done_marker,
+            non_sse_preview: preview,
+        }
+    } else {
+        WireResponseSummary {
+            raw_body: Some(raw.to_string()),
+            sse_data_lines: 0,
+            has_done_marker: false,
+            non_sse_preview: None,
+        }
+    }
+}
+
+fn log_wire_response(model: &str, raw: &str) {
+    let summary = summarize_wire_response(raw);
+    if let Some(body) = summary.raw_body {
+        tracing::info!(
+            provider = "openai-compat",
+            model = %model,
+            response_body = %body,
+            "provider wire response"
+        );
+    } else {
+        tracing::info!(
+            provider = "openai-compat",
+            model = %model,
+            sse_data_lines = summary.sse_data_lines,
+            has_done_marker = summary.has_done_marker,
+            non_sse_preview = summary.non_sse_preview.as_deref().unwrap_or(""),
+            "provider wire response (stream summary; completion chunks suppressed)"
+        );
+    }
+}
+
+fn maybe_strip_json_fence(content: &str) -> &str {
+    let trimmed = content.trim();
+    if let Some(rest) = trimmed.strip_prefix("```json") {
+        return rest.strip_suffix("```").unwrap_or(rest).trim();
+    }
+    if let Some(rest) = trimmed.strip_prefix("```") {
+        return rest.strip_suffix("```").unwrap_or(rest).trim();
+    }
+    trimmed
+}
+
+fn missing_required_keys(schema: &Value, params: &Value) -> Option<Vec<String>> {
+    let required = schema.get("required")?.as_array()?;
+    let provided = params.as_object()?;
+    let missing = required
+        .iter()
+        .filter_map(|v| v.as_str())
+        .filter(|key| !provided.contains_key(*key))
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+    Some(missing)
+}
+
+fn score_tool_match(params: &Value, tool: &ToolDefinition) -> Option<(usize, usize)> {
+    let obj = params.as_object()?;
+    let schema = &tool.function.parameters;
+    let missing = missing_required_keys(schema, params)?;
+    if !missing.is_empty() {
+        return None;
+    }
+
+    let properties = schema
+        .get("properties")
+        .and_then(|v| v.as_object())
+        .cloned()
+        .unwrap_or_default();
+    let recognized = obj.keys().filter(|k| properties.contains_key(*k)).count();
+    let extras = obj.len().saturating_sub(recognized);
+    Some((recognized, extras))
+}
+
+fn infer_bare_object_tool_call(params: &Value, tools: &[ToolDefinition]) -> Option<ToolCall> {
+    let mut best: Option<(&ToolDefinition, usize, usize)> = None;
+
+    for tool in tools {
+        let Some((recognized, extras)) = score_tool_match(params, tool) else {
+            continue;
+        };
+
+        match best {
+            None => best = Some((tool, recognized, extras)),
+            Some((_, best_recognized, best_extras)) => {
+                if recognized > best_recognized
+                    || (recognized == best_recognized && extras < best_extras)
+                {
+                    best = Some((tool, recognized, extras));
+                } else if recognized == best_recognized && extras == best_extras {
+                    // Ambiguous match: don't guess.
+                    best = None;
+                }
+            }
+        }
+    }
+
+    let (tool, _, _) = best?;
+    Some(ToolCall {
+        id: "fallback_tool_call_0".into(),
+        call_type: "function".into(),
+        function: crate::provider::ToolCallFunction {
+            name: tool.function.name.clone(),
+            arguments: serde_json::to_string(params).ok()?,
+        },
+    })
+}
+
+fn infer_content_tool_calls(content: &str, tools: &[ToolDefinition]) -> Option<Vec<ToolCall>> {
+    if tools.is_empty() {
+        return None;
+    }
+
+    let trimmed = maybe_strip_json_fence(content);
+    let value: Value = serde_json::from_str(trimmed).ok()?;
+
+    if let Some(obj) = value.as_object() {
+        if let Some(tool_calls) = obj.get("tool_calls").and_then(|v| v.as_array()) {
+            let parsed = tool_calls
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, call)| {
+                    let call_obj = call.as_object()?;
+                    let function = call_obj.get("function")?.as_object()?;
+                    let name = function.get("name")?.as_str()?.to_string();
+                    let arguments = function.get("arguments")?;
+                    let arguments = if let Some(s) = arguments.as_str() {
+                        s.to_string()
+                    } else {
+                        serde_json::to_string(arguments).ok()?
+                    };
+                    Some(ToolCall {
+                        id: call_obj
+                            .get("id")
+                            .and_then(|v| v.as_str())
+                            .map(str::to_string)
+                            .unwrap_or_else(|| format!("fallback_tool_call_{idx}")),
+                        call_type: "function".into(),
+                        function: crate::provider::ToolCallFunction { name, arguments },
+                    })
+                })
+                .collect::<Vec<_>>();
+            if !parsed.is_empty() {
+                return Some(parsed);
+            }
+        }
+
+        if let Some(arguments) = obj.get("arguments").or_else(|| obj.get("params")) {
+            if let Some(name) = obj
+                .get("name")
+                .or_else(|| obj.get("tool"))
+                .or_else(|| obj.get("tool_name"))
+                .and_then(|v| v.as_str())
+            {
+                let arguments = if let Some(s) = arguments.as_str() {
+                    s.to_string()
+                } else {
+                    serde_json::to_string(arguments).ok()?
+                };
+                return Some(vec![ToolCall {
+                    id: "fallback_tool_call_0".into(),
+                    call_type: "function".into(),
+                    function: crate::provider::ToolCallFunction {
+                        name: name.to_string(),
+                        arguments,
+                    },
+                }]);
+            }
+        }
+    }
+
+    infer_bare_object_tool_call(&value, tools).map(|tc| vec![tc])
+}
+
 #[async_trait::async_trait]
 impl LLMProvider for OpenAIProvider {
     /// Buffered chat — collects full response, returns it all at once
@@ -257,6 +512,9 @@ impl LLMProvider for OpenAIProvider {
             } => res?,
         };
         let text = String::from_utf8_lossy(&bytes);
+        if self.debug_mode.logs_wire() {
+            log_wire_response(&self.model, &text);
+        }
 
         let mut content = String::new();
         let mut reasoning = String::new();
@@ -275,9 +533,29 @@ impl LLMProvider for OpenAIProvider {
             );
         }
 
+        let inferred_tool_calls = if tool_calls.is_empty() {
+            infer_content_tool_calls(&content, tools)
+        } else {
+            None
+        };
+        if let Some(inferred) = inferred_tool_calls.as_ref() {
+            log_tool_fallback_if_enabled(
+                self.debug_mode,
+                &self.model,
+                &content,
+                finish_reason.as_deref(),
+                inferred,
+            );
+        }
+        let content = if inferred_tool_calls.is_some() {
+            String::new()
+        } else {
+            content
+        };
+
         Ok(ChatResponse {
             content: Some(content).filter(|c| !c.is_empty()),
-            tool_calls: Some(tool_calls).filter(|c| !c.is_empty()),
+            tool_calls: inferred_tool_calls.or_else(|| Some(tool_calls).filter(|c| !c.is_empty())),
             usage,
             finish_reason,
             reasoning_content: Some(reasoning).filter(|r| !r.is_empty()),
@@ -303,6 +581,7 @@ impl LLMProvider for OpenAIProvider {
         let mut tool_calls: Vec<ToolCall> = Vec::new();
         let mut usage: Option<Usage> = None;
         let mut finish_reason: Option<String> = None;
+        let mut raw_stream = self.debug_mode.logs_wire().then(String::new);
 
         // Read the HTTP response as a byte stream — chunks arrive as the LLM generates
         let mut stream = response.bytes_stream();
@@ -320,6 +599,9 @@ impl LLMProvider for OpenAIProvider {
             };
             let chunk = chunk_result.context("Failed to read stream chunk")?;
             let chunk_str = String::from_utf8_lossy(&chunk);
+            if let Some(raw) = raw_stream.as_mut() {
+                raw.push_str(&chunk_str);
+            }
             buf.push_str(&chunk_str);
 
             // Process complete lines from the buffer
@@ -350,10 +632,34 @@ impl LLMProvider for OpenAIProvider {
             }
         }
 
+        if let Some(raw) = raw_stream.as_ref() {
+            log_wire_response(&self.model, raw);
+        }
+
+        let inferred_tool_calls = if tool_calls.is_empty() {
+            infer_content_tool_calls(&content, tools)
+        } else {
+            None
+        };
+        if let Some(inferred) = inferred_tool_calls.as_ref() {
+            log_tool_fallback_if_enabled(
+                self.debug_mode,
+                &self.model,
+                &content,
+                finish_reason.as_deref(),
+                inferred,
+            );
+        }
+        let content = if inferred_tool_calls.is_some() {
+            String::new()
+        } else {
+            content
+        };
+
         // Build final ChatResponse and signal done
         let response = ChatResponse {
             content: Some(content).filter(|c| !c.is_empty()),
-            tool_calls: Some(tool_calls).filter(|c| !c.is_empty()),
+            tool_calls: inferred_tool_calls.or_else(|| Some(tool_calls).filter(|c| !c.is_empty())),
             usage,
             finish_reason,
             reasoning_content: Some(reasoning).filter(|r| !r.is_empty()),
@@ -396,11 +702,17 @@ fn truncate(s: &str, max: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use reqwest::StatusCode;
+    use crate::config::ProviderDebugMode;
     use crate::provider::ProviderError;
+    use reqwest::StatusCode;
+    use serde_json::json;
 
     fn classify(code: u16, body: &str) -> ProviderError {
-        ProviderError::from_response(StatusCode::from_u16(code).unwrap(), body, "deepseek/deepseek-v4-flash")
+        ProviderError::from_response(
+            StatusCode::from_u16(code).unwrap(),
+            body,
+            "deepseek/deepseek-v4-flash",
+        )
     }
 
     #[test]
@@ -439,7 +751,10 @@ mod tests {
         ));
         // 404 with model in body → ModelNotFound
         assert!(matches!(
-            classify(404, r#"{"error":{"message":"Model deepseek/deepseek-v4-flash not found"}}"#),
+            classify(
+                404,
+                r#"{"error":{"message":"Model deepseek/deepseek-v4-flash not found"}}"#
+            ),
             ProviderError::ModelNotFound { .. }
         ));
         // 404 without model hint → Other
@@ -449,7 +764,10 @@ mod tests {
         ));
         // Non-JSON body → Other (or BadRequest depending on status)
         let html = "<html>500 internal server error</html>";
-        assert!(matches!(classify(500, html), ProviderError::ServerError { .. }));
+        assert!(matches!(
+            classify(500, html),
+            ProviderError::ServerError { .. }
+        ));
     }
 
     #[test]
@@ -477,10 +795,13 @@ mod tests {
         // Auth/BadRequest/ModelNotFound/Other are not.
         assert!(!classify(401, r#"{"error":{"message":"x"}}"#).is_retryable());
         assert!(!classify(400, r#"{"error":{"message":"x"}}"#).is_retryable());
-        assert!(!classify(
-            404,
-            r#"{"error":{"message":"Model deepseek/deepseek-v4-flash not found"}}"#
-        ).is_retryable());
+        assert!(
+            !classify(
+                404,
+                r#"{"error":{"message":"Model deepseek/deepseek-v4-flash not found"}}"#
+            )
+            .is_retryable()
+        );
     }
 
     #[test]
@@ -493,6 +814,150 @@ mod tests {
         )
         .to_string();
         assert!(model.contains("provider's catalog"), "got {model:?}");
+    }
+
+    fn test_provider(supports_json_mode: bool) -> OpenAIProvider {
+        OpenAIProvider::new(
+            "https://example.com/v1",
+            "test-key",
+            "test-model",
+            128_000,
+            0,
+            supports_json_mode,
+            ProviderDebugMode::Off,
+        )
+        .expect("provider")
+    }
+
+    #[test]
+    fn build_request_omits_response_format_for_normal_tool_requests_even_with_json_mode() {
+        let provider = test_provider(true);
+        let body = provider.build_request(
+            &[Message::User {
+                content: "hi".to_string(),
+            }],
+            &[ToolDefinition {
+                tool_type: "function".into(),
+                function: crate::provider::ToolFunction {
+                    name: "read_file".into(),
+                    description: "Read a file".into(),
+                    parameters: json!({
+                        "type": "object",
+                        "properties": { "path": { "type": "string" } },
+                        "required": ["path"]
+                    }),
+                },
+            }],
+        );
+
+        assert!(body.get("tools").is_some(), "expected tools in request");
+        assert!(
+            body.get("response_format").is_none(),
+            "normal tool turns should not force structured-output mode: {body:?}"
+        );
+    }
+
+    #[test]
+    fn build_request_omits_response_format_without_tools_or_support() {
+        let with_support = test_provider(true);
+        let no_tools = with_support.build_request(
+            &[Message::User {
+                content: "hi".to_string(),
+            }],
+            &[],
+        );
+        assert!(
+            no_tools.get("response_format").is_none(),
+            "got {no_tools:?}"
+        );
+
+        let without_support = test_provider(false);
+        let no_support = without_support.build_request(
+            &[Message::User {
+                content: "hi".to_string(),
+            }],
+            &[ToolDefinition {
+                tool_type: "function".into(),
+                function: crate::provider::ToolFunction {
+                    name: "read_file".into(),
+                    description: "Read a file".into(),
+                    parameters: json!({
+                        "type": "object",
+                        "properties": { "path": { "type": "string" } },
+                        "required": ["path"]
+                    }),
+                },
+            }],
+        );
+        assert!(
+            no_support.get("response_format").is_none(),
+            "got {no_support:?}"
+        );
+    }
+
+    #[test]
+    fn content_fallback_infers_bash_tool_call_from_bare_json_args() {
+        let tools = vec![
+            ToolDefinition {
+                tool_type: "function".into(),
+                function: crate::provider::ToolFunction {
+                    name: "bash".into(),
+                    description: "Run a shell command".into(),
+                    parameters: json!({
+                        "type": "object",
+                        "properties": {
+                            "command": { "type": "string" },
+                            "timeout": { "type": "integer" },
+                            "workdir": { "type": "string" }
+                        },
+                        "required": ["command"]
+                    }),
+                },
+            },
+            ToolDefinition {
+                tool_type: "function".into(),
+                function: crate::provider::ToolFunction {
+                    name: "read_file".into(),
+                    description: "Read a file".into(),
+                    parameters: json!({
+                        "type": "object",
+                        "properties": { "path": { "type": "string" } },
+                        "required": ["path"]
+                    }),
+                },
+            },
+        ];
+
+        let inferred =
+            infer_content_tool_calls(r#"{"command":"ls -la","dependencies":[]}"#, &tools)
+                .expect("expected fallback tool call");
+        assert_eq!(inferred.len(), 1);
+        assert_eq!(inferred[0].function.name, "bash");
+        assert_eq!(
+            serde_json::from_str::<Value>(&inferred[0].function.arguments).unwrap(),
+            json!({"command":"ls -la","dependencies":[]})
+        );
+    }
+
+    #[test]
+    fn wire_response_summary_suppresses_sse_completion_chunks() {
+        let raw = r#"data: {"id":"gen-1","choices":[{"delta":{"content":"   ","role":"assistant"}}]}
+
+data: {"id":"gen-1","choices":[{"delta":{"content":"{\"","role":"assistant"}}]}
+
+data: [DONE]
+"#;
+
+        let summary = summarize_wire_response(raw);
+        assert_eq!(
+            summary,
+            WireResponseSummary {
+                raw_body: None,
+                sse_data_lines: 3,
+                has_done_marker: true,
+                non_sse_preview: None,
+            }
+        );
     }
 
     #[test]

--- a/src/tools/file.rs
+++ b/src/tools/file.rs
@@ -1,8 +1,7 @@
-
 use crate::tools::{Tool, ToolResult};
 use anyhow::Result;
 use async_trait::async_trait;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use tokio_util::sync::CancellationToken;
 
 pub struct ReadFile;
@@ -27,7 +26,9 @@ impl Tool for ReadFile {
         })
     }
     async fn call(&self, params: Value, _cancel: CancellationToken) -> Result<ToolResult> {
-        let path = params["path"].as_str().ok_or_else(|| anyhow::anyhow!("path required"))?;
+        let path = params["path"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("path required"))?;
         let offset = params["offset"].as_i64().unwrap_or(1);
         let limit = params["limit"].as_i64().unwrap_or(500);
 
@@ -77,7 +78,9 @@ impl Tool for WriteFile {
         })
     }
     async fn call(&self, params: Value, _cancel: CancellationToken) -> Result<ToolResult> {
-        let path = params["path"].as_str().ok_or_else(|| anyhow::anyhow!("path required"))?;
+        let path = params["path"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("path required"))?;
         let content = params["content"].as_str().unwrap_or("");
 
         // Create parent directories
@@ -114,7 +117,9 @@ impl Tool for SearchFiles {
         })
     }
     async fn call(&self, params: Value, _cancel: CancellationToken) -> Result<ToolResult> {
-        let pattern = params["pattern"].as_str().ok_or_else(|| anyhow::anyhow!("pattern required"))?;
+        let pattern = params["pattern"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("pattern required"))?;
         let path = params["path"].as_str().unwrap_or(".");
         let limit = params["limit"].as_i64().unwrap_or(20);
 
@@ -168,8 +173,12 @@ impl Tool for PatchFile {
         })
     }
     async fn call(&self, params: Value, _cancel: CancellationToken) -> Result<ToolResult> {
-        let path = params["path"].as_str().ok_or_else(|| anyhow::anyhow!("path required"))?;
-        let old = params["old_string"].as_str().ok_or_else(|| anyhow::anyhow!("old_string required"))?;
+        let path = params["path"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("path required"))?;
+        let old = params["old_string"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("old_string required"))?;
         let new = params["new_string"].as_str().unwrap_or("");
 
         let content = tokio::fs::read_to_string(path).await?;
@@ -196,6 +205,8 @@ impl Tool for PatchFile {
         tokio::fs::write(path, &new_content).await?;
 
         let replaces = content.matches(old).count();
-        Ok(ToolResult::ok(format!("Replaced {replaces} occurrence(s) in {path}")))
+        Ok(ToolResult::ok(format!(
+            "Replaced {replaces} occurrence(s) in {path}"
+        )))
     }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -124,6 +124,138 @@ impl ToolRegistry {
             anyhow::anyhow!("Failed to parse arguments for {name}: {e}. Raw args: {arguments}")
         })?;
 
+        // Lightweight schema validation: check required fields are present
+        // before dispatch. Catches the common "model forgot a required arg"
+        // failure mode early with a clear error containing the schema, so
+        // the agent can self-correct on the next turn (YYC-39).
+        let schema = tool.schema();
+        validate_tool_params(name, &schema, &params, arguments)?;
+
         tool.call(params, cancel).await
+    }
+}
+
+/// Returns a comma-separated list of `required` schema fields that are
+/// missing from `params`, or `None` if all required fields are present (or
+/// the schema doesn't declare any).
+fn missing_required_fields(schema: &Value, params: &Value) -> Option<String> {
+    let required = schema.get("required")?.as_array()?;
+    let provided = params.as_object()?;
+    let missing: Vec<&str> = required
+        .iter()
+        .filter_map(|v| v.as_str())
+        .filter(|key| !provided.contains_key(*key))
+        .collect();
+    if missing.is_empty() {
+        None
+    } else {
+        Some(missing.join(", "))
+    }
+}
+
+fn validate_tool_params(
+    name: &str,
+    schema: &Value,
+    params: &Value,
+    raw_arguments: &str,
+) -> Result<()> {
+    let schema_text =
+        serde_json::to_string(schema).unwrap_or_else(|_| "<unserializable schema>".into());
+
+    if params.as_object().is_none() {
+        anyhow::bail!(
+            "Tool '{name}' arguments must be a JSON object. Schema: {schema_text}. \
+             You provided: {raw_arguments}"
+        );
+    }
+
+    if let Some(missing) = missing_required_fields(schema, params) {
+        let required = schema
+            .get("required")
+            .and_then(|v| v.as_array())
+            .map(|a| {
+                a.iter()
+                    .filter_map(|s| s.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            })
+            .unwrap_or_default();
+        anyhow::bail!(
+            "Tool '{name}' is missing required field(s): {missing}. \
+             Required fields are: [{required}]. Schema: {schema_text}. \
+             You provided: {raw_arguments}"
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tokio_util::sync::CancellationToken;
+
+    #[tokio::test]
+    async fn missing_required_field_yields_clear_error() {
+        let registry = ToolRegistry::new();
+        // edit_file requires path, old_string, new_string. Omit new_string.
+        let bogus_args = json!({
+            "path": "/tmp/x",
+            "old_string": "foo"
+            // new_string missing
+        })
+        .to_string();
+
+        let err = registry
+            .execute("edit_file", &bogus_args, CancellationToken::new())
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("missing required"), "got {msg:?}");
+        assert!(msg.contains("new_string"), "got {msg:?}");
+        assert!(msg.contains("Required fields"), "got {msg:?}");
+        assert!(msg.contains("Schema"), "got {msg:?}");
+    }
+
+    #[tokio::test]
+    async fn malformed_json_yields_clear_error() {
+        let registry = ToolRegistry::new();
+        let err = registry
+            .execute("read_file", "{not valid json", CancellationToken::new())
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("Failed to parse arguments"), "got {msg:?}");
+        assert!(msg.contains("Raw args"), "got {msg:?}");
+    }
+
+    #[test]
+    fn missing_required_handles_empty_or_absent_required() {
+        // Schema with no `required` key — should pass.
+        let schema = json!({"type": "object", "properties": {}});
+        assert!(missing_required_fields(&schema, &json!({})).is_none());
+        // Schema with empty required array — should pass.
+        let schema = json!({"type": "object", "required": []});
+        assert!(missing_required_fields(&schema, &json!({})).is_none());
+        // Required, all present.
+        let schema = json!({"required": ["a", "b"]});
+        assert!(missing_required_fields(&schema, &json!({"a": 1, "b": 2})).is_none());
+        // Required, one missing.
+        let schema = json!({"required": ["a", "b"]});
+        let missing = missing_required_fields(&schema, &json!({"a": 1})).unwrap();
+        assert_eq!(missing, "b");
+    }
+
+    #[tokio::test]
+    async fn non_object_arguments_fail_before_tool_dispatch() {
+        let registry = ToolRegistry::new();
+        let err = registry
+            .execute("read_file", "[]", CancellationToken::new())
+            .await
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("JSON object"), "got {msg:?}");
+        assert!(msg.contains("Schema"), "got {msg:?}");
     }
 }

--- a/src/tools/web.rs
+++ b/src/tools/web.rs
@@ -1,7 +1,7 @@
 use crate::tools::{Tool, ToolResult};
 use anyhow::Result;
 use async_trait::async_trait;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use tokio_util::sync::CancellationToken;
 
 pub struct WebSearch;
@@ -24,7 +24,9 @@ impl Tool for WebSearch {
         })
     }
     async fn call(&self, params: Value, cancel: CancellationToken) -> Result<ToolResult> {
-        let query = params["query"].as_str().ok_or_else(|| anyhow::anyhow!("query required"))?;
+        let query = params["query"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("query required"))?;
 
         // Use DuckDuckGo's lite version for simple scraping
         let url = format!("https://html.duckduckgo.com/html/?q={}", urlencoding(query));
@@ -99,7 +101,11 @@ fn extract_ddg_results(html: &str) -> Vec<DdgResult> {
             .to_string();
 
         if !title.is_empty() {
-            results.push(DdgResult { title, url, snippet });
+            results.push(DdgResult {
+                title,
+                url,
+                snippet,
+            });
             if results.len() >= 5 {
                 break;
             }
@@ -142,7 +148,9 @@ impl Tool for WebFetch {
         })
     }
     async fn call(&self, params: Value, cancel: CancellationToken) -> Result<ToolResult> {
-        let url = params["url"].as_str().ok_or_else(|| anyhow::anyhow!("url required"))?;
+        let url = params["url"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("url required"))?;
 
         let client = reqwest::Client::builder()
             .user_agent("vulcan/0.1 (AI agent; personal use)")
@@ -189,7 +197,10 @@ fn html_to_text(html: &str) -> String {
         if in_script {
             if ch == '<' {
                 // Check for closing script tag
-                if html[html.len().saturating_sub(8)..].to_lowercase().contains("/script") {
+                if html[html.len().saturating_sub(8)..]
+                    .to_lowercase()
+                    .contains("/script")
+                {
                     in_script = false;
                 }
             }
@@ -206,8 +217,16 @@ fn html_to_text(html: &str) -> String {
                 in_tag = true;
                 // Detect script/style blocks to skip
                 let lower = html[..].to_lowercase();
-                if lower.contains("<script") { in_script = true; in_tag = false; continue; }
-                if lower.contains("<style") { in_style = true; in_tag = false; continue; }
+                if lower.contains("<script") {
+                    in_script = true;
+                    in_tag = false;
+                    continue;
+                }
+                if lower.contains("<style") {
+                    in_style = true;
+                    in_tag = false;
+                    continue;
+                }
             }
             '>' if in_tag => {
                 in_tag = false;

--- a/src/tui/markdown.rs
+++ b/src/tui/markdown.rs
@@ -62,7 +62,9 @@ pub fn render_markdown(text: &str) -> Vec<Line<'static>> {
                     5 => "##### ",
                     _ => "###### ",
                 },
-                Style::default().fg(MdTheme::HEADING).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(MdTheme::HEADING)
+                    .add_modifier(Modifier::BOLD),
             )];
             styled.extend(spans);
             lines.push(Line::from(styled));
@@ -76,12 +78,18 @@ pub fn render_markdown(text: &str) -> Vec<Line<'static>> {
             continue;
         }
         if line == ">" {
-            lines.push(Line::from(Span::styled("▎", Style::default().fg(MdTheme::QUOTE))));
+            lines.push(Line::from(Span::styled(
+                "▎",
+                Style::default().fg(MdTheme::QUOTE),
+            )));
             continue;
         }
 
         if let Some(content) = line.strip_prefix("- ").or_else(|| line.strip_prefix("* ")) {
-            let mut spans = vec![Span::styled("• ", Style::default().fg(MdTheme::LIST_BULLET))];
+            let mut spans = vec![Span::styled(
+                "• ",
+                Style::default().fg(MdTheme::LIST_BULLET),
+            )];
             spans.extend(parse_inline(content));
             lines.push(Line::from(spans));
             continue;
@@ -132,7 +140,11 @@ fn heading_level(line: &str) -> Option<usize> {
             return None;
         }
     }
-    if (1..=6).contains(&count) { Some(count) } else { None }
+    if (1..=6).contains(&count) {
+        Some(count)
+    } else {
+        None
+    }
 }
 
 fn strip_ordered_list_prefix(line: &str) -> Option<(&str, &str)> {
@@ -155,7 +167,9 @@ fn render_code_block(lines: &[String]) -> Vec<Line<'static>> {
     if lines.is_empty() {
         result.push(Line::from(Span::styled(
             " ```",
-            Style::default().fg(MdTheme::CODE).add_modifier(Modifier::DIM),
+            Style::default()
+                .fg(MdTheme::CODE)
+                .add_modifier(Modifier::DIM),
         )));
         return result;
     }
@@ -189,7 +203,9 @@ fn parse_inline(text: &str) -> Vec<Span<'static>> {
                 let code: String = chars[start..start + end].iter().collect();
                 spans.push(Span::styled(
                     code,
-                    Style::default().fg(MdTheme::CODE).bg(MdTheme::CODE_BLOCK_BG),
+                    Style::default()
+                        .fg(MdTheme::CODE)
+                        .bg(MdTheme::CODE_BLOCK_BG),
                 ));
                 i = start + end + 1;
                 continue;
@@ -220,7 +236,9 @@ fn parse_inline(text: &str) -> Vec<Span<'static>> {
                 let inner: String = chars[start..start + end].iter().collect();
                 spans.push(Span::styled(
                     inner,
-                    Style::default().fg(MdTheme::ITALIC).add_modifier(Modifier::ITALIC),
+                    Style::default()
+                        .fg(MdTheme::ITALIC)
+                        .add_modifier(Modifier::ITALIC),
                 ));
                 i = start + end + 1;
                 continue;

--- a/src/tui/widgets.rs
+++ b/src/tui/widgets.rs
@@ -37,10 +37,22 @@ pub fn frame(
     if inner.height == 0 {
         return inner;
     }
-    let bar = Rect { x: inner.x, y: inner.y, width: inner.width, height: 1 };
+    let bar = Rect {
+        x: inner.x,
+        y: inner.y,
+        width: inner.width,
+        height: 1,
+    };
     let bar_bg = accent.unwrap_or(Palette::INK);
-    let bar_fg = if accent.is_some() { Palette::INK } else { Palette::PAPER };
-    let bar_style = Style::default().fg(bar_fg).bg(bar_bg).add_modifier(Modifier::BOLD);
+    let bar_fg = if accent.is_some() {
+        Palette::INK
+    } else {
+        Palette::PAPER
+    };
+    let bar_style = Style::default()
+        .fg(bar_fg)
+        .bg(bar_bg)
+        .add_modifier(Modifier::BOLD);
 
     let mut spans = vec![
         Span::styled(" ▓▓ ", bar_style),
@@ -78,9 +90,18 @@ pub fn section_header(f: &mut TuiFrame, area: Rect, label: &str, accent: Option<
         return area;
     }
     let bg = accent.unwrap_or(Palette::INK);
-    let fg = if accent.is_some() { Palette::INK } else { Palette::PAPER };
+    let fg = if accent.is_some() {
+        Palette::INK
+    } else {
+        Palette::PAPER
+    };
     let style = Style::default().fg(fg).bg(bg).add_modifier(Modifier::BOLD);
-    let bar = Rect { x: area.x, y: area.y, width: area.width, height: 1 };
+    let bar = Rect {
+        x: area.x,
+        y: area.y,
+        width: area.width,
+        height: 1,
+    };
     let text = format!(" ▣ {} ", label.to_uppercase());
     let pad_total = area.width as usize;
     let mut display = text.clone();
@@ -100,7 +121,10 @@ pub fn section_header(f: &mut TuiFrame, area: Rect, label: &str, accent: Option<
 pub fn pill(text: &str, color: Color, filled: bool) -> Span<'static> {
     let body = format!(" {} ", text.to_uppercase());
     let style = if filled {
-        Style::default().fg(Palette::PAPER).bg(color).add_modifier(Modifier::BOLD)
+        Style::default()
+            .fg(Palette::PAPER)
+            .bg(color)
+            .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(color).add_modifier(Modifier::BOLD)
     };
@@ -137,7 +161,10 @@ pub fn tool_call_lines(
     let header = format!(" ┏ {name:<28}{label:>14} ");
     lines.push(Line::from(Span::styled(
         header,
-        Style::default().fg(color).bg(Palette::FAINT).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(color)
+            .bg(Palette::FAINT)
+            .add_modifier(Modifier::BOLD),
     )));
     lines.push(Line::from(Span::styled(
         format!(" ┃ {}", args),
@@ -169,7 +196,9 @@ pub fn reasoning_lines(text: &str, hidden: bool) -> Vec<Line<'static>> {
     if hidden {
         return vec![Line::from(Span::styled(
             "░░░ reasoning trace hidden · Ctrl-R to show ░░░",
-            Style::default().fg(Palette::MUTED).add_modifier(Modifier::DIM),
+            Style::default()
+                .fg(Palette::MUTED)
+                .add_modifier(Modifier::DIM),
         ))];
     }
     let mut lines = vec![Line::from(Span::styled(
@@ -194,10 +223,15 @@ pub fn reasoning_lines(text: &str, hidden: bool) -> Vec<Line<'static>> {
 /// Message header: ▆ ROLE · tag
 pub fn message_header(role: &str, accent: Color, tag: Option<&str>) -> Line<'static> {
     let mut spans = vec![
-        Span::styled("▆ ", Style::default().fg(accent).add_modifier(Modifier::BOLD)),
+        Span::styled(
+            "▆ ",
+            Style::default().fg(accent).add_modifier(Modifier::BOLD),
+        ),
         Span::styled(
             role.to_uppercase(),
-            Style::default().fg(Palette::INK).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Palette::INK)
+                .add_modifier(Modifier::BOLD),
         ),
     ];
     if let Some(t) = tag {
@@ -208,16 +242,16 @@ pub fn message_header(role: &str, accent: Color, tag: Option<&str>) -> Line<'sta
 }
 
 /// Render a paragraph with a left accent bar — used for chat message bodies.
-pub fn render_message_body(
-    f: &mut TuiFrame,
-    area: Rect,
-    accent: Color,
-    lines: Vec<Line<'static>>,
-) {
+pub fn render_message_body(f: &mut TuiFrame, area: Rect, accent: Color, lines: Vec<Line<'static>>) {
     if area.width < 3 || area.height == 0 {
         return;
     }
-    let bar = Rect { x: area.x, y: area.y, width: 1, height: area.height };
+    let bar = Rect {
+        x: area.x,
+        y: area.y,
+        width: 1,
+        height: area.height,
+    };
     f.render_widget(
         Paragraph::new(
             std::iter::repeat_with(|| Line::from(Span::styled("▎", Style::default().fg(accent))))
@@ -234,7 +268,9 @@ pub fn render_message_body(
         height: area.height,
     };
     f.render_widget(
-        Paragraph::new(lines).style(body()).wrap(Wrap { trim: false }),
+        Paragraph::new(lines)
+            .style(body())
+            .wrap(Wrap { trim: false }),
         body_area,
     );
 }
@@ -258,7 +294,11 @@ pub fn prompt_row(
     // Top divider
     let layout = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Length(1), Constraint::Length(1), Constraint::Length(1)])
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
         .split(area);
 
     // Divider row
@@ -271,11 +311,17 @@ pub fn prompt_row(
     // Mode pill + caret + input
     let mode_pill = Span::styled(
         format!(" {} ", mode),
-        Style::default().fg(Palette::PAPER).bg(Palette::INK).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(Palette::PAPER)
+            .bg(Palette::INK)
+            .add_modifier(Modifier::BOLD),
     );
     let caret = Span::styled(
         " ❯ ",
-        Style::default().fg(Palette::RED).bg(Palette::PAPER).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(Palette::RED)
+            .bg(Palette::PAPER)
+            .add_modifier(Modifier::BOLD),
     );
     let input_span = Span::styled(
         input.to_string(),
@@ -286,7 +332,11 @@ pub fn prompt_row(
         Style::default()
             .fg(Palette::INK)
             .bg(Palette::PAPER)
-            .add_modifier(if thinking { Modifier::SLOW_BLINK } else { Modifier::empty() }),
+            .add_modifier(if thinking {
+                Modifier::SLOW_BLINK
+            } else {
+                Modifier::empty()
+            }),
     );
     let line = Line::from(vec![mode_pill, caret, input_span, cursor_block]);
     f.render_widget(Paragraph::new(line).style(body()), layout[1]);
@@ -317,7 +367,10 @@ pub fn prompt_row(
             Style::default().fg(Palette::MUTED).bg(Palette::PAPER),
         ));
     }
-    let hint_text_len: u16 = hint_spans.iter().map(|s| s.content.chars().count() as u16).sum();
+    let hint_text_len: u16 = hint_spans
+        .iter()
+        .map(|s| s.content.chars().count() as u16)
+        .sum();
     let model_len = model_status.chars().count() as u16;
     if hint_text_len + model_len + 2 < area.width {
         let pad = " ".repeat((area.width - hint_text_len - model_len - 1) as usize);
@@ -327,7 +380,10 @@ pub fn prompt_row(
         ));
         hint_spans.push(Span::styled(
             format!(" {model_status}"),
-            Style::default().fg(Palette::INK).bg(Palette::PAPER).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Palette::INK)
+                .bg(Palette::PAPER)
+                .add_modifier(Modifier::BOLD),
         ));
     }
     f.render_widget(
@@ -346,7 +402,10 @@ pub fn ticker(f: &mut TuiFrame, area: Rect, cells: &[(String, String, Color)]) {
     }
     let mut spans = vec![Span::styled(
         " TICKER ",
-        Style::default().fg(Palette::PAPER).bg(Palette::RED).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(Palette::PAPER)
+            .bg(Palette::RED)
+            .add_modifier(Modifier::BOLD),
     )];
     for (sub, msg, color) in cells {
         spans.push(Span::styled(
@@ -381,10 +440,7 @@ pub fn ticker(f: &mut TuiFrame, area: Rect, cells: &[(String, String, Color)]) {
             Style::default().bg(Palette::INK),
         ));
     }
-    f.render_widget(
-        Paragraph::new(Line::from(spans)).style(inverse()),
-        area,
-    );
+    f.render_widget(Paragraph::new(Line::from(spans)).style(inverse()), area);
 }
 
 /// Fill a rect with a solid background color (paper by default).


### PR DESCRIPTION
- Add validate_tool_params + missing_required_fields helpers in tools/mod.rs
  that check schema 'required' fields before tool dispatch, with clear
  error messages so the agent can self-correct on the next turn.
- Plumb supports_json_mode from catalog -> Agent -> OpenAIProvider.
  Field is parsed but intentionally NOT used to set response_format
  in build_request (response_format conflicts with tool_calls in
  practice; kept as future work).
- Add ProviderDebugMode enum (Off / ToolFallback / Wire) with helpers
  for selectively logging tool-fallback parsing and request/response
  bodies. Wired through ProviderConfig.
- 4 new validator unit tests + ProviderDebugMode parsing tests.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>