### PR TITLE
YYC-53: Replace TUI design-demo data with real sources

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -52,13 +52,34 @@ struct SlashCommand {
 }
 
 const SLASH_COMMANDS: &[SlashCommand] = &[
-    SlashCommand { name: "exit", description: "Quit Vulcan" },
-    SlashCommand { name: "quit", description: "Quit Vulcan" },
-    SlashCommand { name: "help", description: "Show available commands" },
-    SlashCommand { name: "clear", description: "Clear message history" },
-    SlashCommand { name: "view", description: "Cycle to next view (or 1-5)" },
-    SlashCommand { name: "reasoning", description: "Toggle reasoning trace" },
-    SlashCommand { name: "search", description: "Search past sessions: /search <query>" },
+    SlashCommand {
+        name: "exit",
+        description: "Quit Vulcan",
+    },
+    SlashCommand {
+        name: "quit",
+        description: "Quit Vulcan",
+    },
+    SlashCommand {
+        name: "help",
+        description: "Show available commands",
+    },
+    SlashCommand {
+        name: "clear",
+        description: "Clear message history",
+    },
+    SlashCommand {
+        name: "view",
+        description: "Cycle to next view (or 1-5)",
+    },
+    SlashCommand {
+        name: "reasoning",
+        description: "Toggle reasoning trace",
+    },
+    SlashCommand {
+        name: "search",
+        description: "Search past sessions: /search <query>",
+    },
 ];
 
 fn short_id(id: &str) -> String {
@@ -70,7 +91,10 @@ fn filter_commands(prefix: &str) -> Vec<&'static SlashCommand> {
         return SLASH_COMMANDS.iter().collect();
     }
     let lower = prefix.to_lowercase();
-    SLASH_COMMANDS.iter().filter(|c| c.name.starts_with(&lower)).collect()
+    SLASH_COMMANDS
+        .iter()
+        .filter(|c| c.name.starts_with(&lower))
+        .collect()
 }
 
 fn complete_slash(prefix: &str) -> Option<String> {
@@ -100,22 +124,35 @@ fn complete_slash(prefix: &str) -> Option<String> {
     }
 }
 
+async fn refresh_sessions(agent: &Arc<Mutex<Agent>>, app: &mut AppState) {
+    let (summaries, active_session_id) = {
+        let a = agent.lock().await;
+        (
+            a.memory().list_sessions(12).unwrap_or_default(),
+            a.session_id().to_string(),
+        )
+    };
+    app.hydrate_sessions(&summaries, &active_session_id);
+}
+
 pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
     let mut terminal = init_terminal()?;
 
     // keyboard
     let (key_tx, mut key_rx) = mpsc::unbounded_channel::<KeyEv>();
     let tx_keys = key_tx.clone();
-    std::thread::spawn(move || loop {
-        match event::read() {
-            Ok(ev) => {
-                if tx_keys.send(KeyEv::Press(ev)).is_err() {
+    std::thread::spawn(move || {
+        loop {
+            match event::read() {
+                Ok(ev) => {
+                    if tx_keys.send(KeyEv::Press(ev)).is_err() {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    let _ = tx_keys.send(KeyEv::Error(e.to_string()));
                     break;
                 }
-            }
-            Err(e) => {
-                let _ = tx_keys.send(KeyEv::Error(e.to_string()));
-                break;
             }
         }
     });
@@ -147,7 +184,10 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
         match resume {
             ResumeTarget::None => None,
             ResumeTarget::Last => match a.continue_last_session() {
-                Ok(()) => Some(format!("Resumed last session ({})", short_id(a.session_id()))),
+                Ok(()) => Some(format!(
+                    "Resumed last session ({})",
+                    short_id(a.session_id())
+                )),
                 Err(e) => Some(format!("Could not resume last session: {e}")),
             },
             ResumeTarget::Specific(id) => match a.resume_session(&id) {
@@ -167,6 +207,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
         config.provider.max_context as u32,
     );
     app.audit_log = Some(audit_buf);
+    refresh_sessions(&agent, &mut app).await;
 
     if let Some(note) = resume_note {
         app.messages.push(ChatMessage {
@@ -190,7 +231,8 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                         app.messages.push(ChatMessage::new(ChatRole::User, content));
                     }
                     Message::System { content } => {
-                        app.messages.push(ChatMessage::new(ChatRole::System, content));
+                        app.messages
+                            .push(ChatMessage::new(ChatRole::System, content));
                     }
                     Message::Assistant {
                         content,
@@ -226,7 +268,12 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
             let (main_area, palette_area) = if let Some(ref pal) = palette {
                 let h = (pal.len() as u16 + 2).min(area.height / 2);
                 (
-                    Rect { x: area.x, y: area.y, width: area.width, height: area.height - h },
+                    Rect {
+                        x: area.x,
+                        y: area.y,
+                        width: area.width,
+                        height: area.height - h,
+                    },
                     Some(Rect {
                         x: area.x,
                         y: area.y + area.height - h,
@@ -240,8 +287,10 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
 
             render_view(f, main_area, &app);
             let (cx, cy) = app.cursor();
-            if cx >= main_area.x && cx < main_area.x + main_area.width
-                && cy >= main_area.y && cy < main_area.y + main_area.height
+            if cx >= main_area.x
+                && cx < main_area.x + main_area.width
+                && cy >= main_area.y
+                && cy < main_area.y + main_area.height
             {
                 f.set_cursor_position(Position::new(cx, cy));
             }
@@ -270,6 +319,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                         content: format!("⏸  Agent paused — {summary}"),
                         reasoning: String::new(),
                     });
+                    app.note_pause(&summary);
                     app.pending_pause = Some(p);
                 }
                 continue;
@@ -303,6 +353,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                                 content: format!("▶  Resumed — {label}"),
                                                 reasoning: String::new(),
                                             });
+                                            app.note_resume(label);
                                         }
                                         continue;
                                     }
@@ -457,6 +508,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                             app.messages.push(ChatMessage { role: ChatRole::Agent, content: String::new(), ..Default::default() });
                                             app.thinking = true;
                                             app.scroll = 0;
+                                            app.note_prompt_submitted(&msg);
 
                                             let tx = stream_tx.clone();
                                             let agent = agent.clone();
@@ -517,12 +569,15 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                 last.reasoning.push_str(&chunk);
                             }
                         }
+                        app.note_reasoning();
                     }
                     Some(StreamEvent::Done(resp)) => {
                         app.thinking = false;
                         if let Some(usage) = resp.usage {
                             app.token_used = app.token_used.saturating_add(usage.completion_tokens as u32);
                         }
+                        app.note_done();
+                        refresh_sessions(&agent, &mut app).await;
                     }
                     Some(StreamEvent::Error(e)) => {
                         if let Some(last) = app.messages.last_mut() {
@@ -531,6 +586,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                             }
                         }
                         app.thinking = false;
+                        app.note_error(&e);
                     }
                     Some(StreamEvent::ToolCallStart { name, .. }) => {
                         // Append an in-progress marker to the agent message.
@@ -543,6 +599,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                 last.content.push_str(&format!("{prefix}_[🔧 {name}…]_"));
                             }
                         }
+                        app.note_tool_start(&name);
                     }
                     Some(StreamEvent::ToolCallEnd { name, ok, .. }) => {
                         if let Some(last) = app.messages.last_mut() {
@@ -556,6 +613,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                 }
                             }
                         }
+                        app.note_tool_end(&name, ok);
                     }
                     None => app.thinking = false,
                 }
@@ -574,16 +632,17 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
     Ok(())
 }
 
-fn draw_palette(
-    f: &mut ratatui::Frame,
-    area: Rect,
-    cmds: &[&SlashCommand],
-) {
+fn draw_palette(f: &mut ratatui::Frame, area: Rect, cmds: &[&SlashCommand]) {
     if area.height == 0 {
         return;
     }
     // Title bar
-    let bar = Rect { x: area.x, y: area.y, width: area.width, height: 1 };
+    let bar = Rect {
+        x: area.x,
+        y: area.y,
+        width: area.width,
+        height: 1,
+    };
     let mut header_text = " ▓▓ COMMANDS".to_string();
     if (header_text.chars().count() as u16) < bar.width {
         header_text.push_str(&" ".repeat(bar.width as usize - header_text.chars().count()));

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -4,6 +4,7 @@ use chrono::Local;
 use ratatui::style::Color;
 
 use crate::hooks::audit::{AuditBuffer, AuditKind};
+use crate::memory::SessionSummary;
 
 use super::theme::Palette;
 use super::views::{DiffKind, DiffLine, View};
@@ -37,12 +38,31 @@ impl ChatMessage {
 }
 
 #[derive(Clone, Debug)]
-pub struct SessionRow {
-    pub name: String,
-    pub status: String,
-    pub tokens: String,
-    pub color: Color,
-    pub active: bool,
+pub struct SessionState {
+    pub id: String,
+    pub label: String,
+    pub message_count: usize,
+    pub created_at: i64,
+    pub last_active: i64,
+    pub parent_session_id: Option<String>,
+    pub lineage_label: Option<String>,
+    pub status: SessionStatus,
+    pub is_active: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SessionStatus {
+    Live,
+    Saved,
+}
+
+impl SessionStatus {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Live => "live",
+            Self::Saved => "saved",
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -78,6 +98,78 @@ pub struct TreeNode {
     pub active: bool,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum OrchestrationPhase {
+    #[default]
+    Idle,
+    Thinking,
+    ToolRunning,
+    Paused,
+    Complete,
+    Error,
+}
+
+impl OrchestrationPhase {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Idle => "idle",
+            Self::Thinking => "thinking",
+            Self::ToolRunning => "tool",
+            Self::Paused => "paused",
+            Self::Complete => "done",
+            Self::Error => "error",
+        }
+    }
+
+    fn color(self) -> Color {
+        match self {
+            Self::Idle => Palette::MUTED,
+            Self::Thinking => Palette::YELLOW,
+            Self::ToolRunning => Palette::BLUE,
+            Self::Paused => Palette::RED,
+            Self::Complete => Palette::GREEN,
+            Self::Error => Palette::RED,
+        }
+    }
+
+    fn symbol(self) -> &'static str {
+        match self {
+            Self::Idle => "○",
+            Self::Thinking => "●",
+            Self::ToolRunning => "●",
+            Self::Paused => "⏸",
+            Self::Complete => "✓",
+            Self::Error => "✗",
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct OrchestrationEvent {
+    pub actor: String,
+    pub msg: String,
+    pub color: Color,
+}
+
+#[derive(Clone, Debug)]
+pub struct OrchestrationState {
+    pub phase: OrchestrationPhase,
+    pub active_task: String,
+    pub current_tool: Option<String>,
+    pub recent_events: Vec<OrchestrationEvent>,
+}
+
+impl Default for OrchestrationState {
+    fn default() -> Self {
+        Self {
+            phase: OrchestrationPhase::Idle,
+            active_task: "Awaiting user input".into(),
+            current_tool: None,
+            recent_events: Vec::new(),
+        }
+    }
+}
+
 pub struct AppState {
     pub view: View,
     pub messages: Vec<ChatMessage>,
@@ -87,11 +179,10 @@ pub struct AppState {
     pub show_reasoning: bool,
     pub session_label: String,
 
-    pub sessions: Vec<SessionRow>,
-    pub subagents: Vec<SubAgentTile>,
+    pub sessions: Vec<SessionState>,
+    pub active_session_id: Option<String>,
     pub diff_lines: Vec<DiffLine>,
-    pub ticker: Vec<TickerCell>,
-    pub tree: Vec<TreeNode>,
+    pub orchestration: OrchestrationState,
 
     /// Optional shared handle to the audit-log hook's ring buffer. When
     /// present, the trading-floor tool-log pane renders from it; otherwise it
@@ -118,13 +209,12 @@ impl AppState {
             thinking: false,
             scroll: 0,
             show_reasoning: true,
-            session_label: "auth-refactor · 14:02".into(),
+            session_label: "new session".into(),
 
-            sessions: demo_sessions(),
-            subagents: demo_subagents(),
+            sessions: Vec::new(),
+            active_session_id: None,
             diff_lines: demo_diff(),
-            ticker: demo_ticker(),
-            tree: demo_tree(),
+            orchestration: OrchestrationState::default(),
 
             audit_log: None,
             pending_pause: None,
@@ -186,102 +276,218 @@ impl AppState {
     pub fn cursor(&self) -> (u16, u16) {
         self.cursor.get()
     }
-}
 
-fn demo_sessions() -> Vec<SessionRow> {
-    vec![
-        SessionRow {
-            name: "auth-refactor".into(),
-            status: "live".into(),
-            tokens: "18k".into(),
-            color: Palette::RED,
-            active: true,
-        },
-        SessionRow {
-            name: "perf-investig.".into(),
-            status: "wait".into(),
-            tokens: "42k".into(),
-            color: Palette::YELLOW,
-            active: false,
-        },
-        SessionRow {
-            name: "docs-rewrite".into(),
-            status: "done".into(),
-            tokens: "8k".into(),
-            color: Palette::GREEN,
-            active: false,
-        },
-        SessionRow {
-            name: "fuzz-harness".into(),
-            status: "live".into(),
-            tokens: "64k".into(),
-            color: Palette::BLUE,
-            active: false,
-        },
-        SessionRow {
-            name: "scratch".into(),
-            status: "idle".into(),
-            tokens: "2k".into(),
-            color: Palette::MUTED,
-            active: false,
-        },
-        SessionRow {
-            name: "rfc-storage".into(),
-            status: "idle".into(),
-            tokens: "11k".into(),
-            color: Palette::MUTED,
-            active: false,
-        },
-    ]
-}
+    pub fn hydrate_sessions(&mut self, summaries: &[SessionSummary], active_session_id: &str) {
+        self.active_session_id = Some(active_session_id.to_string());
+        self.sessions = summaries
+            .iter()
+            .map(|s| {
+                let is_active = s.id == active_session_id;
+                SessionState {
+                    id: s.id.clone(),
+                    label: short_session_id(&s.id),
+                    message_count: s.message_count,
+                    created_at: s.created_at,
+                    last_active: s.last_active,
+                    parent_session_id: s.parent_session_id.clone(),
+                    lineage_label: s.lineage_label.clone(),
+                    status: if is_active {
+                        SessionStatus::Live
+                    } else {
+                        SessionStatus::Saved
+                    },
+                    is_active,
+                }
+            })
+            .collect();
+        self.session_label = self
+            .active_session()
+            .map(|s| s.label.clone())
+            .unwrap_or_else(|| short_session_id(active_session_id));
+    }
 
-fn demo_subagents() -> Vec<SubAgentTile> {
-    vec![
-        SubAgentTile {
+    pub fn note_prompt_submitted(&mut self, prompt: &str) {
+        self.orchestration.phase = OrchestrationPhase::Thinking;
+        self.orchestration.current_tool = None;
+        self.orchestration.active_task = format!("Answering: {}", short_text(prompt, 56));
+        self.push_event(
+            "main",
+            format!("received prompt: {}", short_text(prompt, 36)),
+            Palette::RED,
+        );
+    }
+
+    pub fn note_reasoning(&mut self) {
+        if self.orchestration.phase != OrchestrationPhase::ToolRunning {
+            self.orchestration.phase = OrchestrationPhase::Thinking;
+        }
+        if self.orchestration.active_task == "Awaiting user input" {
+            self.orchestration.active_task = "Reasoning about the current turn".into();
+        }
+    }
+
+    pub fn note_tool_start(&mut self, name: &str) {
+        self.orchestration.phase = OrchestrationPhase::ToolRunning;
+        self.orchestration.current_tool = Some(name.to_string());
+        self.orchestration.active_task = format!("Running tool `{name}`");
+        self.push_event("main", format!("started tool `{name}`"), Palette::BLUE);
+    }
+
+    pub fn note_tool_end(&mut self, name: &str, ok: bool) {
+        self.orchestration.phase = if ok {
+            OrchestrationPhase::Thinking
+        } else {
+            OrchestrationPhase::Error
+        };
+        self.orchestration.current_tool = None;
+        self.orchestration.active_task = if ok {
+            format!("Tool `{name}` completed; continuing turn")
+        } else {
+            format!("Tool `{name}` failed")
+        };
+        let color = if ok { Palette::GREEN } else { Palette::RED };
+        let status = if ok { "completed" } else { "failed" };
+        self.push_event("main", format!("tool `{name}` {status}"), color);
+    }
+
+    pub fn note_pause(&mut self, summary: &str) {
+        self.orchestration.phase = OrchestrationPhase::Paused;
+        self.orchestration.active_task = short_text(summary, 64);
+        self.push_event("main", "waiting for user approval".into(), Palette::RED);
+    }
+
+    pub fn note_resume(&mut self, label: &str) {
+        self.orchestration.phase = OrchestrationPhase::Thinking;
+        self.orchestration.active_task = format!("Resumed: {label}");
+        self.push_event("main", format!("resumed — {label}"), Palette::GREEN);
+    }
+
+    pub fn note_done(&mut self) {
+        self.orchestration.phase = OrchestrationPhase::Complete;
+        self.orchestration.current_tool = None;
+        self.orchestration.active_task = "Turn complete".into();
+        self.push_event("main", "completed turn".into(), Palette::GREEN);
+    }
+
+    pub fn note_error(&mut self, msg: &str) {
+        self.orchestration.phase = OrchestrationPhase::Error;
+        self.orchestration.current_tool = None;
+        self.orchestration.active_task = format!("Error: {}", short_text(msg, 56));
+        self.push_event(
+            "main",
+            format!("error: {}", short_text(msg, 36)),
+            Palette::RED,
+        );
+    }
+
+    pub fn subagent_tiles(&self) -> Vec<SubAgentTile> {
+        let mut log = Vec::new();
+        log.push(self.orchestration.active_task.clone());
+        if let Some(tool) = &self.orchestration.current_tool {
+            log.push(format!("current tool · {tool}"));
+        }
+        for event in self.orchestration.recent_events.iter().rev().take(2).rev() {
+            log.push(event.msg.clone());
+        }
+        if let Some(reasoning) = self.latest_reasoning() {
+            log.push(format!("reasoning · {}", short_text(reasoning, 48)));
+        }
+        vec![SubAgentTile {
             name: "main".into(),
             role: "orchestrator".into(),
-            state: "thinking".into(),
-            color: Palette::RED,
-            log: vec![
-                "delegating to 3 subs".into(),
-                "watching token budget".into(),
-                "merging diffs in 12s".into(),
-            ],
-            cpu: vec![2, 3, 4, 6, 4, 5, 7, 3],
-        },
-        SubAgentTile {
-            name: "sub#a3f".into(),
-            role: "users-svc".into(),
-            state: "editing".into(),
-            color: Palette::YELLOW,
-            log: vec![
-                "read auth.rs (847)".into(),
-                "running cargo check".into(),
-                "✓ tests pass".into(),
-            ],
-            cpu: vec![1, 3, 5, 4, 6, 7, 4, 5],
-        },
-        SubAgentTile {
-            name: "sub#b21".into(),
-            role: "billing-svc".into(),
-            state: "running".into(),
-            color: Palette::BLUE,
-            log: vec![
-                "grep AuthMiddleware".into(),
-                "found 6 callsites".into(),
-                "patching trait impl…".into(),
-            ],
-            cpu: vec![2, 4, 3, 5, 7, 8, 6, 9],
-        },
-        SubAgentTile {
-            name: "sub#c08".into(),
-            role: "gateway".into(),
-            state: "blocked".into(),
-            color: Palette::MUTED,
-            log: vec!["waiting on a3f".into(), "queue: 1 task".into(), "—".into()],
-            cpu: vec![1, 1, 1, 2, 1, 1, 2, 1],
-        },
-    ]
+            state: self.orchestration.phase.label().into(),
+            color: self.orchestration.phase.color(),
+            log,
+            cpu: Vec::new(),
+        }]
+    }
+
+    pub fn ticker_cells(&self) -> Vec<TickerCell> {
+        let recent: Vec<TickerCell> = self
+            .orchestration
+            .recent_events
+            .iter()
+            .rev()
+            .take(4)
+            .map(|e| TickerCell {
+                sub: e.actor.clone(),
+                msg: e.msg.clone(),
+                color: e.color,
+            })
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect();
+        if recent.is_empty() {
+            vec![TickerCell {
+                sub: "main".into(),
+                msg: self.orchestration.active_task.clone(),
+                color: self.orchestration.phase.color(),
+            }]
+        } else {
+            recent
+        }
+    }
+
+    pub fn tree_nodes(&self) -> Vec<TreeNode> {
+        let mut nodes = vec![TreeNode {
+            depth: 0,
+            label: format!("root · {}", self.orchestration.active_task),
+            state: self.orchestration.phase.symbol().into(),
+            color: self.orchestration.phase.color(),
+            active: true,
+        }];
+        if let Some(tool) = &self.orchestration.current_tool {
+            nodes.push(TreeNode {
+                depth: 1,
+                label: format!("└─ tool · {tool}"),
+                state: OrchestrationPhase::ToolRunning.symbol().into(),
+                color: Palette::BLUE,
+                active: true,
+            });
+        }
+        nodes
+    }
+
+    pub fn delegated_worker_count(&self) -> usize {
+        0
+    }
+
+    pub fn branch_count(&self) -> usize {
+        self.tree_nodes().len().saturating_sub(1)
+    }
+
+    pub fn latest_reasoning(&self) -> Option<&str> {
+        self.messages
+            .iter()
+            .rev()
+            .find(|m| matches!(m.role, ChatRole::Agent) && !m.reasoning.is_empty())
+            .map(|m| m.reasoning.as_str())
+    }
+
+    pub fn latest_agent_content(&self) -> Option<&str> {
+        self.messages
+            .iter()
+            .rev()
+            .find(|m| matches!(m.role, ChatRole::Agent) && !m.content.is_empty())
+            .map(|m| m.content.as_str())
+    }
+
+    pub fn active_session(&self) -> Option<&SessionState> {
+        self.sessions.iter().find(|session| session.is_active)
+    }
+
+    fn push_event(&mut self, actor: &str, msg: String, color: Color) {
+        self.orchestration.recent_events.push(OrchestrationEvent {
+            actor: actor.into(),
+            msg,
+            color,
+        });
+        if self.orchestration.recent_events.len() > 12 {
+            let overflow = self.orchestration.recent_events.len() - 12;
+            self.orchestration.recent_events.drain(0..overflow);
+        }
+    }
 }
 
 /// Compress a long tool name for the actor column (5 chars wide).
@@ -292,21 +498,57 @@ fn short_tool(name: &str) -> String {
     name.chars().take(5).collect()
 }
 
+fn short_session_id(id: &str) -> String {
+    let short: String = id.chars().take(8).collect();
+    format!("session-{short}")
+}
+
 fn demo_tool_log() -> Vec<ToolLogRow> {
     vec![
-        ToolLogRow { time: "14:02:13".into(), actor: "main".into(), msg: "spawn ×3".into() },
-        ToolLogRow { time: "14:02:15".into(), actor: "a3f".into(), msg: "read_file ✓".into() },
-        ToolLogRow { time: "14:02:18".into(), actor: "b21".into(), msg: "grep ✓ 14m".into() },
-        ToolLogRow { time: "14:02:22".into(), actor: "a3f".into(), msg: "edit ✓ 12h".into() },
-        ToolLogRow { time: "14:02:25".into(), actor: "b21".into(), msg: "edit ●".into() },
-        ToolLogRow { time: "14:02:29".into(), actor: "a3f".into(), msg: "cargo ✓".into() },
-        ToolLogRow { time: "14:02:31".into(), actor: "main".into(), msg: "merge ?".into() },
+        ToolLogRow {
+            time: "14:02:13".into(),
+            actor: "main".into(),
+            msg: "spawn ×3".into(),
+        },
+        ToolLogRow {
+            time: "14:02:15".into(),
+            actor: "a3f".into(),
+            msg: "read_file ✓".into(),
+        },
+        ToolLogRow {
+            time: "14:02:18".into(),
+            actor: "b21".into(),
+            msg: "grep ✓ 14m".into(),
+        },
+        ToolLogRow {
+            time: "14:02:22".into(),
+            actor: "a3f".into(),
+            msg: "edit ✓ 12h".into(),
+        },
+        ToolLogRow {
+            time: "14:02:25".into(),
+            actor: "b21".into(),
+            msg: "edit ●".into(),
+        },
+        ToolLogRow {
+            time: "14:02:29".into(),
+            actor: "a3f".into(),
+            msg: "cargo ✓".into(),
+        },
+        ToolLogRow {
+            time: "14:02:31".into(),
+            actor: "main".into(),
+            msg: "merge ?".into(),
+        },
     ]
 }
 
 fn demo_diff() -> Vec<DiffLine> {
     vec![
-        DiffLine { text: "@@ -88,6 +88,8 @@".into(), kind: DiffKind::Hunk },
+        DiffLine {
+            text: "@@ -88,6 +88,8 @@".into(),
+            kind: DiffKind::Hunk,
+        },
         DiffLine {
             text: "- pub fn verify(&self, t: &Token) {".into(),
             kind: DiffKind::Removed,
@@ -315,35 +557,101 @@ fn demo_diff() -> Vec<DiffLine> {
             text: "+ pub fn verify<'a>(&self, t: &'a Token) -> Result<Claims> {".into(),
             kind: DiffKind::Added,
         },
-        DiffLine { text: "    let claims = decode(t)?;".into(), kind: DiffKind::Ctx },
-        DiffLine { text: "+   self.audit.log(&claims);".into(), kind: DiffKind::Added },
-        DiffLine { text: "    Ok(claims)".into(), kind: DiffKind::Ctx },
+        DiffLine {
+            text: "    let claims = decode(t)?;".into(),
+            kind: DiffKind::Ctx,
+        },
+        DiffLine {
+            text: "+   self.audit.log(&claims);".into(),
+            kind: DiffKind::Added,
+        },
+        DiffLine {
+            text: "    Ok(claims)".into(),
+            kind: DiffKind::Ctx,
+        },
     ]
 }
 
-fn demo_ticker() -> Vec<TickerCell> {
-    let subs = ["a3f", "b21", "c08", "d9k", "e44", "f12"];
-    let msgs = ["✓ tests", "edit", "grep", "run", "wait", "diff", "merge", "fork"];
-    let cols = [Palette::GREEN, Palette::YELLOW, Palette::BLUE, Palette::RED];
-    (0..16)
-        .map(|i| TickerCell {
-            sub: subs[i % subs.len()].into(),
-            msg: msgs[i % msgs.len()].into(),
-            color: cols[i % cols.len()],
-        })
-        .collect()
+fn short_text(text: &str, max: usize) -> String {
+    if text.chars().count() <= max {
+        text.to_string()
+    } else {
+        let mut out: String = text.chars().take(max).collect();
+        out.push('…');
+        out
+    }
 }
 
-fn demo_tree() -> Vec<TreeNode> {
-    vec![
-        TreeNode { depth: 0, label: "main · auth-refactor".into(), state: "★".into(), color: Palette::RED, active: false },
-        TreeNode { depth: 1, label: "├─ plan A: bottom-up".into(), state: "✓".into(), color: Palette::GREEN, active: false },
-        TreeNode { depth: 2, label: "│  ├─ users-svc".into(), state: "✓".into(), color: Palette::GREEN, active: false },
-        TreeNode { depth: 2, label: "│  ├─ billing-svc".into(), state: "●".into(), color: Palette::YELLOW, active: true },
-        TreeNode { depth: 2, label: "│  └─ gateway".into(), state: "○".into(), color: Palette::MUTED, active: false },
-        TreeNode { depth: 1, label: "├─ plan B: feature-flag".into(), state: "✗".into(), color: Palette::RED, active: false },
-        TreeNode { depth: 2, label: "│  └─ rejected: 2× cost".into(), state: " ".into(), color: Palette::MUTED, active: false },
-        TreeNode { depth: 1, label: "└─ plan C: rewrite (sub#x)".into(), state: "?".into(), color: Palette::BLUE, active: false },
-        TreeNode { depth: 2, label: "   └─ exploring…".into(), state: "●".into(), color: Palette::YELLOW, active: false },
-    ]
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::SessionSummary;
+
+    #[test]
+    fn orchestration_state_tracks_prompt_and_tool_flow() {
+        let mut app = AppState::new("test-model".into(), 128_000);
+        app.note_prompt_submitted("list files in the current directory");
+        assert_eq!(app.orchestration.phase, OrchestrationPhase::Thinking);
+        assert!(app.orchestration.active_task.contains("list files"));
+
+        app.note_tool_start("bash");
+        assert_eq!(app.orchestration.phase, OrchestrationPhase::ToolRunning);
+        assert_eq!(app.orchestration.current_tool.as_deref(), Some("bash"));
+
+        let tree = app.tree_nodes();
+        assert_eq!(tree.len(), 2);
+        assert!(tree[1].label.contains("bash"));
+
+        app.note_tool_end("bash", true);
+        assert_eq!(app.orchestration.phase, OrchestrationPhase::Thinking);
+        assert!(app.orchestration.current_tool.is_none());
+
+        app.note_done();
+        assert_eq!(app.orchestration.phase, OrchestrationPhase::Complete);
+        assert_eq!(app.ticker_cells().last().unwrap().msg, "completed turn");
+    }
+
+    #[test]
+    fn subagent_tiles_expose_single_real_orchestrator() {
+        let mut app = AppState::new("test-model".into(), 128_000);
+        app.note_prompt_submitted("check auth middleware");
+        let tiles = app.subagent_tiles();
+        assert_eq!(tiles.len(), 1);
+        assert_eq!(tiles[0].name, "main");
+        assert_eq!(tiles[0].role, "orchestrator");
+        assert!(tiles[0].log[0].contains("check auth middleware"));
+    }
+
+    #[test]
+    fn hydrate_sessions_retains_lineage_and_activity_fields() {
+        let mut app = AppState::new("test-model".into(), 128_000);
+        let parent_id = "parent-12345678".to_string();
+        let child_id = "child-87654321".to_string();
+        app.hydrate_sessions(
+            &[SessionSummary {
+                id: child_id.clone(),
+                created_at: 10,
+                last_active: 20,
+                message_count: 3,
+                parent_session_id: Some(parent_id.clone()),
+                lineage_label: Some("branched from auth cleanup".into()),
+            }],
+            &child_id,
+        );
+
+        assert_eq!(app.sessions.len(), 1);
+        let session = &app.sessions[0];
+        assert_eq!(session.id, child_id);
+        assert_eq!(
+            session.parent_session_id.as_deref(),
+            Some(parent_id.as_str())
+        );
+        assert_eq!(
+            session.lineage_label.as_deref(),
+            Some("branched from auth cleanup")
+        );
+        assert_eq!(session.status, SessionStatus::Live);
+        assert!(session.is_active);
+        assert_eq!(session.message_count, 3);
+    }
 }

--- a/src/tui/views.rs
+++ b/src/tui/views.rs
@@ -7,11 +7,9 @@ use ratatui::{
 };
 
 use super::markdown::render_markdown;
-use super::state::{AppState, ChatRole};
+use super::state::{AppState, ChatRole, SessionStatus};
 use super::theme::{Palette, body, faint_bg};
-use super::widgets::{
-    ToolStatus, fill, frame, message_header, section_header, sparkline, ticker, tool_call_lines,
-};
+use super::widgets::{fill, frame, message_header, section_header, sparkline, ticker};
 
 /// Public dispatch: render the active view inside `area`. The view writes
 /// its desired cursor position into `app` via `cursor_set`.
@@ -77,7 +75,9 @@ fn build_chat_lines(app: &AppState, show_reasoning: bool, dense: bool) -> Vec<Li
     let mut out: Vec<Line<'static>> = Vec::new();
     out.push(Line::from(Span::styled(
         format!("── session · {} ──", app.session_label),
-        Style::default().fg(Palette::MUTED).add_modifier(Modifier::DIM),
+        Style::default()
+            .fg(Palette::MUTED)
+            .add_modifier(Modifier::DIM),
     )));
     out.push(Line::from(""));
 
@@ -110,10 +110,16 @@ fn build_chat_lines(app: &AppState, show_reasoning: bool, dense: bool) -> Vec<Li
             // Streaming and content hasn't started yet — show "thinking…" hint.
             // If reasoning is already streaming above, this still tells the user
             // they're waiting on the answer (not lost).
-            let label = if m.reasoning.is_empty() { "▎ Thinking…" } else { "▎ Answering…" };
+            let label = if m.reasoning.is_empty() {
+                "▎ Thinking…"
+            } else {
+                "▎ Answering…"
+            };
             out.push(Line::from(Span::styled(
                 label,
-                Style::default().fg(Palette::MUTED).add_modifier(Modifier::SLOW_BLINK),
+                Style::default()
+                    .fg(Palette::MUTED)
+                    .add_modifier(Modifier::SLOW_BLINK),
             )));
         } else {
             // Render body with a left accent bar, inline.
@@ -165,7 +171,12 @@ fn single_stack(f: &mut TuiFrame, area: Rect, app: &AppState) {
         layout[1],
         app.mode_label(),
         &app.input,
-        &[("↵", "send"), ("⌃T", "tools"), ("⌃K", "sessions"), ("/", "cmds")],
+        &[
+            ("↵", "send"),
+            ("⌃T", "tools"),
+            ("⌃K", "sessions"),
+            ("/", "cmds"),
+        ],
         &app.model_status(),
         app.thinking,
     );
@@ -194,22 +205,41 @@ fn split_sessions(f: &mut TuiFrame, area: Rect, app: &AppState) {
     // Right pane
     let main = h[1];
     // Active session header bar
-    let header = Rect { x: main.x, y: main.y, width: main.width, height: 1 };
+    let header = Rect {
+        x: main.x,
+        y: main.y,
+        width: main.width,
+        height: 1,
+    };
     let active_name = app
-        .sessions
-        .iter()
-        .find(|s| s.active)
-        .map(|s| s.name.clone())
+        .active_session()
+        .map(|s| s.label.clone())
         .unwrap_or_else(|| app.session_label.clone());
-    let header_text = format!(
-        " {active_name}   · branched from main · {} turns",
-        app.messages.len() / 2
-    );
+    let lineage = app
+        .active_session()
+        .and_then(|s| s.lineage_label.clone())
+        .or_else(|| {
+            app.active_session()
+                .and_then(|s| s.parent_session_id.as_deref())
+                .map(|id| format!("branched from {}", id.chars().take(8).collect::<String>()))
+        })
+        .unwrap_or_else(|| "no lineage".into());
+    let turn_count = app
+        .active_session()
+        .map(|s| s.message_count)
+        .unwrap_or(app.messages.len());
+    let header_text = format!(" {active_name}   · {lineage} · {turn_count} msgs",);
     let mut spans = vec![Span::styled(
         header_text,
-        Style::default().fg(Palette::PAPER).bg(Palette::RED).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(Palette::PAPER)
+            .bg(Palette::RED)
+            .add_modifier(Modifier::BOLD),
     )];
-    let used = spans.iter().map(|s| s.content.chars().count() as u16).sum::<u16>();
+    let used = spans
+        .iter()
+        .map(|s| s.content.chars().count() as u16)
+        .sum::<u16>();
     let live_label = " ● LIVE ";
     if used + live_label.len() as u16 + 1 < main.width {
         let pad = " ".repeat((main.width - used - live_label.len() as u16) as usize);
@@ -219,7 +249,10 @@ fn split_sessions(f: &mut TuiFrame, area: Rect, app: &AppState) {
         ));
         spans.push(Span::styled(
             live_label.to_string(),
-            Style::default().fg(Palette::PAPER).bg(Palette::RED).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Palette::PAPER)
+                .bg(Palette::RED)
+                .add_modifier(Modifier::BOLD),
         ));
     }
     f.render_widget(Paragraph::new(Line::from(spans)), header);
@@ -232,7 +265,10 @@ fn split_sessions(f: &mut TuiFrame, area: Rect, app: &AppState) {
     };
     let lines = build_chat_lines(app, app.show_reasoning, false);
     f.render_widget(
-        Paragraph::new(lines).style(body()).wrap(Wrap { trim: false }).scroll((app.scroll, 0)),
+        Paragraph::new(lines)
+            .style(body())
+            .wrap(Wrap { trim: false })
+            .scroll((app.scroll, 0)),
         Rect {
             x: body_area.x + 1,
             y: body_area.y,
@@ -246,7 +282,12 @@ fn split_sessions(f: &mut TuiFrame, area: Rect, app: &AppState) {
         v[1],
         app.mode_label(),
         &app.input,
-        &[("↵", "send"), ("⌃K", "sessions"), ("⌃N", "new"), ("/", "cmds")],
+        &[
+            ("↵", "send"),
+            ("⌃K", "sessions"),
+            ("⌃N", "new"),
+            ("/", "cmds"),
+        ],
         &app.model_status(),
         app.thinking,
     );
@@ -258,34 +299,71 @@ fn render_session_rail(f: &mut TuiFrame, area: Rect, app: &AppState) {
         return;
     }
     let mut lines: Vec<Line<'static>> = Vec::new();
+    if app.sessions.is_empty() {
+        lines.push(Line::from(Span::styled(
+            " No saved sessions yet.",
+            Style::default().fg(Palette::MUTED),
+        )));
+        lines.push(Line::from(Span::styled(
+            " The active session will appear after hydration.",
+            Style::default().fg(Palette::FAINT),
+        )));
+    }
     for s in &app.sessions {
-        let status_color = match s.status.as_str() {
-            "live" => Palette::GREEN,
-            "wait" => Palette::YELLOW,
-            "done" => Palette::MUTED,
-            _ => Palette::FAINT,
+        let status_color = match s.status {
+            SessionStatus::Live => Palette::GREEN,
+            SessionStatus::Saved => Palette::BLUE,
         };
-        let bar = if s.active { "▌" } else { " " };
-        let bar_color = if s.active { Palette::RED } else { Palette::FAINT };
-        let bg = if s.active { Palette::PAPER } else { Palette::FAINT };
+        let bar = if s.is_active { "▌" } else { " " };
+        let bar_color = if s.is_active {
+            Palette::RED
+        } else {
+            Palette::FAINT
+        };
+        let bg = if s.is_active {
+            Palette::PAPER
+        } else {
+            Palette::FAINT
+        };
         let style = Style::default().fg(Palette::INK).bg(bg);
         lines.push(Line::from(vec![
-            Span::styled(bar, Style::default().fg(bar_color).bg(bg).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                bar,
+                Style::default()
+                    .fg(bar_color)
+                    .bg(bg)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::styled(" █ ", Style::default().fg(status_color).bg(bg)),
-            Span::styled(format!("{}", s.name), style.add_modifier(Modifier::BOLD)),
+            Span::styled(s.label.clone(), style.add_modifier(Modifier::BOLD)),
         ]));
         lines.push(Line::from(vec![
             Span::styled(bar, Style::default().fg(bar_color).bg(bg)),
             Span::styled(
-                format!(" {:<6}    {:>4}", s.status.to_uppercase(), s.tokens),
+                format!(
+                    " {:<6}    {:>4}m",
+                    s.status.label().to_uppercase(),
+                    s.message_count
+                ),
                 Style::default().fg(Palette::MUTED).bg(bg),
             ),
         ]));
+        if let Some(lineage) = &s.lineage_label {
+            lines.push(Line::from(vec![
+                Span::styled(bar, Style::default().fg(bar_color).bg(bg)),
+                Span::styled(
+                    format!(" {}", lineage),
+                    Style::default().fg(Palette::FAINT).bg(bg),
+                ),
+            ]));
+        }
     }
     lines.push(Line::from(""));
     lines.push(Line::from(Span::styled(
         " + NEW SESSION",
-        Style::default().fg(Palette::INK).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(Palette::INK)
+            .add_modifier(Modifier::BOLD),
     )));
     f.render_widget(Paragraph::new(lines).style(faint_bg()), area);
 }
@@ -293,7 +371,11 @@ fn render_session_rail(f: &mut TuiFrame, area: Rect, app: &AppState) {
 // ─── 03 TILED MESH ──────────────────────────────────────────────────────
 
 fn tiled_mesh(f: &mut TuiFrame, area: Rect, app: &AppState) {
-    let outer = frame(f, area, app.view.title(), Some("1 + 3 sub-agents"), None);
+    let status = format!(
+        "1 orchestrator · {} delegated",
+        app.delegated_worker_count()
+    );
+    let outer = frame(f, area, app.view.title(), Some(&status), None);
     let v = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Min(5), Constraint::Length(3)])
@@ -312,21 +394,33 @@ fn tiled_mesh(f: &mut TuiFrame, area: Rect, app: &AppState) {
         .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
         .split(rows[1]);
     let cells = [top[0], top[1], bot[0], bot[1]];
+    let tiles = app.subagent_tiles();
 
     for (i, cell) in cells.iter().enumerate() {
-        let tile = &app.subagents[i.min(app.subagents.len() - 1)];
-        let inner = section_header(f, *cell, &format!("{} · {}", tile.name, tile.role), Some(tile.color));
+        let Some(tile) = tiles.get(i) else {
+            render_empty_activity_tile(f, *cell, "worker slot", "No delegated worker");
+            continue;
+        };
+        let inner = section_header(
+            f,
+            *cell,
+            &format!("{} · {}", tile.name, tile.role),
+            Some(tile.color),
+        );
         let mut lines: Vec<Line<'static>> = Vec::new();
-        let spark = sparkline(&tile.cpu);
         lines.push(Line::from(vec![
-            Span::styled("STATE ", Style::default().fg(Palette::MUTED).add_modifier(Modifier::DIM)),
+            Span::styled(
+                "STATE ",
+                Style::default()
+                    .fg(Palette::MUTED)
+                    .add_modifier(Modifier::DIM),
+            ),
             Span::styled(
                 tile.state.to_uppercase(),
-                Style::default().fg(Palette::INK).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(Palette::INK)
+                    .add_modifier(Modifier::BOLD),
             ),
-            Span::raw("   "),
-            Span::styled("CPU ", Style::default().fg(Palette::MUTED).add_modifier(Modifier::DIM)),
-            Span::styled(spark, Style::default().fg(tile.color).add_modifier(Modifier::BOLD)),
         ]));
         lines.push(Line::from(""));
         for (n, l) in tile.log.iter().enumerate() {
@@ -340,12 +434,21 @@ fn tiled_mesh(f: &mut TuiFrame, area: Rect, app: &AppState) {
         }
         if i == 0 && app.show_reasoning {
             lines.push(Line::from(""));
-            for l in super::widgets::reasoning_lines("holding diff merge until billing-svc clears tests", false) {
-                lines.push(l);
+            if let Some(reasoning) = app.latest_reasoning() {
+                for l in super::widgets::reasoning_lines(reasoning, false) {
+                    lines.push(l);
+                }
+            } else {
+                lines.push(Line::from(Span::styled(
+                    "No live reasoning trace yet.",
+                    Style::default().fg(Palette::MUTED),
+                )));
             }
         }
         f.render_widget(
-            Paragraph::new(lines).style(body()).wrap(Wrap { trim: false }),
+            Paragraph::new(lines)
+                .style(body())
+                .wrap(Wrap { trim: false }),
             Rect {
                 x: inner.x + 1,
                 y: inner.y,
@@ -370,7 +473,9 @@ fn tiled_mesh(f: &mut TuiFrame, area: Rect, app: &AppState) {
 // ─── 04 TREE OF THOUGHT ─────────────────────────────────────────────────
 
 fn tree_of_thought(f: &mut TuiFrame, area: Rect, app: &AppState) {
-    let outer = frame(f, area, app.view.title(), Some("3 branches · 1 active"), None);
+    let tree_nodes = app.tree_nodes();
+    let summary = format!("{} branch runtime slots", app.branch_count());
+    let outer = frame(f, area, app.view.title(), Some(&summary), None);
     let v = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Min(5), Constraint::Length(3)])
@@ -384,103 +489,90 @@ fn tree_of_thought(f: &mut TuiFrame, area: Rect, app: &AppState) {
     fill(f, h[0], faint_bg());
     let inner = section_header(f, h[0], "decision tree", None);
     let mut lines: Vec<Line<'static>> = Vec::new();
-    for n in &app.tree {
-        let bg = if n.active { Palette::PAPER } else { Palette::FAINT };
+    for n in &tree_nodes {
+        let bg = if n.active {
+            Palette::PAPER
+        } else {
+            Palette::FAINT
+        };
         let bar = if n.active { "▌" } else { " " };
-        let bar_color = if n.active { Palette::RED } else { Palette::FAINT };
+        let bar_color = if n.active {
+            Palette::RED
+        } else {
+            Palette::FAINT
+        };
         lines.push(Line::from(vec![
             Span::styled(
                 bar,
-                Style::default().fg(bar_color).bg(bg).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(bar_color)
+                    .bg(bg)
+                    .add_modifier(Modifier::BOLD),
             ),
             Span::styled(
                 format!(" {} ", n.state),
-                Style::default().fg(n.color).bg(bg).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(n.color)
+                    .bg(bg)
+                    .add_modifier(Modifier::BOLD),
             ),
             Span::styled(
                 n.label.clone(),
-                Style::default().fg(Palette::INK).bg(bg).add_modifier(if n.depth == 0 {
-                    Modifier::BOLD
-                } else {
-                    Modifier::empty()
-                }),
+                Style::default()
+                    .fg(Palette::INK)
+                    .bg(bg)
+                    .add_modifier(if n.depth == 0 {
+                        Modifier::BOLD
+                    } else {
+                        Modifier::empty()
+                    }),
             ),
         ]));
     }
     lines.push(Line::from(""));
-    for hint in [
-        " j/k navigate · ↵ focus",
-        " b new branch · x kill",
-        " m merge into parent",
-    ] {
-        lines.push(Line::from(Span::styled(
-            hint,
-            Style::default().fg(Palette::MUTED).bg(Palette::FAINT),
-        )));
-    }
+    lines.push(Line::from(Span::styled(
+        " Delegated branch runtime not enabled yet.",
+        Style::default().fg(Palette::MUTED).bg(Palette::FAINT),
+    )));
+    lines.push(Line::from(Span::styled(
+        " This pane currently shows the root orchestrator state only.",
+        Style::default().fg(Palette::MUTED).bg(Palette::FAINT),
+    )));
     f.render_widget(Paragraph::new(lines).style(faint_bg()), inner);
 
     // Right: focused stream
-    let focus_header = Rect {
-        x: h[1].x,
-        y: h[1].y,
-        width: h[1].width,
-        height: 1,
-    };
-    let mut text = " ▶ FOCUSED: PLAN A → BILLING-SVC".to_string();
-    if (text.chars().count() as u16) < focus_header.width {
-        text.push_str(&" ".repeat((focus_header.width as usize) - text.chars().count()));
-    }
-    f.render_widget(
-        Paragraph::new(text).style(
-            Style::default().fg(Palette::INK).bg(Palette::YELLOW).add_modifier(Modifier::BOLD),
-        ),
-        focus_header,
-    );
-    let body_area = Rect {
-        x: h[1].x,
-        y: h[1].y + 1,
-        width: h[1].width,
-        height: h[1].height.saturating_sub(1),
-    };
+    let focus_inner = section_header(f, h[1], "focused stream", Some(Palette::YELLOW));
     let mut lines = Vec::new();
     lines.push(message_header("orchestrator", Palette::RED, Some("root")));
     lines.push(Line::from(Span::styled(
-        "▎ I forked three plans. A wins on test coverage; C is exploratory.",
-        Style::default().fg(Palette::INK),
-    )));
-    lines.push(Line::from(""));
-    lines.push(message_header("billing-svc", Palette::YELLOW, Some("a.2")));
-    lines.push(Line::from(Span::styled(
-        "▎ Found 6 callsites. Patching AuthMiddleware::verify.",
+        format!("▎ {}", app.orchestration.active_task),
         Style::default().fg(Palette::INK),
     )));
     if app.show_reasoning {
-        lines.push(Line::from(""));
-        for l in super::widgets::reasoning_lines(
-            "Trait bound on Verify needs lifetime relaxation — propagating up.",
-            false,
-        ) {
-            lines.push(l);
+        if let Some(reasoning) = app.latest_reasoning() {
+            lines.push(Line::from(""));
+            for l in super::widgets::reasoning_lines(reasoning, false) {
+                lines.push(l);
+            }
         }
     }
-    lines.push(Line::from(""));
-    for l in tool_call_lines(
-        "edit_file",
-        "services/billing/src/auth.rs L88-L142",
-        ToolStatus::Run,
-        None,
-    ) {
-        lines.push(l);
+    if let Some(content) = app.latest_agent_content() {
+        lines.push(Line::from(""));
+        for line in render_markdown(content) {
+            lines.push(Line::from(line.spans));
+        }
+    } else {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "No focused branch output yet.",
+            Style::default().fg(Palette::MUTED),
+        )));
     }
     f.render_widget(
-        Paragraph::new(lines).style(body()).wrap(Wrap { trim: false }),
-        Rect {
-            x: body_area.x + 1,
-            y: body_area.y,
-            width: body_area.width.saturating_sub(2),
-            height: body_area.height,
-        },
+        Paragraph::new(lines)
+            .style(body())
+            .wrap(Wrap { trim: false }),
+        focus_inner,
     );
 
     let (cx, cy) = super::widgets::prompt_row(
@@ -488,7 +580,12 @@ fn tree_of_thought(f: &mut TuiFrame, area: Rect, app: &AppState) {
         v[1],
         "ASK",
         &app.input,
-        &[("↵", "send"), ("M", "merge"), ("X", "kill"), ("B", "branch")],
+        &[
+            ("↵", "send"),
+            ("M", "merge"),
+            ("X", "kill"),
+            ("B", "branch"),
+        ],
         &app.model_status(),
         app.thinking,
     );
@@ -498,19 +595,20 @@ fn tree_of_thought(f: &mut TuiFrame, area: Rect, app: &AppState) {
 // ─── 05 TRADING FLOOR ───────────────────────────────────────────────────
 
 fn trading_floor(f: &mut TuiFrame, area: Rect, app: &AppState) {
+    let subagents = app.subagent_tiles();
     let status = format!(
         "{} sess · {} sub · ⌬ 38k tok/m",
         app.sessions.len(),
-        app.subagents.len()
+        subagents.len()
     );
     let outer = frame(f, area, app.view.title(), Some(&status), None);
 
     let v = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Min(8),       // grid
-            Constraint::Length(1),    // ticker
-            Constraint::Length(3),    // prompt row
+            Constraint::Min(8),    // grid
+            Constraint::Length(1), // ticker
+            Constraint::Length(3), // prompt row
         ])
         .split(outer);
 
@@ -565,22 +663,25 @@ fn trading_floor(f: &mut TuiFrame, area: Rect, app: &AppState) {
         ])
         .split(sub_inner);
     for (i, cell) in sub_rows.iter().enumerate() {
-        let tile = &app.subagents[i.min(app.subagents.len() - 1)];
+        let Some(tile) = subagents.get(i) else {
+            render_empty_activity_tile(f, *cell, "worker slot", "No delegated worker");
+            continue;
+        };
         let mut lines: Vec<Line<'static>> = Vec::new();
-        let spark = sparkline(&tile.cpu);
         lines.push(Line::from(vec![
-            Span::styled("█ ", Style::default().fg(tile.color).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "█ ",
+                Style::default().fg(tile.color).add_modifier(Modifier::BOLD),
+            ),
             Span::styled(
                 tile.name.clone(),
-                Style::default().fg(Palette::INK).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(Palette::INK)
+                    .add_modifier(Modifier::BOLD),
             ),
             Span::styled(
                 format!(" · {}", tile.role),
                 Style::default().fg(Palette::MUTED),
-            ),
-            Span::styled(
-                format!("   {}", spark),
-                Style::default().fg(tile.color),
             ),
         ]));
         for (n, l) in tile.log.iter().enumerate() {
@@ -595,7 +696,9 @@ fn trading_floor(f: &mut TuiFrame, area: Rect, app: &AppState) {
             )));
         }
         f.render_widget(
-            Paragraph::new(lines).style(body()).wrap(Wrap { trim: false }),
+            Paragraph::new(lines)
+                .style(body())
+                .wrap(Wrap { trim: false }),
             Rect {
                 x: cell.x + 1,
                 y: cell.y,
@@ -609,21 +712,38 @@ fn trading_floor(f: &mut TuiFrame, area: Rect, app: &AppState) {
     // ── sessions list (top-right)
     let ses_inner = section_header(f, top[2], "sessions", None);
     let mut lines: Vec<Line<'static>> = Vec::new();
+    if app.sessions.is_empty() {
+        lines.push(Line::from(Span::styled(
+            " No saved sessions yet.",
+            Style::default().fg(Palette::MUTED),
+        )));
+    }
     for s in &app.sessions {
-        let bg = if s.active { Palette::FAINT } else { Palette::PAPER };
-        let bar = if s.active { "▌" } else { " " };
+        let bg = if s.is_active {
+            Palette::FAINT
+        } else {
+            Palette::PAPER
+        };
+        let bar = if s.is_active { "▌" } else { " " };
+        let accent = match s.status {
+            SessionStatus::Live => Palette::GREEN,
+            SessionStatus::Saved => Palette::BLUE,
+        };
         lines.push(Line::from(vec![
             Span::styled(
                 bar,
-                Style::default().fg(Palette::RED).bg(bg).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(Palette::RED)
+                    .bg(bg)
+                    .add_modifier(Modifier::BOLD),
             ),
-            Span::styled(" █ ", Style::default().fg(s.color).bg(bg)),
+            Span::styled(" █ ", Style::default().fg(accent).bg(bg)),
             Span::styled(
-                format!("{:<14}", s.name),
+                format!("{:<14}", s.label),
                 Style::default().fg(Palette::INK).bg(bg),
             ),
             Span::styled(
-                format!(" {}", s.tokens),
+                format!(" {}m", s.message_count),
                 Style::default().fg(Palette::MUTED).bg(bg),
             ),
         ]));
@@ -639,13 +759,12 @@ fn trading_floor(f: &mut TuiFrame, area: Rect, app: &AppState) {
         let last = i + 1 == row_count;
         let color = if last { Palette::INK } else { Palette::MUTED };
         lines.push(Line::from(vec![
-            Span::styled(
-                format!("{:>8} ", row.time),
-                Style::default().fg(color),
-            ),
+            Span::styled(format!("{:>8} ", row.time), Style::default().fg(color)),
             Span::styled(
                 format!("{:<5} ", row.actor),
-                Style::default().fg(Palette::INK).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(Palette::INK)
+                    .add_modifier(Modifier::BOLD),
             ),
             Span::styled(row.msg.clone(), Style::default().fg(color)),
         ]));
@@ -658,7 +777,9 @@ fn trading_floor(f: &mut TuiFrame, area: Rect, app: &AppState) {
     let mut lines: Vec<Line<'static>> = Vec::new();
     for ln in &app.diff_lines {
         let style = match ln.kind {
-            DiffKind::Hunk => Style::default().fg(Palette::MUTED).add_modifier(Modifier::DIM),
+            DiffKind::Hunk => Style::default()
+                .fg(Palette::MUTED)
+                .add_modifier(Modifier::DIM),
             DiffKind::Added => Style::default().fg(Palette::GREEN),
             DiffKind::Removed => Style::default().fg(Palette::RED),
             DiffKind::Ctx => Style::default().fg(Palette::INK),
@@ -666,7 +787,9 @@ fn trading_floor(f: &mut TuiFrame, area: Rect, app: &AppState) {
         lines.push(Line::from(Span::styled(ln.text.clone(), style)));
     }
     f.render_widget(
-        Paragraph::new(lines).style(body()).wrap(Wrap { trim: false }),
+        Paragraph::new(lines)
+            .style(body())
+            .wrap(Wrap { trim: false }),
         Rect {
             x: diff_inner.x + 1,
             y: diff_inner.y,
@@ -689,9 +812,14 @@ fn trading_floor(f: &mut TuiFrame, area: Rect, app: &AppState) {
         lines.push(Line::from(vec![
             Span::styled(
                 format!(" {label}  "),
-                Style::default().fg(Palette::MUTED).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(Palette::MUTED)
+                    .add_modifier(Modifier::BOLD),
             ),
-            Span::styled(sparkline(&vals), Style::default().fg(color).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                sparkline(&vals),
+                Style::default().fg(color).add_modifier(Modifier::BOLD),
+            ),
         ]));
     }
     lines.push(Line::from(Span::styled(
@@ -701,8 +829,16 @@ fn trading_floor(f: &mut TuiFrame, area: Rect, app: &AppState) {
     let pad = m_inner.width.saturating_sub(2) as usize;
     for (k, v) in [("session", "$0.84"), ("today", "$12.40"), ("cap", "$50.00")] {
         let used = k.len() + v.len() + 2;
-        let middle = if pad > used { " ".repeat(pad - used) } else { String::new() };
-        let color = if k == "cap" { Palette::RED } else { Palette::INK };
+        let middle = if pad > used {
+            " ".repeat(pad - used)
+        } else {
+            String::new()
+        };
+        let color = if k == "cap" {
+            Palette::RED
+        } else {
+            Palette::INK
+        };
         lines.push(Line::from(vec![
             Span::styled(format!(" {k}"), Style::default().fg(Palette::MUTED)),
             Span::styled(middle, Style::default().fg(Palette::PAPER)),
@@ -720,13 +856,18 @@ fn trading_floor(f: &mut TuiFrame, area: Rect, app: &AppState) {
         let div = "─".repeat(v[0].width as usize);
         f.render_widget(
             Paragraph::new(div).style(Style::default().fg(Palette::INK).bg(Palette::PAPER)),
-            Rect { x: v[0].x, y: div_y, width: v[0].width, height: 1 },
+            Rect {
+                x: v[0].x,
+                y: div_y,
+                width: v[0].width,
+                height: 1,
+            },
         );
     }
 
     // ── ticker
     let ticker_cells: Vec<(String, String, ratatui::style::Color)> = app
-        .ticker
+        .ticker_cells()
         .iter()
         .map(|t| (t.sub.clone(), t.msg.clone(), t.color))
         .collect();
@@ -745,6 +886,35 @@ fn trading_floor(f: &mut TuiFrame, area: Rect, app: &AppState) {
     app.cursor_set(cx, cy);
 }
 
+fn render_empty_activity_tile(f: &mut TuiFrame, area: Rect, label: &str, msg: &str) {
+    let inner = section_header(f, area, label, Some(Palette::MUTED));
+    let lines = vec![
+        Line::from(Span::styled(
+            "STATE EMPTY",
+            Style::default()
+                .fg(Palette::MUTED)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(msg, Style::default().fg(Palette::INK))),
+        Line::from(Span::styled(
+            "Delegation/runtime wiring has not been enabled yet.",
+            Style::default().fg(Palette::MUTED),
+        )),
+    ];
+    f.render_widget(
+        Paragraph::new(lines)
+            .style(body())
+            .wrap(Wrap { trim: false }),
+        Rect {
+            x: inner.x + 1,
+            y: inner.y,
+            width: inner.width.saturating_sub(2),
+            height: inner.height,
+        },
+    );
+}
+
 fn draw_v_divider(f: &mut TuiFrame, area: Rect) {
     if area.width < 2 || area.height == 0 {
         return;
@@ -760,7 +930,12 @@ fn draw_v_divider(f: &mut TuiFrame, area: Rect) {
         .collect();
     f.render_widget(
         Paragraph::new(lines),
-        Rect { x, y: area.y, width: 1, height: area.height },
+        Rect {
+            x,
+            y: area.y,
+            width: 1,
+            height: area.height,
+        },
     );
 }
 
@@ -778,4 +953,3 @@ pub struct DiffLine {
     pub text: String,
     pub kind: DiffKind,
 }
-


### PR DESCRIPTION
Wires the non-chat TUI views to live data instead of hardcoded demos.

- New SessionState / SessionStatus / OrchestrationState types in
  src/tui/state.rs replace the demo Vec<SessionRow> + demo_subagents /
  demo_ticker / demo_tree fixtures. AppState now hydrates sessions from
  SessionStore::list_sessions and tracks the active session.
- OrchestrationState records per-turn events (prompt submit, reasoning,
  tool start/end, pause/resume, done, error) and projects them into
  subagent tiles, ticker cells, and tree nodes for the existing layouts.
- Views consume SessionState lineage labels (driven by YYC-65) so
  SplitSessions shows real "branched from" relationships rather than the
  hardcoded "branched from main" string.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>