### PR TITLE
YYC-71: Render reasoning, tool calls, and text in arrival order

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -214,6 +214,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
             role: ChatRole::System,
             content: note,
             reasoning: String::new(),
+                            segments: Vec::new(),
         });
 
         // Hydrate prior turns into the chat panel so resumed sessions show their
@@ -243,6 +244,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                             role: ChatRole::Agent,
                             content: content.unwrap_or_default(),
                             reasoning: reasoning_content.unwrap_or_default(),
+                            segments: Vec::new(),
                         });
                     }
                     Message::Tool { .. } => {} // skip — audit log shows tool activity
@@ -318,6 +320,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                         role: ChatRole::System,
                         content: format!("⏸  Agent paused — {summary}"),
                         reasoning: String::new(),
+                            segments: Vec::new(),
                     });
                     app.note_pause(&summary);
                     app.pending_pause = Some(p);
@@ -352,6 +355,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                                 role: ChatRole::System,
                                                 content: format!("▶  Resumed — {label}"),
                                                 reasoning: String::new(),
+                            segments: Vec::new(),
                                             });
                                             app.note_resume(label);
                                         }
@@ -386,6 +390,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                                     role: ChatRole::System,
                                                     content: "Cancelling current turn… (Ctrl+C again to quit)".into(),
                                                     reasoning: String::new(),
+                            segments: Vec::new(),
                                                 });
                                                 pending_quit = true;
                                             } else {
@@ -394,6 +399,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                                     role: ChatRole::System,
                                                     content: "Press Ctrl+C again to quit, or any key to cancel.".into(),
                                                     reasoning: String::new(),
+                            segments: Vec::new(),
                                                 });
                                             }
                                             continue;
@@ -433,6 +439,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                                             role: ChatRole::System,
                                                             content: format!("Reasoning trace: {}", if app.show_reasoning { "on" } else { "off" }),
                                                             reasoning: String::new(),
+                            segments: Vec::new(),
                                                         });
                                                         continue;
                                                     }
@@ -462,6 +469,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                                                 role: ChatRole::System,
                                                                 content: "Usage: /search <query>".into(),
                                                                 reasoning: String::new(),
+                            segments: Vec::new(),
                                                             });
                                                             continue;
                                                         }
@@ -490,6 +498,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                                             role: ChatRole::System,
                                                             content: report,
                                                             reasoning: String::new(),
+                            segments: Vec::new(),
                                                         });
                                                         continue;
                                                     }
@@ -498,6 +507,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                                             role: ChatRole::System,
                                                             content: format!("Unknown command: {msg}. Try /help"),
                                                             reasoning: String::new(),
+                            segments: Vec::new(),
                                                         });
                                                         continue;
                                                     }
@@ -556,16 +566,24 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                     Some(StreamEvent::Text(chunk)) => {
                         if let Some(last) = app.messages.last_mut() {
                             if matches!(last.role, ChatRole::Agent) {
+                                // Append to both the segment timeline (the
+                                // YYC-71 ordered renderer) and the legacy
+                                // `content` field (kept so other code that
+                                // peeks at .content keeps working).
+                                last.append_text(&chunk);
                                 last.content.push_str(&chunk);
                             }
                         }
                     }
                     Some(StreamEvent::Reasoning(chunk)) => {
                         // Per-token reasoning trace from thinking-mode models.
-                        // Append to the current agent message's reasoning buffer
-                        // so the renderer can show it as the model thinks.
+                        // Push to the segment timeline so it interleaves with
+                        // tool calls in render order; also append to the
+                        // legacy `reasoning` field so latest_reasoning() etc.
+                        // continue to work.
                         if let Some(last) = app.messages.last_mut() {
                             if matches!(last.role, ChatRole::Agent) {
+                                last.append_reasoning(&chunk);
                                 last.reasoning.push_str(&chunk);
                             }
                         }
@@ -589,14 +607,15 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                         app.note_error(&e);
                     }
                     Some(StreamEvent::ToolCallStart { name, .. }) => {
-                        // Append an in-progress marker to the agent message.
-                        // ToolCallEnd will later flip the trailing `…` to `✓` / `✗`.
-                        // Newline before the marker only if there's preamble content;
-                        // otherwise it'd be one orphan blank line in front of the marker.
+                        // Push a tool-call segment into the timeline. The
+                        // renderer interleaves it between Reasoning/Text
+                        // segments in arrival order (YYC-71). The legacy
+                        // `content` string is left alone — its embedded
+                        // `_[🔧 …]_` markers are gone since the renderer now
+                        // gets tool calls from `segments`.
                         if let Some(last) = app.messages.last_mut() {
                             if matches!(last.role, ChatRole::Agent) {
-                                let prefix = if last.content.is_empty() { "" } else { "\n\n" };
-                                last.content.push_str(&format!("{prefix}_[🔧 {name}…]_"));
+                                last.push_tool_start(name.clone());
                             }
                         }
                         app.note_tool_start(&name);
@@ -604,13 +623,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                     Some(StreamEvent::ToolCallEnd { name, ok, .. }) => {
                         if let Some(last) = app.messages.last_mut() {
                             if matches!(last.role, ChatRole::Agent) {
-                                let mark = if ok { "✓" } else { "✗" };
-                                let in_progress = format!("_[🔧 {name}…]_");
-                                let done = format!("_[🔧 {name} {mark}]_");
-                                if let Some(pos) = last.content.find(&in_progress) {
-                                    last.content
-                                        .replace_range(pos..pos + in_progress.len(), &done);
-                                }
+                                last.finish_tool(&name, ok);
                             }
                         }
                         app.note_tool_end(&name, ok);

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -17,14 +17,40 @@ pub enum ChatRole {
     System,
 }
 
+/// In-flight or completed tool call rendered inside an agent message timeline.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ToolStatus {
+    InProgress,
+    /// `bool` is the success flag — true → ✓, false → ✗.
+    Done(bool),
+}
+
+/// One slice of an agent's response timeline, in arrival order. Segments
+/// preserve the natural interleaving of reasoning, tool calls, and text so
+/// the renderer can show the agent's actual flow (think → tool → think →
+/// answer) instead of bunching all reasoning above all tool calls (YYC-71).
+#[derive(Clone, Debug)]
+pub enum MessageSegment {
+    Reasoning(String),
+    Text(String),
+    ToolCall { name: String, status: ToolStatus },
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct ChatMessage {
     pub role: ChatRole,
+    /// Flattened text content (kept for hydration from `Message::Assistant`
+    /// where the wire format only has aggregate content + reasoning, no
+    /// per-event timeline). Used as a fallback by the renderer when
+    /// `segments` is empty.
     pub content: String,
-    /// Reasoning trace for thinking-mode models (`Message::Assistant.reasoning_content`).
-    /// Populated for agent messages from streaming `StreamEvent::Reasoning` deltas
-    /// and from session-resume hydration. Empty for everything else.
+    /// Aggregate reasoning trace for hydrated messages. Renderer falls back
+    /// to this only when `segments` is empty.
     pub reasoning: String,
+    /// Ordered timeline of reasoning fragments, tool calls, and text chunks
+    /// as they arrived. Populated for live streamed agent messages; empty
+    /// for user/system messages and hydrated history.
+    pub segments: Vec<MessageSegment>,
 }
 
 impl ChatMessage {
@@ -33,6 +59,77 @@ impl ChatMessage {
             role,
             content: content.into(),
             reasoning: String::new(),
+            segments: Vec::new(),
+        }
+    }
+
+    /// True if neither the live segment timeline nor the hydrated content
+    /// field has any text. Used by the renderer to decide whether to show
+    /// the streaming "Thinking…" / "Answering…" placeholder.
+    pub fn has_text(&self) -> bool {
+        if !self.content.is_empty() {
+            return true;
+        }
+        self.segments
+            .iter()
+            .any(|s| matches!(s, MessageSegment::Text(t) if !t.is_empty()))
+    }
+
+    /// True if any reasoning has been recorded — either streamed into
+    /// segments or hydrated into the legacy `reasoning` field.
+    pub fn has_reasoning(&self) -> bool {
+        if !self.reasoning.is_empty() {
+            return true;
+        }
+        self.segments
+            .iter()
+            .any(|s| matches!(s, MessageSegment::Reasoning(r) if !r.is_empty()))
+    }
+
+    /// Append a text chunk to the segment timeline, coalescing with the
+    /// trailing segment if it's also text.
+    pub fn append_text(&mut self, chunk: &str) {
+        match self.segments.last_mut() {
+            Some(MessageSegment::Text(t)) => t.push_str(chunk),
+            _ => self.segments.push(MessageSegment::Text(chunk.to_string())),
+        }
+    }
+
+    /// Append a reasoning chunk to the segment timeline, coalescing with the
+    /// trailing segment if it's also reasoning. New tool calls or text break
+    /// the run, so subsequent reasoning starts a fresh segment — that's the
+    /// whole point of YYC-71.
+    pub fn append_reasoning(&mut self, chunk: &str) {
+        match self.segments.last_mut() {
+            Some(MessageSegment::Reasoning(r)) => r.push_str(chunk),
+            _ => self
+                .segments
+                .push(MessageSegment::Reasoning(chunk.to_string())),
+        }
+    }
+
+    pub fn push_tool_start(&mut self, name: impl Into<String>) {
+        self.segments.push(MessageSegment::ToolCall {
+            name: name.into(),
+            status: ToolStatus::InProgress,
+        });
+    }
+
+    /// Mark the most recent in-progress ToolCall with this name as done.
+    /// Walks segments in reverse so concurrent dispatch (YYC-34) still
+    /// pairs each end with its own start as the matching tail.
+    pub fn finish_tool(&mut self, name: &str, ok: bool) {
+        for seg in self.segments.iter_mut().rev() {
+            if let MessageSegment::ToolCall {
+                name: n,
+                status: status @ ToolStatus::InProgress,
+            } = seg
+            {
+                if n == name {
+                    *status = ToolStatus::Done(ok);
+                    return;
+                }
+            }
         }
     }
 }
@@ -653,5 +750,77 @@ mod tests {
         assert_eq!(session.status, SessionStatus::Live);
         assert!(session.is_active);
         assert_eq!(session.message_count, 3);
+    }
+
+    #[test]
+    fn segments_interleave_reasoning_tool_text_in_arrival_order() {
+        // Simulates the exact YYC-71 sequence: think → tool → think → answer.
+        let mut m = ChatMessage::new(ChatRole::Agent, "");
+        m.append_reasoning("checking the file");
+        m.push_tool_start("read_file");
+        m.finish_tool("read_file", true);
+        m.append_reasoning("now writing");
+        m.push_tool_start("write_file");
+        m.finish_tool("write_file", true);
+        m.append_text("Done!");
+
+        let kinds: Vec<&str> = m
+            .segments
+            .iter()
+            .map(|s| match s {
+                MessageSegment::Reasoning(_) => "reasoning",
+                MessageSegment::Text(_) => "text",
+                MessageSegment::ToolCall { .. } => "tool",
+            })
+            .collect();
+        assert_eq!(
+            kinds,
+            vec!["reasoning", "tool", "reasoning", "tool", "text"]
+        );
+    }
+
+    #[test]
+    fn append_reasoning_coalesces_until_broken_by_other_segment() {
+        let mut m = ChatMessage::new(ChatRole::Agent, "");
+        m.append_reasoning("first ");
+        m.append_reasoning("chunk");
+        m.push_tool_start("bash");
+        m.append_reasoning("after tool");
+        // Three segments: reasoning, tool, reasoning — second reasoning is
+        // its own segment because the tool call broke the run.
+        assert_eq!(m.segments.len(), 3);
+        match &m.segments[0] {
+            MessageSegment::Reasoning(r) => assert_eq!(r, "first chunk"),
+            other => panic!("expected reasoning, got {other:?}"),
+        }
+        match &m.segments[2] {
+            MessageSegment::Reasoning(r) => assert_eq!(r, "after tool"),
+            other => panic!("expected reasoning, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn finish_tool_pairs_with_most_recent_in_progress_call_of_same_name() {
+        // Parallel dispatch (YYC-34): two write_file calls in flight; the
+        // first to finish should pair with the most recent matching start
+        // that's still in-progress.
+        let mut m = ChatMessage::new(ChatRole::Agent, "");
+        m.push_tool_start("write_file");
+        m.push_tool_start("write_file");
+        m.finish_tool("write_file", true);
+
+        let statuses: Vec<ToolStatus> = m
+            .segments
+            .iter()
+            .filter_map(|s| match s {
+                MessageSegment::ToolCall { status, .. } => Some(*status),
+                _ => None,
+            })
+            .collect();
+        // Most-recent in-progress finishes first; the older one stays open.
+        assert_eq!(
+            statuses,
+            vec![ToolStatus::InProgress, ToolStatus::Done(true)]
+        );
     }
 }

--- a/src/tui/views.rs
+++ b/src/tui/views.rs
@@ -7,7 +7,7 @@ use ratatui::{
 };
 
 use super::markdown::render_markdown;
-use super::state::{AppState, ChatRole, SessionStatus};
+use super::state::{AppState, ChatRole, MessageSegment, SessionStatus, ToolStatus};
 use super::theme::{Palette, body, faint_bg};
 use super::widgets::{fill, frame, message_header, section_header, sparkline, ticker};
 
@@ -97,37 +97,90 @@ fn build_chat_lines(app: &AppState, show_reasoning: bool, dense: bool) -> Vec<Li
         };
         out.push(message_header(role_label, accent, None));
 
-        // Reasoning trace from a thinking-mode model, when present and toggle is on.
-        // Rendered before the agent's content so the visual order matches the
-        // model's natural output (think → answer).
-        if show_reasoning && matches!(m.role, ChatRole::Agent) && !m.reasoning.is_empty() {
-            for l in super::widgets::reasoning_lines(&m.reasoning, false) {
-                out.push(l);
-            }
-        }
+        let is_agent = matches!(m.role, ChatRole::Agent);
 
-        if matches!(m.role, ChatRole::Agent) && m.content.is_empty() {
-            // Streaming and content hasn't started yet — show "thinking…" hint.
-            // If reasoning is already streaming above, this still tells the user
-            // they're waiting on the answer (not lost).
-            let label = if m.reasoning.is_empty() {
-                "▎ Thinking…"
-            } else {
-                "▎ Answering…"
-            };
-            out.push(Line::from(Span::styled(
-                label,
-                Style::default()
-                    .fg(Palette::MUTED)
-                    .add_modifier(Modifier::SLOW_BLINK),
-            )));
+        if is_agent && !m.segments.is_empty() {
+            // Live timeline (YYC-71): render reasoning, tool calls, and text
+            // in arrival order. Reasoning fragments only emit when the
+            // toggle is on; tool calls always emit.
+            let mut text_emitted = false;
+            for seg in &m.segments {
+                match seg {
+                    MessageSegment::Reasoning(r) if show_reasoning && !r.is_empty() => {
+                        for l in super::widgets::reasoning_lines(r, false) {
+                            out.push(l);
+                        }
+                    }
+                    MessageSegment::Reasoning(_) => {}
+                    MessageSegment::ToolCall { name, status } => {
+                        let body = match status {
+                            ToolStatus::InProgress => format!("_[🔧 {name}…]_"),
+                            ToolStatus::Done(true) => format!("_[🔧 {name} ✓]_"),
+                            ToolStatus::Done(false) => format!("_[🔧 {name} ✗]_"),
+                        };
+                        let rendered = render_markdown(&body);
+                        for line in rendered {
+                            let mut spans =
+                                vec![Span::styled("▎ ", Style::default().fg(accent))];
+                            spans.extend(line.spans.into_iter());
+                            out.push(Line::from(spans));
+                        }
+                    }
+                    MessageSegment::Text(t) if !t.is_empty() => {
+                        text_emitted = true;
+                        let rendered = render_markdown(t);
+                        for line in rendered {
+                            let mut spans =
+                                vec![Span::styled("▎ ", Style::default().fg(accent))];
+                            spans.extend(line.spans.into_iter());
+                            out.push(Line::from(spans));
+                        }
+                    }
+                    MessageSegment::Text(_) => {}
+                }
+            }
+            // Show waiting placeholder when only reasoning has streamed and
+            // no body text has appeared yet.
+            if !text_emitted {
+                let label = if m.has_reasoning() {
+                    "▎ Answering…"
+                } else {
+                    "▎ Thinking…"
+                };
+                out.push(Line::from(Span::styled(
+                    label,
+                    Style::default()
+                        .fg(Palette::MUTED)
+                        .add_modifier(Modifier::SLOW_BLINK),
+                )));
+            }
         } else {
-            // Render body with a left accent bar, inline.
-            let rendered = render_markdown(&m.content);
-            for line in rendered {
-                let mut spans = vec![Span::styled("▎ ", Style::default().fg(accent))];
-                spans.extend(line.spans.into_iter());
-                out.push(Line::from(spans));
+            // Hydrated history (no segment timeline) — fall back to the
+            // legacy reasoning-then-content layout.
+            if show_reasoning && is_agent && !m.reasoning.is_empty() {
+                for l in super::widgets::reasoning_lines(&m.reasoning, false) {
+                    out.push(l);
+                }
+            }
+            if is_agent && m.content.is_empty() {
+                let label = if m.reasoning.is_empty() {
+                    "▎ Thinking…"
+                } else {
+                    "▎ Answering…"
+                };
+                out.push(Line::from(Span::styled(
+                    label,
+                    Style::default()
+                        .fg(Palette::MUTED)
+                        .add_modifier(Modifier::SLOW_BLINK),
+                )));
+            } else {
+                let rendered = render_markdown(&m.content);
+                for line in rendered {
+                    let mut spans = vec![Span::styled("▎ ", Style::default().fg(accent))];
+                    spans.extend(line.spans.into_iter());
+                    out.push(Line::from(spans));
+                }
             }
         }
         if !dense || i + 1 == app.messages.len() {


### PR DESCRIPTION
Previously the agent thinking block aggregated every reasoning chunk
into a single block above all tool markers, even when the actual model
flow was think → tool → think → tool → answer. The bunched-up display
made it hard to track what the agent was doing.

ChatMessage gains a `segments: Vec<MessageSegment>` timeline plus
helpers (append_text, append_reasoning, push_tool_start, finish_tool).
Stream handlers in src/tui/mod.rs push to it as events arrive; the
renderer in src/tui/views.rs walks segments in order, emitting
reasoning blocks, tool markers, and markdown body inline.

The legacy `content` and `reasoning` fields are kept as the fallback
path for hydrated history (Message::Assistant only carries aggregate
content + reasoning_content, no per-event timeline). Renderer prefers
segments when populated; falls back to the old layout otherwise.

finish_tool walks segments in reverse and pairs with the most recent
in-progress call of the same name — keeps parallel dispatch (YYC-34)
honest when two same-name tools are in flight.

3 new tests: arrival-order interleave, reasoning coalescing across
non-reasoning breaks, and concurrent-tool finish pairing.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>