### PR TITLE
YYC-58: PromptMode state machine (Insert / Command / Ask / Busy)

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -278,6 +278,9 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
             None
         };
 
+        // YYC-58: derive prompt mode from current state once per tick.
+        app.refresh_prompt_mode();
+
         // YYC-69: keep the chat viewport pinned to the latest content while
         // the user hasn't scrolled away. `chat_max_scroll` is published by
         // the renderer on the previous frame, so this lags one tick after a
@@ -636,7 +639,17 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                         app.scroll = app.scroll.saturating_add(10).min(max);
                                         app.at_bottom = app.scroll >= max;
                                     }
-                                    KeyCode::Esc => exit = true,
+                                    KeyCode::Esc => {
+                                        // YYC-58: in Command mode (slash buffer pending), Esc
+                                        // clears the buffer and drops back to Insert; only Esc
+                                        // with an empty buffer exits.
+                                        if app.input.starts_with('/') {
+                                            app.input.clear();
+                                            app.slash_menu_selection = 0;
+                                        } else {
+                                            exit = true;
+                                        }
+                                    }
                                     _ => { pending_quit = false; }
                                 }
                             }

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -9,6 +9,36 @@ use crate::memory::SessionSummary;
 use super::theme::Palette;
 use super::views::{DiffKind, DiffLine, View};
 
+/// Prompt-row state machine (YYC-58). Drives the mode badge and the
+/// per-mode key dispatch + hint set. `Busy` is a transient state pinned
+/// while the agent is mid-turn (YYC-61); it lives on this enum so the
+/// queue path can use one classification rather than a parallel flag.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum PromptMode {
+    /// Default text entry.
+    #[default]
+    Insert,
+    /// User is typing a slash command.
+    Command,
+    /// Agent has paused for a user response (AgentPause).
+    Ask,
+    /// Agent is mid-turn; characters still type but Enter enqueues
+    /// instead of sending (YYC-61).
+    Busy,
+}
+
+impl PromptMode {
+    /// Short uppercase badge shown in the prompt row's mode pill.
+    pub fn badge(self) -> &'static str {
+        match self {
+            PromptMode::Insert => "INSERT",
+            PromptMode::Command => "CMD",
+            PromptMode::Ask => "ASK",
+            PromptMode::Busy => "BUSY",
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Default)]
 pub enum ChatRole {
     User,
@@ -285,6 +315,9 @@ pub struct AppState {
     /// Highlighted row in the slash command palette (YYC-70). Reset to 0
     /// whenever the filter changes; navigated via arrow keys or Ctrl+J/K.
     pub slash_menu_selection: usize,
+    /// Prompt-row mode (YYC-58). Drives the mode badge, the per-mode
+    /// hint set, and which key bindings the dispatcher honors.
+    pub prompt_mode: PromptMode,
     pub show_reasoning: bool,
     pub session_label: String,
 
@@ -320,6 +353,7 @@ impl AppState {
             at_bottom: true,
             chat_max_scroll: Cell::new(0),
             slash_menu_selection: 0,
+            prompt_mode: PromptMode::Insert,
             show_reasoning: true,
             session_label: "new session".into(),
 
@@ -372,7 +406,58 @@ impl AppState {
     }
 
     pub fn mode_label(&self) -> &'static str {
-        if self.thinking { "RUN" } else { "INSERT" }
+        // YYC-58: badge follows the prompt mode rather than thinking flag.
+        // Busy is set externally when a turn starts (YYC-61).
+        self.prompt_mode.badge()
+    }
+
+    /// Per-mode hint pairs for the prompt-row footer (YYC-58). Centralized
+    /// so call sites in views don't drift apart on the bindings each mode
+    /// advertises.
+    pub fn prompt_hints(&self) -> &'static [(&'static str, &'static str)] {
+        match self.prompt_mode {
+            PromptMode::Insert => &[
+                ("↵", "send"),
+                ("⌃T", "tools"),
+                ("⌃K", "sessions"),
+                ("/", "cmds"),
+            ],
+            PromptMode::Command => &[
+                ("↵", "run"),
+                ("↑↓", "select"),
+                ("Tab", "complete"),
+                ("Esc", "cancel"),
+            ],
+            PromptMode::Ask => &[("y", "proceed"), ("n", "deny"), ("Esc", "cancel")],
+            PromptMode::Busy => &[
+                ("↵", "queue"),
+                ("⌃C", "cancel"),
+                ("⌃⌫", "drop last"),
+            ],
+        }
+    }
+
+    /// True while an agent turn is in flight. Backed by `thinking` for now;
+    /// kept as a method so callers (queue, dispatcher) don't reach into the
+    /// flag directly (YYC-61, YYC-62).
+    pub fn is_busy(&self) -> bool {
+        self.thinking
+    }
+
+    /// Recompute `prompt_mode` from observable state (pending pause,
+    /// thinking flag, input prefix). Called once per loop tick before
+    /// draw so the badge tracks reality without each call site updating
+    /// it manually.
+    pub fn refresh_prompt_mode(&mut self) {
+        self.prompt_mode = if self.pending_pause.is_some() {
+            PromptMode::Ask
+        } else if self.thinking {
+            PromptMode::Busy
+        } else if self.input.starts_with('/') {
+            PromptMode::Command
+        } else {
+            PromptMode::Insert
+        };
     }
 
     pub fn model_status(&self) -> String {
@@ -812,6 +897,45 @@ mod tests {
             MessageSegment::Reasoning(r) => assert_eq!(r, "after tool"),
             other => panic!("expected reasoning, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn refresh_prompt_mode_picks_command_when_input_starts_with_slash() {
+        let mut app = AppState::new("test".into(), 100);
+        app.input = "/help".into();
+        app.refresh_prompt_mode();
+        assert_eq!(app.prompt_mode, PromptMode::Command);
+    }
+
+    #[test]
+    fn refresh_prompt_mode_returns_to_insert_when_slash_cleared() {
+        let mut app = AppState::new("test".into(), 100);
+        app.input = "/help".into();
+        app.refresh_prompt_mode();
+        app.input.clear();
+        app.refresh_prompt_mode();
+        assert_eq!(app.prompt_mode, PromptMode::Insert);
+    }
+
+    #[test]
+    fn refresh_prompt_mode_uses_busy_when_thinking() {
+        let mut app = AppState::new("test".into(), 100);
+        app.thinking = true;
+        app.refresh_prompt_mode();
+        assert_eq!(app.prompt_mode, PromptMode::Busy);
+        assert_eq!(app.mode_label(), "BUSY");
+    }
+
+    #[test]
+    fn refresh_prompt_mode_busy_overrides_command_prefix() {
+        // While the agent is mid-turn the badge should still read BUSY
+        // even if the user typed `/` in the prompt — the slash menu can
+        // be shown but the mode pill reflects the agent state.
+        let mut app = AppState::new("test".into(), 100);
+        app.thinking = true;
+        app.input = "/queue".into();
+        app.refresh_prompt_mode();
+        assert_eq!(app.prompt_mode, PromptMode::Busy);
     }
 
     #[test]

--- a/src/tui/views.rs
+++ b/src/tui/views.rs
@@ -236,12 +236,7 @@ fn single_stack(f: &mut TuiFrame, area: Rect, app: &AppState) {
         layout[1],
         app.mode_label(),
         &app.input,
-        &[
-            ("↵", "send"),
-            ("⌃T", "tools"),
-            ("⌃K", "sessions"),
-            ("/", "cmds"),
-        ],
+        app.prompt_hints(),
         &app.model_status(),
         app.thinking,
     );
@@ -348,12 +343,7 @@ fn split_sessions(f: &mut TuiFrame, area: Rect, app: &AppState) {
         v[1],
         app.mode_label(),
         &app.input,
-        &[
-            ("↵", "send"),
-            ("⌃K", "sessions"),
-            ("⌃N", "new"),
-            ("/", "cmds"),
-        ],
+        app.prompt_hints(),
         &app.model_status(),
         app.thinking,
     );
@@ -527,9 +517,9 @@ fn tiled_mesh(f: &mut TuiFrame, area: Rect, app: &AppState) {
     let (cx, cy) = super::widgets::prompt_row(
         f,
         v[1],
-        "CMD",
+        app.mode_label(),
         &app.input,
-        &[("↵", "route to main"), ("⌃J", "switch tile"), ("/", "cmds")],
+        app.prompt_hints(),
         &app.model_status(),
         app.thinking,
     );
@@ -644,14 +634,9 @@ fn tree_of_thought(f: &mut TuiFrame, area: Rect, app: &AppState) {
     let (cx, cy) = super::widgets::prompt_row(
         f,
         v[1],
-        "ASK",
+        app.mode_label(),
         &app.input,
-        &[
-            ("↵", "send"),
-            ("M", "merge"),
-            ("X", "kill"),
-            ("B", "branch"),
-        ],
+        app.prompt_hints(),
         &app.model_status(),
         app.thinking,
     );
@@ -946,7 +931,7 @@ fn trading_floor(f: &mut TuiFrame, area: Rect, app: &AppState) {
         v[2],
         app.mode_label(),
         &app.input,
-        &[("↵", "send"), ("⌃1-5", "view"), ("/", "cmds")],
+        app.prompt_hints(),
         &app.model_status(),
         app.thinking,
     );


### PR DESCRIPTION
Replaces the ad-hoc thinking-flag-driven mode label with a proper
state machine. AppState gains `prompt_mode: PromptMode` and a
`refresh_prompt_mode()` reducer that recomputes from observable state
(pending pause → Ask, thinking → Busy, slash prefix → Command, else
Insert). The reducer fires once per loop tick before draw, so call
sites don't have to remember to update the badge.

`Busy` is included on the enum now (used by YYC-61's queue path) so
the queue can classify modes through one enum rather than a parallel
flag. `is_busy()` helper exposes the mid-turn state to other modules.

Per-mode hint sets centralized on `AppState::prompt_hints()` — the
five view call sites were each carrying their own array, sometimes
with hardcoded mode strings ("CMD", "ASK") that didn't track reality.
All five views now read from the same source.

Esc in Command mode clears the slash buffer instead of exiting; Esc
with a non-slash input still exits.

4 new tests cover slash → Command, clear → Insert, thinking → Busy,
and Busy precedence over a slash-typed input mid-turn.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>