### PR TITLE
YYC-61: Prompt input queue during agent turns

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -137,6 +137,39 @@ fn complete_slash(prefix: &str) -> Option<String> {
     }
 }
 
+/// Spawn a fresh agent turn for `msg`. Updates chat state (User + empty
+/// Agent message), flips thinking on, re-engages auto-follow, then spawns
+/// `run_prompt_stream` against the agent. Used by the Enter handler for
+/// new submissions and by the Done handler when draining the queue
+/// (YYC-61).
+fn submit_prompt(
+    app: &mut AppState,
+    agent: &Arc<Mutex<Agent>>,
+    stream_tx: &mpsc::UnboundedSender<StreamEvent>,
+    msg: String,
+) {
+    app.messages.push(ChatMessage {
+        role: ChatRole::User,
+        content: msg.clone(),
+        ..Default::default()
+    });
+    app.messages.push(ChatMessage {
+        role: ChatRole::Agent,
+        content: String::new(),
+        ..Default::default()
+    });
+    app.thinking = true;
+    app.at_bottom = true;
+    app.note_prompt_submitted(&msg);
+
+    let tx = stream_tx.clone();
+    let a = agent.clone();
+    tokio::spawn(async move {
+        let mut a = a.lock().await;
+        let _ = a.run_prompt_stream(&msg, tx).await;
+    });
+}
+
 async fn refresh_sessions(agent: &Arc<Mutex<Agent>>, app: &mut AppState) {
     let (summaries, active_session_id) = {
         let a = agent.lock().await;
@@ -396,6 +429,18 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                             }
                                             continue;
                                         }
+                                        // YYC-61: queue management hotkeys.
+                                        // Ctrl+Backspace pops the most recent queued
+                                        // submission; Ctrl+Shift+Backspace drops the
+                                        // entire queue.
+                                        KeyCode::Backspace => {
+                                            if key.modifiers.contains(KeyModifiers::SHIFT) {
+                                                app.queue.clear();
+                                            } else {
+                                                app.queue.pop_back();
+                                            }
+                                            continue;
+                                        }
                                         // YYC-70: Ctrl+J / Ctrl+K navigate the
                                         // slash menu when it's open.
                                         KeyCode::Char('j') | KeyCode::Char('k') => {
@@ -460,6 +505,24 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                                 let idx = app.slash_menu_selection.min(candidates.len() - 1);
                                                 app.input = format!("/{}", candidates[idx].name);
                                             }
+                                        }
+                                        // YYC-61: while the agent is busy, plain text Enter
+                                        // submissions go onto the queue rather than dispatching
+                                        // immediately. Drained when the current turn ends.
+                                        // Slash commands are still gated to the idle path
+                                        // (YYC-62 will add per-command mid-turn-safe routing).
+                                        if !app.input.is_empty()
+                                            && app.thinking
+                                            && !app.input.starts_with('/')
+                                        {
+                                            let msg = app.input.trim().to_string();
+                                            if !msg.is_empty() {
+                                                app.queue.push_back(msg);
+                                            }
+                                            app.input.clear();
+                                            app.slash_menu_selection = 0;
+                                            pending_quit = false;
+                                            continue;
                                         }
                                         if !app.input.is_empty() && !app.thinking {
                                             let msg = app.input.trim().to_string();
@@ -566,21 +629,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                                 }
                                             }
 
-                                            app.messages.push(ChatMessage { role: ChatRole::User, content: msg.clone(), ..Default::default() });
-                                            app.messages.push(ChatMessage { role: ChatRole::Agent, content: String::new(), ..Default::default() });
-                                            app.thinking = true;
-                                            // New prompt: re-engage auto-follow. The next render
-                                            // will publish the updated max scroll and the loop
-                                            // will pin scroll to it.
-                                            app.at_bottom = true;
-                                            app.note_prompt_submitted(&msg);
-
-                                            let tx = stream_tx.clone();
-                                            let agent = agent.clone();
-                                            tokio::spawn(async move {
-                                                let mut a = agent.lock().await;
-                                                let _ = a.run_prompt_stream(&msg, tx).await;
-                                            });
+                                            submit_prompt(&mut app, &agent, &stream_tx, msg);
                                         }
                                     }
                                     KeyCode::Char(c) => {
@@ -697,6 +746,11 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                         }
                         app.note_done();
                         refresh_sessions(&agent, &mut app).await;
+                        // YYC-61: drain one queued prompt per turn end. Subsequent
+                        // queued prompts ride the next Done event in the same way.
+                        if let Some(next) = app.queue.pop_front() {
+                            submit_prompt(&mut app, &agent, &stream_tx, next);
+                        }
                     }
                     Some(StreamEvent::Error(e)) => {
                         if let Some(last) = app.messages.last_mut() {

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -1,4 +1,5 @@
 use std::cell::Cell;
+use std::collections::VecDeque;
 
 use chrono::Local;
 use ratatui::style::Color;
@@ -318,6 +319,10 @@ pub struct AppState {
     /// Prompt-row mode (YYC-58). Drives the mode badge, the per-mode
     /// hint set, and which key bindings the dispatcher honors.
     pub prompt_mode: PromptMode,
+    /// Pending prompts submitted while the agent was busy (YYC-61).
+    /// Drained one-at-a-time from the front when each turn completes.
+    /// In-memory only — never persisted to sessions.db.
+    pub queue: VecDeque<String>,
     pub show_reasoning: bool,
     pub session_label: String,
 
@@ -354,6 +359,7 @@ impl AppState {
             chat_max_scroll: Cell::new(0),
             slash_menu_selection: 0,
             prompt_mode: PromptMode::Insert,
+            queue: VecDeque::new(),
             show_reasoning: true,
             session_label: "new session".into(),
 
@@ -936,6 +942,28 @@ mod tests {
         app.input = "/queue".into();
         app.refresh_prompt_mode();
         assert_eq!(app.prompt_mode, PromptMode::Busy);
+    }
+
+    #[test]
+    fn queue_starts_empty_and_pushes_in_fifo_order() {
+        let mut app = AppState::new("test".into(), 100);
+        assert!(app.queue.is_empty());
+        app.queue.push_back("first".into());
+        app.queue.push_back("second".into());
+        assert_eq!(app.queue.pop_front().as_deref(), Some("first"));
+        assert_eq!(app.queue.pop_front().as_deref(), Some("second"));
+        assert!(app.queue.is_empty());
+    }
+
+    #[test]
+    fn queue_pop_back_removes_most_recent_only() {
+        let mut app = AppState::new("test".into(), 100);
+        app.queue.push_back("a".into());
+        app.queue.push_back("b".into());
+        app.queue.push_back("c".into());
+        app.queue.pop_back();
+        let remaining: Vec<&str> = app.queue.iter().map(String::as_str).collect();
+        assert_eq!(remaining, vec!["a", "b"]);
     }
 
     #[test]

--- a/src/tui/views.rs
+++ b/src/tui/views.rs
@@ -198,6 +198,36 @@ fn build_chat_lines(app: &AppState, show_reasoning: bool, dense: bool) -> Vec<Li
             out.push(Line::from(""));
         }
     }
+
+    // YYC-61: ghosted preview of pending queued submissions, rendered
+    // beneath the latest agent message so the user sees what's been
+    // staged behind the in-flight turn.
+    if !app.queue.is_empty() {
+        out.push(Line::from(Span::styled(
+            format!("── queue · {} pending ──", app.queue.len()),
+            Style::default()
+                .fg(Palette::MUTED)
+                .add_modifier(Modifier::DIM),
+        )));
+        for (idx, qmsg) in app.queue.iter().enumerate() {
+            let preview: String = qmsg.chars().take(120).collect();
+            out.push(Line::from(vec![
+                Span::styled(
+                    format!("▸ #{:<2} ", idx + 1),
+                    Style::default()
+                        .fg(Palette::MUTED)
+                        .add_modifier(Modifier::DIM),
+                ),
+                Span::styled(
+                    preview,
+                    Style::default()
+                        .fg(Palette::MUTED)
+                        .add_modifier(Modifier::DIM),
+                ),
+            ]));
+        }
+        out.push(Line::from(""));
+    }
     out
 }
 


### PR DESCRIPTION
Plain text submissions during a busy turn now go onto an in-memory
VecDeque<String> instead of being silently swallowed. The queue
drains one prompt per Done event — the next turn fires automatically
the moment the current one finishes.

- AppState gains `queue: VecDeque<String>` (in-memory only — never
  written to sessions.db, dropped on session exit).
- Enter handler in Busy mode pushes plain text to the queue and
  clears the input. Slash commands are still gated to the idle path
  (YYC-62 will mark per-command mid-turn-safe routing).
- New `submit_prompt()` helper extracts the agent-message append +
  thinking-flag flip + run_prompt_stream spawn so the Enter site and
  the queue-drain site share one path.
- Done handler pops queue front and re-enters submit_prompt — keeps
  draining as long as queue has work.
- Ctrl+Backspace pops the most recent queued submission;
  Ctrl+Shift+Backspace empties the queue entirely.
- Chat surface renders ghosted "queue · N pending" preview block
  beneath the latest agent message so the user can see what's staged.

Errored turns deliberately don't auto-drain — keeps the queue parked
until the user reacts.

2 new tests: FIFO ordering and pop_back semantics.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>