### PR TITLE
YYC-59: Inline AgentPause action pills + keyboard dispatch

### DIFF
--- a/src/hooks/safety.rs
+++ b/src/hooks/safety.rs
@@ -17,7 +17,7 @@ use serde_json::Value;
 use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
 
-use crate::pause::{AgentPause, AgentResume, PauseKind, PauseSender};
+use crate::pause::{AgentPause, AgentResume, OptionKind, PauseKind, PauseOption, PauseSender};
 
 use super::{HookHandler, HookOutcome};
 
@@ -117,6 +117,30 @@ impl HookHandler for SafetyHook {
                     reason: reason.to_string(),
                 },
                 reply: reply_tx,
+                // YYC-59: surface inline pills so the TUI can render
+                // semantic action buttons. Falls back to the legacy
+                // a/r/d modal automatically if a future caller leaves
+                // this empty.
+                options: vec![
+                    PauseOption {
+                        key: 'y',
+                        label: "allow".into(),
+                        kind: OptionKind::Primary,
+                        resume: AgentResume::Allow,
+                    },
+                    PauseOption {
+                        key: 'r',
+                        label: "remember".into(),
+                        kind: OptionKind::Neutral,
+                        resume: AgentResume::AllowAndRemember,
+                    },
+                    PauseOption {
+                        key: 'n',
+                        label: "deny".into(),
+                        kind: OptionKind::Destructive,
+                        resume: AgentResume::Deny,
+                    },
+                ],
             };
 
             if tx.send(pause).await.is_err() {
@@ -263,6 +287,38 @@ mod tests {
 
         // And the command should now be in the approval cache.
         assert!(hook_arc.is_approved(dangerous));
+    }
+
+    #[tokio::test]
+    async fn safety_pause_carries_inline_pill_options() {
+        // YYC-59: safety hook should populate the y/r/n option set so the
+        // TUI can render inline pills + key-dispatch the choice.
+        let (tx, mut rx) = crate::pause::channel(4);
+        let hook = SafetyHook::with_pause_emitter(tx);
+        let dangerous = "rm -rf /";
+        let args = serde_json::json!({ "command": dangerous });
+        let cancel = CancellationToken::new();
+
+        let hook_arc = std::sync::Arc::new(hook);
+        let h = hook_arc.clone();
+        let c = cancel.clone();
+        let task = tokio::spawn(async move { h.before_tool_call("bash", &args, c).await });
+
+        let pause = rx.recv().await.expect("pause should arrive");
+        let keys: Vec<char> = pause.options.iter().map(|o| o.key).collect();
+        assert_eq!(keys, vec!['y', 'r', 'n']);
+        assert!(pause
+            .options
+            .iter()
+            .any(|o| o.key == 'y' && matches!(o.kind, OptionKind::Primary)));
+        assert!(pause
+            .options
+            .iter()
+            .any(|o| o.key == 'n' && matches!(o.kind, OptionKind::Destructive)));
+
+        // Drain the task with a deny so the spawned future doesn't leak.
+        pause.reply.send(AgentResume::Deny).ok();
+        let _ = task.await;
     }
 
     #[tokio::test]

--- a/src/pause.rs
+++ b/src/pause.rs
@@ -16,11 +16,40 @@
 use serde_json::Value;
 use tokio::sync::oneshot;
 
+/// Visual classification for a pause option's pill (YYC-59). Drives color
+/// — primary actions render filled, destructive in red, neutral in ink.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OptionKind {
+    Primary,
+    Neutral,
+    Destructive,
+}
+
+/// One inline action pill on a pause prompt (YYC-59). The hook emitting
+/// the pause declares the keys/labels/colors; the TUI renders the pills
+/// and routes a matching keystroke back as an `AgentResume`.
+#[derive(Debug, Clone)]
+pub struct PauseOption {
+    /// Single-char keyboard shortcut (e.g. 'y', 'n', 'e').
+    pub key: char,
+    /// Human-readable label rendered inside the pill ("proceed", "deny").
+    pub label: String,
+    /// Color/styling class for the pill.
+    pub kind: OptionKind,
+    /// Resume variant to send back on press. Carrying it on the option
+    /// lets each pause define its own key→action mapping without the TUI
+    /// hardcoding semantics.
+    pub resume: AgentResume,
+}
+
 /// One pause emission: what's being asked, plus a reply channel.
 #[derive(Debug)]
 pub struct AgentPause {
     pub kind: PauseKind,
     pub reply: oneshot::Sender<AgentResume>,
+    /// Inline action pills the TUI should render with the prompt
+    /// (YYC-59). Empty → TUI falls back to the legacy a/r/d modal.
+    pub options: Vec<PauseOption>,
 }
 
 /// What the agent is asking the user.

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -362,14 +362,26 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
         tokio::select! {
             pause = pause_rx.recv() => {
                 if let Some(p) = pause {
-                    let summary = match &p.kind {
-                        PauseKind::SafetyApproval { command, reason, .. } => {
+                    // YYC-59: pause now carries inline pill options, so the
+                    // bracket-list hint is redundant when options is present.
+                    let summary = match (&p.kind, p.options.is_empty()) {
+                        (PauseKind::SafetyApproval { command, reason, .. }, false) => {
+                            format!("Safety: {reason}\n  $ {command}")
+                        }
+                        (PauseKind::ToolArgConfirm { tool, summary, .. }, false) => {
+                            format!("Confirm tool '{tool}': {summary}")
+                        }
+                        (PauseKind::SkillSave { suggested_name, .. }, false) => {
+                            format!("Save this as a skill named '{suggested_name}'?")
+                        }
+                        // No options → legacy bracket-list hint stays in.
+                        (PauseKind::SafetyApproval { command, reason, .. }, true) => {
                             format!("Safety: {reason}\n  $ {command}\n  [a]llow once, [r]emember & allow, [d]eny")
                         }
-                        PauseKind::ToolArgConfirm { tool, summary, .. } => {
+                        (PauseKind::ToolArgConfirm { tool, summary, .. }, true) => {
                             format!("Confirm tool '{tool}': {summary}\n  [a]llow once, [r]emember & allow, [d]eny")
                         }
-                        PauseKind::SkillSave { suggested_name, .. } => {
+                        (PauseKind::SkillSave { suggested_name, .. }, true) => {
                             format!("Save this as a skill named '{suggested_name}'?\n  [a]llow once, [d]eny")
                         }
                     };
@@ -392,12 +404,31 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                 // ── If a pause is active, intercept the keys that
                                 // dispatch a response. Anything else falls through
                                 // to normal handling so the user can still scroll, etc.
-                                if app.pending_pause.is_some() {
-                                    let resume = match key.code {
-                                        KeyCode::Char('a') | KeyCode::Char('A') => Some(AgentResume::Allow),
-                                        KeyCode::Char('r') | KeyCode::Char('R') => Some(AgentResume::AllowAndRemember),
-                                        KeyCode::Char('d') | KeyCode::Char('D') | KeyCode::Esc => Some(AgentResume::Deny),
-                                        _ => None,
+                                if let Some(p) = app.pending_pause.as_ref() {
+                                    // YYC-59: if the pause carries inline options, the
+                                    // user's keystroke is matched against options[i].key
+                                    // (case-insensitive) and the option's `resume` is
+                                    // sent back. Esc is always Deny. Falls back to the
+                                    // legacy a/r/d modal when options is empty.
+                                    let resume = if !p.options.is_empty() {
+                                        match key.code {
+                                            KeyCode::Esc => Some(AgentResume::Deny),
+                                            KeyCode::Char(c) => p
+                                                .options
+                                                .iter()
+                                                .find(|o| {
+                                                    o.key.eq_ignore_ascii_case(&c)
+                                                })
+                                                .map(|o| o.resume.clone()),
+                                            _ => None,
+                                        }
+                                    } else {
+                                        match key.code {
+                                            KeyCode::Char('a') | KeyCode::Char('A') => Some(AgentResume::Allow),
+                                            KeyCode::Char('r') | KeyCode::Char('R') => Some(AgentResume::AllowAndRemember),
+                                            KeyCode::Char('d') | KeyCode::Char('D') | KeyCode::Esc => Some(AgentResume::Deny),
+                                            _ => None,
+                                        }
                                     };
                                     if let Some(r) = resume {
                                         if let Some(p) = app.pending_pause.take() {

--- a/src/tui/views.rs
+++ b/src/tui/views.rs
@@ -199,6 +199,34 @@ fn build_chat_lines(app: &AppState, show_reasoning: bool, dense: bool) -> Vec<Li
         }
     }
 
+    // YYC-59: inline action pills for an active AgentPause. Rendered
+    // beneath the latest assistant message so the user sees what
+    // they're being asked to choose.
+    if let Some(p) = app.pending_pause.as_ref() {
+        if !p.options.is_empty() {
+            let mut pill_spans: Vec<Span<'static>> = Vec::new();
+            pill_spans.push(Span::styled(
+                "▎ ",
+                Style::default().fg(Palette::INK),
+            ));
+            for (i, opt) in p.options.iter().enumerate() {
+                if i > 0 {
+                    pill_spans.push(Span::raw("  "));
+                }
+                let color = match opt.kind {
+                    crate::pause::OptionKind::Primary => Palette::BLUE,
+                    crate::pause::OptionKind::Neutral => Palette::INK,
+                    crate::pause::OptionKind::Destructive => Palette::RED,
+                };
+                let filled = matches!(opt.kind, crate::pause::OptionKind::Primary);
+                let label = format!("[{}] {}", opt.key, opt.label);
+                pill_spans.push(super::widgets::pill(&label, color, filled));
+            }
+            out.push(Line::from(pill_spans));
+            out.push(Line::from(""));
+        }
+    }
+
     // YYC-61: ghosted preview of pending queued submissions, rendered
     // beneath the latest agent message so the user sees what's been
     // staged behind the in-flight turn.


### PR DESCRIPTION
Pauses can now declare semantic action options (key + label + color +
resume variant). The TUI renders them as inline pills below the
chat surface and matches keystrokes against the option set instead of
a hardcoded a/r/d modal.

- pause.rs adds `OptionKind` (Primary / Neutral / Destructive) and
  `PauseOption { key, label, kind, resume }`. AgentPause carries
  `options: Vec<PauseOption>`; an empty Vec falls back to the legacy
  modal so any existing call site keeps working.
- SafetyHook populates options with y=allow (Primary), r=remember
  (Neutral), n=deny (Destructive).
- TUI key handler routes the active pause's options first; case-
  insensitive char match → option.resume. Esc still maps to Deny.
- Pills render via the existing widgets::pill helper, colored per
  OptionKind. Bracket-list hint in the system message is suppressed
  when options are present (the pills replace it).

1 new test asserting the safety hook publishes the y/r/n option set
with the right OptionKinds.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>