### PR TITLE
YYC-66: Capture and render real edit diffs in the TUI

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -37,6 +37,9 @@ pub struct Agent {
     /// next call to `run_prompt` / `run_prompt_stream` swaps in a fresh token
     /// so cancel applies to the in-flight turn only, not future ones.
     turn_cancel: CancellationToken,
+    /// Latest file edit, captured by `WriteFile`/`PatchFile` (YYC-66).
+    /// TUI clones this Arc and renders the inner Option each frame.
+    diff_sink: crate::tools::EditDiffSink,
 }
 
 impl Agent {
@@ -138,7 +141,8 @@ impl Agent {
             .context("Failed to initialize LLM provider")?,
         );
 
-        let tools = ToolRegistry::new();
+        let diff_sink = crate::tools::new_diff_sink();
+        let tools = ToolRegistry::new_with_diff_sink(Some(diff_sink.clone()));
         let skills = Arc::new(SkillRegistry::new(&config.skills_dir));
         let memory = SessionStore::new();
         let context = ContextManager::new(provider.max_context());
@@ -170,7 +174,14 @@ impl Agent {
             session_id,
             turns: 0,
             turn_cancel: CancellationToken::new(),
+            diff_sink,
         })
+    }
+
+    /// Borrow the shared edit-diff sink (YYC-66). The TUI clones this Arc
+    /// and peeks the inner Option each frame to render the latest edit.
+    pub fn diff_sink(&self) -> &crate::tools::EditDiffSink {
+        &self.diff_sink
     }
 
     pub fn session_id(&self) -> &str {
@@ -221,6 +232,7 @@ impl Agent {
             session_id: Uuid::new_v4().to_string(),
             turns: 0,
             turn_cancel: CancellationToken::new(),
+            diff_sink: crate::tools::new_diff_sink(),
         }
     }
 

--- a/src/tools/file.rs
+++ b/src/tools/file.rs
@@ -57,7 +57,15 @@ impl Tool for ReadFile {
     }
 }
 
-pub struct WriteFile;
+pub struct WriteFile {
+    diff_sink: Option<crate::tools::EditDiffSink>,
+}
+
+impl WriteFile {
+    pub fn new(diff_sink: Option<crate::tools::EditDiffSink>) -> Self {
+        Self { diff_sink }
+    }
+}
 
 #[async_trait]
 impl Tool for WriteFile {
@@ -83,6 +91,15 @@ impl Tool for WriteFile {
             .ok_or_else(|| anyhow::anyhow!("path required"))?;
         let content = params["content"].as_str().unwrap_or("");
 
+        // YYC-66: snapshot the existing content before overwriting so the
+        // diff sink has a meaningful "before" — empty string for a fresh
+        // file is correct (it didn't exist).
+        let before = if self.diff_sink.is_some() {
+            tokio::fs::read_to_string(path).await.unwrap_or_default()
+        } else {
+            String::new()
+        };
+
         // Create parent directories
         if let Some(parent) = std::path::Path::new(path).parent() {
             tokio::fs::create_dir_all(parent).await?;
@@ -90,6 +107,18 @@ impl Tool for WriteFile {
 
         tokio::fs::write(path, content).await?;
         let bytes = content.len();
+
+        if let Some(sink) = &self.diff_sink {
+            let diff = crate::tools::EditDiff {
+                path: path.to_string(),
+                tool: "write_file".into(),
+                before: crate::tools::snippet(&before, 6, 800),
+                after: crate::tools::snippet(content, 6, 800),
+                at: chrono::Local::now(),
+            };
+            *sink.lock().unwrap() = Some(diff);
+        }
+
         Ok(ToolResult::ok(format!("Wrote {bytes} bytes to {path}")))
     }
 }
@@ -151,7 +180,15 @@ impl Tool for SearchFiles {
     }
 }
 
-pub struct PatchFile;
+pub struct PatchFile {
+    diff_sink: Option<crate::tools::EditDiffSink>,
+}
+
+impl PatchFile {
+    pub fn new(diff_sink: Option<crate::tools::EditDiffSink>) -> Self {
+        Self { diff_sink }
+    }
+}
 
 #[async_trait]
 impl Tool for PatchFile {
@@ -205,8 +242,80 @@ impl Tool for PatchFile {
         tokio::fs::write(path, &new_content).await?;
 
         let replaces = content.matches(old).count();
+
+        // YYC-66: capture the before/after snippets so the TUI diff pane
+        // shows actual edited text rather than demo data.
+        if let Some(sink) = &self.diff_sink {
+            let diff = crate::tools::EditDiff {
+                path: path.to_string(),
+                tool: "edit_file".into(),
+                before: crate::tools::snippet(old, 6, 800),
+                after: crate::tools::snippet(new, 6, 800),
+                at: chrono::Local::now(),
+            };
+            *sink.lock().unwrap() = Some(diff);
+        }
+
         Ok(ToolResult::ok(format!(
             "Replaced {replaces} occurrence(s) in {path}"
         )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tempfile::tempdir;
+    use tokio_util::sync::CancellationToken;
+
+    #[tokio::test]
+    async fn write_file_captures_before_after_into_diff_sink() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("hello.txt");
+        let path_str = path.to_string_lossy().to_string();
+        // Pre-existing content so "before" is non-empty.
+        std::fs::write(&path, "old contents\n").unwrap();
+
+        let sink = crate::tools::new_diff_sink();
+        let tool = WriteFile::new(Some(sink.clone()));
+        tool.call(
+            json!({"path": path_str, "content": "new contents\n"}),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        let diff = sink.lock().unwrap().clone().expect("diff captured");
+        assert_eq!(diff.tool, "write_file");
+        assert_eq!(diff.path, path_str);
+        assert_eq!(diff.before, "old contents");
+        assert_eq!(diff.after, "new contents");
+    }
+
+    #[tokio::test]
+    async fn patch_file_captures_old_and_new_strings_into_diff_sink() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("a.rs");
+        let path_str = path.to_string_lossy().to_string();
+        std::fs::write(&path, "fn foo() { 1 }\n").unwrap();
+
+        let sink = crate::tools::new_diff_sink();
+        let tool = PatchFile::new(Some(sink.clone()));
+        tool.call(
+            json!({
+                "path": path_str,
+                "old_string": "1",
+                "new_string": "42",
+            }),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        let diff = sink.lock().unwrap().clone().expect("diff captured");
+        assert_eq!(diff.tool, "edit_file");
+        assert_eq!(diff.before, "1");
+        assert_eq!(diff.after, "42");
     }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -67,6 +67,42 @@ pub mod file;
 pub mod shell;
 pub mod web;
 
+/// Compact record of the most recent file-edit operation (YYC-66).
+/// Captured by `WriteFile`/`PatchFile` after a successful write so the
+/// TUI's diff pane can render real activity instead of demo data.
+#[derive(Debug, Clone)]
+pub struct EditDiff {
+    pub path: String,
+    /// Tool that produced the edit ("write_file" / "edit_file").
+    pub tool: String,
+    /// Snippet of the file contents *before* the edit. Empty for
+    /// freshly-created files.
+    pub before: String,
+    /// Snippet of the file contents *after* the edit.
+    pub after: String,
+    pub at: chrono::DateTime<chrono::Local>,
+}
+
+/// Shared latest-edit slot. `None` until the first successful edit;
+/// overwritten on every subsequent edit. The TUI clones the Arc and
+/// peeks the inner Option each render.
+pub type EditDiffSink = Arc<std::sync::Mutex<Option<EditDiff>>>;
+
+pub fn new_diff_sink() -> EditDiffSink {
+    Arc::new(std::sync::Mutex::new(None))
+}
+
+/// Trim a string to a max number of lines + chars so the TUI doesn't
+/// stash megabyte-sized files in memory just to render a 6-line preview.
+pub(crate) fn snippet(text: &str, max_lines: usize, max_chars: usize) -> String {
+    let limited: String = text.chars().take(max_chars).collect();
+    limited
+        .lines()
+        .take(max_lines)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 /// Registry of available tools — tools are discovered at startup via the `inventory` pattern
 pub struct ToolRegistry {
     tools: HashMap<String, Arc<dyn Tool>>,
@@ -74,13 +110,21 @@ pub struct ToolRegistry {
 
 impl ToolRegistry {
     pub fn new() -> Self {
+        Self::new_with_diff_sink(None)
+    }
+
+    /// Build a tool registry that wires `WriteFile`/`PatchFile` to a
+    /// shared diff sink (YYC-66). Pass `Some(sink)` to capture edits;
+    /// `None` keeps the legacy behavior (tools don't observe their own
+    /// writes).
+    pub fn new_with_diff_sink(sink: Option<EditDiffSink>) -> Self {
         let mut registry = Self {
             tools: HashMap::new(),
         };
         registry.register(Arc::new(file::ReadFile));
-        registry.register(Arc::new(file::WriteFile));
+        registry.register(Arc::new(file::WriteFile::new(sink.clone())));
         registry.register(Arc::new(file::SearchFiles));
-        registry.register(Arc::new(file::PatchFile));
+        registry.register(Arc::new(file::PatchFile::new(sink)));
         registry.register(Arc::new(web::WebSearch));
         registry.register(Arc::new(web::WebFetch));
         for tool in shell::make_tools() {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -270,6 +270,11 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
         config.provider.max_context as u32,
     );
     app.audit_log = Some(audit_buf);
+    // YYC-66: clone the agent's diff sink so the TUI can render real edits.
+    {
+        let a = agent.lock().await;
+        app.diff_sink = Some(a.diff_sink().clone());
+    }
     refresh_sessions(&agent, &mut app).await;
 
     if let Some(note) = resume_note {

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -344,6 +344,11 @@ pub struct AppState {
     pub sessions: Vec<SessionState>,
     pub active_session_id: Option<String>,
     pub diff_lines: Vec<DiffLine>,
+    /// Live edit-diff sink shared with the agent (YYC-66). Renderers
+    /// peek the inner Option each frame to surface the latest edit; we
+    /// fall back to `diff_lines` (demo) only until the first real edit
+    /// arrives, after which the live diff replaces it.
+    pub diff_sink: Option<crate::tools::EditDiffSink>,
     pub orchestration: OrchestrationState,
 
     /// Optional shared handle to the audit-log hook's ring buffer. When
@@ -390,6 +395,7 @@ impl AppState {
             sessions: Vec::new(),
             active_session_id: None,
             diff_lines: demo_diff(),
+            diff_sink: None,
             orchestration: OrchestrationState::default(),
 
             audit_log: None,
@@ -503,6 +509,14 @@ impl AppState {
             format_thousands(self.prompt_tokens_last),
             format_thousands(self.token_max),
         )
+    }
+
+    /// Snapshot the most recent file edit, if the diff sink is wired up
+    /// and an edit has been captured (YYC-66). Locks briefly to clone the
+    /// value so the renderer doesn't hold the mutex across draws.
+    pub fn latest_diff(&self) -> Option<crate::tools::EditDiff> {
+        let sink = self.diff_sink.as_ref()?;
+        sink.lock().ok()?.clone()
     }
 
     /// Cumulative token count (input + output across all turns). Used by

--- a/src/tui/views.rs
+++ b/src/tui/views.rs
@@ -886,19 +886,58 @@ fn trading_floor(f: &mut TuiFrame, area: Rect, app: &AppState) {
     f.render_widget(Paragraph::new(lines).style(body()), tl_inner);
     draw_v_divider(f, bot[0]);
 
-    // ── diff (bot-mid)
-    let diff_inner = section_header(f, bot[1], "diff · users/auth.rs", None);
+    // ── diff (bot-mid). YYC-66: prefer the live edit sink; fall back to
+    // demo data only if no real edit has happened yet AND the sink isn't
+    // wired up (sink wired but empty → render an honest empty state).
+    let live_diff = app.latest_diff();
+    let diff_title: String = match (&live_diff, app.diff_sink.is_some()) {
+        (Some(d), _) => format!("diff · {}", d.path),
+        (None, true) => "diff · no edits this session".into(),
+        (None, false) => "diff · users/auth.rs".into(),
+    };
+    let diff_inner = section_header(f, bot[1], &diff_title, None);
     let mut lines: Vec<Line<'static>> = Vec::new();
-    for ln in &app.diff_lines {
-        let style = match ln.kind {
-            DiffKind::Hunk => Style::default()
+    if let Some(d) = live_diff {
+        // Compact two-block render: prefix old lines with "-" in red,
+        // new lines with "+" in green. Header shows tool + timestamp.
+        lines.push(Line::from(Span::styled(
+            format!("@@ {} · {}", d.tool, d.at.format("%H:%M:%S")),
+            Style::default()
                 .fg(Palette::MUTED)
                 .add_modifier(Modifier::DIM),
-            DiffKind::Added => Style::default().fg(Palette::GREEN),
-            DiffKind::Removed => Style::default().fg(Palette::RED),
-            DiffKind::Ctx => Style::default().fg(Palette::INK),
-        };
-        lines.push(Line::from(Span::styled(ln.text.clone(), style)));
+        )));
+        for line in d.before.lines() {
+            lines.push(Line::from(Span::styled(
+                format!("- {line}"),
+                Style::default().fg(Palette::RED),
+            )));
+        }
+        for line in d.after.lines() {
+            lines.push(Line::from(Span::styled(
+                format!("+ {line}"),
+                Style::default().fg(Palette::GREEN),
+            )));
+        }
+    } else if app.diff_sink.is_some() {
+        // Sink wired but empty — be honest, no fake diff.
+        lines.push(Line::from(Span::styled(
+            "  No file edits captured yet. Run an edit_file or write_file tool.",
+            Style::default().fg(Palette::MUTED),
+        )));
+    } else {
+        // No sink at all — fall back to the demo data so the layout
+        // still looks alive (e.g. headless preview environments).
+        for ln in &app.diff_lines {
+            let style = match ln.kind {
+                DiffKind::Hunk => Style::default()
+                    .fg(Palette::MUTED)
+                    .add_modifier(Modifier::DIM),
+                DiffKind::Added => Style::default().fg(Palette::GREEN),
+                DiffKind::Removed => Style::default().fg(Palette::RED),
+                DiffKind::Ctx => Style::default().fg(Palette::INK),
+            };
+            lines.push(Line::from(Span::styled(ln.text.clone(), style)));
+        }
     }
     f.render_widget(
         Paragraph::new(lines)


### PR DESCRIPTION
The TradingFloor diff pane now shows real file edits instead of demo
data. WriteFile and PatchFile capture before/after snippets through a
shared sink the agent owns; the TUI clones the Arc and peeks the
inner Option each frame.

- tools::EditDiff carries path, tool name, before/after snippets, and
  timestamp. Snippets are clamped (6 lines / 800 chars) so megabyte
  files don't bloat the in-memory record.
- tools::EditDiffSink = Arc<Mutex<Option<EditDiff>>>; tools::new_diff_sink()
  builds an empty one. ToolRegistry::new_with_diff_sink wires the sink
  into WriteFile + PatchFile constructors. Agent owns the sink and
  exposes it via diff_sink().
- WriteFile reads the existing file before overwriting so the "before"
  is meaningful (empty string for fresh files). PatchFile uses the
  caller-supplied old_string/new_string directly.
- AppState gains diff_sink + latest_diff() helper. The TradingFloor
  diff pane renders three states: live diff (real), wired-but-empty
  (honest no-edits-yet), no-sink (demo fallback for headless preview).

2 new tests cover write_file and edit_file capturing into the sink
through tempdirs.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>