### PR TITLE
YYC-67: Live cost and runtime telemetry for TUI metrics panes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,96 @@
 
 > A Rust AI agent — forged at the forge, tested by fire.
 
-Vulcan (formerly Ferris) is a pure-Rust personal AI agent for the command line. It combines an interactive TUI chat interface with a tool-calling LLM backend, designed for speed, portability, and deep extensibility.
+Vulcan is a pure-Rust personal AI agent for the command line. It combines an interactive TUI chat interface with a tool-calling LLM backend, designed for speed, portability, and deep extensibility.
+
+Built on a **hook-driven architecture** — every lifecycle point (prompt assembly, tool dispatch, session boundaries) is an extension surface for audit, safety, skills injection, and custom behavior.
 
 ## Features
 
-- **Interactive TUI** — ratatui-based terminal UI with chat message panel, input bar, markdown rendering, and thinking indicator
+### 🖥️ Terminal UI
+- **Multi-view TUI** — 5 ratatui views (Trading Floor, Single Stack, Split Sessions, Tiled Mesh, Tree of Thought) with smooth keyboard navigation
+- **Markdown rendering** — agent responses render inline code, lists, headings, and more
+- **Reasoning trace** — toggle visibility of model reasoning/thinking traces inline
+- **Prompt mode state machine** — Insert / Command / Ask / Busy modes with per-mode key binding hints
+- **Slash commands** — `/help`, `/clear`, `/view`, `/reasoning`, `/search`, `/exit` with fuzzy filter + tab completion + palette navigation
+- **Prompt queue** — queue inputs while the agent is busy; drained automatically when the turn completes
+- **Live tool activity** — see tool calls start/complete in real-time with ✓/✗ status
+- **Live edit diffs** — real file-edit diffs rendered in the UI (not demo data)
+- **Live telemetry** — per-session token counts, estimated cost (from provider pricing), tool/error counters, elapsed session time
+- **Auto-scroll** — viewport follows the latest content; pauses on manual scroll, re-engages on new submission
+
+### 🤖 Agent Capabilities
+- **Interactive chat** — multi-turn conversation with context management and history
 - **One-shot mode** — `vulcan prompt "your question"` for scripting and pipelines
-- **Session persistence** — conversations saved to JSONL with resume support (`vulcan session <id>`)
-- **Tool calling** — file system operations, shell commands, and web search/fetch
-- **Hook system** — Pi-style 5-event extension surface (`BeforePrompt`, `BeforeToolCall`, `AfterToolCall`, `BeforeAgentEnd`, `session_start/session_end`) for audit, skill injection, and safety gating
-- **Skill system** — markdown-based skill registry with YAML frontmatter, loaded as prompt injections
-- **LLM provider** — OpenAI-compatible streaming provider supporting OpenRouter, Anthropic, Ollama, and any OpenAI-compatible endpoint
-- **Configurable** — TOML config (`~/.vulcan/config.toml`) with env-var API key support
-- **Logging** — tracing-based, writes to file in TUI mode / stderr in CLI mode
+- **Session persistence** — SQLite-backed storage with FTS5 full-text search across all sessions
+- **Session resume** — resume the last session or a specific session by ID
+- **Cross-session search** — `vulcan search "query"` for BM25-ranked full-text search across saved conversations
+- **Session lineage** — parent-session tracking for branching conversation trees
+
+### 🛠️ Tool System
+Seven built-in tools with schema validation and required-field checking:
+
+| Tool | Description |
+|------|-------------|
+| `read_file` | Read files with optional offset/limit |
+| `write_file` | Write/create files (captures diff) |
+| `edit_file` | Find-and-replace edits (captures diff) |
+| `search_files` | Ripgrep-style regex search |
+| `bash` | One-shot shell command execution (PTY-backed) |
+| `pty_create` / `pty_write` / `pty_read` / `pty_resize` / `pty_close` / `pty_list` | Persistent interactive PTY sessions |
+| `web_search` | DuckDuckGo web search |
+| `web_fetch` | URL content fetch (markdown extraction) |
+
+### 🔌 Hook System (Pi-style Extension Surface)
+Seven wire-in points — every hook has priority ordering, timeout isolation, and error containment:
+
+| Event | Purpose |
+|-------|---------|
+| `BeforePrompt` | Inject transient messages (skills, system prompts) |
+| `BeforeToolCall` | Block or modify tool arguments (safety gate) |
+| `AfterToolCall` | Inspect or replace tool results |
+| `BeforeAgentEnd` | Force the agent loop to continue |
+| `session_start` | Lifecycle — session opened |
+| `session_end` | Lifecycle — session closed |
+
+**Built-in hooks:**
+- **SafetyHook** — blocks dangerous shell commands (rm -rf /, dd, mkfs, chmod 777, fork bombs, force pushes, curl|bash) with interactive approval (allow once / remember & allow / deny) via inline action pills
+- **AuditHook** — ring-buffered tool-call audit log, surfaced in the TUI tool-log pane
+- **SkillsHook** — injects available skills into the prompt at startup
+
+### ⏸️ AgentPause Mechanism
+Generic mid-loop user-interruption system. When a hook needs user input (safety approval, tool confirmation, skill-save prompt), it emits an `AgentPause` with inline action pills. The TUI renders an overlay, dispatches keystrokes back via oneshot channels, and the agent resumes — all without blocking other futures.
+
+### 🔗 LLM Provider
+- **OpenAI-compatible** — works with OpenRouter, Anthropic, OpenAI, Ollama, DeepSeek, any OpenAI-compatible endpoint
+- **Streaming** — SSE-based streaming with text, reasoning, and tool call events
+- **Retry logic** — exponential backoff with jitter (1s, 2s, 4s, 8s, 16s) for 429/5xx/network errors
+- **Structured error taxonomy** — `Auth`, `RateLimited`, `ModelNotFound`, `BadRequest`, `ServerError`, `Network` — each with actionable user-facing messages
+- **Reasoning passthrough** — supports DeepSeek `reasoning_content` with dual-field serialization (`reasoning_content` + `reasoning`) for OpenRouter compatibility
+- **Provider model catalog** — auto-fetches model metadata at startup, validates model exists, fuzzy-suggests alternatives, auto-populates `context_length` and pricing
+
+### ⚙️ Configuration
+TOML config at `~/.vulcan/config.toml` (or `./config.toml`):
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `provider.type` | `openai-compat` | Provider type |
+| `provider.base_url` | `https://openrouter.ai/api/v1` | API base URL |
+| `provider.model` | `deepseek/deepseek-v4-flash` | Model identifier |
+| `provider.max_context` | `128000` | Max context tokens |
+| `provider.max_retries` | `4` | Transient error retries |
+| `provider.catalog_cache_ttl_hours` | `24` | Model catalog cache lifetime |
+| `provider.disable_catalog` | `false` | Skip catalog fetch at startup |
+| `provider.debug` | `"off"` | Debug logging level (`off`, `tool-fallback`, `wire`) |
+| `tools.yolo_mode` | `false` | Skip safety confirmations |
+| `compaction.enabled` | `true` | Auto-compress context at threshold |
+| `compaction.trigger_ratio` | `0.85` | Compaction trigger ratio |
+| `compaction.reserved_tokens` | `50000` | Reserved tokens for response |
+
+API key: set `VULCAN_API_KEY` env var or add `provider.api_key` to config.
+
+### 📦 Skill System
+Markdown-based skill registry with YAML frontmatter, loaded as prompt injections via the SkillsHook. Skills live in `~/.vulcan/skills/` and auto-create when the agent detects repeated tool patterns.
 
 ## Quick Start
 
@@ -28,26 +105,33 @@ vulcan
 # One-shot prompt
 vulcan prompt "What is the capital of France?"
 
-# Resume a session
+# Resume last session
+vulcan --continue
+
+# Resume specific session
 vulcan session <session-id>
+
+# Search past sessions
+vulcan search "some query"
 ```
 
 The TUI uses ratatui with crossterm — it works on any terminal that supports an alternate screen.
 
-## Configuration
+### TUI Keyboard Shortcuts
 
-Config lives at `~/.vulcan/config.toml`. See `config.example.toml` for all options.
-
-| Setting | Default | Description |
-|---------|---------|-------------|
-| `provider.type` | `openai-compat` | Provider type |
-| `provider.base_url` | `https://openrouter.ai/api/v1` | API base URL |
-| `provider.model` | `deepseek/deepseek-v4-flash` | Model identifier |
-| `provider.max_context` | `128000` | Max context tokens |
-| `tools.yolo_mode` | `false` | Skip safety confirmations |
-| `compaction.enabled` | `true` | Auto-compress context at threshold |
-
-API key: set `VULCAN_API_KEY` env var or add `provider.api_key` to config.
+| Key | Action |
+|-----|--------|
+| `Enter` | Send prompt / run command |
+| `Esc` | Cancel / deny pause |
+| `Ctrl+1..5` | Switch views (1=Single Stack, 5=Trading Floor) |
+| `Ctrl+T` | Focus tools view |
+| `Ctrl+K` | Focus sessions view |
+| `Ctrl+Backspace` | Drop last queued prompt |
+| `Ctrl+Shift+Backspace` | Clear entire prompt queue |
+| `Ctrl+C` | Cancel in-flight agent turn |
+| `Tab` | Complete slash command |
+| `↑↓` or `Ctrl+J/K` | Navigate slash command palette |
+| `y` / `n` / `r` | Allow / deny / remember (pause prompts) |
 
 ## Architecture
 
@@ -55,61 +139,59 @@ API key: set `VULCAN_API_KEY` env var or add `provider.api_key` to config.
 main.rs ──► Cli ──► Chat (TUI) ──► Agent ──► Provider ──► LLM API
                     │                 │
                     │            HookRegistry
-                    │              ├─ audit
-                    │              ├─ skills
+                    │              ├─ safety (blocks dangerous commands)
+                    │              ├─ audit (ring-buffered tool log)
+                    │              ├─ skills (prompt injections)
                     │              └─ (user-defined)
+                    │
+                    │           AgentPause channel
+                    │              └─ SafetyApproval / ToolArgConfirm / SkillSave
                     │
                  ToolSet
                   ├─ file (read, write, search, edit)
-                  ├─ shell (bash execution)
+                  ├─ shell/pty (bash, pty_create/write/read/resize/close/list)
                   └─ web (search, fetch)
 ```
-
-The **hook system** is the foundational extension surface:
-
-- `BeforePrompt` — inject messages (skills, system prompts)
-- `BeforeToolCall` — block or modify tool arguments (safety gate)
-- `AfterToolCall` — inspect or replace tool results
-- `BeforeAgentEnd` — final processing before returning to user
-- `session_start` / `session_end` — lifecycle hooks
-
-All hooks support both streaming and buffered LLM paths.
 
 ## Project Structure
 
 ```
 src/
-├── main.rs            Entry point
-├── lib.rs             Module tree
-├── cli.rs             CLI argument parsing (clap)
-├── config.rs          TOML config loader
-├── agent.rs           Core agent loop (tool dispatch, hook wiring)
-├── context.rs         Context window management
-├── prompt_builder.rs  System prompt construction
-├── memory.rs          Cross-session memory
+├── main.rs             Entry point (CLI dispatch, logging init)
+├── lib.rs              Module tree
+├── cli.rs              CLI argument parsing (clap) — chat, prompt, session, search
+├── config.rs           TOML config loader, vulcan_home(), API key resolution
+├── agent.rs            Core agent loop (tool dispatch, hook wiring, streaming)
+├── context.rs          Context window management (token tracking, compaction)
+├── prompt_builder.rs   System prompt construction
+├── memory.rs           SQLite session store, FTS5 search, lineage tracking
+├── pause.rs            AgentPause mechanism (generic mid-loop user interruption)
 ├── hooks/
-│   ├── mod.rs         Hook trait, outcomes, registry
-│   ├── audit.rs       Built-in audit hook (tool call logging)
-│   └── skills.rs      Skills-as-hooks injection
+│   ├── mod.rs          Hook trait, outcomes, registry (priority, timeout)
+│   ├── audit.rs        Built-in audit hook (ring-buffered tool call log)
+│   ├── safety.rs       Built-in safety hook (dangerous command blocking)
+│   └── skills.rs       Skills-as-hooks injection
 ├── platform/
-│   └── mod.rs         Platform abstraction
+│   └── mod.rs          Platform abstraction
 ├── provider/
-│   ├── mod.rs         Provider trait
-│   └── openai.rs      OpenAI-compatible streaming implementation
-├── tools/
-│   ├── mod.rs         Tool trait
-│   ├── file.rs        File system tools
-│   ├── shell.rs       Bash/PTY execution
-│   └── web.rs         Web search and fetch
+│   ├── mod.rs          Provider trait, error taxonomy, message types, streaming events
+│   ├── openai.rs       OpenAI-compatible streaming implementation (SSE, retry, reasoning)
+│   ├── catalog.rs      Model catalog fetcher (OpenRouter-rich / OpenAI-sparse, caching, fuzzy suggest)
+│   └── mock.rs         Test mock provider
 ├── skills/
-│   └── mod.rs         Skill registry (markdown + YAML frontmatter)
+│   └── mod.rs          Skill registry (markdown + YAML frontmatter)
+├── tools/
+│   ├── mod.rs          Tool trait, registry, schema validation, EditDiff
+│   ├── file.rs         ReadFile, WriteFile, SearchFiles, PatchFile (with diff capture)
+│   ├── shell.rs        Bash + PTY session management (create/write/read/resize/close/list)
+│   └── web.rs          Web search (DuckDuckGo) and fetch tools
 └── tui/
-    ├── mod.rs         TUI loop and rendering
-    ├── markdown.rs    Markdown-to-ratatui parser
-    ├── state.rs       TUI state management
-    ├── theme.rs       Visual theme
-    ├── views.rs       Layout components
-    └── widgets.rs     Custom widgets
+    ├── mod.rs          TUI loop, key dispatch, pause handling, slash commands
+    ├── state.rs        App state, ChatMessage, PromptMode, orchestration state
+    ├── markdown.rs     Markdown-to-ratatui parser
+    ├── theme.rs        Color palette and styles
+    ├── views.rs        Five view renderers (TradingFloor, SingleStack, SplitSessions, etc.)
+    └── widgets.rs      Custom widgets (frame, section_header, sparkline, ticker, etc.)
 ```
 
 ## Building
@@ -117,17 +199,17 @@ src/
 ```bash
 cargo build             # Debug build
 cargo build --release   # Optimized release (size-optimized: LTO, strip)
-cargo test              # Run tests
+cargo test              # Run all tests
 cargo test <name>       # Single test
 ```
 
-Set `VULCAN_LOG=debug` for verbose logging.
+Set `VULCAN_LOG=debug` for verbose logging; `VULCAN_LOG=trace` for wire-level provider debugging.
 
 ## Roadmap
 
-Phase 1 (current) — core agent, tools, TUI, hooks, skills, config, JSONL persistence
-Phase 2 — SQLite session store, FTS5 search, context compaction, cron scheduling
-Phase 3 — external hook handlers, platform connectors (Discord, Telegram), gateway daemon
+**Current** — core agent, multi-view TUI, SQLite persistence with FTS5, tool system (file/shell/pty/web), hook system (safety/audit/skills), provider model catalog, streaming with reasoning passthrough, inline segment timeline, prompt queue, live cost/telemetry, edit diffs, session lineage.
+
+**Planned** — context compaction with LLM summarization, external hook handlers (Python/JS), platform connectors (Discord, Telegram), gateway daemon, cron scheduling, sub-agent orchestration.
 
 Tracked in Linear: [Vulcan — Rust AI Agent](https://linear.app/yycholla/project/vulcan-rust-ai-agent-37bc34d04e48)
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -40,6 +40,10 @@ pub struct Agent {
     /// Latest file edit, captured by `WriteFile`/`PatchFile` (YYC-66).
     /// TUI clones this Arc and renders the inner Option each frame.
     diff_sink: crate::tools::EditDiffSink,
+    /// Per-token pricing for the active model, sourced from the provider
+    /// catalog at startup (YYC-67). `None` when the catalog is disabled
+    /// or the provider doesn't publish pricing.
+    pricing: Option<crate::provider::catalog::Pricing>,
 }
 
 impl Agent {
@@ -83,6 +87,7 @@ impl Agent {
         // values rather than blocking startup over a metadata fetch.
         let mut effective_max_context = config.provider.max_context;
         let mut supports_json_mode = false;
+        let mut pricing: Option<crate::provider::catalog::Pricing> = None;
         if !config.provider.disable_catalog {
             match Self::fetch_catalog(config, &api_key).await {
                 Ok(models) => {
@@ -90,6 +95,7 @@ impl Agent {
                     match found {
                         Some(model_info) => {
                             supports_json_mode = model_info.features.json_mode;
+                            pricing = model_info.pricing.clone();
                             if model_info.context_length > 0
                                 && config.provider.max_context == 128_000
                             {
@@ -175,6 +181,7 @@ impl Agent {
             turns: 0,
             turn_cancel: CancellationToken::new(),
             diff_sink,
+            pricing,
         })
     }
 
@@ -182,6 +189,13 @@ impl Agent {
     /// and peeks the inner Option each frame to render the latest edit.
     pub fn diff_sink(&self) -> &crate::tools::EditDiffSink {
         &self.diff_sink
+    }
+
+    /// Per-token pricing for the configured model, when known (YYC-67).
+    /// The TUI uses this with the cumulative token totals (YYC-60) to
+    /// compute estimated session cost.
+    pub fn pricing(&self) -> Option<&crate::provider::catalog::Pricing> {
+        self.pricing.as_ref()
     }
 
     pub fn session_id(&self) -> &str {
@@ -233,6 +247,7 @@ impl Agent {
             turns: 0,
             turn_cancel: CancellationToken::new(),
             diff_sink: crate::tools::new_diff_sink(),
+            pricing: None,
         }
     }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -271,9 +271,11 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
     );
     app.audit_log = Some(audit_buf);
     // YYC-66: clone the agent's diff sink so the TUI can render real edits.
+    // YYC-67: pull catalog pricing for the cost estimate.
     {
         let a = agent.lock().await;
         app.diff_sink = Some(a.diff_sink().clone());
+        app.pricing = a.pricing().cloned();
     }
     refresh_sessions(&agent, &mut app).await;
 
@@ -853,6 +855,8 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                             }
                         }
                         app.thinking = false;
+                        // YYC-67: record provider-level error for telemetry.
+                        app.provider_errors_total = app.provider_errors_total.saturating_add(1);
                         app.note_error(&e);
                     }
                     Some(StreamEvent::ToolCallStart { name, .. }) => {
@@ -874,6 +878,11 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                             if matches!(last.role, ChatRole::Agent) {
                                 last.finish_tool(&name, ok);
                             }
+                        }
+                        // YYC-67: tool call telemetry.
+                        app.tool_calls_total = app.tool_calls_total.saturating_add(1);
+                        if !ok {
+                            app.tool_errors_total = app.tool_errors_total.saturating_add(1);
                         }
                         app.note_tool_end(&name, ok);
                     }

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -349,6 +349,18 @@ pub struct AppState {
     /// fall back to `diff_lines` (demo) only until the first real edit
     /// arrives, after which the live diff replaces it.
     pub diff_sink: Option<crate::tools::EditDiffSink>,
+    /// Per-token pricing pulled from the provider catalog at startup
+    /// (YYC-67). Used with `prompt_tokens_total + completion_tokens_total`
+    /// to compute estimated session cost.
+    pub pricing: Option<crate::provider::catalog::Pricing>,
+    /// Number of tool dispatches this session (counts every ToolCallEnd).
+    pub tool_calls_total: u32,
+    /// Tool dispatches that ended with `ok=false`.
+    pub tool_errors_total: u32,
+    /// Provider-level errors surfaced via StreamEvent::Error.
+    pub provider_errors_total: u32,
+    /// When the TUI session started — used for elapsed-time displays.
+    pub session_started: std::time::Instant,
     pub orchestration: OrchestrationState,
 
     /// Optional shared handle to the audit-log hook's ring buffer. When
@@ -396,6 +408,11 @@ impl AppState {
             active_session_id: None,
             diff_lines: demo_diff(),
             diff_sink: None,
+            pricing: None,
+            tool_calls_total: 0,
+            tool_errors_total: 0,
+            provider_errors_total: 0,
+            session_started: std::time::Instant::now(),
             orchestration: OrchestrationState::default(),
 
             audit_log: None,
@@ -508,6 +525,18 @@ impl AppState {
             self.model_label,
             format_thousands(self.prompt_tokens_last),
             format_thousands(self.token_max),
+        )
+    }
+
+    /// Estimated session cost in USD, computed from cumulative token
+    /// totals (YYC-60) and per-token pricing (YYC-67). `None` when
+    /// pricing isn't available — the renderer should show "—" rather
+    /// than a fake number.
+    pub fn estimated_cost(&self) -> Option<f64> {
+        let p = self.pricing.as_ref()?;
+        Some(
+            (self.prompt_tokens_total as f64) * p.input_per_token
+                + (self.completion_tokens_total as f64) * p.output_per_token,
         )
     }
 
@@ -1025,6 +1054,28 @@ mod tests {
         assert!((app.context_ratio() - 0.5).abs() < 1e-6);
         app.prompt_tokens_last = 95_000;
         assert!(app.context_ratio() > 0.9);
+    }
+
+    #[test]
+    fn estimated_cost_returns_none_without_pricing() {
+        let mut app = AppState::new("test".into(), 100_000);
+        app.prompt_tokens_total = 1_000;
+        app.completion_tokens_total = 500;
+        assert!(app.estimated_cost().is_none());
+    }
+
+    #[test]
+    fn estimated_cost_multiplies_tokens_by_per_token_pricing() {
+        let mut app = AppState::new("test".into(), 100_000);
+        app.prompt_tokens_total = 1_000;
+        app.completion_tokens_total = 500;
+        app.pricing = Some(crate::provider::catalog::Pricing {
+            input_per_token: 0.000_001,
+            output_per_token: 0.000_002,
+        });
+        let cost = app.estimated_cost().unwrap();
+        // 1000*0.000001 + 500*0.000002 = 0.001 + 0.001 = 0.002
+        assert!((cost - 0.002).abs() < 1e-9, "got {cost}");
     }
 
     #[test]

--- a/src/tui/views.rs
+++ b/src/tui/views.rs
@@ -9,7 +9,7 @@ use ratatui::{
 use super::markdown::render_markdown;
 use super::state::{AppState, ChatRole, MessageSegment, SessionStatus, ToolStatus};
 use super::theme::{Palette, body, faint_bg};
-use super::widgets::{fill, frame, message_header, section_header, sparkline, ticker};
+use super::widgets::{fill, frame, message_header, section_header, ticker};
 
 /// Public dispatch: render the active view inside `area`. The view writes
 /// its desired cursor position into `app` via `cursor_set`.
@@ -952,54 +952,82 @@ fn trading_floor(f: &mut TuiFrame, area: Rect, app: &AppState) {
     );
     draw_v_divider(f, bot[1]);
 
-    // ── metrics (bot-right)
+    // ── metrics (bot-right). YYC-67: replaced demo sparklines with real
+    // session counters. Cost shows "—" when pricing isn't available
+    // rather than inventing a number.
     let m_inner = section_header(f, bot[2], "metrics", None);
-    let metrics: Vec<(&str, Vec<u16>, ratatui::style::Color)> = vec![
-        ("tok/m", vec![2, 4, 3, 5, 7, 8, 6, 9, 7, 8], Palette::RED),
-        ("tools", vec![1, 1, 2, 3, 2, 4, 5, 3, 4, 6], Palette::BLUE),
-        ("cost ", vec![1, 2, 2, 3, 4, 4, 5, 6, 7, 8], Palette::YELLOW),
-        ("err  ", vec![0, 0, 0, 1, 0, 0, 0, 0, 1, 0], Palette::MUTED),
-    ];
-    let mut lines: Vec<Line<'static>> = Vec::new();
-    for (label, vals, color) in metrics {
-        lines.push(Line::from(vec![
-            Span::styled(
-                format!(" {label}  "),
-                Style::default()
-                    .fg(Palette::MUTED)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(
-                sparkline(&vals),
-                Style::default().fg(color).add_modifier(Modifier::BOLD),
-            ),
-        ]));
-    }
-    lines.push(Line::from(Span::styled(
-        format!(" {}", "─".repeat(m_inner.width.saturating_sub(2) as usize)),
-        Style::default().fg(Palette::INK),
-    )));
     let pad = m_inner.width.saturating_sub(2) as usize;
-    for (k, v) in [("session", "$0.84"), ("today", "$12.40"), ("cap", "$50.00")] {
-        let used = k.len() + v.len() + 2;
+
+    let cost_str = match app.estimated_cost() {
+        Some(c) => format!("${:.4}", c),
+        None => "—".to_string(),
+    };
+    let elapsed_secs = app.session_started.elapsed().as_secs();
+    let elapsed_str = if elapsed_secs >= 3600 {
+        format!("{}h{:02}m", elapsed_secs / 3600, (elapsed_secs % 3600) / 60)
+    } else if elapsed_secs >= 60 {
+        format!("{}m{:02}s", elapsed_secs / 60, elapsed_secs % 60)
+    } else {
+        format!("{}s", elapsed_secs)
+    };
+
+    let entries: Vec<(&str, String, ratatui::style::Color)> = vec![
+        (
+            "input",
+            super::state::format_thousands(app.prompt_tokens_total),
+            Palette::INK,
+        ),
+        (
+            "output",
+            super::state::format_thousands(app.completion_tokens_total),
+            Palette::INK,
+        ),
+        (
+            "tools",
+            app.tool_calls_total.to_string(),
+            if app.tool_calls_total == 0 {
+                Palette::MUTED
+            } else {
+                Palette::BLUE
+            },
+        ),
+        (
+            "errors",
+            format!(
+                "{} prov · {} tool",
+                app.provider_errors_total, app.tool_errors_total
+            ),
+            if app.provider_errors_total + app.tool_errors_total == 0 {
+                Palette::MUTED
+            } else {
+                Palette::RED
+            },
+        ),
+        ("cost", cost_str, Palette::YELLOW),
+        ("uptime", elapsed_str, Palette::MUTED),
+    ];
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    for (k, v, color) in entries {
+        let used = k.len() + v.chars().count() + 2;
         let middle = if pad > used {
             " ".repeat(pad - used)
         } else {
             String::new()
         };
-        let color = if k == "cap" {
-            Palette::RED
-        } else {
-            Palette::INK
-        };
         lines.push(Line::from(vec![
             Span::styled(format!(" {k}"), Style::default().fg(Palette::MUTED)),
             Span::styled(middle, Style::default().fg(Palette::PAPER)),
-            Span::styled(
-                v.to_string(),
-                Style::default().fg(color).add_modifier(Modifier::BOLD),
-            ),
+            Span::styled(v, Style::default().fg(color).add_modifier(Modifier::BOLD)),
         ]));
+    }
+    if app.pricing.is_none() {
+        lines.push(Line::from(Span::styled(
+            " (catalog has no pricing for this model — cost shown as —)",
+            Style::default()
+                .fg(Palette::MUTED)
+                .add_modifier(Modifier::DIM),
+        )));
     }
     f.render_widget(Paragraph::new(lines).style(body()), m_inner);
 


### PR DESCRIPTION
Replaces the demo sparkline metrics in TradingFloor with real session
counters. Honest "no data" / "—" states when a metric isn't available
(e.g. pricing missing from the provider catalog) instead of inventing
numbers.

- Agent: pulls Pricing from the matched ModelInfo at startup,
  exposes via `pricing()`.
- AppState gains:
  - `pricing: Option<Pricing>` — sourced from agent at TUI startup.
  - `tool_calls_total`, `tool_errors_total`, `provider_errors_total` —
    incremented on ToolCallEnd and StreamEvent::Error.
  - `session_started: Instant` — for uptime display.
  - `estimated_cost()` helper: prompt_total * input_per_token +
    completion_total * output_per_token. Returns None when pricing
    isn't known.
- Metrics pane renders six rows: input tokens, output tokens, tool
  call count, error breakdown (provider | tool), estimated cost,
  uptime. Cost row shows "—" + a footer note when pricing missing.

2 new tests cover estimated_cost with and without pricing.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>