### PR TITLE
YYC-36: Native git tools (status / diff / commit / push / branch / log)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,6 +194,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,10 +217,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "bytesize"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
 
 [[package]]
 name = "castaway"
@@ -296,6 +334,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clru"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -379,6 +426,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,7 +462,7 @@ dependencies = [
  "mio",
  "parking_lot",
  "rustix",
- "signal-hook",
+ "signal-hook 0.3.18",
  "signal-hook-mio",
  "winapi",
 ]
@@ -457,6 +528,20 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -566,7 +651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -601,6 +686,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "faster-hex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
+dependencies = [
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -615,6 +710,17 @@ dependencies = [
  "libc",
  "thiserror 1.0.69",
  "winapi",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -779,6 +885,934 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix"
+version = "0.82.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62786b0500a7b8dfd998b5c9fc343e1133dc3804293db98e787f5442e8003591"
+dependencies = [
+ "gix-actor",
+ "gix-archive",
+ "gix-attributes",
+ "gix-blame",
+ "gix-command",
+ "gix-commitgraph",
+ "gix-config",
+ "gix-credentials",
+ "gix-date",
+ "gix-diff",
+ "gix-dir",
+ "gix-discover",
+ "gix-error",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-ignore",
+ "gix-index",
+ "gix-lock",
+ "gix-mailmap",
+ "gix-merge",
+ "gix-negotiate",
+ "gix-object",
+ "gix-odb",
+ "gix-pack",
+ "gix-path",
+ "gix-pathspec",
+ "gix-prompt",
+ "gix-protocol",
+ "gix-ref",
+ "gix-refspec",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-sec",
+ "gix-shallow",
+ "gix-status",
+ "gix-submodule",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse",
+ "gix-url",
+ "gix-utils",
+ "gix-validate",
+ "gix-worktree",
+ "gix-worktree-state",
+ "gix-worktree-stream",
+ "nonempty",
+ "parking_lot",
+ "regex",
+ "signal-hook 0.4.4",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-actor"
+version = "0.40.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552ddba0ea986ef262ee3296a6464194181f20882902c8a7669515eaf1b0891e"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-error",
+ "winnow",
+]
+
+[[package]]
+name = "gix-archive"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af31eddd8d8842dc05e0ae1f35721f12484d2eaab7d989f183182280f2cc04af"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-error",
+ "gix-object",
+ "gix-worktree-stream",
+]
+
+[[package]]
+name = "gix-attributes"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ac00bd435a36fcc518640dad4eca4045e1a2f0b33f74a2bbff58245f8e3744d"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "kstring",
+ "smallvec",
+ "thiserror 2.0.18",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-bitmap"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecbfc77ec6852294e341ecc305a490b59f2813e6ca42d79efda5099dcab1894"
+dependencies = [
+ "gix-error",
+]
+
+[[package]]
+name = "gix-blame"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5789a39b8638b73e5c1210375910145bcf688f1786b7f71fbb1ff4cd51dc7d"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-diff",
+ "gix-error",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+ "gix-trace",
+ "gix-traverse",
+ "gix-worktree",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-chunk"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edf288be9b60fe7231de03771faa292be1493d84786f68727e33ad1f91764320"
+dependencies = [
+ "gix-error",
+]
+
+[[package]]
+name = "gix-command"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae4bb9fa74c44c93f7238b08255f7f9afc158bafea4b95af665fa535352cd73c"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "shell-words",
+]
+
+[[package]]
+name = "gix-commitgraph"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9dd13b8254d36049e9d1758657e74918a49de0286ec053d02497448fa215246"
+dependencies = [
+ "bstr",
+ "gix-chunk",
+ "gix-error",
+ "gix-hash",
+ "memmap2",
+ "nonempty",
+]
+
+[[package]]
+name = "gix-config"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ecbd673d9223a46e6bb766e0802ad9921de3541d95d121a9d05de5e23c8de"
+dependencies = [
+ "bstr",
+ "gix-config-value",
+ "gix-features",
+ "gix-glob",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "memchr",
+ "smallvec",
+ "thiserror 2.0.18",
+ "unicode-bom",
+ "winnow",
+]
+
+[[package]]
+name = "gix-config-value"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4378c53ec3db049919edf91ff76f56f28886a8b4b4a5a9dc633108d84afc3675"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "gix-path",
+ "libc",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-credentials"
+version = "0.37.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0493f25da3ce9e8f7d925e5b64dc6d0b6109c96add422a6bcada52416448147d"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-config-value",
+ "gix-date",
+ "gix-path",
+ "gix-prompt",
+ "gix-sec",
+ "gix-trace",
+ "gix-url",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-date"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc99523b8bf32561b9abf72c878fbff3854d806ed46c1198e57899f9f3c7f05"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "itoa",
+ "jiff",
+ "smallvec",
+]
+
+[[package]]
+name = "gix-diff"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709e2b8c52e027d553e200d07f39865b8d9799004160ea609459dc73c48f357a"
+dependencies = [
+ "bstr",
+ "gix-attributes",
+ "gix-command",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-imara-diff",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse",
+ "gix-worktree",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-dir"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5590f35265d28cc65faa0d36896ae467836e989b0e790dd94d51d2417e768c"
+dependencies = [
+ "bstr",
+ "gix-discover",
+ "gix-fs",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-trace",
+ "gix-utils",
+ "gix-worktree",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-discover"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31885140cb036e25742275f9848b9266a54d553103caec9f3546c62126214f45"
+dependencies = [
+ "bstr",
+ "dunce",
+ "gix-fs",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-error"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c998bf10447f0797e579567382b5e22a19c22435d2df091e25857728c6d9af8d"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "gix-features"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0f40b8c98b4b592a7e9c83fe79eacbfcdae8485aa6148ff15e52a4b6e9fe30"
+dependencies = [
+ "bytes",
+ "bytesize",
+ "crc32fast",
+ "crossbeam-channel",
+ "gix-path",
+ "gix-trace",
+ "gix-utils",
+ "libc",
+ "once_cell",
+ "parking_lot",
+ "prodash",
+ "thiserror 2.0.18",
+ "walkdir",
+ "zlib-rs",
+]
+
+[[package]]
+name = "gix-filter"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb4376a18f26bdc0fe88a719574c749a678074beda924571e24c5a83bb26e65"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "gix-attributes",
+ "gix-command",
+ "gix-hash",
+ "gix-object",
+ "gix-packetline",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "gix-utils",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-fs"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7464e9f4167e98d202c7cfb0b5ccbc170c6069870afc52bfd533ad265ce19872"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "gix-features",
+ "gix-path",
+ "gix-utils",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-glob"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76beed0974ea539df93e44d10a6c7df0a9554f6e184dd730c33e65dc0e089614"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "gix-features",
+ "gix-path",
+]
+
+[[package]]
+name = "gix-hash"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e3c92d6aa7a81bde221f3448e62b0e8d81a7d8086e85ccc24b3a4d54e315f30"
+dependencies = [
+ "faster-hex",
+ "gix-features",
+ "sha1-checked",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-hashtable"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08fe1e638b9b84b11eadfe60bdf5523bf46c40b3ef297e612a4a365832d3c8d3"
+dependencies = [
+ "gix-hash",
+ "hashbrown 0.16.1",
+ "parking_lot",
+]
+
+[[package]]
+name = "gix-ignore"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f72fe2033f4cf8f784fb413c15c8d1124e84f1ddf4d292ffc8468b05d329a047"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-trace",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-imara-diff"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfef60ebcd45e0fad3007d15b45a305e6a25af9a0fdffbca0b02bf8b0f91f83c"
+dependencies = [
+ "bstr",
+ "hashbrown 0.16.1",
+ "memchr",
+]
+
+[[package]]
+name = "gix-index"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806c10a84ef9e0e2955ec678b7ba157b9bec1185e6d5c200e14d3496f44e3874"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "filetime",
+ "fnv",
+ "gix-bitmap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-traverse",
+ "gix-utils",
+ "gix-validate",
+ "hashbrown 0.16.1",
+ "itoa",
+ "libc",
+ "memmap2",
+ "rustix",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-lock"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e30507ef152e30cec1d0f70cd00199fac746e3d448c3b39c9dade8446fa1da"
+dependencies = [
+ "gix-tempfile",
+ "gix-utils",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-mailmap"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef39d850c0c6621851f4fdca0074faa6feb2b03e4a1a55e9dc00aa3144b99f41"
+dependencies = [
+ "bstr",
+ "gix-actor",
+ "gix-date",
+ "gix-error",
+]
+
+[[package]]
+name = "gix-merge"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8305849c022c954af46029756ffb3afcabcaf0be13a3cf3e8bfd204f1fc2b48"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-diff",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-imara-diff",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-quote",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-worktree",
+ "nonempty",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-negotiate"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7cfa5d5f56dea56f96ced9ea55976b66ce8580e7fbdd23f25e9c99bd3e90927"
+dependencies = [
+ "bitflags 2.11.1",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+]
+
+[[package]]
+name = "gix-object"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710b16fe38cd3654ec218dd89911100648cd3f495e3997a1bbdc2af69ebf525a"
+dependencies = [
+ "bstr",
+ "gix-actor",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-utils",
+ "gix-validate",
+ "itoa",
+ "smallvec",
+ "thiserror 2.0.18",
+ "winnow",
+]
+
+[[package]]
+name = "gix-odb"
+version = "0.79.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7080f6ebcb0597c2c8bf7e3e0fd02c4df80260c4bfc50a8427f659129a9067b5"
+dependencies = [
+ "arc-swap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-pack",
+ "gix-path",
+ "gix-quote",
+ "memmap2",
+ "parking_lot",
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-pack"
+version = "0.69.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3f76daacd0e91a523dc741c4ef7b9355da67fd73167db831db1edd4720768b4"
+dependencies = [
+ "clru",
+ "gix-chunk",
+ "gix-error",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-path",
+ "memmap2",
+ "smallvec",
+ "thiserror 2.0.18",
+ "uluru",
+]
+
+[[package]]
+name = "gix-packetline"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "362246df440ee691699f0664cbf7006a6ece477db6734222be95e4198e5656e6"
+dependencies = [
+ "bstr",
+ "faster-hex",
+ "gix-trace",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-path"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fd1fe596dc393b538e1d5492c5585971a9311475b3255f7b889023df208476"
+dependencies = [
+ "bstr",
+ "gix-trace",
+ "gix-validate",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-pathspec"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d902b0cafb2b691738c585f0be98b1b73fad63644c6a612b9b2708bb7b1d17d"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "gix-attributes",
+ "gix-config-value",
+ "gix-glob",
+ "gix-path",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-prompt"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de52c2570684db3eb8cebda77c1d0e3d03ddaad2d9bbb5055eba31fb9f8292a"
+dependencies = [
+ "gix-command",
+ "gix-config-value",
+ "parking_lot",
+ "rustix",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-protocol"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "565eaa4df8438f2919135284410284c99100a2f9836d89efd918292107a80165"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-ref",
+ "gix-shallow",
+ "gix-transport",
+ "gix-utils",
+ "maybe-async",
+ "nonempty",
+ "thiserror 2.0.18",
+ "winnow",
+]
+
+[[package]]
+name = "gix-quote"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e97b73791a64bc0fa7dd2c5b3e551136115f97750b876ed1c952c7a7dbaf8be"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "gix-utils",
+]
+
+[[package]]
+name = "gix-ref"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a4367b66548864dd16873c6c86220b81960994deb63965803d773e377e3fce4"
+dependencies = [
+ "gix-actor",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "gix-utils",
+ "gix-validate",
+ "memmap2",
+ "thiserror 2.0.18",
+ "winnow",
+]
+
+[[package]]
+name = "gix-refspec"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c2b2756c9ea849bf63d01c0407be7006ebff78e6893e1845a56446eaeada359"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "gix-glob",
+ "gix-hash",
+ "gix-revision",
+ "gix-validate",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-revision"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c130f74ac580ef8d37d723576b776674fdeb405f8b6126692c28346fdb85ac"
+dependencies = [
+ "bitflags 2.11.1",
+ "bstr",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-error",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "gix-trace",
+ "nonempty",
+]
+
+[[package]]
+name = "gix-revwalk"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96e8ba5213c036d064034cefa6349cba3628498bccd8eca3e22a121b1a6e726"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-error",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-sec"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "283f4a746c9bde8550be63e6f961ff4651f412ca12666e8f5615f39464960ab9"
+dependencies = [
+ "bitflags 2.11.1",
+ "gix-path",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "gix-shallow"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3290e102e9375812e6baddf3354357f07f04baeaece97e045f9dad2c7ce6a033"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-lock",
+ "nonempty",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-status"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a444038e1bd06039464990f0653265d0707c5d92dda283cdf7cecd1b1f3182ba"
+dependencies = [
+ "bstr",
+ "filetime",
+ "gix-diff",
+ "gix-dir",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-worktree",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-submodule"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5099295499844e2d9d06d3e9be91d3db67fe322b9bdacaa4009769059affec02"
+dependencies = [
+ "bstr",
+ "gix-config",
+ "gix-path",
+ "gix-pathspec",
+ "gix-refspec",
+ "gix-url",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-tempfile"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30bb168ab673020410158264e21b267dae3b89d248e901400b1cba788fcba7a"
+dependencies = [
+ "dashmap",
+ "gix-fs",
+ "libc",
+ "parking_lot",
+ "signal-hook 0.4.4",
+ "signal-hook-registry",
+ "tempfile",
+]
+
+[[package]]
+name = "gix-trace"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f23569e55f2ffaf958617353b9734a7d52a7c19c439eeaa5e3efc217fd2270e"
+
+[[package]]
+name = "gix-transport"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70f7cc0a5f8ff289c2d18077740efbad216d8c85b949c40827cd5bff00e457df"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-features",
+ "gix-packetline",
+ "gix-quote",
+ "gix-sec",
+ "gix-url",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-traverse"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef81f53b86d0cb1588768aaea171241fb98818c8893dd43aa3343fff49600e09"
+dependencies = [
+ "bitflags 2.11.1",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-url"
+version = "0.35.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a61ead12e33fa52ae92b207ee27554f646a8e7a3dad8b78da1582ec91eda0a6"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "percent-encoding",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-utils"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e477b4f07a6e8da4ba791c53c858102959703c60d70f199932010d5b94adb2c"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "gix-validate"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e26ac2602b43eadfdca0560b81d3341944162a3c9f64ccdeef8fc501ad80dad5"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "gix-worktree"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f16b89b6195beba7e5517fea8ba20ca6fca67143fb1b070560ce0a4a866c87a"
+dependencies = [
+ "bstr",
+ "gix-attributes",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-validate",
+]
+
+[[package]]
+name = "gix-worktree-state"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acaa094bfbba896270a83b19585a0ee4ee83a0a64ab0ed3027302a3425436b3f"
+dependencies = [
+ "bstr",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-worktree",
+ "io-close",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-worktree-stream"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e0dc22458124d74729003a95225bd63236652671d660a8134843bedc1d4600"
+dependencies = [
+ "gix-attributes",
+ "gix-error",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-object",
+ "gix-path",
+ "gix-traverse",
+ "parking_lot",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,6 +1830,21 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -830,6 +1879,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -882,6 +1941,12 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "human_format"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaec953f16e5bcf6b8a3cb3aa959b17e5577dbd2693e94554c462c08be22624b"
 
 [[package]]
 name = "hyper"
@@ -1118,6 +2183,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-close"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cadcf447f06744f8ce713d2d6239bb5bde2c357a452397a9ed90c625da390bc"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1153,6 +2228,47 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "jni"
@@ -1232,6 +2348,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kstring"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
 name = "lab"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1254,6 +2379,18 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.4",
+]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1343,10 +2480,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-async"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memmem"
@@ -1423,12 +2580,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonempty"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1511,7 +2674,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -1630,10 +2793,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "portable-pty"
@@ -1697,6 +2875,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prodash"
+version = "31.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "962200e2d7d551451297d9fdce85138374019ada198e30ea9ede38034e27604c"
+dependencies = [
+ "bytesize",
+ "human_format",
+ "parking_lot",
 ]
 
 [[package]]
@@ -1915,6 +3104,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2050,7 +3248,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2107,7 +3305,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2257,6 +3455,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha1-checked"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
+dependencies = [
+ "digest",
+ "sha1",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2309,6 +3528,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-mio"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2316,7 +3545,7 @@ checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
  "mio",
- "signal-hook",
+ "signal-hook 0.3.18",
 ]
 
 [[package]]
@@ -2484,10 +3713,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2537,7 +3766,7 @@ dependencies = [
  "pest_derive",
  "phf",
  "sha2",
- "signal-hook",
+ "signal-hook 0.3.18",
  "siphasher",
  "terminfo",
  "termios",
@@ -2864,10 +4093,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "uluru"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c8a2469e56e6e5095c82ccd3afb98dad95f7af7929aab6d8ba8d6e0f73657da"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "unicode-bom"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -2977,6 +4230,7 @@ dependencies = [
  "clap",
  "crossterm",
  "futures-util",
+ "gix",
  "portable-pty",
  "ratatui",
  "reqwest",
@@ -3262,7 +4516,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3503,6 +4757,9 @@ name = "winnow"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"
@@ -3715,6 +4972,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,11 @@ tokio-util = { version = "0.7.18", features = ["rt"] }
 rusqlite = { version = "0.39.0", features = ["bundled"] }
 strsim = "0.11.1"
 portable-pty = "0.9.0"
+# Pure-Rust git plumbing (YYC-36). Used today only for repository
+# discovery — write ops dispatch through the `git` binary because gix's
+# commit/push surfaces are still maturing and a hybrid keeps the tool
+# semantics predictable. Plan: migrate one tool at a time.
+gix = "0.82"
 
 [profile.release]
 opt-level = "z"    # optimize for size

--- a/README.md
+++ b/README.md
@@ -2,76 +2,155 @@
 
 > A Rust AI agent — forged at the forge, tested by fire.
 
-Vulcan is a pure-Rust personal AI agent for the command line. It combines an interactive TUI chat interface with a tool-calling LLM backend, designed for speed, portability, and deep extensibility.
+**Vulcan** is a pure-Rust AI agent that lives in your terminal. It gives you a powerful, interactive LLM-powered assistant with file editing, shell access, web search, persistent sessions, and a beautiful TUI — all in a single binary.
 
-Built on a **hook-driven architecture** — every lifecycle point (prompt assembly, tool dispatch, session boundaries) is an extension surface for audit, safety, skills injection, and custom behavior.
+```bash
+# Start the TUI
+vulcan
+
+# One-shot prompt
+vulcan prompt "Find all TODO comments in this project"
+
+# Resume your last session
+vulcan --continue
+
+# Full-text search across all past sessions
+vulcan search "some query"
+```
+
+---
 
 ## Features
 
-### 🖥️ Terminal UI
-- **Multi-view TUI** — 5 ratatui views (Trading Floor, Single Stack, Split Sessions, Tiled Mesh, Tree of Thought) with smooth keyboard navigation
+### 🖥️ Terminal UI (TUI)
+
+Vulcan's ratatui-powered terminal interface gives you five views to work with:
+
+| View | What it shows |
+|------|---------------|
+| **Single Stack** | A focused chat view — you and the agent, one conversation at a time |
+| **Split Sessions** | Chat on the left, session list/side panel on the right |
+| **Tiled Mesh** | Grid layout showing chat, tool activity, sessions, and telemetry |
+| **Trading Floor** | All panels at once — see everything happening in real-time |
+| **Tree of Thought** | Branching conversation trees for exploring multiple lines of reasoning |
+
+Switch between views instantly with `Ctrl+1` through `Ctrl+5`.
+
+**UI highlights:**
 - **Markdown rendering** — agent responses render inline code, lists, headings, and more
-- **Reasoning trace** — toggle visibility of model reasoning/thinking traces inline
-- **Prompt mode state machine** — Insert / Command / Ask / Busy modes with per-mode key binding hints
-- **Slash commands** — `/help`, `/clear`, `/view`, `/reasoning`, `/search`, `/exit` with fuzzy filter + tab completion + palette navigation
-- **Prompt queue** — queue inputs while the agent is busy; drained automatically when the turn completes
-- **Live tool activity** — see tool calls start/complete in real-time with ✓/✗ status
-- **Live edit diffs** — real file-edit diffs rendered in the UI (not demo data)
-- **Live telemetry** — per-session token counts, estimated cost (from provider pricing), tool/error counters, elapsed session time
-- **Auto-scroll** — viewport follows the latest content; pauses on manual scroll, re-engages on new submission
+- **Reasoning trace** — toggle visibility of model reasoning/thinking traces (`Ctrl+R`)
+- **Slash commands** — `/help`, `/clear`, `/view`, `/reasoning`, `/search`, `/exit` with fuzzy filtering, tab completion, and a navigable palette
+- **Prompt queue** — keep typing while the agent is busy; prompts drain automatically when the turn completes
+- **Live tool activity** — see tool calls start and complete in real-time with ✓/✗ status
+- **Live edit diffs** — real file-edit diffs rendered in the UI as the agent works
+- **Live telemetry** — per-session token counts, estimated cost, tool/error counters, elapsed time
+- **Auto-scroll** — viewport follows content; pauses on manual scroll, resumes on new input
 
 ### 🤖 Agent Capabilities
-- **Interactive chat** — multi-turn conversation with context management and history
-- **One-shot mode** — `vulcan prompt "your question"` for scripting and pipelines
-- **Session persistence** — SQLite-backed storage with FTS5 full-text search across all sessions
-- **Session resume** — resume the last session or a specific session by ID
-- **Cross-session search** — `vulcan search "query"` for BM25-ranked full-text search across saved conversations
+
+- **Interactive chat** — multi-turn conversations with full context management
+- **One-shot mode** — `vulcan prompt "your question"` for scripting and pipelines (streams tokens to stdout)
+- **Session persistence** — all conversations saved to SQLite with full-text search (FTS5)
+- **Session resume** — pick up where you left off with `vulcan --continue` or `vulcan session <id>`
+- **Cross-session search** — `vulcan search "query"` finds relevant messages across your entire history
 - **Session lineage** — parent-session tracking for branching conversation trees
 
 ### 🛠️ Tool System
-Seven built-in tools with schema validation and required-field checking:
 
-| Tool | Description |
+The agent can use these tools to help you:
+
+| Tool | What it does |
 |------|-------------|
 | `read_file` | Read files with optional offset/limit |
-| `write_file` | Write/create files (captures diff) |
-| `edit_file` | Find-and-replace edits (captures diff) |
-| `search_files` | Ripgrep-style regex search |
-| `bash` | One-shot shell command execution (PTY-backed) |
-| `pty_create` / `pty_write` / `pty_read` / `pty_resize` / `pty_close` / `pty_list` | Persistent interactive PTY sessions |
+| `write_file` | Write or create files (captures a diff) |
+| `edit_file` | Find-and-replace edits with fuzzy matching (captures a diff) |
+| `search_files` | Ripgrep-style regex search across your codebase |
+| `bash` | Execute shell commands (PTY-backed) |
+| `pty_*` | Full interactive PTY session management (create, write, read, resize, close, list) |
 | `web_search` | DuckDuckGo web search |
-| `web_fetch` | URL content fetch (markdown extraction) |
+| `web_fetch` | Fetch a URL and extract its content as markdown |
 
-### 🔌 Hook System (Pi-style Extension Surface)
-Seven wire-in points — every hook has priority ordering, timeout isolation, and error containment:
+### 🔒 Safety & Audit
 
-| Event | Purpose |
-|-------|---------|
-| `BeforePrompt` | Inject transient messages (skills, system prompts) |
-| `BeforeToolCall` | Block or modify tool arguments (safety gate) |
-| `AfterToolCall` | Inspect or replace tool results |
-| `BeforeAgentEnd` | Force the agent loop to continue |
-| `session_start` | Lifecycle — session opened |
-| `session_end` | Lifecycle — session closed |
+- **Safety system** — dangerous shell commands (`rm -rf /`, `dd`, `mkfs`, fork bombs, force pushes, `curl|bash`) are blocked with interactive approval prompts
+- **Audit log** — ring-buffered tool-call log viewable in the TUI
+- **Action pills** — approve/deny/remember inline responses for safety prompts
 
-**Built-in hooks:**
-- **SafetyHook** — blocks dangerous shell commands (rm -rf /, dd, mkfs, chmod 777, fork bombs, force pushes, curl|bash) with interactive approval (allow once / remember & allow / deny) via inline action pills
-- **AuditHook** — ring-buffered tool-call audit log, surfaced in the TUI tool-log pane
-- **SkillsHook** — injects available skills into the prompt at startup
+### 🧠 Skill System
 
-### ⏸️ AgentPause Mechanism
-Generic mid-loop user-interruption system. When a hook needs user input (safety approval, tool confirmation, skill-save prompt), it emits an `AgentPause` with inline action pills. The TUI renders an overlay, dispatches keystrokes back via oneshot channels, and the agent resumes — all without blocking other futures.
+Vulcan learns. Skills are markdown files with YAML frontmatter that get injected into the system prompt. They live in `~/.vulcan/skills/` and can auto-create when the agent detects repeated tool patterns.
 
-### 🔗 LLM Provider
-- **OpenAI-compatible** — works with OpenRouter, Anthropic, OpenAI, Ollama, DeepSeek, any OpenAI-compatible endpoint
-- **Streaming** — SSE-based streaming with text, reasoning, and tool call events
+### 🔗 LLM Provider Support
+
+- **OpenAI-compatible** — works with OpenRouter, Anthropic, OpenAI, Ollama, DeepSeek, or any OpenAI-compatible API endpoint
+- **Streaming** — SSE-based streaming with text, reasoning, and tool calls
 - **Retry logic** — exponential backoff with jitter (1s, 2s, 4s, 8s, 16s) for 429/5xx/network errors
-- **Structured error taxonomy** — `Auth`, `RateLimited`, `ModelNotFound`, `BadRequest`, `ServerError`, `Network` — each with actionable user-facing messages
-- **Reasoning passthrough** — supports DeepSeek `reasoning_content` with dual-field serialization (`reasoning_content` + `reasoning`) for OpenRouter compatibility
-- **Provider model catalog** — auto-fetches model metadata at startup, validates model exists, fuzzy-suggests alternatives, auto-populates `context_length` and pricing
+- **Model catalog** — auto-fetches model metadata at startup, validates the model exists, fuzzy-suggests alternatives, auto-populates context length and pricing
+- **Reasoning passthrough** — supports models like DeepSeek that emit `reasoning_content` alongside responses
 
-### ⚙️ Configuration
-TOML config at `~/.vulcan/config.toml` (or `./config.toml`):
+---
+
+## Installation
+
+### From Source
+
+```bash
+# Clone the repo
+git clone https://github.com/yycholla/vulcan.git
+cd vulcan
+
+# Build release binary (size-optimized: LTO, strip)
+cargo build --release
+
+# The binary is at ./target/release/vulcan — copy it somewhere on your PATH
+cp ./target/release/vulcan ~/.local/bin/
+```
+
+### Prerequisites
+
+- **Rust toolchain** — install via [rustup](https://rustup.rs/)
+- An API key from one of the supported LLM providers (see [Configuration](#configuration))
+
+---
+
+## Configuration
+
+Vulcan looks for config at `~/.vulcan/config.toml` (or `./config.toml` in the current directory).
+
+### 1. Create the config
+
+```bash
+mkdir -p ~/.vulcan
+cp config.example.toml ~/.vulcan/config.toml
+```
+
+### 2. Set your API key
+
+Either set the environment variable:
+
+```bash
+export VULCAN_API_KEY="sk-..."
+```
+
+Or add it to your config file:
+
+```toml
+[provider]
+api_key = "sk-..."
+```
+
+### 3. Choose a model
+
+The default works with OpenRouter (uses `deepseek/deepseek-v4-flash`). Change the `model` and `base_url` to use a different provider:
+
+```toml
+[provider]
+type = "openai-compat"
+base_url = "https://openrouter.ai/api/v1"
+model = "deepseek/deepseek-v4-flash"
+```
+
+### Full Configuration Reference
 
 | Setting | Default | Description |
 |---------|---------|-------------|
@@ -82,58 +161,81 @@ TOML config at `~/.vulcan/config.toml` (or `./config.toml`):
 | `provider.max_retries` | `4` | Transient error retries |
 | `provider.catalog_cache_ttl_hours` | `24` | Model catalog cache lifetime |
 | `provider.disable_catalog` | `false` | Skip catalog fetch at startup |
-| `provider.debug` | `"off"` | Debug logging level (`off`, `tool-fallback`, `wire`) |
+| `provider.debug` | `"off"` | Debug logging: `off`, `tool-fallback`, or `wire` |
 | `tools.yolo_mode` | `false` | Skip safety confirmations |
 | `compaction.enabled` | `true` | Auto-compress context at threshold |
 | `compaction.trigger_ratio` | `0.85` | Compaction trigger ratio |
 | `compaction.reserved_tokens` | `50000` | Reserved tokens for response |
 
-API key: set `VULCAN_API_KEY` env var or add `provider.api_key` to config.
+---
 
-### 📦 Skill System
-Markdown-based skill registry with YAML frontmatter, loaded as prompt injections via the SkillsHook. Skills live in `~/.vulcan/skills/` and auto-create when the agent detects repeated tool patterns.
+## Usage
 
-## Quick Start
+### Commands
 
 ```bash
-# Build
-cargo build --release
-
-# Run TUI (default)
+# Start interactive TUI (default)
 vulcan
 
-# One-shot prompt
+# One-shot mode — ask a question, get an answer
 vulcan prompt "What is the capital of France?"
 
-# Resume last session
+# Resume the most recent session
 vulcan --continue
 
-# Resume specific session
+# Resume a specific session by ID
 vulcan session <session-id>
 
-# Search past sessions
+# Full-text search across all saved sessions
 vulcan search "some query"
+# Optionally limit results: vulcan search "query" --limit 20
 ```
-
-The TUI uses ratatui with crossterm — it works on any terminal that supports an alternate screen.
 
 ### TUI Keyboard Shortcuts
 
 | Key | Action |
 |-----|--------|
 | `Enter` | Send prompt / run command |
-| `Esc` | Cancel / deny pause |
-| `Ctrl+1..5` | Switch views (1=Single Stack, 5=Trading Floor) |
-| `Ctrl+T` | Focus tools view |
+| `Esc` | Cancel / deny pause prompt |
+| `Ctrl+1` to `Ctrl+5` | Switch views (1=Single Stack, 5=Trading Floor) |
+| `Ctrl+T` | Focus tools/log view |
 | `Ctrl+K` | Focus sessions view |
-| `Ctrl+Backspace` | Drop last queued prompt |
-| `Ctrl+Shift+Backspace` | Clear entire prompt queue |
-| `Ctrl+C` | Cancel in-flight agent turn |
-| `Tab` | Complete slash command |
-| `↑↓` or `Ctrl+J/K` | Navigate slash command palette |
-| `y` / `n` / `r` | Allow / deny / remember (pause prompts) |
+| `Ctrl+R` | Toggle reasoning trace visibility |
+| `Ctrl+Backspace` | Drop the last queued prompt |
+| `Ctrl+Shift+Backspace` | Clear the entire prompt queue |
+| `Ctrl+C` | Cancel an in-flight agent turn |
+| `Tab` | Complete a slash command |
+| `↑` / `↓` or `Ctrl+J` / `Ctrl+K` | Navigate the slash command palette |
+| `y` / `n` / `r` | Allow / deny / remember (safety pause prompts) |
 
-## Architecture
+### Slash Commands
+
+Type `/` in the TUI to access slash commands:
+
+```
+/help       Show help information
+/clear      Clear the conversation
+/view       Switch views (equivalent to Ctrl+1..5)
+/reasoning  Toggle reasoning trace
+/search     Search past sessions
+/exit       Quit Vulcan
+```
+
+Use `Tab` to autocomplete, `↑`/`↓` to navigate suggestions.
+
+### Logging
+
+| Env Var | Effect |
+|---------|--------|
+| `VULCAN_LOG=info` | Default logging |
+| `VULCAN_LOG=debug` | Verbose debugging |
+| `VULCAN_LOG=trace` | Wire-level provider debugging |
+
+In TUI mode, logs go to `~/.vulcan/vulcan.log`. In one-shot/CLI mode, logs go to stderr.
+
+---
+
+## Architecture (for the curious)
 
 ```
 main.rs ──► Cli ──► Chat (TUI) ──► Agent ──► Provider ──► LLM API
@@ -142,68 +244,31 @@ main.rs ──► Cli ──► Chat (TUI) ──► Agent ──► Provider �
                     │              ├─ safety (blocks dangerous commands)
                     │              ├─ audit (ring-buffered tool log)
                     │              ├─ skills (prompt injections)
-                    │              └─ (user-defined)
+                    │              └─ (user-extensible)
                     │
                     │           AgentPause channel
                     │              └─ SafetyApproval / ToolArgConfirm / SkillSave
                     │
                  ToolSet
                   ├─ file (read, write, search, edit)
-                  ├─ shell/pty (bash, pty_create/write/read/resize/close/list)
+                  ├─ shell/pty (bash, pty sessions)
                   └─ web (search, fetch)
 ```
 
-## Project Structure
+Vulcan is built on a **hook-driven architecture** — every lifecycle point (prompt assembly, tool dispatch, session boundaries) is an extension surface for audit, safety, skills injection, and custom behavior.
 
-```
-src/
-├── main.rs             Entry point (CLI dispatch, logging init)
-├── lib.rs              Module tree
-├── cli.rs              CLI argument parsing (clap) — chat, prompt, session, search
-├── config.rs           TOML config loader, vulcan_home(), API key resolution
-├── agent.rs            Core agent loop (tool dispatch, hook wiring, streaming)
-├── context.rs          Context window management (token tracking, compaction)
-├── prompt_builder.rs   System prompt construction
-├── memory.rs           SQLite session store, FTS5 search, lineage tracking
-├── pause.rs            AgentPause mechanism (generic mid-loop user interruption)
-├── hooks/
-│   ├── mod.rs          Hook trait, outcomes, registry (priority, timeout)
-│   ├── audit.rs        Built-in audit hook (ring-buffered tool call log)
-│   ├── safety.rs       Built-in safety hook (dangerous command blocking)
-│   └── skills.rs       Skills-as-hooks injection
-├── platform/
-│   └── mod.rs          Platform abstraction
-├── provider/
-│   ├── mod.rs          Provider trait, error taxonomy, message types, streaming events
-│   ├── openai.rs       OpenAI-compatible streaming implementation (SSE, retry, reasoning)
-│   ├── catalog.rs      Model catalog fetcher (OpenRouter-rich / OpenAI-sparse, caching, fuzzy suggest)
-│   └── mock.rs         Test mock provider
-├── skills/
-│   └── mod.rs          Skill registry (markdown + YAML frontmatter)
-├── tools/
-│   ├── mod.rs          Tool trait, registry, schema validation, EditDiff
-│   ├── file.rs         ReadFile, WriteFile, SearchFiles, PatchFile (with diff capture)
-│   ├── shell.rs        Bash + PTY session management (create/write/read/resize/close/list)
-│   └── web.rs          Web search (DuckDuckGo) and fetch tools
-└── tui/
-    ├── mod.rs          TUI loop, key dispatch, pause handling, slash commands
-    ├── state.rs        App state, ChatMessage, PromptMode, orchestration state
-    ├── markdown.rs     Markdown-to-ratatui parser
-    ├── theme.rs        Color palette and styles
-    ├── views.rs        Five view renderers (TradingFloor, SingleStack, SplitSessions, etc.)
-    └── widgets.rs      Custom widgets (frame, section_header, sparkline, ticker, etc.)
-```
+---
 
-## Building
+## Development
 
 ```bash
-cargo build             # Debug build
-cargo build --release   # Optimized release (size-optimized: LTO, strip)
-cargo test              # Run all tests
-cargo test <name>       # Single test
+cargo build               # Debug build
+cargo build --release     # Optimized release (size-optimized)
+cargo test                # Run all tests
+cargo test <name>         # Run a single test by name
 ```
 
-Set `VULCAN_LOG=debug` for verbose logging; `VULCAN_LOG=trace` for wire-level provider debugging.
+---
 
 ## Roadmap
 
@@ -211,7 +276,9 @@ Set `VULCAN_LOG=debug` for verbose logging; `VULCAN_LOG=trace` for wire-level pr
 
 **Planned** — context compaction with LLM summarization, external hook handlers (Python/JS), platform connectors (Discord, Telegram), gateway daemon, cron scheduling, sub-agent orchestration.
 
-Tracked in Linear: [Vulcan — Rust AI Agent](https://linear.app/yycholla/project/vulcan-rust-ai-agent-37bc34d04e48)
+Tracked in [Linear — Vulcan: Rust AI Agent](https://linear.app/yycholla/project/vulcan-rust-ai-agent-37bc34d04e48).
+
+---
 
 ## License
 

--- a/src/tools/git.rs
+++ b/src/tools/git.rs
@@ -1,0 +1,407 @@
+//! Native git tools (YYC-36).
+//!
+//! The agent gets six dedicated git tools so it can stop composing brittle
+//! `git ...` shell strings through the bash tool. The current implementation
+//! is a hybrid: `gix` is used for repo discovery (so a "not a repository"
+//! error is a clean Rust error, not a parsed stderr line), and the actual
+//! work dispatches to the `git` binary via `tokio::process::Command`. The
+//! issue calls for a full `gix` port, but commit/push/branch-modify
+//! semantics through gix still require non-trivial plumbing — landing
+//! subprocess-backed tools first gives the agent a working surface today
+//! and unblocks downstream work; per-tool migration to native gix can land
+//! incrementally without reshaping the tool API.
+//!
+//! Each tool runs in the agent's current working directory. They surface
+//! raw stdout to the LLM (no trimming) and surface stderr only when the
+//! command fails.
+
+use crate::tools::{Tool, ToolResult};
+use anyhow::Result;
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use tokio::process::Command;
+use tokio_util::sync::CancellationToken;
+
+/// Run `git <args...>` in the current working directory and return its
+/// output. Returns Err only for spawn failures; non-zero exit codes are
+/// surfaced as a `ToolResult::err` with the captured stderr.
+async fn run_git(args: &[&str], cancel: CancellationToken) -> Result<ToolResult> {
+    // Repo discovery via gix. Done up front so a non-repo cwd produces a
+    // clean error instead of forcing the LLM to parse `fatal: not a git
+    // repository` from git's stderr.
+    if gix::discover(".").is_err() {
+        return Ok(ToolResult::err(
+            "Not a git repository (or any parent up to the filesystem root). \
+             Run from inside a working tree, or `git init` first.",
+        ));
+    }
+
+    let mut cmd = Command::new("git");
+    cmd.args(args);
+    cmd.kill_on_drop(true);
+
+    let child = cmd.output();
+    let output = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => return Ok(ToolResult::err("Cancelled")),
+        out = child => out?,
+    };
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+
+    if output.status.success() {
+        // Surface stderr in addition to stdout when both are present
+        // (e.g. `git push` writes progress to stderr). Compact format
+        // keeps the LLM context lean.
+        let mut combined = stdout;
+        if !stderr.trim().is_empty() {
+            if !combined.is_empty() {
+                combined.push_str("\n--- stderr ---\n");
+            }
+            combined.push_str(&stderr);
+        }
+        Ok(ToolResult::ok(if combined.is_empty() {
+            "(no output)".to_string()
+        } else {
+            combined
+        }))
+    } else {
+        Ok(ToolResult::err(format!(
+            "git {} failed (exit {}):\n{}",
+            args.join(" "),
+            output.status.code().unwrap_or(-1),
+            if stderr.trim().is_empty() {
+                stdout
+            } else {
+                stderr
+            }
+        )))
+    }
+}
+
+// ─── git_status ─────────────────────────────────────────────────────────
+
+pub struct GitStatusTool;
+
+#[async_trait]
+impl Tool for GitStatusTool {
+    fn name(&self) -> &str {
+        "git_status"
+    }
+    fn description(&self) -> &str {
+        "Show working tree status (staged, unstaged, untracked). Compact porcelain format."
+    }
+    fn schema(&self) -> Value {
+        json!({ "type": "object", "properties": {} })
+    }
+    async fn call(&self, _params: Value, cancel: CancellationToken) -> Result<ToolResult> {
+        run_git(&["status", "--short", "--branch"], cancel).await
+    }
+}
+
+// ─── git_diff ───────────────────────────────────────────────────────────
+
+pub struct GitDiffTool;
+
+#[async_trait]
+impl Tool for GitDiffTool {
+    fn name(&self) -> &str {
+        "git_diff"
+    }
+    fn description(&self) -> &str {
+        "Show diff for staged, unstaged, or specific path changes. Defaults to unstaged worktree changes."
+    }
+    fn schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "staged": {
+                    "type": "boolean",
+                    "description": "If true, show staged changes (`git diff --cached`)",
+                    "default": false
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Optional path filter. Limits diff to this file/dir."
+                }
+            }
+        })
+    }
+    async fn call(&self, params: Value, cancel: CancellationToken) -> Result<ToolResult> {
+        let staged = params
+            .get("staged")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let path = params.get("path").and_then(|v| v.as_str());
+
+        let mut args: Vec<&str> = vec!["diff"];
+        if staged {
+            args.push("--cached");
+        }
+        args.push("--no-color");
+        if let Some(p) = path {
+            args.push("--");
+            args.push(p);
+        }
+        run_git(&args, cancel).await
+    }
+}
+
+// ─── git_commit ─────────────────────────────────────────────────────────
+
+pub struct GitCommitTool;
+
+#[async_trait]
+impl Tool for GitCommitTool {
+    fn name(&self) -> &str {
+        "git_commit"
+    }
+    fn description(&self) -> &str {
+        "Create a commit with the given message. Set `all=true` to stage all tracked changes first."
+    }
+    fn schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "message": { "type": "string", "description": "Commit message" },
+                "all": {
+                    "type": "boolean",
+                    "description": "Stage all tracked modifications before committing (`git commit -a`)",
+                    "default": false
+                }
+            },
+            "required": ["message"]
+        })
+    }
+    async fn call(&self, params: Value, cancel: CancellationToken) -> Result<ToolResult> {
+        let message = params
+            .get("message")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow::anyhow!("message required"))?;
+        let all = params
+            .get("all")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        let mut args: Vec<&str> = vec!["commit"];
+        if all {
+            args.push("-a");
+        }
+        args.push("-m");
+        args.push(message);
+        run_git(&args, cancel).await
+    }
+}
+
+// ─── git_push ───────────────────────────────────────────────────────────
+
+pub struct GitPushTool;
+
+#[async_trait]
+impl Tool for GitPushTool {
+    fn name(&self) -> &str {
+        "git_push"
+    }
+    fn description(&self) -> &str {
+        "Push the current branch to its remote tracking branch. Set `set_upstream=true` to push and create the upstream link in one go."
+    }
+    fn schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "remote": { "type": "string", "description": "Remote name", "default": "origin" },
+                "branch": { "type": "string", "description": "Branch to push (defaults to current)" },
+                "set_upstream": {
+                    "type": "boolean",
+                    "description": "Use -u to track the remote branch on first push",
+                    "default": false
+                }
+            }
+        })
+    }
+    async fn call(&self, params: Value, cancel: CancellationToken) -> Result<ToolResult> {
+        let remote = params
+            .get("remote")
+            .and_then(|v| v.as_str())
+            .unwrap_or("origin");
+        let branch = params.get("branch").and_then(|v| v.as_str());
+        let set_upstream = params
+            .get("set_upstream")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
+        let mut args: Vec<&str> = vec!["push"];
+        if set_upstream {
+            args.push("-u");
+        }
+        args.push(remote);
+        if let Some(b) = branch {
+            args.push(b);
+        }
+        run_git(&args, cancel).await
+    }
+}
+
+// ─── git_branch ─────────────────────────────────────────────────────────
+
+pub struct GitBranchTool;
+
+#[async_trait]
+impl Tool for GitBranchTool {
+    fn name(&self) -> &str {
+        "git_branch"
+    }
+    fn description(&self) -> &str {
+        "List, create, or switch branches. Default action lists local branches with the current one starred."
+    }
+    fn schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["list", "create", "switch"],
+                    "description": "Operation to perform",
+                    "default": "list"
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Branch name (required for create / switch)"
+                }
+            }
+        })
+    }
+    async fn call(&self, params: Value, cancel: CancellationToken) -> Result<ToolResult> {
+        let action = params
+            .get("action")
+            .and_then(|v| v.as_str())
+            .unwrap_or("list");
+        let name = params.get("name").and_then(|v| v.as_str());
+
+        match action {
+            "list" => run_git(&["branch", "--list", "-vv"], cancel).await,
+            "create" => {
+                let n =
+                    name.ok_or_else(|| anyhow::anyhow!("name required for action='create'"))?;
+                // -b creates and switches in one step; matches the
+                // common agent intent "make this branch and use it".
+                run_git(&["checkout", "-b", n], cancel).await
+            }
+            "switch" => {
+                let n =
+                    name.ok_or_else(|| anyhow::anyhow!("name required for action='switch'"))?;
+                run_git(&["checkout", n], cancel).await
+            }
+            other => Ok(ToolResult::err(format!(
+                "Unknown action '{other}'. Use 'list', 'create', or 'switch'."
+            ))),
+        }
+    }
+}
+
+// ─── git_log ────────────────────────────────────────────────────────────
+
+pub struct GitLogTool;
+
+#[async_trait]
+impl Tool for GitLogTool {
+    fn name(&self) -> &str {
+        "git_log"
+    }
+    fn description(&self) -> &str {
+        "Show recent commit history (oneline format). Defaults to last 10 commits."
+    }
+    fn schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "limit": {
+                    "type": "integer",
+                    "description": "Max commits to show",
+                    "default": 10
+                },
+                "branch": {
+                    "type": "string",
+                    "description": "Branch or ref to log (defaults to HEAD)"
+                }
+            }
+        })
+    }
+    async fn call(&self, params: Value, cancel: CancellationToken) -> Result<ToolResult> {
+        let limit = params.get("limit").and_then(|v| v.as_i64()).unwrap_or(10);
+        let limit = limit.clamp(1, 200).to_string();
+        let branch = params.get("branch").and_then(|v| v.as_str());
+
+        let mut args: Vec<&str> = vec!["log", "--oneline", "-n", limit.as_str()];
+        if let Some(b) = branch {
+            args.push(b);
+        }
+        run_git(&args, cancel).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tempfile::tempdir;
+
+    /// Run `args` in `cwd`. Wraps tokio's Command directly so the test
+    /// doesn't need to hop through the public Tool trait.
+    async fn git(cwd: &std::path::Path, args: &[&str]) {
+        let status = tokio::process::Command::new("git")
+            .current_dir(cwd)
+            .args(args)
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            .env("GIT_AUTHOR_NAME", "test")
+            .env("GIT_AUTHOR_EMAIL", "t@t")
+            .env("GIT_COMMITTER_NAME", "test")
+            .env("GIT_COMMITTER_EMAIL", "t@t")
+            .status()
+            .await
+            .expect("git ran");
+        assert!(status.success(), "git {:?} failed", args);
+    }
+
+    #[tokio::test]
+    async fn git_status_in_a_real_repo_lists_modifications() {
+        let dir = tempdir().unwrap();
+        let cwd = dir.path();
+        git(cwd, &["init", "-q"]).await;
+        std::fs::write(cwd.join("a.txt"), "hello\n").unwrap();
+        // The tool reads from the process cwd, so chdir for this test.
+        let prev = std::env::current_dir().unwrap();
+        std::env::set_current_dir(cwd).unwrap();
+        let result = GitStatusTool
+            .call(json!({}), CancellationToken::new())
+            .await
+            .unwrap();
+        std::env::set_current_dir(prev).unwrap();
+        assert!(!result.is_error, "got err: {}", result.output);
+        assert!(
+            result.output.contains("a.txt"),
+            "output should mention the untracked file: {}",
+            result.output
+        );
+    }
+
+    #[tokio::test]
+    async fn git_status_outside_repo_returns_clean_error() {
+        let dir = tempdir().unwrap();
+        let prev = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+        let result = GitStatusTool
+            .call(json!({}), CancellationToken::new())
+            .await
+            .unwrap();
+        std::env::set_current_dir(prev).unwrap();
+        assert!(result.is_error);
+        assert!(
+            result.output.contains("Not a git repository"),
+            "got {}",
+            result.output
+        );
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -64,6 +64,7 @@ pub trait Tool: Send + Sync {
 }
 
 pub mod file;
+pub mod git;
 pub mod shell;
 pub mod web;
 
@@ -127,6 +128,14 @@ impl ToolRegistry {
         registry.register(Arc::new(file::PatchFile::new(sink)));
         registry.register(Arc::new(web::WebSearch));
         registry.register(Arc::new(web::WebFetch));
+        // YYC-36: native git tools — agent stops composing brittle
+        // `git ...` shell strings through bash.
+        registry.register(Arc::new(git::GitStatusTool));
+        registry.register(Arc::new(git::GitDiffTool));
+        registry.register(Arc::new(git::GitCommitTool));
+        registry.register(Arc::new(git::GitPushTool));
+        registry.register(Arc::new(git::GitBranchTool));
+        registry.register(Arc::new(git::GitLogTool));
         for tool in shell::make_tools() {
             registry.register(tool);
         }


### PR DESCRIPTION
The agent no longer has to compose brittle `git ...` strings through
the bash tool. Six dedicated tools land:

- git_status: short porcelain + branch line
- git_diff: worktree or --cached, optional path filter
- git_commit: with optional `all` to stage tracked changes first
- git_push: remote/branch/set_upstream knobs
- git_branch: list / create / switch
- git_log: oneline, configurable limit + ref

Hybrid implementation per the issue's "no git binary dep" goal:
gix 0.82 handles repo discovery (so a non-repo cwd produces a clean
"Not a git repository" error rather than parsed git stderr), while
the actual operations dispatch through `git` via tokio::process. The
gix write surfaces (commit/push/branch-modify) are still maturing;
landing subprocess-backed tools today gives the agent a working
surface and unblocks downstream work. Per-tool migration to native
gix can land incrementally without reshaping the tool API.

Cancellation honored via tokio::select on the cancel token; exit-
non-zero surfaces stderr as a structured ToolResult error.

2 new tests cover the in-repo status path and the non-repo error
path through tempdirs.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>