### PR TITLE
YYC-45: Tree-sitter foundation + structural code tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2241,7 +2241,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2591,7 +2591,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3248,7 +3248,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3305,7 +3305,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3427,6 +3427,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -3611,6 +3612,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3713,10 +3720,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4075,6 +4082,86 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter"
+version = "0.26.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "887bd495d0582c5e3e0d8ece2233666169fa56a9644d172fc22ad179ab2d0538"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-go"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8560a4d2f835cc0d4d2c2e03cbd0dde2f6114b43bc491164238d333e28b16ea"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-javascript"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68204f2abc0627a90bdf06e605f5c470aa26fdcb2081ea553a04bdad756693f5"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-json"
+version = "0.24.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d727acca406c0020cffc6cf35516764f36c8e3dc4408e5ebe2cb35a947ec471"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-python"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bf85fd39652e740bf60f46f4cda9492c3a9ad75880575bf14960f775cb74a1c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4245,6 +4332,13 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "tree-sitter",
+ "tree-sitter-go",
+ "tree-sitter-javascript",
+ "tree-sitter-json",
+ "tree-sitter-python",
+ "tree-sitter-rust",
+ "tree-sitter-typescript",
  "uuid",
 ]
 
@@ -4516,7 +4610,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,17 @@ portable-pty = "0.9.0"
 # semantics predictable. Plan: migrate one tool at a time.
 gix = "0.82"
 
+# Code intelligence (YYC-45). Tree-sitter parses without per-language
+# servers; grammars are statically linked (binary cost is the price for
+# zero runtime deps). Versions verified against crates.io latest stable.
+tree-sitter = "0.26.8"
+tree-sitter-rust = "0.24.2"
+tree-sitter-python = "0.25.0"
+tree-sitter-typescript = "0.23.2"
+tree-sitter-javascript = "0.25.0"
+tree-sitter-go = "0.25.0"
+tree-sitter-json = "0.24.8"
+
 [profile.release]
 opt-level = "z"    # optimize for size
 lto = true

--- a/src/code/mod.rs
+++ b/src/code/mod.rs
@@ -1,0 +1,214 @@
+//! Code intelligence (YYC-44 epic).
+//!
+//! Tree-sitter-backed parsing today (YYC-45); LSP layer (YYC-46) lands
+//! alongside. Both share `Language` here so language detection has one
+//! source of truth.
+
+use std::path::Path;
+use std::sync::Mutex;
+use tree_sitter::{Language as TsLanguage, Parser as TsParser};
+
+/// Languages with first-class structural support. Extend by adding a
+/// variant + extension match + grammar in `parser_for`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Language {
+    Rust,
+    Python,
+    TypeScript,
+    JavaScript,
+    Go,
+    Json,
+}
+
+impl Language {
+    /// Detect by file extension. Path is canonicalized through
+    /// `extension()` so case differences ("FOO.RS") still hit.
+    pub fn from_path(path: &Path) -> Option<Self> {
+        let ext = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|s| s.to_ascii_lowercase())?;
+        match ext.as_str() {
+            "rs" => Some(Self::Rust),
+            "py" | "pyi" => Some(Self::Python),
+            "ts" | "tsx" => Some(Self::TypeScript),
+            "js" | "jsx" | "mjs" | "cjs" => Some(Self::JavaScript),
+            "go" => Some(Self::Go),
+            "json" => Some(Self::Json),
+            _ => None,
+        }
+    }
+
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Rust => "rust",
+            Self::Python => "python",
+            Self::TypeScript => "typescript",
+            Self::JavaScript => "javascript",
+            Self::Go => "go",
+            Self::Json => "json",
+        }
+    }
+
+    /// Tree-sitter grammar for this language.
+    fn grammar(self) -> TsLanguage {
+        match self {
+            Self::Rust => tree_sitter_rust::LANGUAGE.into(),
+            Self::Python => tree_sitter_python::LANGUAGE.into(),
+            Self::TypeScript => tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+            Self::JavaScript => tree_sitter_javascript::LANGUAGE.into(),
+            Self::Go => tree_sitter_go::LANGUAGE.into(),
+            Self::Json => tree_sitter_json::LANGUAGE.into(),
+        }
+    }
+
+    /// Tree-sitter S-expression query that matches top-level
+    /// definitions interesting to a code outline. Captures `name` (the
+    /// symbol name) and `kind` (a literal so the consumer can tell
+    /// `function` from `struct` etc.).
+    pub fn outline_query(self) -> &'static str {
+        match self {
+            Self::Rust => OUTLINE_RUST,
+            Self::Python => OUTLINE_PYTHON,
+            Self::TypeScript => OUTLINE_TS,
+            Self::JavaScript => OUTLINE_JS,
+            Self::Go => OUTLINE_GO,
+            Self::Json => "",
+        }
+    }
+}
+
+const OUTLINE_RUST: &str = r#"
+(function_item name: (identifier) @name) @function
+(struct_item name: (type_identifier) @name) @struct
+(enum_item name: (type_identifier) @name) @enum
+(trait_item name: (type_identifier) @name) @trait
+(impl_item type: (type_identifier) @name) @impl
+(mod_item name: (identifier) @name) @module
+(const_item name: (identifier) @name) @const
+(static_item name: (identifier) @name) @static
+(type_item name: (type_identifier) @name) @typedef
+"#;
+
+const OUTLINE_PYTHON: &str = r#"
+(function_definition name: (identifier) @name) @function
+(class_definition name: (identifier) @name) @class
+"#;
+
+const OUTLINE_TS: &str = r#"
+(function_declaration name: (identifier) @name) @function
+(class_declaration name: (type_identifier) @name) @class
+(interface_declaration name: (type_identifier) @name) @interface
+(type_alias_declaration name: (type_identifier) @name) @typedef
+(enum_declaration name: (identifier) @name) @enum
+"#;
+
+const OUTLINE_JS: &str = r#"
+(function_declaration name: (identifier) @name) @function
+(class_declaration name: (identifier) @name) @class
+"#;
+
+const OUTLINE_GO: &str = r#"
+(function_declaration name: (identifier) @name) @function
+(method_declaration name: (field_identifier) @name) @method
+(type_declaration (type_spec name: (type_identifier) @name)) @type
+"#;
+
+/// Lazy-initialized per-language parser cache. Cheap to clone the
+/// `Arc<ParserCache>` but parsers themselves aren't `Send + Sync` once
+/// borrowed mutably — wrap each in a Mutex.
+pub struct ParserCache {
+    rust: Mutex<Option<TsParser>>,
+    python: Mutex<Option<TsParser>>,
+    typescript: Mutex<Option<TsParser>>,
+    javascript: Mutex<Option<TsParser>>,
+    go: Mutex<Option<TsParser>>,
+    json: Mutex<Option<TsParser>>,
+}
+
+impl ParserCache {
+    pub fn new() -> Self {
+        Self {
+            rust: Mutex::new(None),
+            python: Mutex::new(None),
+            typescript: Mutex::new(None),
+            javascript: Mutex::new(None),
+            go: Mutex::new(None),
+            json: Mutex::new(None),
+        }
+    }
+
+    /// Run `f` against a parser configured for `lang`. The parser is
+    /// initialized on first use and reused across calls.
+    pub fn with_parser<R>(
+        &self,
+        lang: Language,
+        f: impl FnOnce(&mut TsParser) -> R,
+    ) -> anyhow::Result<R> {
+        let slot = match lang {
+            Language::Rust => &self.rust,
+            Language::Python => &self.python,
+            Language::TypeScript => &self.typescript,
+            Language::JavaScript => &self.javascript,
+            Language::Go => &self.go,
+            Language::Json => &self.json,
+        };
+        let mut guard = slot.lock().unwrap();
+        if guard.is_none() {
+            let mut p = TsParser::new();
+            p.set_language(&lang.grammar())
+                .map_err(|e| anyhow::anyhow!("set_language for {}: {e}", lang.name()))?;
+            *guard = Some(p);
+        }
+        Ok(f(guard.as_mut().unwrap()))
+    }
+}
+
+impl Default for ParserCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn language_detection_by_extension() {
+        assert_eq!(
+            Language::from_path(&PathBuf::from("foo.rs")),
+            Some(Language::Rust)
+        );
+        assert_eq!(
+            Language::from_path(&PathBuf::from("FOO.RS")),
+            Some(Language::Rust)
+        );
+        assert_eq!(
+            Language::from_path(&PathBuf::from("a/b.py")),
+            Some(Language::Python)
+        );
+        assert_eq!(
+            Language::from_path(&PathBuf::from("a/b.tsx")),
+            Some(Language::TypeScript)
+        );
+        assert_eq!(
+            Language::from_path(&PathBuf::from("a/b.unknown")),
+            None
+        );
+    }
+
+    #[test]
+    fn parser_cache_initializes_lazily_and_reuses() {
+        let cache = ParserCache::new();
+        let parsed_first = cache
+            .with_parser(Language::Rust, |p| p.parse("fn main() {}", None).is_some())
+            .unwrap();
+        assert!(parsed_first);
+        let parsed_again = cache
+            .with_parser(Language::Rust, |p| p.parse("fn other() {}", None).is_some())
+            .unwrap();
+        assert!(parsed_again);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod agent;
 pub mod cli;
+pub mod code;
 pub mod config;
 pub mod context;
 pub mod hooks;

--- a/src/tools/code.rs
+++ b/src/tools/code.rs
@@ -1,0 +1,412 @@
+//! Tree-sitter-backed structural code tools (YYC-45).
+//!
+//! - `code_outline`: symbol tree with line ranges. Token-cheap
+//!   replacement for "read the whole file."
+//! - `code_extract`: return just one named function/method/class body.
+//! - `code_query`: run a tree-sitter S-expression query across files.
+//!
+//! All three reuse a per-language parser cache held by the registry to
+//! avoid re-initializing parsers per call.
+
+use crate::code::{Language, ParserCache};
+use crate::tools::{Tool, ToolResult};
+use anyhow::Result;
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
+use tree_sitter::{Query, QueryCursor, StreamingIterator};
+
+/// Cap output size so the LLM doesn't get megabyte responses on large
+/// repos. The agent can narrow with paths or query refinements.
+const MAX_OUTLINE_SYMBOLS: usize = 500;
+const MAX_QUERY_HITS: usize = 200;
+
+#[derive(Clone)]
+pub struct CodeOutlineTool {
+    cache: Arc<ParserCache>,
+}
+
+impl CodeOutlineTool {
+    pub fn new(cache: Arc<ParserCache>) -> Self {
+        Self { cache }
+    }
+}
+
+#[async_trait]
+impl Tool for CodeOutlineTool {
+    fn name(&self) -> &str {
+        "code_outline"
+    }
+    fn description(&self) -> &str {
+        "Structural outline of a source file: top-level functions/types/etc with line ranges. JSON. Cheaper than read_file when the agent only needs the shape of a file."
+    }
+    fn schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string", "description": "Path to source file" }
+            },
+            "required": ["path"]
+        })
+    }
+    async fn call(&self, params: Value, _cancel: CancellationToken) -> Result<ToolResult> {
+        let path = params["path"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("path required"))?;
+        let pb = PathBuf::from(path);
+        let lang = match Language::from_path(&pb) {
+            Some(l) => l,
+            None => {
+                return Ok(ToolResult::err(format!(
+                    "Unsupported file type for code_outline: {path}"
+                )));
+            }
+        };
+        let source = tokio::fs::read_to_string(path).await?;
+        let symbols = outline(&self.cache, lang, &source)?;
+        let payload = json!({
+            "path": path,
+            "language": lang.name(),
+            "truncated": symbols.len() >= MAX_OUTLINE_SYMBOLS,
+            "symbols": symbols,
+        });
+        Ok(ToolResult::ok(serde_json::to_string_pretty(&payload)?))
+    }
+}
+
+#[derive(Clone)]
+pub struct CodeExtractTool {
+    cache: Arc<ParserCache>,
+}
+
+impl CodeExtractTool {
+    pub fn new(cache: Arc<ParserCache>) -> Self {
+        Self { cache }
+    }
+}
+
+#[async_trait]
+impl Tool for CodeExtractTool {
+    fn name(&self) -> &str {
+        "code_extract"
+    }
+    fn description(&self) -> &str {
+        "Return the source body of a single named symbol (function / class / type). When the agent already knows what it wants and shouldn't pay for surrounding code."
+    }
+    fn schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string", "description": "Path to source file" },
+                "symbol": { "type": "string", "description": "Symbol name (case-sensitive). First match wins." }
+            },
+            "required": ["path", "symbol"]
+        })
+    }
+    async fn call(&self, params: Value, _cancel: CancellationToken) -> Result<ToolResult> {
+        let path = params["path"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("path required"))?;
+        let symbol = params["symbol"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("symbol required"))?;
+        let pb = PathBuf::from(path);
+        let lang = Language::from_path(&pb).ok_or_else(|| {
+            anyhow::anyhow!("Unsupported file type for code_extract: {path}")
+        })?;
+        let source = tokio::fs::read_to_string(path).await?;
+        let symbols = outline(&self.cache, lang, &source)?;
+        let hit = symbols.into_iter().find(|s| s.name == symbol);
+        match hit {
+            None => Ok(ToolResult::err(format!(
+                "Symbol '{symbol}' not found in {path}. Try `code_outline` to see available names."
+            ))),
+            Some(s) => {
+                let snippet: String = source
+                    .lines()
+                    .skip(s.start_line.saturating_sub(1))
+                    .take(s.end_line.saturating_sub(s.start_line.saturating_sub(1)))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                Ok(ToolResult::ok(format!(
+                    "{}:{}-{} ({})\n{snippet}",
+                    path, s.start_line, s.end_line, s.kind
+                )))
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct CodeQueryTool {
+    cache: Arc<ParserCache>,
+}
+
+impl CodeQueryTool {
+    pub fn new(cache: Arc<ParserCache>) -> Self {
+        Self { cache }
+    }
+}
+
+#[async_trait]
+impl Tool for CodeQueryTool {
+    fn name(&self) -> &str {
+        "code_query"
+    }
+    fn description(&self) -> &str {
+        "Run a tree-sitter S-expression query against one source file. Strictly more expressive than ripgrep for structural patterns: '(function_item name: (identifier) @name)' to find all Rust fn names."
+    }
+    fn schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string", "description": "Source file to query" },
+                "query": {
+                    "type": "string",
+                    "description": "Tree-sitter S-expression query. Captures (e.g. @name) are returned with their text + position."
+                }
+            },
+            "required": ["path", "query"]
+        })
+    }
+    async fn call(&self, params: Value, _cancel: CancellationToken) -> Result<ToolResult> {
+        let path = params["path"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("path required"))?;
+        let query_text = params["query"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("query required"))?;
+        let pb = PathBuf::from(path);
+        let lang = Language::from_path(&pb).ok_or_else(|| {
+            anyhow::anyhow!("Unsupported file type for code_query: {path}")
+        })?;
+        let source = tokio::fs::read_to_string(path).await?;
+        let hits = run_query(&self.cache, lang, &source, query_text)?;
+        let truncated = hits.len() >= MAX_QUERY_HITS;
+        let payload = json!({
+            "path": path,
+            "language": lang.name(),
+            "truncated": truncated,
+            "hits": hits,
+        });
+        Ok(ToolResult::ok(serde_json::to_string_pretty(&payload)?))
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct OutlineSymbol {
+    pub name: String,
+    pub kind: String,
+    pub start_line: usize,
+    pub end_line: usize,
+}
+
+fn outline(
+    cache: &ParserCache,
+    lang: Language,
+    source: &str,
+) -> Result<Vec<OutlineSymbol>> {
+    let query_text = lang.outline_query();
+    if query_text.is_empty() {
+        return Ok(Vec::new());
+    }
+    cache.with_parser(lang, |parser| {
+        let tree = parser.parse(source, None).ok_or_else(|| {
+            anyhow::anyhow!("tree-sitter failed to parse source")
+        })?;
+        let query = Query::new(&lang.grammar_for_query(), query_text)
+            .map_err(|e| anyhow::anyhow!("query compile: {e}"))?;
+        let name_idx = query.capture_index_for_name("name");
+        let mut cursor = QueryCursor::new();
+        let mut iter = cursor.matches(&query, tree.root_node(), source.as_bytes());
+        let mut out = Vec::new();
+        while let Some(m) = iter.next() {
+            // The kind capture is the last one (the @function / @struct
+            // wrapping the whole node). The name capture is "name".
+            let mut name = None;
+            let mut kind_node = None;
+            let mut kind_label = "symbol".to_string();
+            for cap in m.captures.iter() {
+                let cap_name = &query.capture_names()[cap.index as usize];
+                if Some(cap.index) == name_idx {
+                    name = Some(
+                        cap.node
+                            .utf8_text(source.as_bytes())
+                            .unwrap_or("")
+                            .to_string(),
+                    );
+                } else {
+                    kind_node = Some(cap.node);
+                    kind_label = (*cap_name).to_string();
+                }
+            }
+            if let (Some(n), Some(node)) = (name, kind_node) {
+                let start = node.start_position().row + 1;
+                let end = node.end_position().row + 1;
+                out.push(OutlineSymbol {
+                    name: n,
+                    kind: kind_label,
+                    start_line: start,
+                    end_line: end,
+                });
+                if out.len() >= MAX_OUTLINE_SYMBOLS {
+                    break;
+                }
+            }
+        }
+        Ok(out)
+    })?
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct QueryHit {
+    pub capture: String,
+    pub text: String,
+    pub start_line: usize,
+    pub end_line: usize,
+}
+
+fn run_query(
+    cache: &ParserCache,
+    lang: Language,
+    source: &str,
+    query_text: &str,
+) -> Result<Vec<QueryHit>> {
+    cache.with_parser(lang, |parser| {
+        let tree = parser
+            .parse(source, None)
+            .ok_or_else(|| anyhow::anyhow!("tree-sitter failed to parse source"))?;
+        let query = Query::new(&lang.grammar_for_query(), query_text)
+            .map_err(|e| anyhow::anyhow!("query compile: {e}"))?;
+        let mut cursor = QueryCursor::new();
+        let mut iter = cursor.matches(&query, tree.root_node(), source.as_bytes());
+        let mut hits = Vec::new();
+        while let Some(m) = iter.next() {
+            for cap in m.captures.iter() {
+                let cap_name = (*query.capture_names()[cap.index as usize]).to_string();
+                let text = cap
+                    .node
+                    .utf8_text(source.as_bytes())
+                    .unwrap_or("")
+                    .to_string();
+                hits.push(QueryHit {
+                    capture: cap_name,
+                    text,
+                    start_line: cap.node.start_position().row + 1,
+                    end_line: cap.node.end_position().row + 1,
+                });
+                if hits.len() >= MAX_QUERY_HITS {
+                    return Ok(hits);
+                }
+            }
+        }
+        Ok(hits)
+    })?
+}
+
+// Helper trait to expose grammar() for use in this module without
+// re-implementing the grammar match. Defined here (vs `code/mod.rs`) so
+// the code module's API stays minimal.
+trait LanguageExt {
+    fn grammar_for_query(&self) -> tree_sitter::Language;
+}
+
+impl LanguageExt for Language {
+    fn grammar_for_query(&self) -> tree_sitter::Language {
+        match self {
+            Language::Rust => tree_sitter_rust::LANGUAGE.into(),
+            Language::Python => tree_sitter_python::LANGUAGE.into(),
+            Language::TypeScript => tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+            Language::JavaScript => tree_sitter_javascript::LANGUAGE.into(),
+            Language::Go => tree_sitter_go::LANGUAGE.into(),
+            Language::Json => tree_sitter_json::LANGUAGE.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn outline_extracts_rust_top_level_items() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("a.rs");
+        std::fs::write(
+            &path,
+            "fn alpha() {}\nstruct Beta { x: i32 }\nimpl Beta {}\n",
+        )
+        .unwrap();
+        let cache = Arc::new(ParserCache::new());
+        let tool = CodeOutlineTool::new(cache);
+        let result = tool
+            .call(
+                json!({"path": path.to_string_lossy()}),
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+        assert!(!result.is_error, "{}", result.output);
+        let payload: Value = serde_json::from_str(&result.output).unwrap();
+        let names: Vec<String> = payload["symbols"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|s| s["name"].as_str().unwrap_or("").to_string())
+            .collect();
+        assert!(names.contains(&"alpha".to_string()), "got {names:?}");
+        assert!(names.contains(&"Beta".to_string()), "got {names:?}");
+    }
+
+    #[tokio::test]
+    async fn extract_returns_just_the_named_function() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("a.rs");
+        std::fs::write(
+            &path,
+            "fn alpha() { 1 }\n\nfn beta() {\n    let x = 2;\n    x + 3\n}\n",
+        )
+        .unwrap();
+        let cache = Arc::new(ParserCache::new());
+        let tool = CodeExtractTool::new(cache);
+        let result = tool
+            .call(
+                json!({"path": path.to_string_lossy(), "symbol": "beta"}),
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+        assert!(!result.is_error, "{}", result.output);
+        assert!(result.output.contains("fn beta()"), "got {}", result.output);
+        assert!(result.output.contains("x + 3"));
+        assert!(!result.output.contains("fn alpha"), "got {}", result.output);
+    }
+
+    #[tokio::test]
+    async fn query_returns_capture_hits() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("a.rs");
+        std::fs::write(&path, "fn one() {}\nfn two() {}\n").unwrap();
+        let cache = Arc::new(ParserCache::new());
+        let tool = CodeQueryTool::new(cache);
+        let result = tool
+            .call(
+                json!({
+                    "path": path.to_string_lossy(),
+                    "query": "(function_item name: (identifier) @name)"
+                }),
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+        assert!(!result.is_error, "{}", result.output);
+        let payload: Value = serde_json::from_str(&result.output).unwrap();
+        let hits = payload["hits"].as_array().unwrap();
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0]["text"], "one");
+        assert_eq!(hits[1]["text"], "two");
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -63,6 +63,7 @@ pub trait Tool: Send + Sync {
     async fn call(&self, params: Value, cancel: CancellationToken) -> Result<ToolResult>;
 }
 
+pub mod code;
 pub mod file;
 pub mod git;
 pub mod shell;
@@ -128,6 +129,13 @@ impl ToolRegistry {
         registry.register(Arc::new(file::PatchFile::new(sink)));
         registry.register(Arc::new(web::WebSearch));
         registry.register(Arc::new(web::WebFetch));
+        // YYC-45: tree-sitter structural code tools. One parser cache
+        // shared across all three so we only initialize each grammar
+        // once per session.
+        let parser_cache = Arc::new(crate::code::ParserCache::new());
+        registry.register(Arc::new(code::CodeOutlineTool::new(parser_cache.clone())));
+        registry.register(Arc::new(code::CodeExtractTool::new(parser_cache.clone())));
+        registry.register(Arc::new(code::CodeQueryTool::new(parser_cache)));
         // YYC-36: native git tools — agent stops composing brittle
         // `git ...` shell strings through bash.
         registry.register(Arc::new(git::GitStatusTool));


### PR DESCRIPTION
New `code` module + three tree-sitter-backed tools that let the agent
reason about code structure without re-reading whole files:

- code/mod.rs: Language enum (rust/python/typescript/javascript/go/json
  via extension), per-language ParserCache (lazy-init, mutex-wrapped,
  reusable across calls), per-language outline queries that capture
  the interesting top-level node types.
- tools/code.rs:
  - code_outline: structured JSON of top-level symbols with line
    ranges. Token-cheap replacement for read_file when only the file
    shape is needed.
  - code_extract: returns just one named function/class/type by name.
  - code_query: arbitrary tree-sitter S-expression queries — strictly
    more expressive than ripgrep for structural patterns.

Caps output (500 symbols, 200 query hits) so megabyte responses don't
blow up the LLM context. Caller can narrow with paths or refined
queries.

Cargo.toml adds tree-sitter 0.26.8 + grammars for the supported
languages — all verified at crates.io latest stable. Static linking
trades binary size for zero runtime deps.

5 new tests cover language detection, parser cache reuse, outline
extraction, single-symbol extract, and S-expression query hits.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>