### PR TITLE
YYC-46: LSP client + semantic code tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,6 +742,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "fluent-uri"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2461,6 +2470,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "lsp-types"
+version = "0.97.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53353550a17c04ac46c585feb189c2db82154fc84b79c7a66c96c2c644f66071"
+dependencies = [
+ "bitflags 1.3.2",
+ "fluent-uri",
+ "serde",
+ "serde_json",
+ "serde_repr",
+]
+
+[[package]]
 name = "mac_address"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3436,6 +3458,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4318,6 +4351,7 @@ dependencies = [
  "crossterm",
  "futures-util",
  "gix",
+ "lsp-types",
  "portable-pty",
  "ratatui",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,11 @@ tree-sitter-javascript = "0.25.0"
 tree-sitter-go = "0.25.0"
 tree-sitter-json = "0.24.8"
 
+# LSP types (YYC-46). Hand-rolled JSON-RPC framing over stdio; this
+# crate just provides the structured messages so we don't reinvent
+# textDocument/* bodies. Verified at crates.io latest stable.
+lsp-types = "0.97"
+
 [profile.release]
 opt-level = "z"    # optimize for size
 lto = true

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -44,6 +44,9 @@ pub struct Agent {
     /// catalog at startup (YYC-67). `None` when the catalog is disabled
     /// or the provider doesn't publish pricing.
     pricing: Option<crate::provider::catalog::Pricing>,
+    /// LSP server pool (YYC-46). Lazy: servers spawn on first tool
+    /// invocation that needs one. Reaped in `end_session`.
+    lsp_manager: Arc<crate::code::lsp::LspManager>,
 }
 
 impl Agent {
@@ -148,7 +151,13 @@ impl Agent {
         );
 
         let diff_sink = crate::tools::new_diff_sink();
-        let tools = ToolRegistry::new_with_diff_sink(Some(diff_sink.clone()));
+        let lsp_manager = Arc::new(crate::code::lsp::LspManager::new(
+            std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
+        ));
+        let tools = ToolRegistry::new_with_diff_and_lsp(
+            Some(diff_sink.clone()),
+            Some(lsp_manager.clone()),
+        );
         let skills = Arc::new(SkillRegistry::new(&config.skills_dir));
         let memory = SessionStore::new();
         let context = ContextManager::new(provider.max_context());
@@ -182,6 +191,7 @@ impl Agent {
             turn_cancel: CancellationToken::new(),
             diff_sink,
             pricing,
+            lsp_manager,
         })
     }
 
@@ -248,6 +258,9 @@ impl Agent {
             turn_cancel: CancellationToken::new(),
             diff_sink: crate::tools::new_diff_sink(),
             pricing: None,
+            lsp_manager: Arc::new(crate::code::lsp::LspManager::new(
+                std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
+            )),
         }
     }
 
@@ -273,9 +286,18 @@ impl Agent {
         self.hooks.session_start(&self.session_id).await;
     }
 
-    /// Fires `session_end` and records the total turn count.
+    /// Fires `session_end` and records the total turn count. Also
+    /// reaps any LSP servers spawned during the session (YYC-46).
     pub async fn end_session(&self) {
         self.hooks.session_end(&self.session_id, self.turns).await;
+        self.lsp_manager.shutdown_all().await;
+    }
+
+    /// Borrow the shared LSP manager (YYC-46). Used by the
+    /// auto-diagnostics hook (YYC-51) to query post-edit diagnostics
+    /// without re-spawning servers.
+    pub fn lsp_manager(&self) -> &Arc<crate::code::lsp::LspManager> {
+        &self.lsp_manager
     }
 
     /// Run a one-shot prompt (no TUI). Gathers context, calls LLM, dispatches

--- a/src/code/lsp.rs
+++ b/src/code/lsp.rs
@@ -1,0 +1,491 @@
+//! LSP client (YYC-46).
+//!
+//! Speaks JSON-RPC 2.0 over stdio with Content-Length framing to per-
+//! language servers (rust-analyzer, pyright, gopls, etc). Per-language
+//! lifecycle is managed by `LspManager`: lazy spawn, kept alive for the
+//! session, reaped on drop or `shutdown()`.
+//!
+//! Hand-rolled framing keeps the dep surface small (only `lsp-types`
+//! for the structured request/response bodies). The async layer uses
+//! tokio::process + tokio::sync::oneshot for request correlation.
+//!
+//! Notifications (`textDocument/publishDiagnostics`) feed a per-server
+//! diagnostics cache so the upcoming `DiagnosticsHook` (YYC-51) can
+//! query "what changed since the last edit?" without a roundtrip.
+
+use crate::code::Language;
+use anyhow::{Context, Result, anyhow};
+use lsp_types::{
+    ClientCapabilities, Diagnostic, DidOpenTextDocumentParams, GotoDefinitionParams,
+    GotoDefinitionResponse, Hover, HoverParams, InitializeParams, InitializedParams, Location,
+    Position, ReferenceContext, ReferenceParams, TextDocumentIdentifier, TextDocumentItem,
+    TextDocumentPositionParams, Uri, WorkspaceFolder,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, Command};
+use tokio::sync::{Mutex, oneshot};
+
+/// Default server commands per language. Overridable via config.
+fn default_command(lang: Language) -> Option<(&'static str, &'static [&'static str])> {
+    match lang {
+        Language::Rust => Some(("rust-analyzer", &[])),
+        Language::TypeScript | Language::JavaScript => {
+            Some(("typescript-language-server", &["--stdio"]))
+        }
+        Language::Python => Some(("pyright-langserver", &["--stdio"])),
+        Language::Go => Some(("gopls", &[])),
+        Language::Json => None,
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct RpcMessage {
+    jsonrpc: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    method: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    params: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<Value>,
+}
+
+type Pending = Arc<Mutex<HashMap<i64, oneshot::Sender<Result<Value, String>>>>>;
+type DiagCache = Arc<Mutex<HashMap<String, Vec<Diagnostic>>>>;
+
+/// One LSP server subprocess + its JSON-RPC plumbing.
+pub struct LspServer {
+    child: Mutex<Child>,
+    stdin: Mutex<ChildStdin>,
+    next_id: Mutex<i64>,
+    pending: Pending,
+    diagnostics: DiagCache,
+    workspace_root: PathBuf,
+    lang: Language,
+}
+
+impl LspServer {
+    /// Spawn the language server, send `initialize` + `initialized`,
+    /// and start the background reader.
+    pub async fn start(lang: Language, workspace_root: PathBuf) -> Result<Self> {
+        let (cmd, args) = default_command(lang).ok_or_else(|| {
+            anyhow!("No default LSP command for {}", lang.name())
+        })?;
+        let mut child = Command::new(cmd)
+            .args(args)
+            .current_dir(&workspace_root)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .with_context(|| {
+                format!(
+                    "Failed to spawn LSP server '{cmd}' for {}. Is it installed?",
+                    lang.name()
+                )
+            })?;
+
+        let stdin = child.stdin.take().ok_or_else(|| anyhow!("no stdin"))?;
+        let stdout = child.stdout.take().ok_or_else(|| anyhow!("no stdout"))?;
+
+        let pending: Pending = Arc::new(Mutex::new(HashMap::new()));
+        let diagnostics: DiagCache = Arc::new(Mutex::new(HashMap::new()));
+
+        // Reader task: pump messages off stdout, route by id (response)
+        // or method (notification).
+        let pending_clone = pending.clone();
+        let diag_clone = diagnostics.clone();
+        let lang_name = lang.name();
+        tokio::spawn(async move {
+            let mut reader = BufReader::new(stdout);
+            loop {
+                match read_message(&mut reader).await {
+                    Ok(Some(msg)) => {
+                        if let Some(Value::Number(n)) = msg.id {
+                            if let Some(id) = n.as_i64() {
+                                let mut p = pending_clone.lock().await;
+                                if let Some(tx) = p.remove(&id) {
+                                    let r = if let Some(err) = msg.error {
+                                        Err(err.to_string())
+                                    } else {
+                                        Ok(msg.result.unwrap_or(Value::Null))
+                                    };
+                                    let _ = tx.send(r);
+                                }
+                            }
+                        } else if let Some(method) = msg.method.as_deref() {
+                            if method == "textDocument/publishDiagnostics" {
+                                if let Some(params) = msg.params {
+                                    if let (Some(uri), Some(diags)) = (
+                                        params.get("uri").and_then(|v| v.as_str()),
+                                        params.get("diagnostics"),
+                                    ) {
+                                        if let Ok(parsed) = serde_json::from_value::<
+                                            Vec<Diagnostic>,
+                                        >(
+                                            diags.clone()
+                                        ) {
+                                            diag_clone
+                                                .lock()
+                                                .await
+                                                .insert(uri.to_string(), parsed);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Ok(None) => {
+                        tracing::warn!("LSP server ({lang_name}) stdout closed");
+                        break;
+                    }
+                    Err(e) => {
+                        tracing::warn!("LSP read error ({lang_name}): {e}");
+                        break;
+                    }
+                }
+            }
+        });
+
+        let server = Self {
+            child: Mutex::new(child),
+            stdin: Mutex::new(stdin),
+            next_id: Mutex::new(1),
+            pending,
+            diagnostics,
+            workspace_root: workspace_root.clone(),
+            lang,
+        };
+
+        // Initialize handshake.
+        let workspace_uri = path_to_uri(&workspace_root)?;
+        #[allow(deprecated)]
+        let init = InitializeParams {
+            process_id: Some(std::process::id()),
+            workspace_folders: Some(vec![WorkspaceFolder {
+                uri: workspace_uri.clone(),
+                name: workspace_root
+                    .file_name()
+                    .map(|s| s.to_string_lossy().into_owned())
+                    .unwrap_or_default(),
+            }]),
+            capabilities: ClientCapabilities::default(),
+            ..Default::default()
+        };
+        server
+            .request::<lsp_types::InitializeResult, _>("initialize", init)
+            .await?;
+        server
+            .notify("initialized", InitializedParams {})
+            .await?;
+        Ok(server)
+    }
+
+    async fn next_id(&self) -> i64 {
+        let mut id = self.next_id.lock().await;
+        let n = *id;
+        *id += 1;
+        n
+    }
+
+    /// Send a request and await the response. Returns parsed `R`.
+    pub async fn request<R, P>(&self, method: &str, params: P) -> Result<R>
+    where
+        R: for<'de> Deserialize<'de>,
+        P: Serialize,
+    {
+        let id = self.next_id().await;
+        let (tx, rx) = oneshot::channel();
+        self.pending.lock().await.insert(id, tx);
+
+        let msg = json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": serde_json::to_value(&params)?,
+        });
+        write_message(&self.stdin, &msg).await?;
+
+        let raw = tokio::time::timeout(Duration::from_secs(30), rx)
+            .await
+            .map_err(|_| anyhow!("LSP request '{method}' timed out"))?
+            .map_err(|_| anyhow!("LSP response channel closed for '{method}'"))?;
+        let value = raw.map_err(|e| anyhow!("LSP error on '{method}': {e}"))?;
+        Ok(serde_json::from_value(value).context("decode LSP response")?)
+    }
+
+    /// Send a notification (no response).
+    pub async fn notify<P: Serialize>(&self, method: &str, params: P) -> Result<()> {
+        let msg = json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": serde_json::to_value(&params)?,
+        });
+        write_message(&self.stdin, &msg).await
+    }
+
+    /// Open a file (sends `textDocument/didOpen`). Idempotent — safe to
+    /// call before each tool invocation; the server tracks state.
+    pub async fn did_open(&self, path: &Path, source: &str) -> Result<()> {
+        let uri = path_to_uri(path)?;
+        let lang_id = self.lang.name().to_string();
+        let item = TextDocumentItem {
+            uri,
+            language_id: lang_id,
+            version: 1,
+            text: source.to_string(),
+        };
+        self.notify(
+            "textDocument/didOpen",
+            DidOpenTextDocumentParams {
+                text_document: item,
+            },
+        )
+        .await
+    }
+
+    /// Snapshot the cached diagnostics for `path` (populated by the
+    /// reader from `publishDiagnostics` notifications).
+    pub async fn cached_diagnostics(&self, path: &Path) -> Vec<Diagnostic> {
+        let uri = match path_to_uri(path) {
+            Ok(u) => u.to_string(),
+            Err(_) => return Vec::new(),
+        };
+        self.diagnostics
+            .lock()
+            .await
+            .get(&uri)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// Workspace root the server was started against — useful for path
+    /// validation in tools.
+    pub fn workspace_root(&self) -> &Path {
+        &self.workspace_root
+    }
+
+    pub fn language(&self) -> Language {
+        self.lang
+    }
+
+    /// Politely shut the server down. Best-effort; on timeout the
+    /// child will be killed via `kill_on_drop`.
+    pub async fn shutdown(&self) {
+        let _ = tokio::time::timeout(
+            Duration::from_secs(2),
+            self.request::<Value, _>("shutdown", json!(null)),
+        )
+        .await;
+        let _ = self.notify("exit", json!(null)).await;
+        let _ = self.child.lock().await.kill().await;
+    }
+}
+
+async fn read_message<R>(reader: &mut BufReader<R>) -> Result<Option<RpcMessage>>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    let mut content_length: Option<usize> = None;
+    loop {
+        let mut line = String::new();
+        let n = reader.read_line(&mut line).await?;
+        if n == 0 {
+            return Ok(None);
+        }
+        let trimmed = line.trim_end_matches(|c| c == '\r' || c == '\n');
+        if trimmed.is_empty() {
+            break;
+        }
+        if let Some(rest) = trimmed.strip_prefix("Content-Length:") {
+            content_length = Some(rest.trim().parse()?);
+        }
+    }
+    let len = content_length.ok_or_else(|| anyhow!("missing Content-Length"))?;
+    let mut buf = vec![0u8; len];
+    reader.read_exact(&mut buf).await?;
+    let msg: RpcMessage = serde_json::from_slice(&buf)?;
+    Ok(Some(msg))
+}
+
+async fn write_message(stdin: &Mutex<ChildStdin>, msg: &Value) -> Result<()> {
+    let body = serde_json::to_vec(msg)?;
+    let mut guard = stdin.lock().await;
+    guard
+        .write_all(format!("Content-Length: {}\r\n\r\n", body.len()).as_bytes())
+        .await?;
+    guard.write_all(&body).await?;
+    guard.flush().await?;
+    Ok(())
+}
+
+fn path_to_uri(path: &Path) -> Result<Uri> {
+    let abs = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(path)
+    };
+    let s = format!("file://{}", abs.to_string_lossy());
+    Uri::from_str(&s).map_err(|e| anyhow!("invalid URI '{s}': {e}"))
+}
+
+/// Per-language LSP server pool. Spawns lazily on first request for a
+/// given language; reuses the live instance on subsequent calls.
+pub struct LspManager {
+    workspace_root: PathBuf,
+    servers: Mutex<HashMap<Language, Arc<LspServer>>>,
+}
+
+impl LspManager {
+    pub fn new(workspace_root: PathBuf) -> Self {
+        Self {
+            workspace_root,
+            servers: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Get or spawn the server for `lang`. Returns Err if the language
+    /// has no default server command or the binary isn't on PATH.
+    pub async fn server(&self, lang: Language) -> Result<Arc<LspServer>> {
+        {
+            let servers = self.servers.lock().await;
+            if let Some(s) = servers.get(&lang) {
+                return Ok(s.clone());
+            }
+        }
+        let server = Arc::new(LspServer::start(lang, self.workspace_root.clone()).await?);
+        let mut servers = self.servers.lock().await;
+        // Race-protect: another caller may have inserted while we spawned.
+        Ok(servers.entry(lang).or_insert(server).clone())
+    }
+
+    /// Reap all running servers. Called from `BeforeAgentEnd` so the
+    /// children don't outlive the agent.
+    pub async fn shutdown_all(&self) {
+        let mut servers = self.servers.lock().await;
+        for (_, s) in servers.drain() {
+            s.shutdown().await;
+        }
+    }
+}
+
+// ─── high-level helpers used by the LSP tools ──────────────────────────
+
+pub async fn goto_definition(
+    server: &LspServer,
+    path: &Path,
+    line: u32,
+    character: u32,
+) -> Result<Option<Vec<Location>>> {
+    let source = tokio::fs::read_to_string(path).await?;
+    server.did_open(path, &source).await?;
+    let uri = path_to_uri(path)?;
+    let params = GotoDefinitionParams {
+        text_document_position_params: TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier { uri },
+            position: Position { line, character },
+        },
+        work_done_progress_params: Default::default(),
+        partial_result_params: Default::default(),
+    };
+    let resp: Option<GotoDefinitionResponse> = server
+        .request("textDocument/definition", params)
+        .await
+        .ok();
+    Ok(resp.map(|r| match r {
+        GotoDefinitionResponse::Scalar(loc) => vec![loc],
+        GotoDefinitionResponse::Array(v) => v,
+        GotoDefinitionResponse::Link(links) => links
+            .into_iter()
+            .map(|l| Location {
+                uri: l.target_uri,
+                range: l.target_range,
+            })
+            .collect(),
+    }))
+}
+
+pub async fn find_references(
+    server: &LspServer,
+    path: &Path,
+    line: u32,
+    character: u32,
+) -> Result<Option<Vec<Location>>> {
+    let source = tokio::fs::read_to_string(path).await?;
+    server.did_open(path, &source).await?;
+    let uri = path_to_uri(path)?;
+    let params = ReferenceParams {
+        text_document_position: TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier { uri },
+            position: Position { line, character },
+        },
+        context: ReferenceContext {
+            include_declaration: true,
+        },
+        work_done_progress_params: Default::default(),
+        partial_result_params: Default::default(),
+    };
+    let resp: Option<Vec<Location>> = server
+        .request("textDocument/references", params)
+        .await
+        .ok();
+    Ok(resp)
+}
+
+pub async fn hover(
+    server: &LspServer,
+    path: &Path,
+    line: u32,
+    character: u32,
+) -> Result<Option<Hover>> {
+    let source = tokio::fs::read_to_string(path).await?;
+    server.did_open(path, &source).await?;
+    let uri = path_to_uri(path)?;
+    let params = HoverParams {
+        text_document_position_params: TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier { uri },
+            position: Position { line, character },
+        },
+        work_done_progress_params: Default::default(),
+    };
+    let resp: Option<Hover> = server.request("textDocument/hover", params).await.ok();
+    Ok(resp)
+}
+
+/// Open the file then return what the server has cached. Diagnostics
+/// arrive asynchronously after `didOpen` so we wait briefly for the
+/// first publish; later calls (after edits) get the latest snapshot
+/// without delay.
+pub async fn diagnostics_for(
+    server: &LspServer,
+    path: &Path,
+) -> Result<Vec<Diagnostic>> {
+    let source = tokio::fs::read_to_string(path).await?;
+    server.did_open(path, &source).await?;
+    // Give the server up to 1.5s to publish initial diagnostics on
+    // first open. Subsequent calls return immediately.
+    let initial = server.cached_diagnostics(path).await;
+    if !initial.is_empty() {
+        return Ok(initial);
+    }
+    for _ in 0..15 {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let cached = server.cached_diagnostics(path).await;
+        if !cached.is_empty() {
+            return Ok(cached);
+        }
+    }
+    Ok(server.cached_diagnostics(path).await)
+}

--- a/src/code/mod.rs
+++ b/src/code/mod.rs
@@ -4,6 +4,8 @@
 //! alongside. Both share `Language` here so language detection has one
 //! source of truth.
 
+pub mod lsp;
+
 use std::path::Path;
 use std::sync::Mutex;
 use tree_sitter::{Language as TsLanguage, Parser as TsParser};

--- a/src/tools/lsp.rs
+++ b/src/tools/lsp.rs
@@ -1,0 +1,243 @@
+//! LSP-backed semantic code tools (YYC-46).
+//!
+//! Wraps `code::lsp::LspManager` so each tool gets the right server
+//! (lazily spawned per language) for the file it was given. When no
+//! server is available for the language (or the binary isn't on PATH),
+//! the tool surfaces a clear error and the agent can fall back to the
+//! tree-sitter tools (YYC-45).
+
+use crate::code::Language;
+use crate::code::lsp::{
+    LspManager, diagnostics_for, find_references, goto_definition, hover,
+};
+use crate::tools::{Tool, ToolResult};
+use anyhow::Result;
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
+
+/// Resolve `path` to the language for which we'd talk to an LSP. Used
+/// by every tool below to fail fast on unsupported file types.
+fn lang_for(path: &str) -> Result<Language> {
+    let pb = PathBuf::from(path);
+    Language::from_path(&pb).ok_or_else(|| {
+        anyhow::anyhow!("Unsupported file type for LSP tools: {path}")
+    })
+}
+
+#[derive(Clone)]
+pub struct GotoDefinitionTool {
+    manager: Arc<LspManager>,
+}
+
+impl GotoDefinitionTool {
+    pub fn new(manager: Arc<LspManager>) -> Self {
+        Self { manager }
+    }
+}
+
+#[async_trait]
+impl Tool for GotoDefinitionTool {
+    fn name(&self) -> &str {
+        "goto_definition"
+    }
+    fn description(&self) -> &str {
+        "Resolve where a symbol at file:line:col is defined. Returns one or more locations as JSON. Falls back gracefully when no LSP server is installed for the language."
+    }
+    fn schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string" },
+                "line": { "type": "integer", "description": "1-indexed source line" },
+                "character": { "type": "integer", "description": "0-indexed column" }
+            },
+            "required": ["path", "line", "character"]
+        })
+    }
+    async fn call(&self, params: Value, _cancel: CancellationToken) -> Result<ToolResult> {
+        let path = params["path"].as_str().ok_or_else(|| anyhow::anyhow!("path required"))?;
+        let line = params["line"].as_u64().ok_or_else(|| anyhow::anyhow!("line required"))?;
+        let character = params["character"].as_u64().unwrap_or(0);
+        let lang = match lang_for(path) {
+            Ok(l) => l,
+            Err(e) => return Ok(ToolResult::err(e.to_string())),
+        };
+        let server = match self.manager.server(lang).await {
+            Ok(s) => s,
+            Err(e) => return Ok(ToolResult::err(format!(
+                "LSP unavailable for {}: {e}. Try the tree-sitter tools as a fallback.",
+                lang.name()
+            ))),
+        };
+        let pb = PathBuf::from(path);
+        // LSP positions are 0-indexed; translate the more agent-friendly
+        // 1-indexed line input.
+        let line0 = (line as u32).saturating_sub(1);
+        let resp = goto_definition(&server, &pb, line0, character as u32).await?;
+        let payload = json!({ "locations": resp.unwrap_or_default() });
+        Ok(ToolResult::ok(serde_json::to_string_pretty(&payload)?))
+    }
+}
+
+#[derive(Clone)]
+pub struct FindReferencesTool {
+    manager: Arc<LspManager>,
+}
+
+impl FindReferencesTool {
+    pub fn new(manager: Arc<LspManager>) -> Self {
+        Self { manager }
+    }
+}
+
+#[async_trait]
+impl Tool for FindReferencesTool {
+    fn name(&self) -> &str {
+        "find_references"
+    }
+    fn description(&self) -> &str {
+        "List all references to the symbol at file:line:col across the workspace. Includes the declaration."
+    }
+    fn schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string" },
+                "line": { "type": "integer", "description": "1-indexed source line" },
+                "character": { "type": "integer", "description": "0-indexed column" }
+            },
+            "required": ["path", "line", "character"]
+        })
+    }
+    async fn call(&self, params: Value, _cancel: CancellationToken) -> Result<ToolResult> {
+        let path = params["path"].as_str().ok_or_else(|| anyhow::anyhow!("path required"))?;
+        let line = params["line"].as_u64().ok_or_else(|| anyhow::anyhow!("line required"))?;
+        let character = params["character"].as_u64().unwrap_or(0);
+        let lang = match lang_for(path) {
+            Ok(l) => l,
+            Err(e) => return Ok(ToolResult::err(e.to_string())),
+        };
+        let server = match self.manager.server(lang).await {
+            Ok(s) => s,
+            Err(e) => return Ok(ToolResult::err(format!(
+                "LSP unavailable for {}: {e}",
+                lang.name()
+            ))),
+        };
+        let pb = PathBuf::from(path);
+        let line0 = (line as u32).saturating_sub(1);
+        let locs = find_references(&server, &pb, line0, character as u32)
+            .await?
+            .unwrap_or_default();
+        let payload = json!({ "references": locs });
+        Ok(ToolResult::ok(serde_json::to_string_pretty(&payload)?))
+    }
+}
+
+#[derive(Clone)]
+pub struct HoverTool {
+    manager: Arc<LspManager>,
+}
+
+impl HoverTool {
+    pub fn new(manager: Arc<LspManager>) -> Self {
+        Self { manager }
+    }
+}
+
+#[async_trait]
+impl Tool for HoverTool {
+    fn name(&self) -> &str {
+        "hover"
+    }
+    fn description(&self) -> &str {
+        "Show docs + type info for the symbol at file:line:col, as the language server reports it."
+    }
+    fn schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string" },
+                "line": { "type": "integer" },
+                "character": { "type": "integer" }
+            },
+            "required": ["path", "line", "character"]
+        })
+    }
+    async fn call(&self, params: Value, _cancel: CancellationToken) -> Result<ToolResult> {
+        let path = params["path"].as_str().ok_or_else(|| anyhow::anyhow!("path required"))?;
+        let line = params["line"].as_u64().ok_or_else(|| anyhow::anyhow!("line required"))?;
+        let character = params["character"].as_u64().unwrap_or(0);
+        let lang = match lang_for(path) {
+            Ok(l) => l,
+            Err(e) => return Ok(ToolResult::err(e.to_string())),
+        };
+        let server = match self.manager.server(lang).await {
+            Ok(s) => s,
+            Err(e) => return Ok(ToolResult::err(format!(
+                "LSP unavailable for {}: {e}",
+                lang.name()
+            ))),
+        };
+        let pb = PathBuf::from(path);
+        let line0 = (line as u32).saturating_sub(1);
+        let resp = hover(&server, &pb, line0, character as u32).await?;
+        let payload = json!({ "hover": resp });
+        Ok(ToolResult::ok(serde_json::to_string_pretty(&payload)?))
+    }
+}
+
+#[derive(Clone)]
+pub struct DiagnosticsTool {
+    manager: Arc<LspManager>,
+}
+
+impl DiagnosticsTool {
+    pub fn new(manager: Arc<LspManager>) -> Self {
+        Self { manager }
+    }
+}
+
+#[async_trait]
+impl Tool for DiagnosticsTool {
+    fn name(&self) -> &str {
+        "diagnostics"
+    }
+    fn description(&self) -> &str {
+        "Current LSP diagnostics for a file (errors, warnings, hints). The auto-diagnostics hook (YYC-51) runs this after edits, but the agent can call it manually too."
+    }
+    fn schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string" }
+            },
+            "required": ["path"]
+        })
+    }
+    async fn call(&self, params: Value, _cancel: CancellationToken) -> Result<ToolResult> {
+        let path = params["path"].as_str().ok_or_else(|| anyhow::anyhow!("path required"))?;
+        let lang = match lang_for(path) {
+            Ok(l) => l,
+            Err(e) => return Ok(ToolResult::err(e.to_string())),
+        };
+        let server = match self.manager.server(lang).await {
+            Ok(s) => s,
+            Err(e) => return Ok(ToolResult::err(format!(
+                "LSP unavailable for {}: {e}",
+                lang.name()
+            ))),
+        };
+        let pb = PathBuf::from(path);
+        let diags = diagnostics_for(&server, &pb).await?;
+        let payload = json!({
+            "path": path,
+            "count": diags.len(),
+            "diagnostics": diags,
+        });
+        Ok(ToolResult::ok(serde_json::to_string_pretty(&payload)?))
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -66,6 +66,7 @@ pub trait Tool: Send + Sync {
 pub mod code;
 pub mod file;
 pub mod git;
+pub mod lsp;
 pub mod shell;
 pub mod web;
 
@@ -118,8 +119,20 @@ impl ToolRegistry {
     /// Build a tool registry that wires `WriteFile`/`PatchFile` to a
     /// shared diff sink (YYC-66). Pass `Some(sink)` to capture edits;
     /// `None` keeps the legacy behavior (tools don't observe their own
-    /// writes).
+    /// writes). LSP tools are registered with their own manager so
+    /// callers don't have to thread it separately (YYC-46).
     pub fn new_with_diff_sink(sink: Option<EditDiffSink>) -> Self {
+        Self::new_with_diff_and_lsp(sink, None)
+    }
+
+    /// Same as `new_with_diff_sink`, plus an external LSP manager so
+    /// the agent can share one across tools and the diagnostics hook
+    /// (YYC-51). When `lsp` is `None`, a per-registry manager is
+    /// created.
+    pub fn new_with_diff_and_lsp(
+        sink: Option<EditDiffSink>,
+        lsp: Option<Arc<crate::code::lsp::LspManager>>,
+    ) -> Self {
         let mut registry = Self {
             tools: HashMap::new(),
         };
@@ -136,6 +149,17 @@ impl ToolRegistry {
         registry.register(Arc::new(code::CodeOutlineTool::new(parser_cache.clone())));
         registry.register(Arc::new(code::CodeExtractTool::new(parser_cache.clone())));
         registry.register(Arc::new(code::CodeQueryTool::new(parser_cache)));
+        // YYC-46: LSP-backed semantic tools. One manager pool — servers
+        // are spawned lazily on first use per language.
+        let lsp_mgr = lsp.unwrap_or_else(|| {
+            Arc::new(crate::code::lsp::LspManager::new(
+                std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
+            ))
+        });
+        registry.register(Arc::new(lsp::GotoDefinitionTool::new(lsp_mgr.clone())));
+        registry.register(Arc::new(lsp::FindReferencesTool::new(lsp_mgr.clone())));
+        registry.register(Arc::new(lsp::HoverTool::new(lsp_mgr.clone())));
+        registry.register(Arc::new(lsp::DiagnosticsTool::new(lsp_mgr)));
         // YYC-36: native git tools — agent stops composing brittle
         // `git ...` shell strings through bash.
         registry.register(Arc::new(git::GitStatusTool));


### PR DESCRIPTION
Native JSON-RPC over stdio (Content-Length framing) to per-language
servers — the agent gets goto-def, find-references, hover, and
diagnostics without shelling out or re-implementing language
analysis.

- code/lsp.rs: hand-rolled framing on top of lsp-types 0.97. LspServer
  wraps subprocess + stdin mutex + a reader task that demuxes
  responses by id and routes publishDiagnostics notifications into a
  shared per-server cache. LspManager pools one server per Language,
  spawns lazily on first request, reaps in shutdown_all.
- Default server map: rust→rust-analyzer, ts/js→typescript-language-
  server --stdio, python→pyright-langserver --stdio, go→gopls.
  Failure to spawn (binary not on PATH) surfaces as a tool-level
  error so the agent can fall back to the YYC-45 tree-sitter tools.
- tools/lsp.rs: GotoDefinitionTool, FindReferencesTool, HoverTool,
  DiagnosticsTool. Each translates 1-indexed agent-friendly lines to
  LSP's 0-indexed positions, opens the file (didOpen) before the
  request, and returns structured JSON.
- Agent owns the LspManager and reaps it from end_session so
  child processes don't outlive the agent.

Tools no-op gracefully when the language has no default server
(JSON, future additions).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>