### PR TITLE
YYC-50: Code-graph indexing — symbols (call/type edges deferred)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,6 +444,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1822,6 +1841,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2155,6 +2187,22 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -4351,6 +4399,7 @@ dependencies = [
  "crossterm",
  "futures-util",
  "gix",
+ "ignore",
  "lsp-types",
  "portable-pty",
  "ratatui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,10 @@ tree-sitter-json = "0.24.8"
 # textDocument/* bodies. Verified at crates.io latest stable.
 lsp-types = "0.97"
 
+# Workspace walker that respects .gitignore (YYC-50). Used by the
+# code-graph indexer so we don't index target/, node_modules/, etc.
+ignore = "0.4.25"
+
 [profile.release]
 opt-level = "z"    # optimize for size
 lto = true

--- a/src/code/graph.rs
+++ b/src/code/graph.rs
@@ -1,0 +1,286 @@
+//! SQLite-backed code graph (YYC-50).
+//!
+//! Tracks symbol declarations across the workspace so the agent can
+//! ask "where is `foo` defined?" without re-parsing every file. Built
+//! from tree-sitter outlines (YYC-45) — fast, no LSP dependency at
+//! index time. Call-edges + type-hierarchy edges are deferred to a
+//! follow-up; the schema reserves the columns so they can land
+//! incrementally without breaking the index.
+//!
+//! Index location: `~/.vulcan/code_graph/<sanitized-cwd>.db`. Per-cwd
+//! isolation so two different projects don't collide.
+
+use crate::code::{Language, ParserCache};
+use anyhow::{Context, Result};
+use rusqlite::{Connection, params};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::Mutex;
+use tree_sitter::{Query, QueryCursor, StreamingIterator};
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SymbolRow {
+    pub file: String,
+    pub language: String,
+    pub kind: String,
+    pub name: String,
+    pub start_line: usize,
+    pub end_line: usize,
+}
+
+pub struct CodeGraph {
+    conn: Mutex<Connection>,
+    workspace_root: PathBuf,
+    parsers: Arc<ParserCache>,
+}
+
+impl CodeGraph {
+    /// Open or create the graph DB for `workspace_root`. The DB lives
+    /// under `~/.vulcan/code_graph/<sanitized>.db` so each project
+    /// gets its own isolated index.
+    pub fn open(workspace_root: PathBuf, parsers: Arc<ParserCache>) -> Result<Self> {
+        let db_path = db_path_for(&workspace_root)?;
+        if let Some(parent) = db_path.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
+        let conn = Connection::open(&db_path)
+            .with_context(|| format!("open code graph at {}", db_path.display()))?;
+        // Schema mirrors the issue's plan — symbols today, edges
+        // (calls/implements/inherits) reserved for the call-hierarchy
+        // follow-up.
+        conn.execute_batch(
+            r#"
+            CREATE TABLE IF NOT EXISTS symbols (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                file            TEXT NOT NULL,
+                language        TEXT NOT NULL,
+                kind            TEXT NOT NULL,
+                name            TEXT NOT NULL,
+                start_line      INTEGER NOT NULL,
+                end_line        INTEGER NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_symbols_name ON symbols(name);
+            CREATE INDEX IF NOT EXISTS idx_symbols_file ON symbols(file);
+
+            CREATE TABLE IF NOT EXISTS calls (
+                caller_id INTEGER NOT NULL,
+                callee_id INTEGER NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS implements (
+                impl_id  INTEGER NOT NULL,
+                trait_id INTEGER NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS inherits (
+                child_id  INTEGER NOT NULL,
+                parent_id INTEGER NOT NULL
+            );
+            "#,
+        )
+        .context("init code graph schema")?;
+
+        Ok(Self {
+            conn: Mutex::new(conn),
+            workspace_root,
+            parsers,
+        })
+    }
+
+    /// Walk the workspace, parse every supported source file, and
+    /// upsert its symbols. Returns `(files_indexed, symbols_inserted)`.
+    /// Respects `.gitignore`. Existing rows for re-indexed files are
+    /// dropped first so the operation is idempotent.
+    pub fn reindex(&self) -> Result<(usize, usize)> {
+        let walker = ignore::WalkBuilder::new(&self.workspace_root)
+            .standard_filters(true)
+            .build();
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        let mut files = 0usize;
+        let mut symbols = 0usize;
+        for entry in walker {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+            if !entry.file_type().map(|t| t.is_file()).unwrap_or(false) {
+                continue;
+            }
+            let path = entry.path();
+            let lang = match Language::from_path(path) {
+                Some(l) => l,
+                None => continue,
+            };
+            let source = match std::fs::read_to_string(path) {
+                Ok(s) => s,
+                Err(_) => continue,
+            };
+            let rel = path
+                .strip_prefix(&self.workspace_root)
+                .unwrap_or(path)
+                .to_string_lossy()
+                .into_owned();
+
+            tx.execute("DELETE FROM symbols WHERE file = ?", params![rel])?;
+            let extracted = extract_symbols(&self.parsers, lang, &source)?;
+            for s in &extracted {
+                tx.execute(
+                    "INSERT INTO symbols (file, language, kind, name, start_line, end_line)
+                     VALUES (?, ?, ?, ?, ?, ?)",
+                    params![
+                        rel,
+                        lang.name(),
+                        s.kind,
+                        s.name,
+                        s.start_line as i64,
+                        s.end_line as i64,
+                    ],
+                )?;
+                symbols += 1;
+            }
+            files += 1;
+        }
+        tx.commit()?;
+        Ok((files, symbols))
+    }
+
+    /// Look up symbols by exact name. Used by `find_symbol` tool.
+    pub fn find_by_name(&self, name: &str, limit: usize) -> Result<Vec<SymbolRow>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT file, language, kind, name, start_line, end_line
+             FROM symbols WHERE name = ? ORDER BY file LIMIT ?",
+        )?;
+        let rows = stmt
+            .query_map(params![name, limit as i64], |row| {
+                Ok(SymbolRow {
+                    file: row.get(0)?,
+                    language: row.get(1)?,
+                    kind: row.get(2)?,
+                    name: row.get(3)?,
+                    start_line: row.get::<_, i64>(4)? as usize,
+                    end_line: row.get::<_, i64>(5)? as usize,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+
+    /// Total indexed symbol count — used by the index status report.
+    pub fn count(&self) -> Result<usize> {
+        let conn = self.conn.lock().unwrap();
+        let n: i64 = conn.query_row("SELECT COUNT(*) FROM symbols", [], |r| r.get(0))?;
+        Ok(n as usize)
+    }
+
+    pub fn workspace_root(&self) -> &Path {
+        &self.workspace_root
+    }
+}
+
+fn db_path_for(workspace_root: &Path) -> Result<PathBuf> {
+    let home = crate::config::vulcan_home();
+    // Sanitize cwd into a filename. Replace path separators with `_`
+    // so e.g. "/home/foo/bar" → "home_foo_bar.db".
+    let key = workspace_root
+        .to_string_lossy()
+        .trim_start_matches('/')
+        .replace(['/', '\\'], "_");
+    Ok(home.join("code_graph").join(format!("{key}.db")))
+}
+
+fn extract_symbols(
+    parsers: &ParserCache,
+    lang: Language,
+    source: &str,
+) -> Result<Vec<SymbolRow>> {
+    let query_text = lang.outline_query();
+    if query_text.is_empty() {
+        return Ok(Vec::new());
+    }
+    parsers.with_parser(lang, |parser| {
+        let tree = parser
+            .parse(source, None)
+            .ok_or_else(|| anyhow::anyhow!("parse failed"))?;
+        let grammar = match lang {
+            Language::Rust => tree_sitter_rust::LANGUAGE.into(),
+            Language::Python => tree_sitter_python::LANGUAGE.into(),
+            Language::TypeScript => tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+            Language::JavaScript => tree_sitter_javascript::LANGUAGE.into(),
+            Language::Go => tree_sitter_go::LANGUAGE.into(),
+            Language::Json => return Ok(Vec::new()),
+        };
+        let query = Query::new(&grammar, query_text)
+            .map_err(|e| anyhow::anyhow!("query: {e}"))?;
+        let name_idx = query.capture_index_for_name("name");
+        let mut cursor = QueryCursor::new();
+        let mut iter = cursor.matches(&query, tree.root_node(), source.as_bytes());
+        let mut out = Vec::new();
+        while let Some(m) = iter.next() {
+            let mut name = None;
+            let mut node = None;
+            let mut kind = "symbol".to_string();
+            for cap in m.captures {
+                let cap_name = &query.capture_names()[cap.index as usize];
+                if Some(cap.index) == name_idx {
+                    name = Some(
+                        cap.node
+                            .utf8_text(source.as_bytes())
+                            .unwrap_or("")
+                            .to_string(),
+                    );
+                } else {
+                    node = Some(cap.node);
+                    kind = (*cap_name).to_string();
+                }
+            }
+            if let (Some(n), Some(node)) = (name, node) {
+                out.push(SymbolRow {
+                    file: String::new(),
+                    language: lang.name().to_string(),
+                    kind,
+                    name: n,
+                    start_line: node.start_position().row + 1,
+                    end_line: node.end_position().row + 1,
+                });
+            }
+        }
+        Ok(out)
+    })?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn reindex_and_find_symbol_round_trip() {
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join("a.rs"), "fn alpha() {}\nstruct Beta;\n").unwrap();
+        std::fs::write(dir.path().join("b.rs"), "fn alpha() {}\n").unwrap();
+        let graph =
+            CodeGraph::open(dir.path().to_path_buf(), Arc::new(ParserCache::new())).unwrap();
+        let (files, symbols) = graph.reindex().unwrap();
+        assert_eq!(files, 2);
+        assert!(symbols >= 3, "expected ≥3 symbols, got {symbols}");
+
+        let alphas = graph.find_by_name("alpha", 10).unwrap();
+        assert_eq!(alphas.len(), 2);
+        let betas = graph.find_by_name("Beta", 10).unwrap();
+        assert_eq!(betas.len(), 1);
+        assert_eq!(betas[0].kind, "struct");
+    }
+
+    #[test]
+    fn reindex_replaces_stale_rows() {
+        let dir = tempdir().unwrap();
+        std::fs::write(dir.path().join("a.rs"), "fn old_name() {}\n").unwrap();
+        let graph =
+            CodeGraph::open(dir.path().to_path_buf(), Arc::new(ParserCache::new())).unwrap();
+        graph.reindex().unwrap();
+        std::fs::write(dir.path().join("a.rs"), "fn new_name() {}\n").unwrap();
+        graph.reindex().unwrap();
+        assert!(graph.find_by_name("old_name", 5).unwrap().is_empty());
+        assert_eq!(graph.find_by_name("new_name", 5).unwrap().len(), 1);
+    }
+}

--- a/src/code/mod.rs
+++ b/src/code/mod.rs
@@ -4,6 +4,7 @@
 //! alongside. Both share `Language` here so language detection has one
 //! source of truth.
 
+pub mod graph;
 pub mod lsp;
 
 use std::path::Path;

--- a/src/tools/code_graph.rs
+++ b/src/tools/code_graph.rs
@@ -1,0 +1,105 @@
+//! Code-graph tools (YYC-50). Today: workspace symbol index + fast
+//! lookup. Call-edges + impact-analysis are deferred to a follow-up
+//! (need real LSP call hierarchy work); the schema reserves columns
+//! so they can land incrementally.
+
+use crate::code::graph::CodeGraph;
+use crate::tools::{Tool, ToolResult};
+use anyhow::Result;
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
+
+#[derive(Clone)]
+pub struct IndexCodeGraphTool {
+    graph: Arc<CodeGraph>,
+}
+
+impl IndexCodeGraphTool {
+    pub fn new(graph: Arc<CodeGraph>) -> Self {
+        Self { graph }
+    }
+}
+
+#[async_trait]
+impl Tool for IndexCodeGraphTool {
+    fn name(&self) -> &str {
+        "index_code_graph"
+    }
+    fn description(&self) -> &str {
+        "(Re)build the workspace symbol index. Walks the cwd respecting .gitignore, parses each supported source file via tree-sitter, persists symbols to ~/.vulcan/code_graph/. Run once per session (or after large file movements) — `find_symbol` reads from the cached index."
+    }
+    fn schema(&self) -> Value {
+        json!({ "type": "object", "properties": {} })
+    }
+    async fn call(&self, _params: Value, cancel: CancellationToken) -> Result<ToolResult> {
+        let graph = self.graph.clone();
+        let task = tokio::task::spawn_blocking(move || graph.reindex());
+        let result = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => return Ok(ToolResult::err("Cancelled")),
+            r = task => r??,
+        };
+        let (files, symbols) = result;
+        Ok(ToolResult::ok(format!(
+            "Indexed {symbols} symbols across {files} files into {}",
+            self.graph.workspace_root().display()
+        )))
+    }
+}
+
+#[derive(Clone)]
+pub struct FindSymbolTool {
+    graph: Arc<CodeGraph>,
+}
+
+impl FindSymbolTool {
+    pub fn new(graph: Arc<CodeGraph>) -> Self {
+        Self { graph }
+    }
+}
+
+#[async_trait]
+impl Tool for FindSymbolTool {
+    fn name(&self) -> &str {
+        "find_symbol"
+    }
+    fn description(&self) -> &str {
+        "Look up where a symbol is declared across the indexed workspace. Returns one row per declaration with file + line range. Run `index_code_graph` first to populate the index."
+    }
+    fn schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "name": { "type": "string", "description": "Exact symbol name (case-sensitive)" },
+                "limit": { "type": "integer", "default": 25 }
+            },
+            "required": ["name"]
+        })
+    }
+    async fn call(&self, params: Value, _cancel: CancellationToken) -> Result<ToolResult> {
+        let name = params["name"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("name required"))?;
+        let limit = params["limit"]
+            .as_u64()
+            .map(|n| n as usize)
+            .unwrap_or(25);
+        let graph = self.graph.clone();
+        let name_owned = name.to_string();
+        let rows =
+            tokio::task::spawn_blocking(move || graph.find_by_name(&name_owned, limit)).await??;
+        if rows.is_empty() {
+            return Ok(ToolResult::ok(format!(
+                "No declarations of '{name}' in the indexed workspace. \
+                 Run `index_code_graph` if the index is stale."
+            )));
+        }
+        let payload = json!({
+            "name": name,
+            "matches": rows,
+        });
+        Ok(ToolResult::ok(serde_json::to_string_pretty(&payload)?))
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -65,6 +65,7 @@ pub trait Tool: Send + Sync {
 
 pub mod code;
 pub mod code_edit;
+pub mod code_graph;
 pub mod file;
 pub mod git;
 pub mod lsp;
@@ -149,7 +150,7 @@ impl ToolRegistry {
         let parser_cache = Arc::new(crate::code::ParserCache::new());
         registry.register(Arc::new(code::CodeOutlineTool::new(parser_cache.clone())));
         registry.register(Arc::new(code::CodeExtractTool::new(parser_cache.clone())));
-        registry.register(Arc::new(code::CodeQueryTool::new(parser_cache)));
+        registry.register(Arc::new(code::CodeQueryTool::new(parser_cache.clone())));
         // YYC-46: LSP-backed semantic tools. One manager pool — servers
         // are spawned lazily on first use per language.
         let lsp_mgr = lsp.unwrap_or_else(|| {
@@ -164,6 +165,16 @@ impl ToolRegistry {
         // YYC-49: AST-aware structural edits.
         registry.register(Arc::new(code_edit::ReplaceFunctionBodyTool));
         registry.register(Arc::new(code_edit::RenameSymbolTool::new(lsp_mgr)));
+        // YYC-50: workspace symbol index. Lazy — the agent has to run
+        // `index_code_graph` once before `find_symbol` returns hits.
+        let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+        if let Ok(graph) = crate::code::graph::CodeGraph::open(cwd, parser_cache.clone()) {
+            let graph_arc = Arc::new(graph);
+            registry.register(Arc::new(code_graph::IndexCodeGraphTool::new(
+                graph_arc.clone(),
+            )));
+            registry.register(Arc::new(code_graph::FindSymbolTool::new(graph_arc)));
+        }
         // YYC-36: native git tools — agent stops composing brittle
         // `git ...` shell strings through bash.
         registry.register(Arc::new(git::GitStatusTool));


### PR DESCRIPTION
SQLite-backed workspace symbol index so the agent can ask "where is
X declared?" in O(1) instead of grepping the whole tree on every call.

- src/code/graph.rs: CodeGraph wraps a SQLite DB at
  ~/.vulcan/code_graph/<sanitized-cwd>.db (per-cwd isolation). Schema
  has a populated `symbols` table plus reserved `calls`,
  `implements`, `inherits` tables for the call-hierarchy follow-up.
- reindex(): walks the workspace via the `ignore` crate (respects
  .gitignore), parses each supported source file via the YYC-45
  tree-sitter cache, replaces stale rows in a transaction. Returns
  (files_indexed, symbols_inserted).
- find_by_name(): exact-name lookup with a per-name index.
- src/tools/code_graph.rs:
  - index_code_graph: kicks off (re)build via spawn_blocking so the
    async loop isn't pinned during indexing. Honors cancellation.
  - find_symbol: fast lookup. Hints to run index_code_graph if no
    hits.

Call-hierarchy + impact-analysis (find_callers / find_callees /
type_hierarchy / impact_analysis) deferred to a follow-up — they need
real LSP `callHierarchy/*` plumbing and proper edge invalidation.
Schema reserves the columns so they can land incrementally without
breaking the on-disk format.

Cargo: adds `ignore = "0.4.25"` (verified at crates.io latest stable).

2 new tests cover round-trip indexing and stale-row replacement.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>