### PR TITLE
YYC-48: Embedding-based semantic code search

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -38,3 +38,17 @@ enabled = true
 trigger_ratio = 0.85
 # Reserved tokens for LLM response generation
 reserved_tokens = 50000
+
+[embeddings]
+# Off by default — flip to true after configuring an OpenAI-compatible
+# embeddings endpoint. The agent then registers `index_code_embeddings`
+# and `code_search_semantic` (YYC-48).
+enabled = false
+# Base URL. Leave blank to fall back to [provider].base_url — convenient
+# for OpenRouter / OpenAI users whose chat + embedding origins match.
+# base_url = "https://api.openai.com/v1"
+# Optional override for the API key. Falls back to [provider].api_key
+# (or VULCAN_API_KEY) when omitted.
+# api_key = "sk-..."
+model = "text-embedding-3-small"
+dim = 1536

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -155,10 +155,36 @@ impl Agent {
         let lsp_manager = Arc::new(crate::code::lsp::LspManager::new(
             std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
         ));
-        let tools = ToolRegistry::new_with_diff_and_lsp(
+        let mut tools = ToolRegistry::new_with_diff_and_lsp(
             Some(diff_sink.clone()),
             Some(lsp_manager.clone()),
         );
+
+        // YYC-48: register embedding tools when [embeddings] is
+        // enabled. The index opens its own SQLite store; failure is
+        // logged but non-fatal — the agent still has every other tool.
+        if config.embeddings.enabled {
+            let parser_cache = Arc::new(crate::code::ParserCache::new());
+            let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+            match crate::code::embed::EmbeddingIndex::open(
+                cwd,
+                parser_cache,
+                config.embeddings.clone(),
+                config.provider.base_url.clone(),
+                api_key.clone().into(),
+            ) {
+                Ok(index) => {
+                    let arc = Arc::new(index);
+                    tools.register(Arc::new(
+                        crate::tools::code_search::IndexEmbeddingsTool::new(arc.clone()),
+                    ));
+                    tools.register(Arc::new(
+                        crate::tools::code_search::CodeSearchSemanticTool::new(arc),
+                    ));
+                }
+                Err(e) => tracing::warn!("embedding index unavailable: {e}"),
+            }
+        }
         let skills = Arc::new(SkillRegistry::new(&config.skills_dir));
         let memory = SessionStore::new();
         let context = ContextManager::new(provider.max_context());

--- a/src/code/embed.rs
+++ b/src/code/embed.rs
@@ -1,0 +1,426 @@
+//! Embedding-based code retrieval (YYC-48).
+//!
+//! Tree-sitter chunking (one chunk per top-level symbol) + a remote
+//! OpenAI-compatible embeddings endpoint + brute-force cosine ranking
+//! over a SQLite store. Local-model support is deferred — the candle/
+//! ort dep cost wasn't worth it for v1, and most users already have an
+//! API key for the chat endpoint.
+//!
+//! Storage: `~/.vulcan/embeddings/<sanitized-cwd>.db`. Per-cwd
+//! isolation matches the code-graph (YYC-50) layout.
+
+use crate::code::{Language, ParserCache};
+use crate::config::EmbeddingsConfig;
+use anyhow::{Context, Result, anyhow};
+use rusqlite::{Connection, params};
+use serde::Serialize;
+use serde_json::json;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use tree_sitter::{Query, QueryCursor, StreamingIterator};
+
+#[derive(Debug, Clone)]
+pub struct CodeChunk {
+    pub file: String,
+    pub language: String,
+    pub kind: String,
+    pub name: String,
+    pub start_line: usize,
+    pub end_line: usize,
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct EmbeddingHit {
+    pub file: String,
+    pub kind: String,
+    pub name: String,
+    pub start_line: usize,
+    pub end_line: usize,
+    pub score: f32,
+}
+
+pub struct EmbeddingIndex {
+    conn: Mutex<Connection>,
+    workspace_root: PathBuf,
+    parsers: Arc<ParserCache>,
+    cfg: EmbeddingsConfig,
+    /// Provider's chat-endpoint base URL + key, used as the fallback
+    /// when [embeddings] doesn't override them (YYC-48).
+    fallback_base_url: String,
+    fallback_api_key: Option<String>,
+    client: reqwest::Client,
+}
+
+impl EmbeddingIndex {
+    pub fn open(
+        workspace_root: PathBuf,
+        parsers: Arc<ParserCache>,
+        cfg: EmbeddingsConfig,
+        fallback_base_url: String,
+        fallback_api_key: Option<String>,
+    ) -> Result<Self> {
+        let db_path = db_path_for(&workspace_root)?;
+        if let Some(parent) = db_path.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
+        let conn = Connection::open(&db_path)
+            .with_context(|| format!("open embeddings at {}", db_path.display()))?;
+        conn.execute_batch(
+            r#"
+            CREATE TABLE IF NOT EXISTS chunks (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                file        TEXT NOT NULL,
+                language    TEXT NOT NULL,
+                kind        TEXT NOT NULL,
+                name        TEXT NOT NULL,
+                start_line  INTEGER NOT NULL,
+                end_line    INTEGER NOT NULL,
+                text        TEXT NOT NULL,
+                embedding   BLOB NOT NULL,
+                dim         INTEGER NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_chunks_file ON chunks(file);
+            "#,
+        )?;
+        Ok(Self {
+            conn: Mutex::new(conn),
+            workspace_root,
+            parsers,
+            cfg,
+            fallback_base_url,
+            fallback_api_key,
+            client: reqwest::Client::new(),
+        })
+    }
+
+    fn endpoint(&self) -> String {
+        let base = if self.cfg.base_url.is_empty() {
+            &self.fallback_base_url
+        } else {
+            &self.cfg.base_url
+        };
+        format!("{}/embeddings", base.trim_end_matches('/'))
+    }
+
+    fn api_key(&self) -> Option<&str> {
+        self.cfg
+            .api_key
+            .as_deref()
+            .or(self.fallback_api_key.as_deref())
+    }
+
+    /// Embed a batch of strings. Returns one Vec<f32> per input, in
+    /// order. Calls the OpenAI-compatible /embeddings endpoint.
+    pub async fn embed(&self, inputs: &[String]) -> Result<Vec<Vec<f32>>> {
+        if inputs.is_empty() {
+            return Ok(Vec::new());
+        }
+        let key = self
+            .api_key()
+            .ok_or_else(|| anyhow!("no API key configured for embeddings"))?;
+        let url = self.endpoint();
+        let body = json!({
+            "model": self.cfg.model,
+            "input": inputs,
+        });
+        let resp = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("Bearer {key}"))
+            .json(&body)
+            .send()
+            .await?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(anyhow!("embeddings endpoint returned {status}: {text}"));
+        }
+        let json: serde_json::Value = resp.json().await?;
+        let data = json
+            .get("data")
+            .and_then(|d| d.as_array())
+            .ok_or_else(|| anyhow!("no `data` array in embeddings response"))?;
+        let mut out = Vec::with_capacity(data.len());
+        for entry in data {
+            let v = entry
+                .get("embedding")
+                .and_then(|e| e.as_array())
+                .ok_or_else(|| anyhow!("missing embedding in response entry"))?;
+            let parsed: Result<Vec<f32>> = v
+                .iter()
+                .map(|n| {
+                    n.as_f64()
+                        .map(|f| f as f32)
+                        .ok_or_else(|| anyhow!("non-numeric embedding entry"))
+                })
+                .collect();
+            out.push(parsed?);
+        }
+        Ok(out)
+    }
+
+    /// Walk the workspace, chunk source files into top-level symbols,
+    /// embed each, persist. Returns `(chunks_indexed, files_visited)`.
+    pub async fn reindex(&self) -> Result<(usize, usize)> {
+        let walker = ignore::WalkBuilder::new(&self.workspace_root)
+            .standard_filters(true)
+            .build();
+        let mut all_chunks: Vec<CodeChunk> = Vec::new();
+        let mut files = 0usize;
+        for entry in walker {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+            if !entry.file_type().map(|t| t.is_file()).unwrap_or(false) {
+                continue;
+            }
+            let path = entry.path();
+            let lang = match Language::from_path(path) {
+                Some(l) => l,
+                None => continue,
+            };
+            let source = match std::fs::read_to_string(path) {
+                Ok(s) => s,
+                Err(_) => continue,
+            };
+            let rel = path
+                .strip_prefix(&self.workspace_root)
+                .unwrap_or(path)
+                .to_string_lossy()
+                .into_owned();
+            let chunks = chunk_file(&self.parsers, lang, &rel, &source)?;
+            files += 1;
+            all_chunks.extend(chunks);
+        }
+        if all_chunks.is_empty() {
+            return Ok((0, files));
+        }
+        // Wipe + repopulate. Incremental updates land as a follow-up.
+        {
+            let conn = self.conn.lock().unwrap();
+            conn.execute("DELETE FROM chunks", [])?;
+        }
+
+        // Batch embed in groups of 64 to keep request bodies small and
+        // share token budget across files.
+        let mut total = 0usize;
+        for batch in all_chunks.chunks(64) {
+            let inputs: Vec<String> = batch.iter().map(|c| c.text.clone()).collect();
+            let vectors = self.embed(&inputs).await?;
+            if vectors.len() != batch.len() {
+                return Err(anyhow!(
+                    "embeddings response had {} entries for {} inputs",
+                    vectors.len(),
+                    batch.len()
+                ));
+            }
+            let conn = self.conn.lock().unwrap();
+            for (chunk, vec) in batch.iter().zip(vectors.into_iter()) {
+                let blob = vec_to_bytes(&vec);
+                conn.execute(
+                    "INSERT INTO chunks (file, language, kind, name, start_line, end_line, text, embedding, dim)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    params![
+                        chunk.file,
+                        chunk.language,
+                        chunk.kind,
+                        chunk.name,
+                        chunk.start_line as i64,
+                        chunk.end_line as i64,
+                        chunk.text,
+                        blob,
+                        vec.len() as i64,
+                    ],
+                )?;
+                total += 1;
+            }
+        }
+        Ok((total, files))
+    }
+
+    /// Embed `query` and return the top-k chunks by cosine similarity.
+    /// Brute force — fine up to a few thousand chunks. A vector index
+    /// (sqlite-vss / lance) is the obvious next step.
+    pub async fn search(&self, query: &str, top_k: usize) -> Result<Vec<EmbeddingHit>> {
+        let q = self.embed(&[query.to_string()]).await?;
+        let qv = q
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow!("empty embedding response for query"))?;
+
+        let rows: Vec<(String, String, String, i64, i64, Vec<u8>)> = {
+            let conn = self.conn.lock().unwrap();
+            let mut stmt = conn.prepare(
+                "SELECT file, kind, name, start_line, end_line, embedding FROM chunks",
+            )?;
+            stmt.query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, i64>(4)?,
+                    row.get::<_, Vec<u8>>(5)?,
+                ))
+            })?
+            .collect::<Result<_, _>>()?
+        };
+
+        let mut scored: Vec<EmbeddingHit> = rows
+            .into_iter()
+            .filter_map(|(file, kind, name, start, end, blob)| {
+                let v = bytes_to_vec(&blob)?;
+                let score = cosine(&qv, &v);
+                Some(EmbeddingHit {
+                    file,
+                    kind,
+                    name,
+                    start_line: start as usize,
+                    end_line: end as usize,
+                    score,
+                })
+            })
+            .collect();
+        scored.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+        scored.truncate(top_k);
+        Ok(scored)
+    }
+
+    pub fn workspace_root(&self) -> &Path {
+        &self.workspace_root
+    }
+}
+
+fn chunk_file(
+    parsers: &ParserCache,
+    lang: Language,
+    relpath: &str,
+    source: &str,
+) -> Result<Vec<CodeChunk>> {
+    let query_text = lang.outline_query();
+    if query_text.is_empty() {
+        return Ok(Vec::new());
+    }
+    parsers.with_parser(lang, |parser| {
+        let tree = parser
+            .parse(source, None)
+            .ok_or_else(|| anyhow!("parse failed"))?;
+        let grammar = match lang {
+            Language::Rust => tree_sitter_rust::LANGUAGE.into(),
+            Language::Python => tree_sitter_python::LANGUAGE.into(),
+            Language::TypeScript => tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+            Language::JavaScript => tree_sitter_javascript::LANGUAGE.into(),
+            Language::Go => tree_sitter_go::LANGUAGE.into(),
+            Language::Json => return Ok(Vec::new()),
+        };
+        let query = Query::new(&grammar, query_text)
+            .map_err(|e| anyhow!("query: {e}"))?;
+        let name_idx = query.capture_index_for_name("name");
+        let mut cursor = QueryCursor::new();
+        let mut iter = cursor.matches(&query, tree.root_node(), source.as_bytes());
+        let mut out = Vec::new();
+        while let Some(m) = iter.next() {
+            let mut name = None;
+            let mut node = None;
+            let mut kind = "symbol".to_string();
+            for cap in m.captures {
+                let cap_name = &query.capture_names()[cap.index as usize];
+                if Some(cap.index) == name_idx {
+                    name = Some(
+                        cap.node
+                            .utf8_text(source.as_bytes())
+                            .unwrap_or("")
+                            .to_string(),
+                    );
+                } else {
+                    node = Some(cap.node);
+                    kind = (*cap_name).to_string();
+                }
+            }
+            if let (Some(n), Some(node)) = (name, node) {
+                let start = node.start_position().row + 1;
+                let end = node.end_position().row + 1;
+                let text = node.utf8_text(source.as_bytes()).unwrap_or("").to_string();
+                out.push(CodeChunk {
+                    file: relpath.to_string(),
+                    language: lang.name().to_string(),
+                    kind,
+                    name: n,
+                    start_line: start,
+                    end_line: end,
+                    text,
+                });
+            }
+        }
+        Ok(out)
+    })?
+}
+
+fn db_path_for(workspace_root: &Path) -> Result<PathBuf> {
+    let home = crate::config::vulcan_home();
+    let key = workspace_root
+        .to_string_lossy()
+        .trim_start_matches('/')
+        .replace(['/', '\\'], "_");
+    Ok(home.join("embeddings").join(format!("{key}.db")))
+}
+
+fn vec_to_bytes(v: &[f32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(v.len() * 4);
+    for f in v {
+        out.extend_from_slice(&f.to_le_bytes());
+    }
+    out
+}
+
+fn bytes_to_vec(b: &[u8]) -> Option<Vec<f32>> {
+    if b.len() % 4 != 0 {
+        return None;
+    }
+    let mut out = Vec::with_capacity(b.len() / 4);
+    for chunk in b.chunks_exact(4) {
+        let arr = [chunk[0], chunk[1], chunk[2], chunk[3]];
+        out.push(f32::from_le_bytes(arr));
+    }
+    Some(out)
+}
+
+fn cosine(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() {
+        return 0.0;
+    }
+    let mut dot = 0.0;
+    let mut na = 0.0;
+    let mut nb = 0.0;
+    for i in 0..a.len() {
+        dot += a[i] * b[i];
+        na += a[i] * a[i];
+        nb += b[i] * b[i];
+    }
+    let denom = (na.sqrt() * nb.sqrt()).max(f32::EPSILON);
+    dot / denom
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vec_bytes_round_trip() {
+        let v = vec![1.0_f32, -2.5, 0.0, 3.14159];
+        let b = vec_to_bytes(&v);
+        let back = bytes_to_vec(&b).unwrap();
+        assert_eq!(v, back);
+    }
+
+    #[test]
+    fn cosine_known_values() {
+        let a = vec![1.0, 0.0, 0.0];
+        let b = vec![0.0, 1.0, 0.0];
+        assert!(cosine(&a, &b).abs() < 1e-6);
+        let c = vec![1.0, 1.0, 0.0];
+        assert!((cosine(&a, &c) - (1.0 / 2.0_f32.sqrt())).abs() < 1e-6);
+    }
+}

--- a/src/code/mod.rs
+++ b/src/code/mod.rs
@@ -4,6 +4,7 @@
 //! alongside. Both share `Language` here so language detection has one
 //! source of truth.
 
+pub mod embed;
 pub mod graph;
 pub mod lsp;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,6 +25,34 @@ pub struct Config {
 
     #[serde(default)]
     pub compaction: CompactionConfig,
+
+    #[serde(default)]
+    pub embeddings: EmbeddingsConfig,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct EmbeddingsConfig {
+    /// Off by default — set true once an embedding endpoint + model
+    /// are configured. Tools surface a "not configured" error when
+    /// disabled rather than reaching for a remote API the user
+    /// didn't ask for.
+    #[serde(default)]
+    pub enabled: bool,
+    /// OpenAI-compatible embeddings endpoint (e.g.
+    /// `https://api.openai.com/v1`). Defaults to the same provider
+    /// base URL when blank — convenient for OpenRouter / OpenAI users
+    /// whose chat and embedding endpoints share an origin.
+    #[serde(default)]
+    pub base_url: String,
+    /// Optional separate API key for the embeddings endpoint.
+    /// Falls back to the provider's `api_key` (or `VULCAN_API_KEY`).
+    pub api_key: Option<String>,
+    /// Embedding model name (e.g. "text-embedding-3-small").
+    #[serde(default = "default_embedding_model")]
+    pub model: String,
+    /// Embedding dimensionality. Used to validate responses.
+    #[serde(default = "default_embedding_dim")]
+    pub dim: usize,
 }
 
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
@@ -143,8 +171,28 @@ impl Default for Config {
             tools: ToolsConfig::default(),
             skills_dir: default_skills_dir(),
             compaction: CompactionConfig::default(),
+            embeddings: EmbeddingsConfig::default(),
         }
     }
+}
+
+impl Default for EmbeddingsConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            base_url: String::new(),
+            api_key: None,
+            model: default_embedding_model(),
+            dim: default_embedding_dim(),
+        }
+    }
+}
+
+fn default_embedding_model() -> String {
+    "text-embedding-3-small".into()
+}
+fn default_embedding_dim() -> usize {
+    1536
 }
 
 fn default_provider_type() -> String {

--- a/src/tools/code_search.rs
+++ b/src/tools/code_search.rs
@@ -1,0 +1,103 @@
+//! Embedding-backed semantic search tools (YYC-48).
+//!
+//! `index_code_embeddings` runs the indexer (long-running on first
+//! call); `code_search_semantic` answers ranked queries.
+
+use crate::code::embed::EmbeddingIndex;
+use crate::tools::{Tool, ToolResult};
+use anyhow::Result;
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
+
+#[derive(Clone)]
+pub struct IndexEmbeddingsTool {
+    index: Arc<EmbeddingIndex>,
+}
+
+impl IndexEmbeddingsTool {
+    pub fn new(index: Arc<EmbeddingIndex>) -> Self {
+        Self { index }
+    }
+}
+
+#[async_trait]
+impl Tool for IndexEmbeddingsTool {
+    fn name(&self) -> &str {
+        "index_code_embeddings"
+    }
+    fn description(&self) -> &str {
+        "(Re)build the semantic embedding index of the workspace. Walks cwd, chunks each supported source file by top-level symbol via tree-sitter, embeds each chunk, persists to ~/.vulcan/embeddings/. Long-running on first call. Requires [embeddings] enabled in config + an API key."
+    }
+    fn schema(&self) -> Value {
+        json!({ "type": "object", "properties": {} })
+    }
+    async fn call(&self, _params: Value, cancel: CancellationToken) -> Result<ToolResult> {
+        let index = self.index.clone();
+        let task = async move { index.reindex().await };
+        let result = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => return Ok(ToolResult::err("Cancelled")),
+            r = task => r,
+        };
+        match result {
+            Err(e) => Ok(ToolResult::err(format!("Indexing failed: {e}"))),
+            Ok((chunks, files)) => Ok(ToolResult::ok(format!(
+                "Indexed {chunks} chunks across {files} files into {}",
+                self.index.workspace_root().display()
+            ))),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct CodeSearchSemanticTool {
+    index: Arc<EmbeddingIndex>,
+}
+
+impl CodeSearchSemanticTool {
+    pub fn new(index: Arc<EmbeddingIndex>) -> Self {
+        Self { index }
+    }
+}
+
+#[async_trait]
+impl Tool for CodeSearchSemanticTool {
+    fn name(&self) -> &str {
+        "code_search_semantic"
+    }
+    fn description(&self) -> &str {
+        "Semantic code search: 'find me code that does X'. Embeds the query and ranks against indexed chunks by cosine similarity. Run `index_code_embeddings` first. Complements ripgrep (literal) and code_query (structural)."
+    }
+    fn schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "query": { "type": "string", "description": "Natural-language description" },
+                "top_k": { "type": "integer", "default": 8 }
+            },
+            "required": ["query"]
+        })
+    }
+    async fn call(&self, params: Value, _cancel: CancellationToken) -> Result<ToolResult> {
+        let query = params["query"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("query required"))?;
+        let top_k = params["top_k"].as_u64().map(|n| n as usize).unwrap_or(8);
+        match self.index.search(query, top_k).await {
+            Err(e) => Ok(ToolResult::err(format!("Search failed: {e}"))),
+            Ok(hits) if hits.is_empty() => Ok(ToolResult::ok(
+                "No matches. Run `index_code_embeddings` if the index is empty or stale."
+                    .to_string(),
+            )),
+            Ok(hits) => {
+                let payload = json!({
+                    "query": query,
+                    "matches": hits,
+                });
+                Ok(ToolResult::ok(serde_json::to_string_pretty(&payload)?))
+            }
+        }
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -66,6 +66,7 @@ pub trait Tool: Send + Sync {
 pub mod code;
 pub mod code_edit;
 pub mod code_graph;
+pub mod code_search;
 pub mod file;
 pub mod git;
 pub mod lsp;


### PR DESCRIPTION
YYC-48: Embedding-based semantic code search

Two new tools that complement ripgrep (literal) and code_query
(structural) — semantic 'find me code that does X' via vector
embeddings of tree-sitter chunks.

- src/code/embed.rs: EmbeddingIndex wraps a SQLite store (BLOB
  embeddings) at ~/.vulcan/embeddings/<sanitized-cwd>.db. Chunks are
  one tree-sitter symbol each (function/method/class/etc) — coherent
  units beat whole-file embeddings on relevance.
- Embedding endpoint: OpenAI-compatible POST /embeddings via reqwest.
  Batched in groups of 64 to keep request bodies small. Falls back to
  the provider's base_url + api_key when [embeddings] omits them
  (works out of the box for OpenAI / OpenRouter users).
- Search: brute-force cosine over all rows. Up to a few thousand
  chunks this is fine; an index (sqlite-vss / lance) is the obvious
  next step.
- src/tools/code_search.rs:
  - index_code_embeddings: long-running indexer; cancellation honored.
  - code_search_semantic: ranked top-k chunks with file/line refs.
- Config gate [embeddings].enabled (default false) so the agent
  doesn't reach for a remote API the user didn't ask for. Tools only
  register when enabled.

Local-model embeddings (candle/ort) deferred — the dep cost wasn't
worth it for v1, and most Vulcan users already have an LLM API key.

2 new tests: vec_to_bytes/bytes_to_vec round-trip + cosine known
values.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

YYC-48: Document [embeddings] block in config.example.toml

Followup to the YYC-48 commit — the example config didn't show users
how to flip on the new embedding tools.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>