### PR TITLE
YYC-78: Long-output auto-collapse — "N more lines elided" footer

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -631,16 +631,19 @@ impl Agent {
                         let result = this.dispatch_tool(&name, &args, cancel).await;
                         let elapsed_ms = started.elapsed().as_millis() as u64;
                         let ok = !result.is_error;
-                        // YYC-74: truncated output preview + meta line
-                        // for the card body.
+                        // YYC-74: truncated output preview + meta line.
+                        // YYC-78: elided line count for the auto-collapse
+                        // "N more lines" indicator.
                         let output_preview = preview_output(&result.output);
                         let result_meta = summarize_tool_result(&name, &result.output);
+                        let elided = elided_lines(&result.output, output_preview.as_deref());
                         let _ = ui_tx.send(StreamEvent::ToolCallEnd {
                             id: id.clone(),
                             name: name.clone(),
                             ok,
                             output_preview,
                             result_meta,
+                            elided_lines: elided,
                             elapsed_ms,
                         });
                         (id, result)
@@ -1053,17 +1056,26 @@ fn summarize_tool_result(name: &str, output: &str) -> Option<String> {
 }
 
 /// Truncated tool result for the YYC-74 card preview block — caps at
-/// ~6 lines / 400 chars. The full output still goes to the LLM via
+/// ~12 lines / 1 KB. The full output still goes to the LLM via
 /// `Message::Tool`; this is purely for rendering.
 fn preview_output(text: &str) -> Option<String> {
     let trimmed = text.trim();
     if trimmed.is_empty() {
         return None;
     }
-    let chars: Vec<char> = trimmed.chars().take(400).collect();
+    let chars: Vec<char> = trimmed.chars().take(1024).collect();
     let head: String = chars.iter().collect();
-    let lines: Vec<&str> = head.lines().take(6).collect();
+    let lines: Vec<&str> = head.lines().take(12).collect();
     Some(lines.join("\n"))
+}
+
+/// Number of full output lines hidden by `preview_output` (YYC-78).
+/// Used by the card to render `… N more lines elided` when the
+/// result was clipped.
+fn elided_lines(text: &str, preview: Option<&str>) -> usize {
+    let total = text.trim().lines().count();
+    let shown = preview.map(|p| p.lines().count()).unwrap_or(0);
+    total.saturating_sub(shown)
 }
 
 #[cfg(test)]
@@ -1380,12 +1392,26 @@ mod tests {
     }
 
     #[test]
-    fn preview_output_caps_to_six_lines_and_400_chars() {
-        let big = (1..=20).map(|n| format!("line {n}")).collect::<Vec<_>>().join("\n");
+    fn preview_output_caps_to_twelve_lines_and_one_kb() {
+        // YYC-78 raised the cap so collapsed cards still show useful
+        // context up front.
+        let big = (1..=40).map(|n| format!("line {n}")).collect::<Vec<_>>().join("\n");
         let preview = preview_output(&big).unwrap();
-        assert_eq!(preview.lines().count(), 6);
+        assert_eq!(preview.lines().count(), 12);
         assert!(preview.contains("line 1"));
-        assert!(!preview.contains("line 7"));
+        assert!(!preview.contains("line 13"));
+    }
+
+    #[test]
+    fn elided_lines_counts_what_was_clipped() {
+        let big = (1..=40).map(|n| format!("line {n}")).collect::<Vec<_>>().join("\n");
+        let preview = preview_output(&big);
+        let elided = elided_lines(&big, preview.as_deref());
+        assert_eq!(elided, 28);
+        // Short output → no elision.
+        let short = "one\ntwo\nthree";
+        let preview = preview_output(short);
+        assert_eq!(elided_lines(short, preview.as_deref()), 0);
     }
 
     #[test]

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -364,6 +364,9 @@ pub enum StreamEvent {
         /// "847 lines · 26.8 KB", "5 matches", "+142 -3"). Rendered as
         /// a dimmed sub-header in the YYC-74 card.
         result_meta: Option<String>,
+        /// Lines elided beyond the preview (YYC-78 long-output
+        /// auto-collapse). 0 when the full output fit.
+        elided_lines: usize,
         elapsed_ms: u64,
     },
     /// The stream is complete (with optional final ChatResponse)

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -880,6 +880,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                         ok,
                         output_preview,
                         result_meta,
+                        elided_lines,
                         elapsed_ms,
                         ..
                     }) => {
@@ -887,11 +888,13 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                             if matches!(last.role, ChatRole::Agent) {
                                 // YYC-74: stamp preview + meta + timing
                                 // onto the matching segment for the card.
+                                // YYC-78: stash elided count for collapse footer.
                                 last.finish_tool_with(
                                     &name,
                                     ok,
                                     output_preview,
                                     result_meta,
+                                    elided_lines,
                                     Some(elapsed_ms),
                                 );
                             }

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -95,6 +95,9 @@ pub enum MessageSegment {
         /// "5 matches", "+12 -3"). Renders as a dimmed sub-header in
         /// the YYC-74 card.
         result_meta: Option<String>,
+        /// Lines elided beyond the preview (YYC-78). When > 0 the card
+        /// renders a "… N more lines elided" footer.
+        elided_lines: usize,
         elapsed_ms: Option<u64>,
     },
 }
@@ -188,6 +191,7 @@ impl ChatMessage {
             params_summary,
             output_preview: None,
             result_meta: None,
+            elided_lines: 0,
             elapsed_ms: None,
         });
     }
@@ -196,17 +200,18 @@ impl ChatMessage {
     /// Walks segments in reverse so concurrent dispatch (YYC-34) still
     /// pairs each end with its own start as the matching tail.
     pub fn finish_tool(&mut self, name: &str, ok: bool) {
-        self.finish_tool_with(name, ok, None, None, None);
+        self.finish_tool_with(name, ok, None, None, 0, None);
     }
 
     /// Same as `finish_tool` but also stamps the result preview, meta
-    /// summary, and timing for the YYC-74 card.
+    /// summary, elided count, and timing for the YYC-74 card.
     pub fn finish_tool_with(
         &mut self,
         name: &str,
         ok: bool,
         output_preview: Option<String>,
         result_meta: Option<String>,
+        elided_lines: usize,
         elapsed_ms: Option<u64>,
     ) {
         for seg in self.segments.iter_mut().rev() {
@@ -215,6 +220,7 @@ impl ChatMessage {
                 status,
                 output_preview: op,
                 result_meta: rm,
+                elided_lines: el,
                 elapsed_ms: em,
                 ..
             } = seg
@@ -223,6 +229,7 @@ impl ChatMessage {
                     *status = ToolStatus::Done(ok);
                     *op = output_preview;
                     *rm = result_meta;
+                    *el = elided_lines;
                     *em = elapsed_ms;
                     return;
                 }
@@ -1206,6 +1213,7 @@ mod tests {
             true,
             Some("hello\nworld".into()),
             Some("2 lines".into()),
+            0,
             Some(345),
         );
         match &m.segments[0] {

--- a/src/tui/views.rs
+++ b/src/tui/views.rs
@@ -145,15 +145,18 @@ fn build_chat_lines_w(
                         params_summary,
                         output_preview,
                         result_meta,
+                        elided_lines,
                         elapsed_ms,
                     } => {
                         // YYC-74: structured bordered tool-call card.
+                        // YYC-78: elided_lines drives the auto-collapse footer.
                         for line in super::widgets::tool_card(
                             name,
                             *status,
                             params_summary.as_deref(),
                             output_preview.as_deref(),
                             result_meta.as_deref(),
+                            *elided_lines,
                             *elapsed_ms,
                             accent,
                             width,

--- a/src/tui/widgets.rs
+++ b/src/tui/widgets.rs
@@ -472,6 +472,7 @@ pub fn tool_card(
     params_summary: Option<&str>,
     output_preview: Option<&str>,
     result_meta: Option<&str>,
+    elided_lines: usize,
     elapsed_ms: Option<u64>,
     _accent: Color,
     width: u16,
@@ -614,6 +615,28 @@ pub fn tool_card(
             render_body(&mut spans, used);
             out.push(Line::from(spans));
         }
+    }
+
+    // ── YYC-78: long-output footer when the result was clipped.
+    if elided_lines > 0 {
+        let footer = format!(
+            "… {elided_lines} more line{} elided",
+            if elided_lines == 1 { "" } else { "s" }
+        );
+        let used = body_indent.chars().count() + footer.chars().count();
+        let mut spans = vec![
+            Span::styled("│", body_border),
+            Span::styled(body_indent.to_string(), Style::default().bg(body_bg)),
+            Span::styled(
+                footer,
+                Style::default()
+                    .fg(Palette::MUTED)
+                    .bg(body_bg)
+                    .add_modifier(Modifier::ITALIC),
+            ),
+        ];
+        render_body(&mut spans, used);
+        out.push(Line::from(spans));
     }
 
     // ── Bottom border on FAINT, closing the rectangle.


### PR DESCRIPTION
Tool outputs now show a clear truncation indicator when the preview
clipped them. Card body footer reads `… N more lines elided` (italic
muted) so the agent + user know the result has more content without
guessing.

- preview_output capped raised to 12 lines / 1 KB (from 6 / 400) so
  the collapsed view still carries useful context up front.
- New `elided_lines(text, preview)` counts the difference between the
  full output's line count and the preview's; the agent emits it
  alongside the preview.
- StreamEvent::ToolCallEnd carries `elided_lines: usize`.
- MessageSegment::ToolCall stores it; finish_tool_with takes it.
- widgets::tool_card renders the footer line on the body band when
  the count is > 0.

Auto-collapse is the v1 strategy. Scroll-cap and side-pane variants
from the design (focus mode, `]` cycle, `o` to side-pane) are
deferred — they need a focus model the chat surface doesn't have
yet. The "elided" hint addresses the immediate "I can't tell what
was truncated" problem.

2 new tests cover the higher cap + the elision count.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>