### PR TITLE
YYC-81: ask_user tool — multiple-choice prompt via AgentPause

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -160,6 +160,15 @@ impl Agent {
             Some(lsp_manager.clone()),
         );
 
+        // YYC-81: ask_user is only useful in interactive (TUI) mode.
+        // Register it whenever a pause channel is wired; it self-
+        // reports when called without one.
+        if pause_tx.is_some() {
+            tools.register(Arc::new(crate::tools::ask_user::AskUserTool::new(
+                pause_tx.clone(),
+            )));
+        }
+
         // YYC-48: register embedding tools when [embeddings] is
         // enabled. The index opens its own SQLite store; failure is
         // logged but non-fatal — the agent still has every other tool.

--- a/src/hooks/safety.rs
+++ b/src/hooks/safety.rs
@@ -171,6 +171,11 @@ impl HookHandler for SafetyHook {
                     reason: format!("{reason} (user denied)"),
                 },
                 Ok(AgentResume::DenyWithReason(r)) => HookOutcome::Block { reason: r },
+                // YYC-81 added Custom — meaningless to a safety hook;
+                // treat as a deny.
+                Ok(AgentResume::Custom(_)) => HookOutcome::Block {
+                    reason: format!("{reason} (custom response on safety prompt — denying)"),
+                },
                 Err(_) => HookOutcome::Block {
                     reason: format!("{reason} (approval channel closed)"),
                 },

--- a/src/pause.rs
+++ b/src/pause.rs
@@ -74,6 +74,9 @@ pub enum PauseKind {
         suggested_name: String,
         body: String,
     },
+    /// Agent-initiated multiple-choice prompt (YYC-81). Each option's
+    /// chosen value comes back as `AgentResume::Custom(value)`.
+    UserChoice { question: String },
 }
 
 /// The user's decision.
@@ -89,6 +92,10 @@ pub enum AgentResume {
     Deny,
     /// Deny with a reason that gets surfaced to the LLM as the block reason.
     DenyWithReason(String),
+    /// Custom value carried back to an agent-initiated pause (YYC-81
+    /// `ask_user`). Hooks that receive this will typically pass the
+    /// inner string through to the tool result as-is.
+    Custom(String),
 }
 
 pub type PauseSender = tokio::sync::mpsc::Sender<AgentPause>;

--- a/src/tools/ask_user.rs
+++ b/src/tools/ask_user.rs
@@ -1,0 +1,145 @@
+//! `ask_user` tool (YYC-81). Agent-initiated multiple-choice prompt
+//! over the existing `AgentPause` channel. The TUI renders inline
+//! pills (YYC-59); the chosen option's `value` comes back as
+//! `AgentResume::Custom` and the tool returns it to the LLM.
+//!
+//! Only registered when a pause emitter is wired (TUI mode); the CLI
+//! one-shot path returns a clear error so the agent knows it can't
+//! ask interactively there.
+
+use crate::pause::{AgentPause, AgentResume, OptionKind, PauseKind, PauseOption, PauseSender};
+use crate::tools::{Tool, ToolResult};
+use anyhow::Result;
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use std::time::Duration;
+use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
+
+pub struct AskUserTool {
+    pause_tx: Option<PauseSender>,
+}
+
+impl AskUserTool {
+    pub fn new(pause_tx: Option<PauseSender>) -> Self {
+        Self { pause_tx }
+    }
+}
+
+#[async_trait]
+impl Tool for AskUserTool {
+    fn name(&self) -> &str {
+        "ask_user"
+    }
+    fn description(&self) -> &str {
+        "Ask the user a multiple-choice question and block until they pick. Each option has {key, label, value}; the chosen value comes back as the tool result. Only available in TUI mode."
+    }
+    fn schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "question": { "type": "string" },
+                "options": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "key": { "type": "string", "description": "Single-char shortcut" },
+                            "label": { "type": "string" },
+                            "value": { "type": "string", "description": "Returned to the agent on press" }
+                        },
+                        "required": ["key", "label", "value"]
+                    }
+                }
+            },
+            "required": ["question", "options"]
+        })
+    }
+    async fn call(&self, params: Value, cancel: CancellationToken) -> Result<ToolResult> {
+        let question = params["question"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("question required"))?
+            .to_string();
+        let options_in = params["options"]
+            .as_array()
+            .ok_or_else(|| anyhow::anyhow!("options must be a non-empty array"))?
+            .clone();
+        if options_in.is_empty() {
+            return Ok(ToolResult::err("options must contain at least one entry"));
+        }
+
+        let tx = match &self.pause_tx {
+            Some(t) => t,
+            None => {
+                return Ok(ToolResult::err(
+                    "ask_user is only available when a pause channel is wired (TUI mode)",
+                ));
+            }
+        };
+
+        // Map JSON entries to PauseOption with Custom(value) resume.
+        let mut options = Vec::with_capacity(options_in.len());
+        for (i, entry) in options_in.iter().enumerate() {
+            let key = entry["key"]
+                .as_str()
+                .and_then(|s| s.chars().next())
+                .ok_or_else(|| anyhow::anyhow!("options[{i}].key must be a single character"))?;
+            let label = entry["label"]
+                .as_str()
+                .ok_or_else(|| anyhow::anyhow!("options[{i}].label required"))?
+                .to_string();
+            let value = entry["value"]
+                .as_str()
+                .ok_or_else(|| anyhow::anyhow!("options[{i}].value required"))?
+                .to_string();
+            // First option = primary; rest = neutral. Lets the TUI
+            // pill colors hint at the suggested default without the
+            // agent having to specify per-option styling.
+            let kind = if i == 0 {
+                OptionKind::Primary
+            } else {
+                OptionKind::Neutral
+            };
+            options.push(PauseOption {
+                key,
+                label,
+                kind,
+                resume: AgentResume::Custom(value),
+            });
+        }
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let pause = AgentPause {
+            kind: PauseKind::UserChoice { question },
+            reply: reply_tx,
+            options,
+        };
+
+        if tx.send(pause).await.is_err() {
+            return Ok(ToolResult::err(
+                "ask_user: pause channel closed before the prompt could be delivered",
+            ));
+        }
+
+        // Block until the user responds (or cancels). 10-minute cap
+        // so a forgotten prompt eventually unblocks the agent.
+        let resume = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => return Ok(ToolResult::err("Cancelled")),
+            r = tokio::time::timeout(Duration::from_secs(600), reply_rx) => match r {
+                Err(_) => return Ok(ToolResult::err("ask_user: timed out waiting for user response")),
+                Ok(Err(_)) => return Ok(ToolResult::err("ask_user: response channel closed")),
+                Ok(Ok(r)) => r,
+            },
+        };
+
+        match resume {
+            AgentResume::Custom(v) => Ok(ToolResult::ok(v)),
+            AgentResume::Allow => Ok(ToolResult::ok("allow".to_string())),
+            AgentResume::AllowAndRemember => Ok(ToolResult::ok("allow_and_remember".to_string())),
+            AgentResume::Deny => Ok(ToolResult::err("user denied")),
+            AgentResume::DenyWithReason(r) => Ok(ToolResult::err(format!("user denied: {r}"))),
+        }
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -63,6 +63,7 @@ pub trait Tool: Send + Sync {
     async fn call(&self, params: Value, cancel: CancellationToken) -> Result<ToolResult>;
 }
 
+pub mod ask_user;
 pub mod cargo;
 pub mod code;
 pub mod code_edit;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -398,6 +398,10 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                         (PauseKind::SkillSave { suggested_name, .. }, false) => {
                             format!("Save this as a skill named '{suggested_name}'?")
                         }
+                        // YYC-81: ask_user always supplies its own pills,
+                        // so the legacy hint case is unreachable but kept
+                        // for exhaustiveness.
+                        (PauseKind::UserChoice { question }, _) => question.clone(),
                         // No options → legacy bracket-list hint stays in.
                         (PauseKind::SafetyApproval { command, reason, .. }, true) => {
                             format!("Safety: {reason}\n  $ {command}\n  [a]llow once, [r]emember & allow, [d]eny")
@@ -461,6 +465,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                                 AgentResume::AllowAndRemember => "allowed (remembered)",
                                                 AgentResume::Deny => "denied",
                                                 AgentResume::DenyWithReason(_) => "denied",
+                                                AgentResume::Custom(_) => "responded",
                                             };
                                             let _ = p.reply.send(r);
                                             app.messages.push(ChatMessage {


### PR DESCRIPTION
Lets the agent ask the user a question mid-loop and block until they
pick. Reuses the YYC-32 AgentPause channel + YYC-59 inline-pill
rendering — no new TUI surface needed.

- pause.rs: new PauseKind::UserChoice { question } variant +
  AgentResume::Custom(String) so per-option values can flow back.
  SafetyHook treats Custom as a deny (defensive).
- tools/ask_user.rs: AskUserTool. Schema `{question, options[{key,
  label, value}]}`. First option styled Primary, rest Neutral so
  the pill colors hint at the suggested default. 10-minute timeout
  on the response so a forgotten prompt eventually unblocks the
  agent. Returns the chosen value as the tool result; CLI mode
  (no pause channel) returns a clear "TUI-only" error.
- TUI pause-summary match arm renders the question text directly
  (no bracket-list legacy hint, since ask_user always supplies
  pills).
- Agent registers the tool only when a pause emitter is present.

Foundations:
- YYC-32 (AgentPause) — pause/resume plumbing.
- YYC-59 (inline pills) — UI surface; option->key mapping.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>