### PR TITLE
YYC-76: Approval modes — ask / session / always per tool

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -31,6 +31,17 @@ catalog_cache_ttl_hours = 24
 # Enable dangerous tools (file overwrite, shell exec) without confirmation
 yolo_mode = false
 
+# Per-tool approval gate (YYC-76). Default is "always" (no prompts) so
+# the gate is opt-in. Set entries to "ask" or "session" for per-tool
+# granularity — TUI will pause on the gate and render inline pills.
+# `yolo_mode = true` above forces the default back to "always" no matter
+# what's set here.
+[tools.approval]
+default = "always"
+# write_file = "session"   # prompt once per session
+# git_push   = "ask"        # prompt every push
+# bash       = "ask"
+
 [compaction]
 # Auto-compress context when token usage is high
 enabled = true

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::config::Config;
 use crate::context::ContextManager;
+use crate::hooks::approval::ApprovalHook;
 use crate::hooks::diagnostics::DiagnosticsHook;
 use crate::hooks::safety::SafetyHook;
 use crate::hooks::skills::SkillsHook;
@@ -209,6 +210,16 @@ impl Agent {
             lsp_manager.clone(),
             diff_sink.clone(),
         )));
+
+        // Built-in hook (YYC-76): per-tool approval gate. Default mode
+        // is Always (no prompts) so the gate is opt-in via
+        // [tools.approval]. yolo_mode=true is the legacy escape
+        // hatch — it leaves the default at Always.
+        let mut approval_cfg = config.tools.approval.clone();
+        if config.tools.yolo_mode {
+            approval_cfg.default = crate::config::ApprovalMode::Always;
+        }
+        hooks.register(Arc::new(ApprovalHook::new(approval_cfg, pause_tx.clone())));
 
         // Built-in hook: block dangerous shell invocations unless yolo_mode is on.
         // Skipped entirely (not even registered as observe-only) when yolo_mode

--- a/src/config.rs
+++ b/src/config.rs
@@ -114,9 +114,48 @@ pub struct ProviderConfig {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct ToolsConfig {
-    /// Enable dangerous tools (file overwrite, shell exec) without confirmation
+    /// Enable dangerous tools (file overwrite, shell exec) without confirmation.
+    /// Legacy alias — when true, the `approval.default` falls back to
+    /// `always` (YYC-76).
     #[serde(default)]
     pub yolo_mode: bool,
+    /// Per-tool approval modes (YYC-76). When unset, every tool runs
+    /// without prompting (matches pre-YYC-76 behavior).
+    #[serde(default)]
+    pub approval: ApprovalConfig,
+}
+
+/// Per-tool approval gate (YYC-76).
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum ApprovalMode {
+    /// Block on every invocation, prompting the user.
+    Ask,
+    /// Pause once per session; subsequent calls run silently.
+    Session,
+    /// Run without prompting (default).
+    #[default]
+    Always,
+}
+
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct ApprovalConfig {
+    /// Default mode for tools not in the per-tool overrides map.
+    /// Defaults to `always` (no prompts) so the gate is opt-in.
+    #[serde(default)]
+    pub default: ApprovalMode,
+    /// Per-tool overrides keyed by tool name (`write_file`, `bash`, etc).
+    #[serde(flatten)]
+    pub per_tool: std::collections::HashMap<String, ApprovalMode>,
+}
+
+impl ApprovalConfig {
+    pub fn mode_for(&self, tool: &str) -> ApprovalMode {
+        self.per_tool
+            .get(tool)
+            .copied()
+            .unwrap_or(self.default)
+    }
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -150,7 +189,10 @@ impl Default for ProviderConfig {
 
 impl Default for ToolsConfig {
     fn default() -> Self {
-        Self { yolo_mode: false }
+        Self {
+            yolo_mode: false,
+            approval: ApprovalConfig::default(),
+        }
     }
 }
 

--- a/src/hooks/approval.rs
+++ b/src/hooks/approval.rs
@@ -1,0 +1,174 @@
+//! Per-tool approval hook (YYC-76).
+//!
+//! Gates BeforeToolCall by the configured approval mode for each tool.
+//! Modes:
+//! - `Always`: run without prompting (default — back-compat with the
+//!   pre-YYC-76 zero-config experience).
+//! - `Session`: pause on first call; cache approval; run silently
+//!   thereafter for the same session.
+//! - `Ask`: pause every call.
+//!
+//! Pauses go through the existing AgentPause channel so the TUI's
+//! YYC-59 inline pills handle the user choice. When no pause emitter
+//! is wired (CLI one-shot mode), the hook conservatively blocks for
+//! `Ask` / `Session` modes so the agent doesn't silently bypass a
+//! requested gate.
+
+use crate::config::{ApprovalConfig, ApprovalMode};
+use crate::hooks::{HookHandler, HookOutcome};
+use crate::pause::{
+    AgentPause, AgentResume, OptionKind, PauseKind, PauseOption, PauseSender,
+};
+use anyhow::Result;
+use serde_json::Value;
+use std::collections::HashSet;
+use std::sync::Mutex;
+use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
+
+pub struct ApprovalHook {
+    cfg: ApprovalConfig,
+    pause_tx: Option<PauseSender>,
+    /// Per-tool session approvals — one entry per `(tool_name)` after
+    /// the user picks "approve session".
+    session_allow: Mutex<HashSet<String>>,
+}
+
+impl ApprovalHook {
+    pub fn new(cfg: ApprovalConfig, pause_tx: Option<PauseSender>) -> Self {
+        Self {
+            cfg,
+            pause_tx,
+            session_allow: Mutex::new(HashSet::new()),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl HookHandler for ApprovalHook {
+    fn name(&self) -> &str {
+        "approval_gate"
+    }
+
+    fn priority(&self) -> i32 {
+        // Run early — well before SafetyHook (50) — so explicit
+        // session-allows for a tool can short-circuit the
+        // command-pattern check.
+        20
+    }
+
+    async fn before_tool_call(
+        &self,
+        tool: &str,
+        args: &Value,
+        cancel: CancellationToken,
+    ) -> Result<HookOutcome> {
+        let mode = self.cfg.mode_for(tool);
+        if matches!(mode, ApprovalMode::Always) {
+            return Ok(HookOutcome::Continue);
+        }
+        if matches!(mode, ApprovalMode::Session)
+            && self.session_allow.lock().unwrap().contains(tool)
+        {
+            return Ok(HookOutcome::Continue);
+        }
+
+        // Need user input but no channel wired — fail safe (block).
+        let tx = match &self.pause_tx {
+            Some(t) => t,
+            None => {
+                return Ok(HookOutcome::Block {
+                    reason: format!(
+                        "tool '{tool}' requires {mode:?} approval but no pause channel is wired"
+                    ),
+                });
+            }
+        };
+
+        let summary = format!(
+            "Tool '{tool}' requires approval (mode: {mode:?}). Args: {args}"
+        );
+        let options = match mode {
+            ApprovalMode::Session => vec![
+                PauseOption {
+                    key: 'y',
+                    label: "approve once".into(),
+                    kind: OptionKind::Primary,
+                    resume: AgentResume::Allow,
+                },
+                PauseOption {
+                    key: 's',
+                    label: "approve session".into(),
+                    kind: OptionKind::Neutral,
+                    resume: AgentResume::AllowAndRemember,
+                },
+                PauseOption {
+                    key: 'n',
+                    label: "deny".into(),
+                    kind: OptionKind::Destructive,
+                    resume: AgentResume::Deny,
+                },
+            ],
+            ApprovalMode::Ask => vec![
+                PauseOption {
+                    key: 'y',
+                    label: "approve".into(),
+                    kind: OptionKind::Primary,
+                    resume: AgentResume::Allow,
+                },
+                PauseOption {
+                    key: 'n',
+                    label: "deny".into(),
+                    kind: OptionKind::Destructive,
+                    resume: AgentResume::Deny,
+                },
+            ],
+            ApprovalMode::Always => unreachable!(),
+        };
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let pause = AgentPause {
+            kind: PauseKind::ToolArgConfirm {
+                tool: tool.to_string(),
+                args: args.clone(),
+                summary,
+            },
+            reply: reply_tx,
+            options,
+        };
+
+        if tx.send(pause).await.is_err() {
+            return Ok(HookOutcome::Block {
+                reason: "approval channel dropped".into(),
+            });
+        }
+
+        let resume = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => {
+                return Ok(HookOutcome::Block {
+                    reason: "Cancelled while awaiting approval".into(),
+                });
+            }
+            r = reply_rx => r,
+        };
+
+        match resume {
+            Ok(AgentResume::Allow) => Ok(HookOutcome::Continue),
+            Ok(AgentResume::AllowAndRemember) => {
+                self.session_allow.lock().unwrap().insert(tool.to_string());
+                Ok(HookOutcome::Continue)
+            }
+            Ok(AgentResume::Deny) => Ok(HookOutcome::Block {
+                reason: "user denied".into(),
+            }),
+            Ok(AgentResume::DenyWithReason(r)) => Ok(HookOutcome::Block { reason: r }),
+            Ok(AgentResume::Custom(_)) => Ok(HookOutcome::Block {
+                reason: "approval prompt got a custom response — denying".into(),
+            }),
+            Err(_) => Ok(HookOutcome::Block {
+                reason: "approval channel closed".into(),
+            }),
+        }
+    }
+}

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -34,6 +34,7 @@ pub enum InjectPosition {
     Append,
 }
 
+pub mod approval;
 pub mod diagnostics;
 
 /// What a handler returns. Each event honors a subset; unsupported variants


### PR DESCRIPTION
Per-tool gate replaces the binary yolo_mode flag (which is kept as
a back-compat alias).

- config.rs: ApprovalMode { Ask, Session, Always } enum +
  ApprovalConfig { default, per_tool: HashMap }. mode_for(tool)
  returns the override or default.
- hooks/approval.rs: new ApprovalHook (BeforeToolCall, priority 20
  so it runs ahead of SafetyHook). Modes:
  - Always → Continue.
  - Session → check in-memory session-allow set; if cached, Continue;
    else pause with `[y]approve once / [s]approve session / [n]deny`
    pills; "approve session" caches.
  - Ask → pause every call with `[y]approve / [n]deny`.
  Pauses route through the existing AgentPause channel + YYC-59
  inline pills. No pause channel wired (CLI mode) → fail-safe Block.
- Custom AgentResume on an approval prompt is treated as deny
  (defensive — only ask_user uses Custom legitimately).
- Agent registers ApprovalHook as a built-in alongside DiagnosticsHook
  and SafetyHook.
- yolo_mode=true forces approval.default = Always so existing configs
  keep working unchanged.
- config.example.toml documents the [tools.approval] block.

Persistence (always-allow surviving session restart) is deferred —
v1 treats Always as "skip prompts" and relies on the user editing
config to make a tool permanent.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>