### PR TITLE
TUI theming foundation — system/default-light/dracula (YYC-52)

### DIFF
--- a/benches/tui_render.rs
+++ b/benches/tui_render.rs
@@ -22,6 +22,7 @@ use divan::{AllocProfiler, Bencher};
 use vulcan::tui::{
     chat_render::{ChatRenderOptions, ChatRenderStore},
     state::{ChatMessage, ChatRole},
+    theme::Theme,
 };
 
 use common::results::{Measurement, append};
@@ -85,7 +86,7 @@ fn visible_lines_first_render(b: Bencher, n: usize) {
     // builds the store outside the timed region.
     b.with_inputs(ChatRenderStore::default)
         .bench_refs(|store| {
-            store.visible_lines_at(&messages, options, 0, usize::from(WINDOW_HEIGHT))
+            store.visible_lines_at(&messages, options, &Theme::system(), 0, usize::from(WINDOW_HEIGHT))
         });
 }
 
@@ -100,12 +101,12 @@ fn visible_lines_cached_tail(b: Bencher, n: usize) {
     };
     let mut store = ChatRenderStore::default();
     // Prime cache with one full render so subsequent iters hit warm paths.
-    let first = store.visible_lines_at(&messages, options, 0, usize::from(WINDOW_HEIGHT));
+    let first = store.visible_lines_at(&messages, options, &Theme::system(), 0, usize::from(WINDOW_HEIGHT));
     let scroll = first.total_lines.saturating_sub(usize::from(WINDOW_HEIGHT));
     // `bench_local` accepts `FnMut`, which lets us keep the warm cache alive
     // across iters without paying a `Sync` tax (and without per-iter cloning).
     b.bench_local(move || {
-        store.visible_lines_at(&messages, options, scroll, usize::from(WINDOW_HEIGHT))
+        store.visible_lines_at(&messages, options, &Theme::system(), scroll, usize::from(WINDOW_HEIGHT))
     });
 }
 
@@ -134,7 +135,7 @@ fn main() {
         let start = std::time::Instant::now();
         for _ in 0..ITERS {
             let mut store = ChatRenderStore::default();
-            let _ = store.visible_lines_at(&messages, options, 0, usize::from(WINDOW_HEIGHT));
+            let _ = store.visible_lines_at(&messages, options, &Theme::system(), 0, usize::from(WINDOW_HEIGHT));
         }
         let ns = (start.elapsed().as_nanos() as f64) / f64::from(ITERS);
         groups
@@ -148,11 +149,11 @@ fn main() {
 
         // cached tail — store kept warm across iters.
         let mut store = ChatRenderStore::default();
-        let first = store.visible_lines_at(&messages, options, 0, usize::from(WINDOW_HEIGHT));
+        let first = store.visible_lines_at(&messages, options, &Theme::system(), 0, usize::from(WINDOW_HEIGHT));
         let scroll = first.total_lines.saturating_sub(usize::from(WINDOW_HEIGHT));
         let start = std::time::Instant::now();
         for _ in 0..ITERS {
-            let _ = store.visible_lines_at(&messages, options, scroll, usize::from(WINDOW_HEIGHT));
+            let _ = store.visible_lines_at(&messages, options, &Theme::system(), scroll, usize::from(WINDOW_HEIGHT));
         }
         let ns = (start.elapsed().as_nanos() as f64) / f64::from(ITERS);
         groups

--- a/benches/tui_render.rs
+++ b/benches/tui_render.rs
@@ -79,6 +79,7 @@ fn visible_lines_first_render(b: Bencher, n: usize) {
         show_reasoning: true,
         dense: false,
         width: WIDTH,
+        muted_style: ratatui::style::Style::default(),
     };
     // Cold store per iter: each iter measures the no-cache path. `with_inputs`
     // builds the store outside the timed region.
@@ -95,6 +96,7 @@ fn visible_lines_cached_tail(b: Bencher, n: usize) {
         show_reasoning: true,
         dense: false,
         width: WIDTH,
+        muted_style: ratatui::style::Style::default(),
     };
     let mut store = ChatRenderStore::default();
     // Prime cache with one full render so subsequent iters hit warm paths.
@@ -125,6 +127,7 @@ fn main() {
             show_reasoning: true,
             dense: false,
             width: WIDTH,
+            muted_style: ratatui::style::Style::default(),
         };
 
         // first render — cold store per iter.

--- a/config.example.toml
+++ b/config.example.toml
@@ -67,3 +67,10 @@ enabled = false
 # api_key = "sk-..."
 model = "text-embedding-3-small"
 dim = 1536
+
+[tui]
+# Theme name. Built-ins:
+#   system          — inherit terminal palette (default)
+#   default-light   — Bauhaus cream/ink, the formalized current look
+#   dracula         — canonical dark palette
+theme = "system"

--- a/src/bin/tui-render-bench.rs
+++ b/src/bin/tui-render-bench.rs
@@ -3,6 +3,7 @@ use std::time::{Duration, Instant};
 use vulcan::tui::{
     chat_render::{ChatRenderOptions, ChatRenderStore},
     state::{ChatMessage, ChatRole},
+    theme::Theme,
 };
 
 const MESSAGE_COUNT: usize = 50_000;
@@ -99,7 +100,7 @@ fn measure_once(
 ) -> SingleRun {
     let before = store.render_count();
     let start = Instant::now();
-    let window = store.visible_lines_at(messages, options, scroll, usize::from(height));
+    let window = store.visible_lines_at(messages, options, &Theme::system(), scroll, usize::from(height));
     let elapsed = start.elapsed();
 
     SingleRun {

--- a/src/bin/tui-render-bench.rs
+++ b/src/bin/tui-render-bench.rs
@@ -17,6 +17,7 @@ fn main() {
         show_reasoning: true,
         dense: false,
         width: WIDTH,
+        muted_style: ratatui::style::Style::default(),
     };
     let mut store = ChatRenderStore::default();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,29 @@ pub struct Config {
 
     #[serde(default)]
     pub embeddings: EmbeddingsConfig,
+
+    #[serde(default)]
+    pub tui: TuiConfig,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct TuiConfig {
+    /// Selected theme name. Built-ins: "system" (default), "default-light",
+    /// "dracula". Unknown names log a warning and fall back to "system".
+    #[serde(default = "default_theme_name")]
+    pub theme: String,
+}
+
+fn default_theme_name() -> String {
+    "system".into()
+}
+
+impl Default for TuiConfig {
+    fn default() -> Self {
+        Self {
+            theme: default_theme_name(),
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -220,6 +243,7 @@ impl Default for Config {
             skills_dir: default_skills_dir(),
             compaction: CompactionConfig::default(),
             embeddings: EmbeddingsConfig::default(),
+            tui: TuiConfig::default(),
         }
     }
 }

--- a/src/tui/chat_render.rs
+++ b/src/tui/chat_render.rs
@@ -8,7 +8,7 @@ use ratatui::{
 use super::{
     markdown::render_markdown,
     state::{ChatMessage, ChatRole, MessageSegment},
-    theme::Palette,
+    theme::{Palette, Theme},
     widgets::{message_header, reasoning_lines, tool_card},
 };
 
@@ -55,18 +55,26 @@ impl ChatRenderStore {
         &mut self,
         messages: &[ChatMessage],
         options: ChatRenderOptions,
+        theme: &Theme,
         scroll: u16,
         height: u16,
         _pending_pause: Option<&crate::pause::AgentPause>,
         _queue_len: usize,
     ) -> VisibleChatLines {
-        self.visible_lines_at(messages, options, usize::from(scroll), usize::from(height))
+        self.visible_lines_at(
+            messages,
+            options,
+            theme,
+            usize::from(scroll),
+            usize::from(height),
+        )
     }
 
     pub fn visible_lines_at(
         &mut self,
         messages: &[ChatMessage],
         options: ChatRenderOptions,
+        theme: &Theme,
         scroll: usize,
         height: usize,
     ) -> VisibleChatLines {
@@ -80,7 +88,7 @@ impl ChatRenderStore {
         let mut materialized_line_count = 0usize;
 
         for (index, message) in messages.iter().enumerate() {
-            let block = self.render_message_block(index, message, options);
+            let block = self.render_message_block(index, message, options, theme);
             let block_start = total_lines;
             let block_end = block_start.saturating_add(block.lines.len());
             total_lines = block_end;
@@ -120,6 +128,7 @@ impl ChatRenderStore {
         index: usize,
         message: &ChatMessage,
         options: ChatRenderOptions,
+        theme: &Theme,
     ) -> &RenderedMessageBlock {
         let key = MessageRenderKey {
             index,
@@ -130,7 +139,7 @@ impl ChatRenderStore {
 
         if !self.blocks.contains_key(&key) {
             self.render_count = self.render_count.saturating_add(1);
-            let block = self.build_message_block(index, message, options);
+            let block = self.build_message_block(index, message, options, theme);
             self.blocks.insert(key, block);
         }
 
@@ -144,6 +153,7 @@ impl ChatRenderStore {
         _index: usize,
         message: &ChatMessage,
         options: ChatRenderOptions,
+        theme: &Theme,
     ) -> RenderedMessageBlock {
         let (role_label, accent) = match message.role {
             ChatRole::User => ("you", Palette::RED),
@@ -151,7 +161,7 @@ impl ChatRenderStore {
             ChatRole::System => ("system", Palette::YELLOW),
         };
         let is_agent = matches!(message.role, ChatRole::Agent);
-        let mut lines = vec![message_header(role_label, accent, None)];
+        let mut lines = vec![message_header(role_label, accent, None, theme)];
 
         if is_agent && !message.segments.is_empty() {
             let mut text_emitted = false;
@@ -160,7 +170,7 @@ impl ChatRenderStore {
                     MessageSegment::Reasoning(reasoning)
                         if options.show_reasoning && !reasoning.is_empty() =>
                     {
-                        lines.extend(reasoning_lines(reasoning, false));
+                        lines.extend(reasoning_lines(reasoning, false, theme));
                     }
                     MessageSegment::Reasoning(_) => {}
                     MessageSegment::ToolCall {
@@ -186,7 +196,7 @@ impl ChatRenderStore {
                     }
                     MessageSegment::Text(text) if !text.is_empty() => {
                         text_emitted = true;
-                        push_markdown_body(&mut lines, text, accent);
+                        push_markdown_body(&mut lines, text, accent, theme);
                     }
                     MessageSegment::Text(_) => {}
                 }
@@ -200,7 +210,7 @@ impl ChatRenderStore {
             }
         } else {
             if options.show_reasoning && is_agent && !message.reasoning.is_empty() {
-                lines.extend(reasoning_lines(&message.reasoning, false));
+                lines.extend(reasoning_lines(&message.reasoning, false, theme));
             }
             if is_agent && message.content.is_empty() {
                 lines.push(agent_placeholder(
@@ -208,7 +218,7 @@ impl ChatRenderStore {
                     options.muted_style,
                 ));
             } else {
-                push_markdown_body(&mut lines, &message.content, accent);
+                push_markdown_body(&mut lines, &message.content, accent, theme);
             }
         }
 
@@ -238,8 +248,13 @@ impl ChatRenderStore {
     }
 }
 
-fn push_markdown_body(lines: &mut Vec<Line<'static>>, text: &str, accent: ratatui::style::Color) {
-    for line in render_markdown(text) {
+fn push_markdown_body(
+    lines: &mut Vec<Line<'static>>,
+    text: &str,
+    accent: ratatui::style::Color,
+    theme: &Theme,
+) {
+    for line in render_markdown(text, theme) {
         let mut spans = vec![Span::styled("▎ ", Style::default().fg(accent))];
         spans.extend(line.spans.into_iter());
         lines.push(Line::from(spans));
@@ -277,7 +292,8 @@ mod tests {
             muted_style: Style::default(),
         };
 
-        let window = store.visible_lines(&messages, options, 10, 5, None, 0);
+        let theme = Theme::system();
+        let window = store.visible_lines(&messages, options, &theme, 10, 5, None, 0);
         assert_eq!(window.lines.len(), 5);
         assert!(window.total_lines > 5);
     }
@@ -294,12 +310,13 @@ mod tests {
             muted_style: Style::default(),
         };
         let narrow = ChatRenderOptions { width: 20, ..wide };
+        let theme = Theme::system();
 
-        let _ = store.visible_lines(&messages, wide, 0, 10, None, 0);
+        let _ = store.visible_lines(&messages, wide, &theme, 0, 10, None, 0);
         let renders_after_wide = store.render_count_for_tests();
-        let _ = store.visible_lines(&messages, wide, 0, 10, None, 0);
+        let _ = store.visible_lines(&messages, wide, &theme, 0, 10, None, 0);
         assert_eq!(store.render_count_for_tests(), renders_after_wide);
-        let _ = store.visible_lines(&messages, narrow, 0, 10, None, 0);
+        let _ = store.visible_lines(&messages, narrow, &theme, 0, 10, None, 0);
         assert!(store.render_count_for_tests() > renders_after_wide);
     }
 
@@ -316,7 +333,8 @@ mod tests {
             muted_style: Style::default(),
         };
 
-        let window = store.visible_lines(&messages, options, 90, 3, None, 0);
+        let theme = Theme::system();
+        let window = store.visible_lines(&messages, options, &theme, 90, 3, None, 0);
 
         assert_eq!(window.lines.len(), 3);
         assert!(window.total_lines > window.lines.len());
@@ -336,7 +354,8 @@ mod tests {
             muted_style: Style::default(),
         };
 
-        let window = store.visible_lines(&messages, options, 4_900, 20, None, 0);
+        let theme = Theme::system();
+        let window = store.visible_lines(&messages, options, &theme, 4_900, 20, None, 0);
 
         assert_eq!(window.lines.len(), 20);
         assert!(window.total_lines > 5_000);
@@ -355,10 +374,11 @@ mod tests {
             width: 100,
             muted_style: Style::default(),
         };
-        let first = store.visible_lines_at(&messages, options, 0, 20);
+        let theme = Theme::system();
+        let first = store.visible_lines_at(&messages, options, &theme, 0, 20);
         let tail_scroll = first.total_lines.saturating_sub(20);
 
-        let window = store.visible_lines_at(&messages, options, tail_scroll, 20);
+        let window = store.visible_lines_at(&messages, options, &theme, tail_scroll, 20);
         let text = window
             .lines
             .iter()
@@ -390,11 +410,12 @@ mod tests {
             muted_style: Style::default(),
         };
 
-        let _ = store.visible_lines(&messages, options, 0, 20, None, 0);
+        let theme = Theme::system();
+        let _ = store.visible_lines(&messages, options, &theme, 0, 20, None, 0);
         let first_count = store.render_count_for_tests();
 
         messages[1].append_text("hello");
-        let _ = store.visible_lines(&messages, options, 0, 20, None, 0);
+        let _ = store.visible_lines(&messages, options, &theme, 0, 20, None, 0);
 
         assert_eq!(store.render_count_for_tests(), first_count + 1);
     }
@@ -409,8 +430,9 @@ mod tests {
             width: 80,
             muted_style: Style::default(),
         };
+        let theme = Theme::system();
 
-        let block = store.render_message_block(0, &message, options);
+        let block = store.render_message_block(0, &message, options, &theme);
         let rendered = block
             .lines
             .iter()
@@ -449,8 +471,9 @@ mod tests {
             width: 80,
             muted_style: Style::default(),
         };
+        let theme = Theme::system();
 
-        let block = store.render_message_block(0, &message, options);
+        let block = store.render_message_block(0, &message, options, &theme);
         let rendered = block
             .lines
             .iter()

--- a/src/tui/chat_render.rs
+++ b/src/tui/chat_render.rs
@@ -17,6 +17,11 @@ pub struct ChatRenderOptions {
     pub show_reasoning: bool,
     pub dense: bool,
     pub width: u16,
+    /// Style for the agent "Thinking…"/"Answering…" placeholder. Caller
+    /// populates from `state.theme.muted` so the placeholder respects
+    /// the active theme. Default `Style::default()` is a safe fallback
+    /// for tests that don't care about styling.
+    pub muted_style: Style,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -188,14 +193,20 @@ impl ChatRenderStore {
             }
 
             if !text_emitted {
-                lines.push(agent_placeholder(message.has_reasoning()));
+                lines.push(agent_placeholder(
+                    message.has_reasoning(),
+                    options.muted_style,
+                ));
             }
         } else {
             if options.show_reasoning && is_agent && !message.reasoning.is_empty() {
                 lines.extend(reasoning_lines(&message.reasoning, false));
             }
             if is_agent && message.content.is_empty() {
-                lines.push(agent_placeholder(!message.reasoning.is_empty()));
+                lines.push(agent_placeholder(
+                    !message.reasoning.is_empty(),
+                    options.muted_style,
+                ));
             } else {
                 push_markdown_body(&mut lines, &message.content, accent);
             }
@@ -235,7 +246,7 @@ fn push_markdown_body(lines: &mut Vec<Line<'static>>, text: &str, accent: ratatu
     }
 }
 
-fn agent_placeholder(has_reasoning: bool) -> Line<'static> {
+fn agent_placeholder(has_reasoning: bool, muted: Style) -> Line<'static> {
     let label = if has_reasoning {
         "▎ Answering…"
     } else {
@@ -243,9 +254,7 @@ fn agent_placeholder(has_reasoning: bool) -> Line<'static> {
     };
     Line::from(Span::styled(
         label,
-        Style::default()
-            .fg(Palette::MUTED)
-            .add_modifier(Modifier::SLOW_BLINK),
+        muted.add_modifier(Modifier::SLOW_BLINK),
     ))
 }
 
@@ -265,6 +274,7 @@ mod tests {
             show_reasoning: true,
             dense: false,
             width: 80,
+            muted_style: Style::default(),
         };
 
         let window = store.visible_lines(&messages, options, 10, 5, None, 0);
@@ -281,6 +291,7 @@ mod tests {
             show_reasoning: true,
             dense: false,
             width: 80,
+            muted_style: Style::default(),
         };
         let narrow = ChatRenderOptions { width: 20, ..wide };
 
@@ -302,6 +313,7 @@ mod tests {
             show_reasoning: true,
             dense: false,
             width: 80,
+            muted_style: Style::default(),
         };
 
         let window = store.visible_lines(&messages, options, 90, 3, None, 0);
@@ -321,6 +333,7 @@ mod tests {
             show_reasoning: true,
             dense: false,
             width: 100,
+            muted_style: Style::default(),
         };
 
         let window = store.visible_lines(&messages, options, 4_900, 20, None, 0);
@@ -340,6 +353,7 @@ mod tests {
             show_reasoning: true,
             dense: false,
             width: 100,
+            muted_style: Style::default(),
         };
         let first = store.visible_lines_at(&messages, options, 0, 20);
         let tail_scroll = first.total_lines.saturating_sub(20);
@@ -373,6 +387,7 @@ mod tests {
             show_reasoning: true,
             dense: false,
             width: 80,
+            muted_style: Style::default(),
         };
 
         let _ = store.visible_lines(&messages, options, 0, 20, None, 0);
@@ -392,6 +407,7 @@ mod tests {
             show_reasoning: true,
             dense: true,
             width: 80,
+            muted_style: Style::default(),
         };
 
         let block = store.render_message_block(0, &message, options);
@@ -431,6 +447,7 @@ mod tests {
             show_reasoning: true,
             dense: true,
             width: 80,
+            muted_style: Style::default(),
         };
 
         let block = store.render_message_block(0, &message, options);

--- a/src/tui/markdown.rs
+++ b/src/tui/markdown.rs
@@ -1,25 +1,11 @@
 use ratatui::{
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
 };
 
-use super::theme::Palette;
+use super::theme::Theme;
 
-struct MdTheme;
-
-impl MdTheme {
-    const HEADING: Color = Color::Rgb(0xD6, 0x3B, 0x2F); // red accent
-    const ITALIC: Color = Color::Rgb(0x2B, 0x4F, 0xA8); // blue accent
-    const CODE: Color = Color::Rgb(0xE8, 0xB4, 0x3C); // yellow accent
-    const LINK: Color = Color::Rgb(0x2B, 0x4F, 0xA8);
-    const STRIKE: Color = Palette::MUTED;
-    const QUOTE: Color = Palette::MUTED;
-    const LIST_BULLET: Color = Color::Rgb(0xD6, 0x3B, 0x2F);
-    const HR: Color = Palette::MUTED;
-    const CODE_BLOCK_BG: Color = Color::Rgb(0x22, 0x20, 0x1B);
-}
-
-pub fn render_markdown(text: &str) -> Vec<Line<'static>> {
+pub fn render_markdown(text: &str, theme: &Theme) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
     let mut in_code_block = false;
     let mut code_block_content: Vec<String> = Vec::new();
@@ -27,7 +13,7 @@ pub fn render_markdown(text: &str) -> Vec<Line<'static>> {
     for raw_line in text.lines() {
         if raw_line.trim_start().starts_with("```") {
             if in_code_block {
-                let block_lines = render_code_block(&code_block_content);
+                let block_lines = render_code_block(&code_block_content, theme);
                 lines.extend(block_lines);
                 code_block_content.clear();
                 in_code_block = false;
@@ -52,7 +38,15 @@ pub fn render_markdown(text: &str) -> Vec<Line<'static>> {
 
         if let Some(level) = heading_level(line) {
             let content = line.trim_start_matches('#').trim();
-            let spans = parse_inline(content);
+            let spans = parse_inline(content, theme);
+            let heading_style = match level {
+                1 => theme.heading_1,
+                2 => theme.heading_2,
+                3 => theme.heading_3,
+                4 => theme.heading_4,
+                5 => theme.heading_5,
+                _ => theme.heading_6,
+            };
             let mut styled = vec![Span::styled(
                 match level {
                     1 => "# ",
@@ -62,9 +56,7 @@ pub fn render_markdown(text: &str) -> Vec<Line<'static>> {
                     5 => "##### ",
                     _ => "###### ",
                 },
-                Style::default()
-                    .fg(MdTheme::HEADING)
-                    .add_modifier(Modifier::BOLD),
+                heading_style,
             )];
             styled.extend(spans);
             lines.push(Line::from(styled));
@@ -72,35 +64,26 @@ pub fn render_markdown(text: &str) -> Vec<Line<'static>> {
         }
 
         if let Some(content) = line.strip_prefix("> ") {
-            let mut spans = vec![Span::styled("▎ ", Style::default().fg(MdTheme::QUOTE))];
-            spans.extend(parse_inline(content));
-            lines.push(Line::from(spans).style(Style::default().fg(MdTheme::QUOTE)));
+            let mut spans = vec![Span::styled("▎ ", theme.blockquote)];
+            spans.extend(parse_inline(content, theme));
+            lines.push(Line::from(spans).style(theme.blockquote));
             continue;
         }
         if line == ">" {
-            lines.push(Line::from(Span::styled(
-                "▎",
-                Style::default().fg(MdTheme::QUOTE),
-            )));
+            lines.push(Line::from(Span::styled("▎", theme.blockquote)));
             continue;
         }
 
         if let Some(content) = line.strip_prefix("- ").or_else(|| line.strip_prefix("* ")) {
-            let mut spans = vec![Span::styled(
-                "• ",
-                Style::default().fg(MdTheme::LIST_BULLET),
-            )];
-            spans.extend(parse_inline(content));
+            let mut spans = vec![Span::styled("• ", theme.list_marker)];
+            spans.extend(parse_inline(content, theme));
             lines.push(Line::from(spans));
             continue;
         }
 
         if let Some((num_str, content)) = strip_ordered_list_prefix(line) {
-            let mut spans = vec![Span::styled(
-                format!("{}. ", num_str),
-                Style::default().fg(MdTheme::LIST_BULLET),
-            )];
-            spans.extend(parse_inline(content));
+            let mut spans = vec![Span::styled(format!("{}. ", num_str), theme.list_marker)];
+            spans.extend(parse_inline(content, theme));
             lines.push(Line::from(spans));
             continue;
         }
@@ -109,16 +92,16 @@ pub fn render_markdown(text: &str) -> Vec<Line<'static>> {
         if trimmed == "---" || trimmed == "***" || trimmed == "___" {
             lines.push(Line::from(Span::styled(
                 "─".repeat(50),
-                Style::default().fg(MdTheme::HR).add_modifier(Modifier::DIM),
+                theme.muted.add_modifier(Modifier::DIM),
             )));
             continue;
         }
 
-        lines.push(Line::from(parse_inline(line)));
+        lines.push(Line::from(parse_inline(line, theme)));
     }
 
     if in_code_block {
-        let block_lines = render_code_block(&code_block_content);
+        let block_lines = render_code_block(&code_block_content, theme);
         lines.extend(block_lines);
     }
 
@@ -162,29 +145,25 @@ fn strip_ordered_list_prefix(line: &str) -> Option<(&str, &str)> {
     }
 }
 
-fn render_code_block(lines: &[String]) -> Vec<Line<'static>> {
+fn render_code_block(lines: &[String], theme: &Theme) -> Vec<Line<'static>> {
     let mut result = Vec::new();
     if lines.is_empty() {
         result.push(Line::from(Span::styled(
             " ```",
-            Style::default()
-                .fg(MdTheme::CODE)
-                .add_modifier(Modifier::DIM),
+            theme.code_block.add_modifier(Modifier::DIM),
         )));
         return result;
     }
     for line in lines {
         result.push(Line::from(Span::styled(
             format!(" │{}", line),
-            Style::default()
-                .fg(MdTheme::CODE)
-                .bg(MdTheme::CODE_BLOCK_BG),
+            theme.code_block,
         )));
     }
     result
 }
 
-fn parse_inline(text: &str) -> Vec<Span<'static>> {
+fn parse_inline(text: &str, theme: &Theme) -> Vec<Span<'static>> {
     let mut spans: Vec<Span<'static>> = Vec::new();
     let chars: Vec<char> = text.chars().collect();
     let len = chars.len();
@@ -201,12 +180,7 @@ fn parse_inline(text: &str) -> Vec<Span<'static>> {
             let start = i + 1;
             if let Some(end) = chars[start..].iter().position(|&c| c == '`') {
                 let code: String = chars[start..start + end].iter().collect();
-                spans.push(Span::styled(
-                    code,
-                    Style::default()
-                        .fg(MdTheme::CODE)
-                        .bg(MdTheme::CODE_BLOCK_BG),
-                ));
+                spans.push(Span::styled(code, theme.inline_code));
                 i = start + end + 1;
                 continue;
             }
@@ -216,7 +190,7 @@ fn parse_inline(text: &str) -> Vec<Span<'static>> {
             let start = i + 2;
             if let Some(end) = chars[start..].windows(2).position(|w| w == ['*', '*']) {
                 let inner: String = chars[start..start + end].iter().collect();
-                let inner_spans = parse_inline(&inner);
+                let inner_spans = parse_inline(&inner, theme);
                 let styled: Vec<Span> = inner_spans
                     .into_iter()
                     .map(|s| {
@@ -236,9 +210,7 @@ fn parse_inline(text: &str) -> Vec<Span<'static>> {
                 let inner: String = chars[start..start + end].iter().collect();
                 spans.push(Span::styled(
                     inner,
-                    Style::default()
-                        .fg(MdTheme::ITALIC)
-                        .add_modifier(Modifier::ITALIC),
+                    Style::default().add_modifier(Modifier::ITALIC),
                 ));
                 i = start + end + 1;
                 continue;
@@ -249,12 +221,7 @@ fn parse_inline(text: &str) -> Vec<Span<'static>> {
             let start = i + 2;
             if let Some(end) = chars[start..].windows(2).position(|w| w == ['~', '~']) {
                 let inner: String = chars[start..start + end].iter().collect();
-                spans.push(Span::styled(
-                    inner,
-                    Style::default()
-                        .fg(MdTheme::STRIKE)
-                        .add_modifier(Modifier::CROSSED_OUT),
-                ));
+                spans.push(Span::styled(inner, theme.strikethrough));
                 i = start + end + 2;
                 continue;
             }
@@ -268,17 +235,10 @@ fn parse_inline(text: &str) -> Vec<Span<'static>> {
                 if after_close < len && chars[after_close] == '(' {
                     let url_start = after_close + 1;
                     if let Some(close_paren) = chars[url_start..].iter().position(|&c| c == ')') {
-                        let inner_spans = parse_inline(&text_inner);
+                        let inner_spans = parse_inline(&text_inner, theme);
                         let styled: Vec<Span> = inner_spans
                             .into_iter()
-                            .map(|s| {
-                                Span::styled(
-                                    s.content.clone(),
-                                    Style::default()
-                                        .fg(MdTheme::LINK)
-                                        .add_modifier(Modifier::UNDERLINED),
-                                )
-                            })
+                            .map(|s| Span::styled(s.content.clone(), theme.link))
                             .collect();
                         spans.extend(styled);
                         i = url_start + close_paren + 1;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -543,7 +543,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
             }
 
             if let (Some(pal), Some(area)) = (palette.as_ref(), palette_area) {
-                draw_palette(f, area, pal, app.slash_menu_selection);
+                draw_palette(f, area, pal, app.slash_menu_selection, &app.theme);
             }
 
             // YYC-86: session picker overlay (--resume flag).
@@ -1187,7 +1187,13 @@ mod tests {
     }
 }
 
-fn draw_palette(f: &mut ratatui::Frame, area: Rect, cmds: &[&SlashCommand], selected: usize) {
+fn draw_palette(
+    f: &mut ratatui::Frame,
+    area: Rect,
+    cmds: &[&SlashCommand],
+    selected: usize,
+    theme: &Theme,
+) {
     if area.height == 0 {
         return;
     }
@@ -1203,12 +1209,7 @@ fn draw_palette(f: &mut ratatui::Frame, area: Rect, cmds: &[&SlashCommand], sele
         header_text.push_str(&" ".repeat(bar.width as usize - header_text.chars().count()));
     }
     f.render_widget(
-        Paragraph::new(header_text).style(
-            Style::default()
-                .fg(Palette::PAPER)
-                .bg(Palette::INK)
-                .add_modifier(Modifier::BOLD),
-        ),
+        Paragraph::new(header_text).style(theme.accent.add_modifier(Modifier::BOLD)),
         bar,
     );
     let inner = Rect {
@@ -1221,29 +1222,28 @@ fn draw_palette(f: &mut ratatui::Frame, area: Rect, cmds: &[&SlashCommand], sele
     if cmds.is_empty() {
         lines.push(Line::from(Span::styled(
             "  No matching commands",
-            Style::default().fg(Palette::MUTED),
+            theme.muted,
         )));
     } else {
         let active = selected.min(cmds.len().saturating_sub(1));
         for (i, cmd) in cmds.iter().enumerate() {
             let is_active = i == active;
-            // YYC-70: highlight the active row with inverted accent.
+            // YYC-70: highlight the active row by swapping fg/bg of accent
+            // (gives a visible selection bar regardless of active theme).
             let (prefix, name_style, desc_style) = if is_active {
+                let active_fg = theme.accent.bg.unwrap_or(theme.body_bg);
+                let active_bg = theme.accent.fg.unwrap_or(theme.body_fg);
+                let active_style = Style::default().fg(active_fg).bg(active_bg);
                 (
                     "▸ ",
-                    Style::default()
-                        .fg(Palette::PAPER)
-                        .bg(Palette::RED)
-                        .add_modifier(Modifier::BOLD),
-                    Style::default().fg(Palette::PAPER).bg(Palette::RED),
+                    active_style.add_modifier(Modifier::BOLD),
+                    active_style,
                 )
             } else {
                 (
                     "  ",
-                    Style::default()
-                        .fg(Palette::RED)
-                        .add_modifier(Modifier::BOLD),
-                    Style::default().fg(Palette::INK),
+                    theme.accent.add_modifier(Modifier::BOLD),
+                    theme.assistant,
                 )
             };
             lines.push(Line::from(vec![
@@ -1256,6 +1256,7 @@ fn draw_palette(f: &mut ratatui::Frame, area: Rect, cmds: &[&SlashCommand], sele
 }
 
 fn draw_session_picker(f: &mut ratatui::Frame, area: Rect, app: &AppState) {
+    let theme = &app.theme;
     let width = area.width.min(56);
     let height = (app.sessions.len() as u16 + 6).min(area.height.saturating_sub(2));
     let x = area.x + (area.width.saturating_sub(width)) / 2;
@@ -1271,10 +1272,10 @@ fn draw_session_picker(f: &mut ratatui::Frame, area: Rect, app: &AppState) {
         return;
     }
 
-    // Fill the box with solid paper background to obscure the view behind.
+    // Fill the box with solid theme-bg to obscure the view behind.
     let fill_bg = rect_with_border(box_area, 0);
     f.render_widget(
-        Paragraph::new(Line::from("")).style(Style::default().bg(Palette::PAPER)),
+        Paragraph::new(Line::from("")).style(Style::default().bg(theme.body_bg)),
         fill_bg,
     );
 
@@ -1296,12 +1297,7 @@ fn draw_session_picker(f: &mut ratatui::Frame, area: Rect, app: &AppState) {
         );
     }
     f.render_widget(
-        Paragraph::new(title).style(
-            Style::default()
-                .fg(Palette::PAPER)
-                .bg(Palette::INK)
-                .add_modifier(Modifier::BOLD),
-        ),
+        Paragraph::new(title).style(theme.accent.add_modifier(Modifier::BOLD)),
         bar,
     );
 
@@ -1317,11 +1313,11 @@ fn draw_session_picker(f: &mut ratatui::Frame, area: Rect, app: &AppState) {
     if app.sessions.is_empty() {
         lines.push(Line::from(Span::styled(
             "  No saved sessions found.",
-            Style::default().fg(Palette::MUTED),
+            theme.muted,
         )));
         lines.push(Line::from(Span::styled(
             "  Start a conversation and sessions will appear here.",
-            Style::default().fg(Palette::FAINT),
+            theme.muted,
         )));
     } else {
         let active = app
@@ -1329,15 +1325,17 @@ fn draw_session_picker(f: &mut ratatui::Frame, area: Rect, app: &AppState) {
             .min(app.sessions.len().saturating_sub(1));
         for (i, s) in app.sessions.iter().enumerate() {
             let is_active = i == active;
+            // YYC-52: active rows get a subtle highlight bg via FAINT;
+            // inactive rows sit on the theme body bg.
             let bg = if is_active {
                 Palette::FAINT
             } else {
-                Palette::PAPER
+                theme.body_bg
             };
             let marker = if is_active { "▸ " } else { "  " };
-            let status_color = match s.status {
-                SessionStatus::Live => Palette::GREEN,
-                SessionStatus::Saved => Palette::BLUE,
+            let status_style = match s.status {
+                SessionStatus::Live => theme.success,
+                SessionStatus::Saved => theme.system,
             };
             let status_label = match s.status {
                 SessionStatus::Live => "LIVE",
@@ -1354,46 +1352,42 @@ fn draw_session_picker(f: &mut ratatui::Frame, area: Rect, app: &AppState) {
                 .unwrap_or_default();
 
             let name_style = Style::default()
-                .fg(Palette::INK)
+                .fg(theme.body_fg)
                 .bg(bg)
                 .add_modifier(if is_active {
                     Modifier::BOLD
                 } else {
                     Modifier::empty()
                 });
-            let meta_style = Style::default().fg(Palette::MUTED).bg(bg);
+            let meta_style = theme.muted.bg(bg);
 
             lines.push(Line::from(vec![
                 Span::styled(marker, name_style.add_modifier(Modifier::BOLD)),
-                Span::styled("█ ", Style::default().fg(status_color).bg(bg)),
+                Span::styled("█ ", status_style.bg(bg)),
                 Span::styled(format!("{:<12}", short_id(&s.id)), name_style.clone()),
                 Span::styled(format!("{:>4}m", s.message_count), meta_style),
                 Span::styled(
                     format!("  {} ", dt),
-                    Style::default().fg(Palette::FAINT).bg(bg),
+                    theme.muted.bg(bg),
                 ),
                 Span::styled(
                     status_label,
-                    Style::default()
-                        .fg(status_color)
-                        .bg(bg)
-                        .add_modifier(Modifier::BOLD),
+                    status_style.bg(bg).add_modifier(Modifier::BOLD),
                 ),
             ]));
 
             // Preview synopsis from first user message, if available.
             if let Some(preview) = &s.preview {
                 lines.push(Line::from(vec![
+                    // Invisible spacer — fg=bg so the marker column stays
+                    // blank but the row keeps its background fill.
                     Span::styled(
                         if is_active { "▸ " } else { "  " },
                         Style::default().fg(bg).bg(bg),
                     ),
                     Span::styled(
                         format!("  {}", preview),
-                        Style::default()
-                            .fg(Palette::MUTED)
-                            .bg(bg)
-                            .add_modifier(Modifier::DIM),
+                        theme.muted.bg(bg).add_modifier(Modifier::DIM),
                     ),
                 ]));
             }
@@ -1403,18 +1397,15 @@ fn draw_session_picker(f: &mut ratatui::Frame, area: Rect, app: &AppState) {
     // Footer hint
     let hint = "  ↑↓ navigate · Enter select · Esc cancel  ";
     lines.push(Line::from(""));
-    lines.push(Line::from(Span::styled(
-        hint,
-        Style::default().fg(Palette::MUTED),
-    )));
+    lines.push(Line::from(Span::styled(hint, theme.muted)));
 
     f.render_widget(
-        Paragraph::new(lines).style(Style::default().bg(Palette::PAPER)),
+        Paragraph::new(lines).style(Style::default().bg(theme.body_bg)),
         list_area,
     );
 
     // Draw a border around the whole thing
-    draw_picker_border(f, box_area);
+    draw_picker_border(f, box_area, theme);
 }
 
 /// Fill the interior of a bordered rect. `border_w` pixels from each edge.
@@ -1428,8 +1419,8 @@ fn rect_with_border(r: Rect, border_w: u16) -> Rect {
 }
 
 /// Simple border drawn with box-drawing characters.
-fn draw_picker_border(f: &mut ratatui::Frame, r: Rect) {
-    let style = Style::default().fg(Palette::INK).bg(Palette::PAPER);
+fn draw_picker_border(f: &mut ratatui::Frame, r: Rect, theme: &Theme) {
+    let style = theme.border;
     // Top
     if r.height > 0 {
         let top = "─".repeat(r.width as usize);

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -28,7 +28,7 @@ pub mod views;
 pub mod widgets;
 
 use state::{AppState, ChatMessage, ChatRole, SessionStatus};
-use theme::{Palette, body};
+use theme::{Palette, Theme, body};
 use views::{View, render_view};
 
 const STREAM_FRAME_BUDGET: Duration = Duration::from_millis(16);
@@ -425,7 +425,8 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
     let mut app = AppState::new(
         config.provider.model.clone(),
         config.provider.max_context as u32,
-    );
+    )
+    .with_theme(Theme::from_name(&config.tui.theme));
     app.audit_log = Some(audit_buf);
     // YYC-66: clone the agent's diff sink so the TUI can render real edits.
     // YYC-67: pull catalog pricing for the cost estimate.

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -22,7 +22,7 @@ use ratatui::style::Color;
 use crate::hooks::audit::{AuditBuffer, AuditKind};
 use crate::memory::SessionSummary;
 
-use super::theme::Palette;
+use super::theme::{Palette, Theme};
 use super::views::{DiffKind, DiffLine, View};
 
 /// Diff render style (YYC-77). Toggled by `/diff-style`.
@@ -511,6 +511,12 @@ pub struct AppState {
     pub show_session_picker: bool,
     /// Index into `sessions` for the highlighted row in the picker.
     pub session_picker_selection: usize,
+
+    /// Active TUI theme — render code reads role styles via `state.theme.<role>`.
+    /// Defaults to `Theme::system()` in `AppState::new` so unconfigured/test
+    /// callers inherit terminal palette; production wires the real config-derived
+    /// theme via `.with_theme(...)` post-construction.
+    pub theme: Theme,
 }
 
 impl AppState {
@@ -554,7 +560,16 @@ impl AppState {
 
             show_session_picker: false,
             session_picker_selection: 0,
+
+            theme: Theme::system(),
         }
+    }
+
+    /// Replace the active theme. Used by the TUI entrypoint to swap the
+    /// default `Theme::system()` for the user's configured theme.
+    pub fn with_theme(mut self, theme: Theme) -> Self {
+        self.theme = theme;
+        self
     }
 
     /// Snapshot the most recent N rows of the audit buffer for the

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -245,3 +245,33 @@ mod theme_tests {
         assert_eq!(unknown.body_bg, system.body_bg);
     }
 }
+
+#[cfg(test)]
+mod theme_swap_tests {
+    use super::*;
+
+    // Pin the property that dracula and default-light differ on roles where
+    // a swap should be visible. If a future palette change accidentally
+    // aligns them, this test forces the change-author to acknowledge it.
+
+    #[test]
+    fn dracula_assistant_differs_from_default_light() {
+        let light = Theme::default_light();
+        let drac = Theme::dracula();
+        assert_ne!(light.assistant, drac.assistant);
+    }
+
+    #[test]
+    fn dracula_code_block_differs_from_default_light() {
+        let light = Theme::default_light();
+        let drac = Theme::dracula();
+        assert_ne!(light.code_block, drac.code_block);
+    }
+
+    #[test]
+    fn system_assistant_inherits_terminal_fg() {
+        // system theme must not paint over the terminal's default text color.
+        let t = Theme::system();
+        assert_eq!(t.assistant.fg, None);
+    }
+}

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -38,3 +38,35 @@ pub fn muted() -> Style {
 pub fn faint_bg() -> Style {
     Style::default().fg(Palette::INK).bg(Palette::FAINT)
 }
+
+#[cfg(test)]
+mod theme_tests {
+    use super::*;
+
+    #[test]
+    fn from_name_system_returns_reset_bg() {
+        let t = Theme::from_name("system");
+        // system theme inherits terminal: body bg should be Reset.
+        assert_eq!(t.body_bg, Color::Reset);
+    }
+
+    #[test]
+    fn from_name_default_light_returns_paper_bg() {
+        let t = Theme::from_name("default-light");
+        // default-light formalizes today's Bauhaus palette.
+        assert_eq!(t.body_bg, Palette::PAPER);
+    }
+
+    #[test]
+    fn from_name_dracula_returns_dracula_bg() {
+        let t = Theme::from_name("dracula");
+        assert_eq!(t.body_bg, Color::Rgb(0x28, 0x2a, 0x36));
+    }
+
+    #[test]
+    fn from_name_unknown_falls_back_to_system() {
+        let unknown = Theme::from_name("nonexistent-theme");
+        let system = Theme::from_name("system");
+        assert_eq!(unknown.body_bg, system.body_bg);
+    }
+}

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -1,4 +1,4 @@
-use ratatui::style::{Color, Style};
+use ratatui::style::{Color, Modifier, Style};
 
 /// Bauhaus / brutalist palette — cream paper, ink black, primary accents.
 /// Matches the Rust AI agent TUI design (`Rust AI agent TUI.html`).
@@ -37,6 +37,181 @@ pub fn muted() -> Style {
 /// Faint backdrop — used for inactive rails and reasoning trace.
 pub fn faint_bg() -> Style {
     Style::default().fg(Palette::INK).bg(Palette::FAINT)
+}
+
+/// Centralized style table — one entry per theming role.
+///
+/// `body_bg`/`body_fg` are referenced by render code that needs the
+/// background color of the chat surface (card fills, inverse-region
+/// inverses) and aren't "roles" in the chat/markdown sense — but
+/// keeping them on `Theme` lets render code avoid reaching back into
+/// `Palette::*` constants when the active theme is non-Bauhaus.
+#[derive(Debug, Clone, Copy)]
+pub struct Theme {
+    // chat
+    pub user: Style,
+    pub assistant: Style,
+    pub system: Style,
+    pub tool_call: Style,
+    pub tool_result: Style,
+    pub error: Style,
+    pub success: Style,
+    pub muted: Style,
+    pub accent: Style,
+    pub border: Style,
+
+    // markdown
+    pub heading_1: Style,
+    pub heading_2: Style,
+    pub heading_3: Style,
+    pub heading_4: Style,
+    pub heading_5: Style,
+    pub heading_6: Style,
+    pub code_block: Style,
+    pub inline_code: Style,
+    pub link: Style,
+    pub blockquote: Style,
+    pub list_marker: Style,
+    pub strikethrough: Style,
+
+    // structural
+    pub body_bg: Color,
+    pub body_fg: Color,
+}
+
+impl Theme {
+    pub fn from_name(name: &str) -> Self {
+        match name {
+            "default-light" => Self::default_light(),
+            "dracula" => Self::dracula(),
+            "system" => Self::system(),
+            other => {
+                tracing::warn!(
+                    "unknown theme '{other}', falling back to 'system'"
+                );
+                Self::system()
+            }
+        }
+    }
+
+    /// Inherits the user's terminal palette: `Color::Reset` for unstyled
+    /// roles, ANSI-named slots (Cyan/Yellow/Red/etc.) for emphasis. Works
+    /// on every terminal; readable on light + dark schemes.
+    pub fn system() -> Self {
+        let plain = Style::default();
+        let bold = Style::default().add_modifier(Modifier::BOLD);
+        let italic = Style::default().add_modifier(Modifier::ITALIC);
+        Self {
+            user: plain,
+            assistant: plain,
+            system: Style::default().fg(Color::Cyan),
+            tool_call: Style::default().fg(Color::Yellow),
+            tool_result: Style::default().fg(Color::Green),
+            error: Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            success: Style::default().fg(Color::Green),
+            muted: Style::default().add_modifier(Modifier::DIM),
+            accent: Style::default().fg(Color::Magenta),
+            border: plain,
+
+            heading_1: bold,
+            heading_2: bold,
+            heading_3: bold,
+            heading_4: bold,
+            heading_5: bold,
+            heading_6: bold,
+            code_block: Style::default().fg(Color::White).bg(Color::Black),
+            inline_code: Style::default().fg(Color::Cyan),
+            link: Style::default().fg(Color::Blue).add_modifier(Modifier::UNDERLINED),
+            blockquote: italic,
+            list_marker: Style::default().fg(Color::Yellow),
+            strikethrough: Style::default().add_modifier(Modifier::CROSSED_OUT),
+
+            body_bg: Color::Reset,
+            body_fg: Color::Reset,
+        }
+    }
+
+    /// Bauhaus / brutalist palette — formalizes today's hardcoded look.
+    /// Cream paper, ink black, primary accents.
+    pub fn default_light() -> Self {
+        let body = Style::default().fg(Palette::INK).bg(Palette::PAPER);
+        let bold = body.add_modifier(Modifier::BOLD);
+        let italic = body.add_modifier(Modifier::ITALIC);
+        Self {
+            user: body,
+            assistant: body,
+            system: Style::default().fg(Palette::BLUE).bg(Palette::PAPER),
+            tool_call: Style::default().fg(Palette::YELLOW).bg(Palette::PAPER),
+            tool_result: Style::default().fg(Palette::GREEN).bg(Palette::PAPER),
+            error: Style::default().fg(Palette::RED).bg(Palette::PAPER).add_modifier(Modifier::BOLD),
+            success: Style::default().fg(Palette::GREEN).bg(Palette::PAPER),
+            muted: Style::default().fg(Palette::MUTED).bg(Palette::PAPER),
+            accent: Style::default().fg(Palette::RED).bg(Palette::PAPER),
+            border: Style::default().fg(Palette::INK).bg(Palette::PAPER),
+
+            heading_1: bold,
+            heading_2: bold,
+            heading_3: bold,
+            heading_4: bold,
+            heading_5: bold,
+            heading_6: bold,
+            code_block: Style::default().fg(Palette::INK).bg(Palette::FAINT),
+            inline_code: Style::default().fg(Palette::RED).bg(Palette::FAINT),
+            link: Style::default().fg(Palette::BLUE).bg(Palette::PAPER).add_modifier(Modifier::UNDERLINED),
+            blockquote: italic,
+            list_marker: Style::default().fg(Palette::BLUE).bg(Palette::PAPER),
+            strikethrough: body.add_modifier(Modifier::CROSSED_OUT),
+
+            body_bg: Palette::PAPER,
+            body_fg: Palette::INK,
+        }
+    }
+
+    /// Canonical Dracula palette — https://draculatheme.com/contribute
+    pub fn dracula() -> Self {
+        const BG: Color = Color::Rgb(0x28, 0x2a, 0x36);
+        const CURRENT_LINE: Color = Color::Rgb(0x44, 0x47, 0x5a);
+        const FG: Color = Color::Rgb(0xf8, 0xf8, 0xf2);
+        const COMMENT: Color = Color::Rgb(0x62, 0x72, 0xa4);
+        const CYAN: Color = Color::Rgb(0x8b, 0xe9, 0xfd);
+        const GREEN: Color = Color::Rgb(0x50, 0xfa, 0x7b);
+        const ORANGE: Color = Color::Rgb(0xff, 0xb8, 0x6c);
+        const PINK: Color = Color::Rgb(0xff, 0x79, 0xc6);
+        const PURPLE: Color = Color::Rgb(0xbd, 0x93, 0xf9);
+        const RED: Color = Color::Rgb(0xff, 0x55, 0x55);
+        const YELLOW: Color = Color::Rgb(0xf1, 0xfa, 0x8c);
+
+        let body = Style::default().fg(FG).bg(BG);
+        let bold_pink = Style::default().fg(PINK).bg(BG).add_modifier(Modifier::BOLD);
+        Self {
+            user: body,
+            assistant: body,
+            system: Style::default().fg(CYAN).bg(BG),
+            tool_call: Style::default().fg(YELLOW).bg(BG),
+            tool_result: Style::default().fg(GREEN).bg(BG),
+            error: Style::default().fg(RED).bg(BG).add_modifier(Modifier::BOLD),
+            success: Style::default().fg(GREEN).bg(BG),
+            muted: Style::default().fg(COMMENT).bg(BG),
+            accent: Style::default().fg(PURPLE).bg(BG),
+            border: Style::default().fg(COMMENT).bg(BG),
+
+            heading_1: bold_pink,
+            heading_2: bold_pink,
+            heading_3: bold_pink,
+            heading_4: bold_pink,
+            heading_5: bold_pink,
+            heading_6: bold_pink,
+            code_block: Style::default().fg(FG).bg(CURRENT_LINE),
+            inline_code: Style::default().fg(ORANGE).bg(CURRENT_LINE),
+            link: Style::default().fg(CYAN).bg(BG).add_modifier(Modifier::UNDERLINED),
+            blockquote: Style::default().fg(COMMENT).bg(BG).add_modifier(Modifier::ITALIC),
+            list_marker: Style::default().fg(PURPLE).bg(BG),
+            strikethrough: body.add_modifier(Modifier::CROSSED_OUT),
+
+            body_bg: BG,
+            body_fg: FG,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/tui/views.rs
+++ b/src/tui/views.rs
@@ -1,7 +1,7 @@
 use ratatui::{
     Frame as TuiFrame,
     layout::{Constraint, Direction, Layout, Rect},
-    style::{Modifier, Style},
+    style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Paragraph, Wrap},
 };
@@ -107,12 +107,14 @@ fn build_chat_window(
             show_reasoning,
             dense,
             width,
+            muted_style: app.theme.muted,
         };
         let message_scroll = window_start.saturating_sub(message_start) as u16;
         let remaining_height = height.saturating_sub(lines.len() as u16);
         let message_window = app.chat_render_store.borrow_mut().visible_lines(
             &app.messages,
             options,
+            &app.theme,
             message_scroll,
             remaining_height,
             app.pending_pause.as_ref(),
@@ -147,9 +149,7 @@ fn build_chat_prefix_lines(app: &AppState) -> Vec<Line<'static>> {
     let mut lines = vec![
         Line::from(Span::styled(
             format!("── session · {} ──", app.session_label),
-            Style::default()
-                .fg(Palette::MUTED)
-                .add_modifier(Modifier::DIM),
+            app.theme.muted.add_modifier(Modifier::DIM),
         )),
         Line::from(""),
     ];
@@ -157,7 +157,7 @@ fn build_chat_prefix_lines(app: &AppState) -> Vec<Line<'static>> {
     if app.messages.is_empty() {
         lines.push(Line::from(Span::styled(
             "Type a message below to start. Press Ctrl+1..5 to switch views.",
-            Style::default().fg(Palette::MUTED),
+            app.theme.muted,
         )));
     }
 
@@ -170,7 +170,7 @@ fn build_chat_suffix_lines(app: &AppState) -> Vec<Line<'static>> {
     if let Some(p) = app.pending_pause.as_ref() {
         if !p.options.is_empty() {
             let mut pill_spans: Vec<Span<'static>> = Vec::new();
-            pill_spans.push(Span::styled("▎ ", Style::default().fg(Palette::INK)));
+            pill_spans.push(Span::styled("▎ ", app.theme.user));
             for (i, opt) in p.options.iter().enumerate() {
                 if i > 0 {
                     pill_spans.push(Span::raw("  "));
@@ -192,25 +192,16 @@ fn build_chat_suffix_lines(app: &AppState) -> Vec<Line<'static>> {
     if !app.queue.is_empty() {
         lines.push(Line::from(Span::styled(
             format!("── queue · {} pending ──", app.queue.len()),
-            Style::default()
-                .fg(Palette::MUTED)
-                .add_modifier(Modifier::DIM),
+            app.theme.muted.add_modifier(Modifier::DIM),
         )));
         for (idx, qmsg) in app.queue.iter().enumerate() {
             let preview: String = qmsg.chars().take(120).collect();
             lines.push(Line::from(vec![
                 Span::styled(
                     format!("▸ #{:<2} ", idx + 1),
-                    Style::default()
-                        .fg(Palette::MUTED)
-                        .add_modifier(Modifier::DIM),
+                    app.theme.muted.add_modifier(Modifier::DIM),
                 ),
-                Span::styled(
-                    preview,
-                    Style::default()
-                        .fg(Palette::MUTED)
-                        .add_modifier(Modifier::DIM),
-                ),
+                Span::styled(preview, app.theme.muted.add_modifier(Modifier::DIM)),
             ]));
         }
         lines.push(Line::from(""));
@@ -253,6 +244,7 @@ fn single_stack(f: &mut TuiFrame, area: Rect, app: &AppState) {
         app.view.title(),
         Some("ses 1/1 · ●live"),
         None,
+        &app.theme,
     );
     let chat_w = inner.width.saturating_sub(2);
     let window = build_chat_window(app, app.show_reasoning, false, chat_w, inner.height);
@@ -278,6 +270,7 @@ fn single_stack(f: &mut TuiFrame, area: Rect, app: &AppState) {
         &app.model_status(),
         app.context_ratio(),
         app.thinking,
+        &app.theme,
     );
     app.cursor_set(cx, cy);
 }
@@ -285,7 +278,7 @@ fn single_stack(f: &mut TuiFrame, area: Rect, app: &AppState) {
 // ─── 02 SPLIT SESSIONS ──────────────────────────────────────────────────
 
 fn split_sessions(f: &mut TuiFrame, area: Rect, app: &AppState) {
-    let outer = frame(f, area, app.view.title(), Some("5 sess · 2 live"), None);
+    let outer = frame(f, area, app.view.title(), Some("5 sess · 2 live"), None, &app.theme);
     let v = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Min(5), Constraint::Length(3)])
@@ -328,12 +321,12 @@ fn split_sessions(f: &mut TuiFrame, area: Rect, app: &AppState) {
         .map(|s| s.message_count)
         .unwrap_or(app.messages.len());
     let header_text = format!(" {active_name}   · {lineage} · {turn_count} msgs",);
+    let accent_bar = Style::default()
+        .fg(app.theme.body_bg)
+        .bg(app.theme.accent.fg.unwrap_or(Color::Reset));
     let mut spans = vec![Span::styled(
         header_text,
-        Style::default()
-            .fg(Palette::PAPER)
-            .bg(Palette::RED)
-            .add_modifier(Modifier::BOLD),
+        accent_bar.add_modifier(Modifier::BOLD),
     )];
     let used = spans
         .iter()
@@ -342,16 +335,10 @@ fn split_sessions(f: &mut TuiFrame, area: Rect, app: &AppState) {
     let live_label = " ● LIVE ";
     if used + live_label.len() as u16 + 1 < main.width {
         let pad = " ".repeat((main.width - used - live_label.len() as u16) as usize);
-        spans.push(Span::styled(
-            pad,
-            Style::default().fg(Palette::PAPER).bg(Palette::RED),
-        ));
+        spans.push(Span::styled(pad, accent_bar));
         spans.push(Span::styled(
             live_label.to_string(),
-            Style::default()
-                .fg(Palette::PAPER)
-                .bg(Palette::RED)
-                .add_modifier(Modifier::BOLD),
+            accent_bar.add_modifier(Modifier::BOLD),
         ));
     }
     f.render_widget(Paragraph::new(Line::from(spans)), header);
@@ -387,6 +374,7 @@ fn split_sessions(f: &mut TuiFrame, area: Rect, app: &AppState) {
         &app.model_status(),
         app.context_ratio(),
         app.thinking,
+        &app.theme,
     );
     app.cursor_set(cx, cy);
 }
@@ -399,30 +387,28 @@ fn render_session_rail(f: &mut TuiFrame, area: Rect, app: &AppState) {
     if app.sessions.is_empty() {
         lines.push(Line::from(Span::styled(
             " No saved sessions yet.",
-            Style::default().fg(Palette::MUTED),
+            app.theme.muted,
         )));
         lines.push(Line::from(Span::styled(
             " The active session will appear after hydration.",
-            Style::default().fg(Palette::FAINT),
+            app.theme.muted.add_modifier(Modifier::DIM),
         )));
     }
+    let accent_fg = app.theme.accent.fg.unwrap_or(Color::Reset);
+    let muted_fg = app.theme.muted.fg.unwrap_or(Color::Reset);
     for s in &app.sessions {
-        let status_color = match s.status {
-            SessionStatus::Live => Palette::GREEN,
-            SessionStatus::Saved => Palette::BLUE,
+        let status_style = match s.status {
+            SessionStatus::Live => app.theme.success,
+            SessionStatus::Saved => app.theme.accent,
         };
         let bar = if s.is_active { "▌" } else { " " };
-        let bar_color = if s.is_active {
-            Palette::RED
-        } else {
-            Palette::FAINT
-        };
+        let bar_color = if s.is_active { accent_fg } else { muted_fg };
         let bg = if s.is_active {
             Palette::PAPER
         } else {
             Palette::FAINT
         };
-        let style = Style::default().fg(Palette::INK).bg(bg);
+        let row_style = app.theme.assistant.bg(bg);
         lines.push(Line::from(vec![
             Span::styled(
                 bar,
@@ -431,8 +417,8 @@ fn render_session_rail(f: &mut TuiFrame, area: Rect, app: &AppState) {
                     .bg(bg)
                     .add_modifier(Modifier::BOLD),
             ),
-            Span::styled(" █ ", Style::default().fg(status_color).bg(bg)),
-            Span::styled(s.label.clone(), style.add_modifier(Modifier::BOLD)),
+            Span::styled(" █ ", status_style.bg(bg)),
+            Span::styled(s.label.clone(), row_style.add_modifier(Modifier::BOLD)),
         ]));
         lines.push(Line::from(vec![
             Span::styled(bar, Style::default().fg(bar_color).bg(bg)),
@@ -442,7 +428,7 @@ fn render_session_rail(f: &mut TuiFrame, area: Rect, app: &AppState) {
                     s.status.label().to_uppercase(),
                     s.message_count
                 ),
-                Style::default().fg(Palette::MUTED).bg(bg),
+                app.theme.muted.bg(bg),
             ),
         ]));
         if let Some(lineage) = &s.lineage_label {
@@ -450,7 +436,7 @@ fn render_session_rail(f: &mut TuiFrame, area: Rect, app: &AppState) {
                 Span::styled(bar, Style::default().fg(bar_color).bg(bg)),
                 Span::styled(
                     format!(" {}", lineage),
-                    Style::default().fg(Palette::FAINT).bg(bg),
+                    app.theme.muted.bg(bg).add_modifier(Modifier::DIM),
                 ),
             ]));
         }
@@ -458,9 +444,7 @@ fn render_session_rail(f: &mut TuiFrame, area: Rect, app: &AppState) {
     lines.push(Line::from(""));
     lines.push(Line::from(Span::styled(
         " + NEW SESSION",
-        Style::default()
-            .fg(Palette::INK)
-            .add_modifier(Modifier::BOLD),
+        app.theme.assistant.add_modifier(Modifier::BOLD),
     )));
     f.render_widget(Paragraph::new(lines).style(faint_bg()), area);
 }
@@ -472,7 +456,7 @@ fn tiled_mesh(f: &mut TuiFrame, area: Rect, app: &AppState) {
         "1 orchestrator · {} delegated",
         app.delegated_worker_count()
     );
-    let outer = frame(f, area, app.view.title(), Some(&status), None);
+    let outer = frame(f, area, app.view.title(), Some(&status), None, &app.theme);
     let v = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Min(5), Constraint::Length(3)])
@@ -506,39 +490,29 @@ fn tiled_mesh(f: &mut TuiFrame, area: Rect, app: &AppState) {
         );
         let mut lines: Vec<Line<'static>> = Vec::new();
         lines.push(Line::from(vec![
-            Span::styled(
-                "STATE ",
-                Style::default()
-                    .fg(Palette::MUTED)
-                    .add_modifier(Modifier::DIM),
-            ),
+            Span::styled("STATE ", app.theme.muted.add_modifier(Modifier::DIM)),
             Span::styled(
                 tile.state.to_uppercase(),
-                Style::default()
-                    .fg(Palette::INK)
-                    .add_modifier(Modifier::BOLD),
+                app.theme.assistant.add_modifier(Modifier::BOLD),
             ),
         ]));
         lines.push(Line::from(""));
         for (n, l) in tile.log.iter().enumerate() {
             lines.push(Line::from(vec![
-                Span::styled(
-                    format!("{:>02} ", n + 1),
-                    Style::default().fg(Palette::MUTED),
-                ),
-                Span::styled(l.clone(), Style::default().fg(Palette::INK)),
+                Span::styled(format!("{:>02} ", n + 1), app.theme.muted),
+                Span::styled(l.clone(), app.theme.assistant),
             ]));
         }
         if i == 0 && app.show_reasoning {
             lines.push(Line::from(""));
             if let Some(reasoning) = app.latest_reasoning() {
-                for l in super::widgets::reasoning_lines(reasoning, false) {
+                for l in super::widgets::reasoning_lines(reasoning, false, &app.theme) {
                     lines.push(l);
                 }
             } else {
                 lines.push(Line::from(Span::styled(
                     "No live reasoning trace yet.",
-                    Style::default().fg(Palette::MUTED),
+                    app.theme.muted,
                 )));
             }
         }
@@ -564,6 +538,7 @@ fn tiled_mesh(f: &mut TuiFrame, area: Rect, app: &AppState) {
         &app.model_status(),
         app.context_ratio(),
         app.thinking,
+        &app.theme,
     );
     app.cursor_set(cx, cy);
 }
@@ -573,7 +548,7 @@ fn tiled_mesh(f: &mut TuiFrame, area: Rect, app: &AppState) {
 fn tree_of_thought(f: &mut TuiFrame, area: Rect, app: &AppState) {
     let tree_nodes = app.tree_nodes();
     let summary = format!("{} branch runtime slots", app.branch_count());
-    let outer = frame(f, area, app.view.title(), Some(&summary), None);
+    let outer = frame(f, area, app.view.title(), Some(&summary), None, &app.theme);
     let v = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Min(5), Constraint::Length(3)])
@@ -587,6 +562,8 @@ fn tree_of_thought(f: &mut TuiFrame, area: Rect, app: &AppState) {
     fill(f, h[0], faint_bg());
     let inner = section_header(f, h[0], "decision tree", None);
     let mut lines: Vec<Line<'static>> = Vec::new();
+    let tree_accent_fg = app.theme.accent.fg.unwrap_or(Color::Reset);
+    let tree_muted_fg = app.theme.muted.fg.unwrap_or(Color::Reset);
     for n in &tree_nodes {
         let bg = if n.active {
             Palette::PAPER
@@ -595,9 +572,9 @@ fn tree_of_thought(f: &mut TuiFrame, area: Rect, app: &AppState) {
         };
         let bar = if n.active { "▌" } else { " " };
         let bar_color = if n.active {
-            Palette::RED
+            tree_accent_fg
         } else {
-            Palette::FAINT
+            tree_muted_fg
         };
         lines.push(Line::from(vec![
             Span::styled(
@@ -616,54 +593,51 @@ fn tree_of_thought(f: &mut TuiFrame, area: Rect, app: &AppState) {
             ),
             Span::styled(
                 n.label.clone(),
-                Style::default()
-                    .fg(Palette::INK)
-                    .bg(bg)
-                    .add_modifier(if n.depth == 0 {
-                        Modifier::BOLD
-                    } else {
-                        Modifier::empty()
-                    }),
+                app.theme.assistant.bg(bg).add_modifier(if n.depth == 0 {
+                    Modifier::BOLD
+                } else {
+                    Modifier::empty()
+                }),
             ),
         ]));
     }
     lines.push(Line::from(""));
     lines.push(Line::from(Span::styled(
         " Delegated branch runtime not enabled yet.",
-        Style::default().fg(Palette::MUTED).bg(Palette::FAINT),
+        app.theme.muted.bg(Palette::FAINT),
     )));
     lines.push(Line::from(Span::styled(
         " This pane currently shows the root orchestrator state only.",
-        Style::default().fg(Palette::MUTED).bg(Palette::FAINT),
+        app.theme.muted.bg(Palette::FAINT),
     )));
     f.render_widget(Paragraph::new(lines).style(faint_bg()), inner);
 
     // Right: focused stream
     let focus_inner = section_header(f, h[1], "focused stream", Some(Palette::YELLOW));
     let mut lines = Vec::new();
-    lines.push(message_header("orchestrator", Palette::RED, Some("root")));
+    lines.push(message_header("orchestrator", tree_accent_fg, Some("root"), &app.theme));
     lines.push(Line::from(Span::styled(
         format!("▎ {}", app.orchestration.active_task),
-        Style::default().fg(Palette::INK),
+        app.theme.assistant,
     )));
     if app.show_reasoning {
         if let Some(reasoning) = app.latest_reasoning() {
             lines.push(Line::from(""));
-            for l in super::widgets::reasoning_lines(reasoning, false) {
+            for l in super::widgets::reasoning_lines(reasoning, false, &app.theme) {
                 lines.push(l);
             }
         }
     }
     if let Some(content) = app.latest_agent_content() {
         lines.push(Line::from(""));
-        for line in render_markdown(content) {
+        for line in render_markdown(content, &app.theme) {
             lines.push(Line::from(line.spans));
         }
     } else {
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
             "No focused branch output yet.",
-            Style::default().fg(Palette::MUTED),
+            app.theme.muted,
         )));
     }
     f.render_widget(
@@ -682,6 +656,7 @@ fn tree_of_thought(f: &mut TuiFrame, area: Rect, app: &AppState) {
         &app.model_status(),
         app.context_ratio(),
         app.thinking,
+        &app.theme,
     );
     app.cursor_set(cx, cy);
 }
@@ -695,7 +670,7 @@ fn trading_floor(f: &mut TuiFrame, area: Rect, app: &AppState) {
         app.sessions.len(),
         subagents.len()
     );
-    let outer = frame(f, area, app.view.title(), Some(&status), None);
+    let outer = frame(f, area, app.view.title(), Some(&status), None, &app.theme);
 
     let v = Layout::default()
         .direction(Direction::Vertical)
@@ -771,25 +746,17 @@ fn trading_floor(f: &mut TuiFrame, area: Rect, app: &AppState) {
             ),
             Span::styled(
                 tile.name.clone(),
-                Style::default()
-                    .fg(Palette::INK)
-                    .add_modifier(Modifier::BOLD),
+                app.theme.assistant.add_modifier(Modifier::BOLD),
             ),
-            Span::styled(
-                format!(" · {}", tile.role),
-                Style::default().fg(Palette::MUTED),
-            ),
+            Span::styled(format!(" · {}", tile.role), app.theme.muted),
         ]));
         for (n, l) in tile.log.iter().enumerate() {
-            let color = if n + 1 == tile.log.len() {
-                Palette::INK
+            let style = if n + 1 == tile.log.len() {
+                app.theme.assistant
             } else {
-                Palette::MUTED
+                app.theme.muted
             };
-            lines.push(Line::from(Span::styled(
-                format!("  {}", l),
-                Style::default().fg(color),
-            )));
+            lines.push(Line::from(Span::styled(format!("  {}", l), style)));
         }
         f.render_widget(
             Paragraph::new(lines)
@@ -811,9 +778,10 @@ fn trading_floor(f: &mut TuiFrame, area: Rect, app: &AppState) {
     if app.sessions.is_empty() {
         lines.push(Line::from(Span::styled(
             " No saved sessions yet.",
-            Style::default().fg(Palette::MUTED),
+            app.theme.muted,
         )));
     }
+    let floor_accent_fg = app.theme.accent.fg.unwrap_or(Color::Reset);
     for s in &app.sessions {
         let bg = if s.is_active {
             Palette::FAINT
@@ -821,27 +789,21 @@ fn trading_floor(f: &mut TuiFrame, area: Rect, app: &AppState) {
             Palette::PAPER
         };
         let bar = if s.is_active { "▌" } else { " " };
-        let accent = match s.status {
-            SessionStatus::Live => Palette::GREEN,
-            SessionStatus::Saved => Palette::BLUE,
+        let status_style = match s.status {
+            SessionStatus::Live => app.theme.success,
+            SessionStatus::Saved => app.theme.accent,
         };
         lines.push(Line::from(vec![
             Span::styled(
                 bar,
                 Style::default()
-                    .fg(Palette::RED)
+                    .fg(floor_accent_fg)
                     .bg(bg)
                     .add_modifier(Modifier::BOLD),
             ),
-            Span::styled(" █ ", Style::default().fg(accent).bg(bg)),
-            Span::styled(
-                format!("{:<14}", s.label),
-                Style::default().fg(Palette::INK).bg(bg),
-            ),
-            Span::styled(
-                format!(" {}m", s.message_count),
-                Style::default().fg(Palette::MUTED).bg(bg),
-            ),
+            Span::styled(" █ ", status_style.bg(bg)),
+            Span::styled(format!("{:<14}", s.label), app.theme.assistant.bg(bg)),
+            Span::styled(format!(" {}m", s.message_count), app.theme.muted.bg(bg)),
         ]));
     }
     f.render_widget(Paragraph::new(lines).style(body()), ses_inner);
@@ -853,16 +815,18 @@ fn trading_floor(f: &mut TuiFrame, area: Rect, app: &AppState) {
     let row_count = log_rows.len();
     for (i, row) in log_rows.iter().enumerate() {
         let last = i + 1 == row_count;
-        let color = if last { Palette::INK } else { Palette::MUTED };
+        let row_style = if last {
+            app.theme.assistant
+        } else {
+            app.theme.muted
+        };
         lines.push(Line::from(vec![
-            Span::styled(format!("{:>8} ", row.time), Style::default().fg(color)),
+            Span::styled(format!("{:>8} ", row.time), row_style),
             Span::styled(
                 format!("{:<5} ", row.actor),
-                Style::default()
-                    .fg(Palette::INK)
-                    .add_modifier(Modifier::BOLD),
+                app.theme.assistant.add_modifier(Modifier::BOLD),
             ),
-            Span::styled(row.msg.clone(), Style::default().fg(color)),
+            Span::styled(row.msg.clone(), row_style),
         ]));
     }
     f.render_widget(Paragraph::new(lines).style(body()), tl_inner);
@@ -1091,6 +1055,7 @@ fn trading_floor(f: &mut TuiFrame, area: Rect, app: &AppState) {
         &app.model_status(),
         app.context_ratio(),
         app.thinking,
+        &app.theme,
     );
     app.cursor_set(cx, cy);
 }

--- a/src/tui/widgets.rs
+++ b/src/tui/widgets.rs
@@ -6,7 +6,17 @@ use ratatui::{
     widgets::{Block, BorderType, Borders, Paragraph, Wrap},
 };
 
-use super::theme::{Palette, body, inverse};
+use super::theme::{Palette, Theme, inverse};
+
+// YYC-52 (Task 9): widgets.rs hosts the structural Bauhaus shell of the
+// TUI — frames, section headers, the prompt row, the ticker, and the
+// tool-call card. Most "structural" styles (the inverse INK/PAPER title
+// bars, the SLATE tool-card header, the RED ticker pill, the mode pill
+// inverse) intentionally remain on `Palette::*` per the design canvas:
+// these elements are the brutalist chrome and don't follow the active
+// chat theme. Chat-role styles (border edges, body fill, muted hint
+// text, capacity-warning fg) are now read from the active `Theme` via
+// the `theme: &Theme` parameter threaded into each public widget.
 
 /// Bauhaus framed window: thick double-line border, title bar with `▓▓` mark
 /// + uppercase title on left, status pill on right. Matches the design's
@@ -19,21 +29,24 @@ pub fn frame(
     title: &str,
     status: Option<&str>,
     accent: Option<Color>,
+    theme: &Theme,
 ) -> Rect {
     if area.width < 4 || area.height < 3 {
         return area;
     }
 
-    // Outer block — paint paper background and a heavy border.
+    // Outer block — paint themed background and the themed border edge.
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Thick)
-        .border_style(Style::default().fg(Palette::INK).bg(Palette::PAPER))
-        .style(body());
+        .border_style(theme.border)
+        .style(Style::default().fg(theme.body_fg).bg(theme.body_bg));
     let inner = block.inner(area);
     f.render_widget(block, area);
 
-    // Title bar = first line inside the border.
+    // Title bar = first line inside the border. The title bar itself is
+    // structural inverse (INK on PAPER) — the design's brutalist chrome
+    // doesn't recolor with the active theme.
     if inner.height == 0 {
         return inner;
     }
@@ -85,6 +98,11 @@ pub fn frame(
 }
 
 /// Render a child "section" header inside a pane (one ink line, paper text).
+///
+/// Section headers are structural inverse chrome (INK/PAPER) per the
+/// Bauhaus design canvas — the bar itself doesn't recolor with the
+/// active theme. The optional `accent` arg lets callers stamp a
+/// theme-derived emphasis color (e.g. `theme.accent.fg`).
 pub fn section_header(f: &mut TuiFrame, area: Rect, label: &str, accent: Option<Color>) -> Rect {
     if area.height == 0 {
         return area;
@@ -118,6 +136,12 @@ pub fn section_header(f: &mut TuiFrame, area: Rect, label: &str, accent: Option<
 }
 
 /// A status pill rendered inline as a Span (uppercase, padded).
+///
+/// Pills are structural design elements: when `filled` the foreground
+/// is the inverse PAPER (per the Bauhaus chrome), and the caller-
+/// supplied `color` is the background. The hollow variant uses the
+/// caller color as the foreground. Theme integration happens at the
+/// call site by passing e.g. `theme.error.fg.unwrap_or(Palette::RED)`.
 pub fn pill(text: &str, color: Color, filled: bool) -> Span<'static> {
     let body = format!(" {} ", text.to_uppercase());
     let style = if filled {
@@ -192,13 +216,16 @@ pub enum ToolStatus {
 }
 
 /// Reasoning trace block — italicized, hatched bg.
-pub fn reasoning_lines(text: &str, hidden: bool) -> Vec<Line<'static>> {
+///
+/// The hidden-trace placeholder text uses the active theme's `muted`
+/// role. The visible reasoning rows sit on the structural FAINT
+/// backdrop (a Bauhaus tint that's always lighter than PAPER) — the
+/// inset-card affordance is design-locked, not themed.
+pub fn reasoning_lines(text: &str, hidden: bool, theme: &Theme) -> Vec<Line<'static>> {
     if hidden {
         return vec![Line::from(Span::styled(
             "░░░ reasoning trace hidden · Ctrl-R to show ░░░",
-            Style::default()
-                .fg(Palette::MUTED)
-                .add_modifier(Modifier::DIM),
+            theme.muted.add_modifier(Modifier::DIM),
         ))];
     }
     let mut lines = vec![Line::from(Span::styled(
@@ -221,7 +248,11 @@ pub fn reasoning_lines(text: &str, hidden: bool) -> Vec<Line<'static>> {
 }
 
 /// Message header: ▆ ROLE · tag
-pub fn message_header(role: &str, accent: Color, tag: Option<&str>) -> Line<'static> {
+///
+/// `accent` is the role color (caller resolves from `theme.user`,
+/// `theme.assistant`, etc.). `theme.body_fg` is used for the role
+/// label so it follows the active theme's foreground.
+pub fn message_header(role: &str, accent: Color, tag: Option<&str>, theme: &Theme) -> Line<'static> {
     let mut spans = vec![
         Span::styled(
             "▆ ",
@@ -230,7 +261,7 @@ pub fn message_header(role: &str, accent: Color, tag: Option<&str>) -> Line<'sta
         Span::styled(
             role.to_uppercase(),
             Style::default()
-                .fg(Palette::INK)
+                .fg(theme.body_fg)
                 .add_modifier(Modifier::BOLD),
         ),
     ];
@@ -242,10 +273,17 @@ pub fn message_header(role: &str, accent: Color, tag: Option<&str>) -> Line<'sta
 }
 
 /// Render a paragraph with a left accent bar — used for chat message bodies.
-pub fn render_message_body(f: &mut TuiFrame, area: Rect, accent: Color, lines: Vec<Line<'static>>) {
+pub fn render_message_body(
+    f: &mut TuiFrame,
+    area: Rect,
+    accent: Color,
+    lines: Vec<Line<'static>>,
+    theme: &Theme,
+) {
     if area.width < 3 || area.height == 0 {
         return;
     }
+    let body_style = Style::default().fg(theme.body_fg).bg(theme.body_bg);
     let bar = Rect {
         x: area.x,
         y: area.y,
@@ -258,7 +296,7 @@ pub fn render_message_body(f: &mut TuiFrame, area: Rect, accent: Color, lines: V
                 .take(area.height as usize)
                 .collect::<Vec<_>>(),
         )
-        .style(body()),
+        .style(body_style),
         bar,
     );
     let body_area = Rect {
@@ -269,7 +307,7 @@ pub fn render_message_body(f: &mut TuiFrame, area: Rect, accent: Color, lines: V
     };
     f.render_widget(
         Paragraph::new(lines)
-            .style(body())
+            .style(body_style)
             .wrap(Wrap { trim: false }),
         body_area,
     );
@@ -279,6 +317,12 @@ pub fn render_message_body(f: &mut TuiFrame, area: Rect, accent: Color, lines: V
 /// dashed key-hint line, and right-aligned model + token gauge.
 ///
 /// Returns the (x, y) where the OS cursor should be placed.
+///
+/// YYC-52: divider, input fill, hint text, and capacity-ok status fg
+/// follow the active theme. The mode pill (inverse PAPER-on-INK) and
+/// the caret (RED) stay structural — they're chrome, not chat content.
+/// Capacity-warning fg colors (yellow/red) stay on the design's warn
+/// palette so the urgency cue is identical across themes.
 pub fn prompt_row(
     f: &mut TuiFrame,
     area: Rect,
@@ -287,14 +331,16 @@ pub fn prompt_row(
     hints: &[(&str, &str)],
     model_status: &str,
     // capacity_ratio (YYC-60): current context / max. Drives the
-    // model_status fg color: ≤70% ink, 70-90% yellow, >90% red.
+    // model_status fg color: ≤70% body_fg, 70-90% yellow, >90% red.
     capacity_ratio: f32,
     thinking: bool,
+    theme: &Theme,
 ) -> (u16, u16) {
     if area.height < 2 {
         return (area.x, area.y);
     }
-    // Top divider
+    let body_style = Style::default().fg(theme.body_fg).bg(theme.body_bg);
+    // Top divider — themed border edge across the prompt row.
     let layout = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -306,12 +352,10 @@ pub fn prompt_row(
 
     // Divider row
     let div = "─".repeat(area.width as usize);
-    f.render_widget(
-        Paragraph::new(div).style(Style::default().fg(Palette::INK).bg(Palette::PAPER)),
-        layout[0],
-    );
+    f.render_widget(Paragraph::new(div).style(theme.border), layout[0]);
 
-    // Mode pill + caret + input
+    // Mode pill is structural inverse (PAPER on INK) — design-locked
+    // so the active mode badge stays unmistakable across themes.
     let mode_pill = Span::styled(
         format!(" {} ", mode),
         Style::default()
@@ -319,30 +363,25 @@ pub fn prompt_row(
             .bg(Palette::INK)
             .add_modifier(Modifier::BOLD),
     );
+    // Caret is structural RED — always the "send" cue, regardless of theme.
     let caret = Span::styled(
         " ❯ ",
         Style::default()
             .fg(Palette::RED)
-            .bg(Palette::PAPER)
+            .bg(theme.body_bg)
             .add_modifier(Modifier::BOLD),
     );
-    let input_span = Span::styled(
-        input.to_string(),
-        Style::default().fg(Palette::INK).bg(Palette::PAPER),
-    );
+    let input_span = Span::styled(input.to_string(), body_style);
     let cursor_block = Span::styled(
         if thinking { "▒" } else { "█" },
-        Style::default()
-            .fg(Palette::INK)
-            .bg(Palette::PAPER)
-            .add_modifier(if thinking {
-                Modifier::SLOW_BLINK
-            } else {
-                Modifier::empty()
-            }),
+        body_style.add_modifier(if thinking {
+            Modifier::SLOW_BLINK
+        } else {
+            Modifier::empty()
+        }),
     );
     let line = Line::from(vec![mode_pill, caret, input_span, cursor_block]);
-    f.render_widget(Paragraph::new(line).style(body()), layout[1]);
+    f.render_widget(Paragraph::new(line).style(body_style), layout[1]);
 
     // Cursor position: after mode pill (mode width + 2 spaces) + caret (3) + input chars
     let mode_width = mode.chars().count() as u16 + 2;
@@ -350,14 +389,14 @@ pub fn prompt_row(
     let cursor_y = layout[1].y;
 
     // Hints row
+    let muted_style = theme.muted;
     let mut hint_spans: Vec<Span<'static>> = Vec::new();
     for (i, (key, label)) in hints.iter().enumerate() {
         if i > 0 {
-            hint_spans.push(Span::styled(
-                "  ",
-                Style::default().fg(Palette::MUTED).bg(Palette::PAPER),
-            ));
+            hint_spans.push(Span::styled("  ", muted_style));
         }
+        // Hint key chip — structural inverse (PAPER-on-INK) so the
+        // keybinding chip is visually consistent across themes.
         hint_spans.push(Span::styled(
             format!(" {key} "),
             Style::default()
@@ -365,10 +404,7 @@ pub fn prompt_row(
                 .bg(Palette::INK)
                 .add_modifier(Modifier::BOLD),
         ));
-        hint_spans.push(Span::styled(
-            format!(" {label}"),
-            Style::default().fg(Palette::MUTED).bg(Palette::PAPER),
-        ));
+        hint_spans.push(Span::styled(format!(" {label}"), muted_style));
     }
     let hint_text_len: u16 = hint_spans
         .iter()
@@ -377,28 +413,27 @@ pub fn prompt_row(
     let model_len = model_status.chars().count() as u16;
     if hint_text_len + model_len + 2 < area.width {
         let pad = " ".repeat((area.width - hint_text_len - model_len - 1) as usize);
-        hint_spans.push(Span::styled(
-            pad,
-            Style::default().fg(Palette::MUTED).bg(Palette::PAPER),
-        ));
+        hint_spans.push(Span::styled(pad, muted_style));
         // YYC-60: color the model_status span by context capacity ratio.
+        // ≤70% follows the active theme's body fg; 70-90% / >90% use the
+        // structural warn palette so the urgency cue is theme-agnostic.
         let status_fg = if capacity_ratio > 0.90 {
             Palette::RED
         } else if capacity_ratio > 0.70 {
             Palette::YELLOW
         } else {
-            Palette::INK
+            theme.body_fg
         };
         hint_spans.push(Span::styled(
             format!(" {model_status}"),
             Style::default()
                 .fg(status_fg)
-                .bg(Palette::PAPER)
+                .bg(theme.body_bg)
                 .add_modifier(Modifier::BOLD),
         ));
     }
     f.render_widget(
-        Paragraph::new(Line::from(hint_spans)).style(body()),
+        Paragraph::new(Line::from(hint_spans)).style(body_style),
         layout[2],
     );
 
@@ -407,6 +442,10 @@ pub fn prompt_row(
 
 /// Bottom ticker strip — used in trading floor view. Scrolling text of recent
 /// sub-agent activity.
+///
+/// The ticker is structural inverse chrome (PAPER on INK) with a RED
+/// "TICKER" pill — the design canvas treats it as a fixed brutalist
+/// element, so it intentionally does not follow the active theme.
 pub fn ticker(f: &mut TuiFrame, area: Rect, cells: &[(String, String, Color)]) {
     if area.height == 0 {
         return;
@@ -466,6 +505,13 @@ pub fn ticker(f: &mut TuiFrame, area: Rect, cells: &[(String, String, Color)]) {
 /// ▎   output_preview line 1
 /// ▎   output_preview line 2
 /// ```
+///
+/// YYC-52: this card is **structural** per the YYC-74 design canvas —
+/// the SLATE header bg, the FAINT body bg, the inverse name pill, and
+/// the GREEN/YELLOW/RED status pills are design-locked. They do not
+/// follow the active theme. Diff coloring inside the body preview also
+/// stays on the structural diff palette so `+` / `-` lines remain
+/// instantly recognizable across themes.
 pub fn tool_card(
     name: &str,
     status: super::state::ToolStatus,


### PR DESCRIPTION
## Summary

- New 22-role `Theme` struct in `src/tui/theme.rs` (10 chat + 12 markdown + 2 structural body fields). Each role is a `ratatui::Style` so modifiers (bold/italic/underline) are first-class.
- Three built-in palettes:
  - **`system`** (default) — `Color::Reset` + ANSI-named, inherits terminal palette
  - **`default-light`** — formalizes today's Bauhaus look (cream paper / ink black)
  - **`dracula`** — canonical dark contrast palette
- `[tui].theme` in `~/.vulcan/config.toml`; unknown names log a warning and fall back to `system`.
- `AppState` carries the active `Theme`; ~140 hardcoded style literals across `src/tui/{mod,markdown,widgets,views,chat_render}.rs` now route through `state.theme.<role>`.
- Companion `Theme::from_name` dispatcher and snapshot tests pin the cross-theme behavior.

13 commits, 108 tests pass (101 pre-existing + 4 dispatcher tests + 3 snapshot tests).

## Default behavior

`system` is the default. Existing users will see a visual change on upgrade — the TUI inherits their terminal palette instead of the hardcoded Bauhaus colors. Users who prefer today's look set `[tui] theme = \"default-light\"`. This is a deliberate trade-off (see design doc) — respecting the user's terminal palette is the right zero-config posture for a CLI tool.

## Visual verification

Manual verification deferred to pre-merge — please run locally:
- [ ] \`cargo run\` with \`theme = \"default-light\"\` matches today's visual appearance
- [ ] \`cargo run\` with \`theme = \"dracula\"\` shows distinct Dracula colors across chat / code blocks / borders
- [ ] \`cargo run\` with \`theme = \"system\"\` (or no \`[tui]\` block) inherits terminal palette with no painted-over collisions on the mode pill / header bar / SLATE card header

Structural styles (mode pill inverse, SLATE card header, ticker pill, FAINT reasoning bg) intentionally stay on \`Palette::*\` — splitting them into roles is a separate follow-up. They'll look the same across all three themes.

## Test plan

- [x] \`cargo build --all-targets\` clean
- [x] \`cargo test --lib\` — 108 pass
- [x] \`Theme::from_name\` returns the right palette per name; falls back to \`system\` on unknown
- [x] \`dracula\`/\`default-light\` differ on \`assistant\` + \`code_block\` (snapshot tests)
- [x] \`system\` theme leaves \`fg\` unset (terminal-driven)
- [ ] Manual visual check (above) before merge
- [ ] CI green

## Out of scope (follow-ups)

- Custom user themes from \`~/.vulcan/themes/*.toml\`
- \`/theme <name>\` runtime slash command (depends on YYC-37)
- Additional built-ins: \`default-dark\`, \`nord\`, \`catppuccin-mocha\`
- Splitting structural styles (mode pill, SLATE card header, ticker pill, FAINT reasoning bg) into Theme roles

Closes YYC-52.