### PR TITLE
feat(gateway): add axum + tower deps behind gateway feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,10 @@ cargo build --all-targets        # compile everything, including tests
 cargo run                         # launch TUI (default subcommand: chat)
 cargo run -- prompt "your text"   # one-shot mode (no TUI)
 cargo run -- session <id>         # resume a saved session
+cargo run --features gateway -- gateway  # run gateway daemon mode
 cargo build --release             # size-optimized binary (opt-level=z, lto, strip)
 cargo test                        # run tests
+cargo test --features gateway gateway::  # gateway feature tests
 cargo test <name_substring>       # single test by name
 ```
 
@@ -49,6 +51,8 @@ Three load-bearing invariants:
 **Tool dispatch** runs `BeforeToolCall` (block / replace args) → execute → `AfterToolCall` (replace result). Today `Tool::call` returns `Result<String>`; the master plan specifies `ToolResult { output, media, is_error }` — that upgrade is tracked in Linear and is the natural next structural change.
 
 **Provider** is OpenAI-compatible (`src/provider/openai.rs`). Both buffered (`chat`) and streaming (`chat_stream`) paths are honored by every hook event; if you add a new event, wire it into both.
+
+**Gateway daemon mode** is the Phase 2 foundation surface under `src/gateway/`. Reading order: `src/gateway/mod.rs` → `src/gateway/lane.rs` → `src/gateway/agent_map.rs` → `src/gateway/queue.rs` → `src/gateway/server.rs`. It owns Axum HTTP routes, durable SQLite inbound/outbound queues, per-lane long-lived agents with idle eviction, and the loopback platform scaffold. Telegram/Discord platform adapters build on the same `PlatformRegistry` and queue contracts.
 
 ## Active naming wart
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -719,6 +719,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -2109,6 +2110,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -4657,6 +4667,8 @@ dependencies = [
  "futures-util",
  "gix",
  "hdrhistogram",
+ "hmac",
+ "http",
  "ignore",
  "lsp-types",
  "portable-pty",
@@ -4665,6 +4677,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2",
  "strsim",
  "subtle",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4666,6 +4666,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strsim",
+ "subtle",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2098,6 +2150,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "human_format"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2117,6 +2175,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2661,6 +2720,12 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "maybe-async"
@@ -3647,6 +3712,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3664,6 +3740,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -4232,6 +4320,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4250,6 +4339,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -4270,6 +4360,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4557,6 +4648,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum",
  "chrono",
  "clap",
  "crossterm",
@@ -4579,6 +4671,8 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml",
+ "tower",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ ignore = "0.4.25"
 
 # Gateway daemon HTTP stack. Optional — only linked under `gateway`.
 axum = { version = "0.8.9", optional = true }
-tower = { version = "0.5.3", optional = true }
+tower = { version = "0.5.3", features = ["util"], optional = true }
 tower-http = { version = "0.6.8", features = ["trace", "cors"], optional = true }
 
 # Heap profiler for the soak binary. Optional — only linked under `bench-soak`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,12 @@ readme = "README.md"
 autobenches = false
 
 [features]
+default = []
 # Enabled only when running the soak binary. Pulls in dhat-rs (heap
 # profiler that swaps the global allocator) and hdrhistogram (latency
 # percentiles) — both optional so production builds skip them entirely.
 bench-soak = ["dep:dhat", "dep:hdrhistogram"]
+gateway = ["dep:axum", "dep:tower", "dep:tower-http"]
 
 [dependencies]
 # Async runtime
@@ -83,6 +85,11 @@ lsp-types = "0.97"
 # Workspace walker that respects .gitignore (YYC-50). Used by the
 # code-graph indexer so we don't index target/, node_modules/, etc.
 ignore = "0.4.25"
+
+# Gateway daemon HTTP stack. Optional — only linked under `gateway`.
+axum = { version = "0.8.9", optional = true }
+tower = { version = "0.5.3", optional = true }
+tower-http = { version = "0.6.8", features = ["trace", "cors"], optional = true }
 
 # Heap profiler for the soak binary. Optional — only linked under `bench-soak`.
 dhat = { version = "0.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ default = []
 # profiler that swaps the global allocator) and hdrhistogram (latency
 # percentiles) — both optional so production builds skip them entirely.
 bench-soak = ["dep:dhat", "dep:hdrhistogram"]
-gateway = ["dep:axum", "dep:tower", "dep:tower-http"]
+gateway = ["dep:axum", "dep:tower", "dep:tower-http", "dep:subtle"]
 
 [dependencies]
 # Async runtime
@@ -90,6 +90,7 @@ ignore = "0.4.25"
 axum = { version = "0.8.9", optional = true }
 tower = { version = "0.5.3", features = ["util"], optional = true }
 tower-http = { version = "0.6.8", features = ["trace", "cors"], optional = true }
+subtle = { version = "2.6.1", optional = true }
 
 # Heap profiler for the soak binary. Optional — only linked under `bench-soak`.
 dhat = { version = "0.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ default = []
 # profiler that swaps the global allocator) and hdrhistogram (latency
 # percentiles) — both optional so production builds skip them entirely.
 bench-soak = ["dep:dhat", "dep:hdrhistogram"]
-gateway = ["dep:axum", "dep:tower", "dep:tower-http", "dep:subtle"]
+gateway = ["dep:axum", "dep:tower", "dep:tower-http", "dep:subtle", "dep:hmac", "dep:sha2"]
 
 [dependencies]
 # Async runtime
@@ -91,6 +91,16 @@ axum = { version = "0.8.9", optional = true }
 tower = { version = "0.5.3", features = ["util"], optional = true }
 tower-http = { version = "0.6.8", features = ["trace", "cors"], optional = true }
 subtle = { version = "2.6.1", optional = true }
+# Webhook HMAC verification (Task 16). hmac 0.12 + sha2 0.10 share `digest 0.10`,
+# already in Cargo.lock transitively — picking the matching majors avoids
+# pulling a second copy of `digest`.
+hmac = { version = "0.12.1", optional = true }
+sha2 = { version = "0.10.9", optional = true }
+
+# `http` types are shared between axum and the `Platform` trait method
+# `verify_webhook`. Promoted to a direct, NON-feature-gated dep so the trait
+# signature compiles in builds without the `gateway` feature too.
+http = "1.4.0"
 
 # Heap profiler for the soak binary. Optional — only linked under `bench-soak`.
 dhat = { version = "0.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ strip = true
 tempfile = "3.27.0"
 divan = "0.1"
 hdrhistogram = "7"
+tokio = { version = "1", features = ["full", "test-util"] }
 
 [[bench]]
 name = "tui_render"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ vulcan --continue
 
 # Full-text search across all past sessions
 vulcan search "some query"
+
+# Run the gateway daemon (requires the gateway feature)
+cargo run --features gateway -- gateway
 ```
 
 ---
@@ -39,7 +42,7 @@ Switch between views instantly with `Ctrl+1` through `Ctrl+5`.
 **UI highlights:**
 - **Markdown rendering** — agent responses render inline code, lists, headings, and more
 - **Reasoning trace** — toggle visibility of model reasoning/thinking traces (`Ctrl+R`)
-- **Slash commands** — `/help`, `/clear`, `/view`, `/reasoning`, `/search`, `/exit` with fuzzy filtering, tab completion, and a navigable palette
+- **Slash commands** — `/help`, `/clear`, `/view`, `/reasoning`, `/model`, `/search`, `/exit` with fuzzy filtering, tab completion, and a navigable palette
 - **Prompt queue** — keep typing while the agent is busy; prompts drain automatically when the turn completes
 - **Live tool activity** — see tool calls start and complete in real-time with ✓/✗ status
 - **Live edit diffs** — real file-edit diffs rendered in the UI as the agent works
@@ -86,6 +89,7 @@ Vulcan learns. Skills are markdown files with YAML frontmatter that get injected
 - **Streaming** — SSE-based streaming with text, reasoning, and tool calls
 - **Retry logic** — exponential backoff with jitter (1s, 2s, 4s, 8s, 16s) for 429/5xx/network errors
 - **Model catalog** — auto-fetches model metadata at startup, validates the model exists, fuzzy-suggests alternatives, auto-populates context length and pricing
+- **Named providers** — configure multiple OpenAI-compatible endpoints and switch to catalog-listed models from the TUI
 - **Reasoning passthrough** — supports models like DeepSeek that emit `reasoning_content` alongside responses
 
 ---
@@ -162,6 +166,11 @@ model = "deepseek/deepseek-v4-flash"
 | `provider.catalog_cache_ttl_hours` | `24` | Model catalog cache lifetime |
 | `provider.disable_catalog` | `false` | Skip catalog fetch at startup |
 | `provider.debug` | `"off"` | Debug logging: `off`, `tool-fallback`, or `wire` |
+| `providers.<name>.*` | unset | Optional named provider profiles usable by `/model <name>/<model>` |
+| `gateway.bind` | `127.0.0.1:7373` | Gateway HTTP bind address |
+| `gateway.api_token` | unset | Bearer token required for `/v1/*` gateway routes |
+| `gateway.idle_ttl_secs` | `1800` | Per-lane agent idle eviction timeout |
+| `gateway.outbound_max_attempts` | `5` | Outbound delivery retries before failure |
 | `tools.yolo_mode` | `false` | Skip safety confirmations |
 | `compaction.enabled` | `true` | Auto-compress context at threshold |
 | `compaction.trigger_ratio` | `0.85` | Compaction trigger ratio |
@@ -189,6 +198,9 @@ vulcan session <session-id>
 # Full-text search across all saved sessions
 vulcan search "some query"
 # Optionally limit results: vulcan search "query" --limit 20
+
+# Gateway daemon mode
+cargo run --features gateway -- gateway
 ```
 
 ### TUI Keyboard Shortcuts
@@ -217,6 +229,7 @@ Type `/` in the TUI to access slash commands:
 /clear      Clear the conversation
 /view       Switch views (equivalent to Ctrl+1..5)
 /reasoning  Toggle reasoning trace
+/model      List available models or switch with /model <id>
 /search     Search past sessions
 /exit       Quit Vulcan
 ```

--- a/config.example.toml
+++ b/config.example.toml
@@ -31,6 +31,16 @@ catalog_cache_ttl_hours = 24
 # ends with a "reached maximum iteration limit" message.
 # max_iterations = 0
 
+# Optional named provider profiles. The active TUI `/model` command uses
+# `[provider]` today; named profiles bind base URL, auth, and default model
+# together for provider switching work tracked after YYC-92.
+# [providers.local]
+# type = "openai-compat"
+# base_url = "http://localhost:11434/v1"
+# api_key = "ollama"
+# model = "qwen2.5-coder:latest"
+# disable_catalog = true
+
 [tools]
 # Enable dangerous tools (file overwrite, shell exec) without confirmation
 yolo_mode = false

--- a/config.example.toml
+++ b/config.example.toml
@@ -74,3 +74,19 @@ dim = 1536
 #   default-light   — Bauhaus cream/ink, the formalized current look
 #   dracula         — canonical dark palette
 theme = "system"
+
+# [gateway]
+# bind = "127.0.0.1:7777"
+# api_token = "..."           # required when running `vulcan gateway`; generated on first run if absent
+# idle_ttl_secs = 1800
+# max_concurrent_lanes = 64
+# outbound_max_attempts = 5
+
+# [gateway.telegram]
+# enabled = false
+# bot_token = "..."
+# webhook_secret = "..."
+
+# [gateway.discord]
+# enabled = false
+# bot_token = "..."

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::config::Config;
+use crate::config::{Config, ProviderConfig};
 use crate::context::ContextManager;
 use crate::hooks::approval::ApprovalHook;
 use crate::hooks::diagnostics::DiagnosticsHook;
@@ -46,6 +46,11 @@ pub struct Agent {
     /// catalog at startup (YYC-67). `None` when the catalog is disabled
     /// or the provider doesn't publish pricing.
     pricing: Option<crate::provider::catalog::Pricing>,
+    /// Active provider profile and resolved auth. Kept so user-facing
+    /// commands can switch models without reconstructing the long-lived
+    /// Agent, hook registry, tools, memory, or session state.
+    provider_config: ProviderConfig,
+    provider_api_key: String,
     /// LSP server pool (YYC-46). Lazy: servers spawn on first tool
     /// invocation that needs one. Reaped in `end_session`.
     lsp_manager: Arc<crate::code::lsp::LspManager>,
@@ -55,6 +60,13 @@ pub struct Agent {
     last_saved_count: usize,
     /// Max agent loop iterations per prompt. 0 = unlimited (default).
     max_iterations: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct ModelSelection {
+    pub model: crate::provider::catalog::ModelInfo,
+    pub max_context: usize,
+    pub pricing: Option<crate::provider::catalog::Pricing>,
 }
 
 impl Agent {
@@ -96,54 +108,10 @@ impl Agent {
         // max_context with whatever the catalog says it actually is. Non-fatal:
         // if the catalog endpoint fails, we log + continue with the configured
         // values rather than blocking startup over a metadata fetch.
-        let mut effective_max_context = config.provider.max_context;
-        let mut supports_json_mode = false;
-        let mut pricing: Option<crate::provider::catalog::Pricing> = None;
-        if !config.provider.disable_catalog {
-            match Self::fetch_catalog(config, &api_key).await {
-                Ok(models) => {
-                    let found = models.iter().find(|m| m.id == config.provider.model);
-                    match found {
-                        Some(model_info) => {
-                            supports_json_mode = model_info.features.json_mode;
-                            pricing = model_info.pricing.clone();
-                            if model_info.context_length > 0
-                                && config.provider.max_context == 128_000
-                            {
-                                effective_max_context = model_info.context_length;
-                                tracing::info!(
-                                    "catalog: using context_length={} for {} (json_mode={})",
-                                    model_info.context_length,
-                                    model_info.id,
-                                    supports_json_mode,
-                                );
-                            }
-                        }
-                        None => {
-                            let suggestions = crate::provider::catalog::fuzzy_suggest(
-                                &models,
-                                &config.provider.model,
-                                3,
-                            );
-                            let hint = if suggestions.is_empty() {
-                                String::new()
-                            } else {
-                                format!(" Did you mean: {}?", suggestions.join(", "))
-                            };
-                            anyhow::bail!(
-                                "Model '{}' not found in provider catalog.{} \
-                                 (See `[provider].model` in config.)",
-                                config.provider.model,
-                                hint,
-                            );
-                        }
-                    }
-                }
-                Err(e) => {
-                    tracing::warn!("catalog fetch failed (continuing with config defaults): {e}");
-                }
-            }
-        }
+        let selection = Self::resolve_model_selection(&config.provider, &api_key).await?;
+        let effective_max_context = selection.max_context;
+        let supports_json_mode = selection.model.features.json_mode;
+        let pricing = selection.pricing.clone();
 
         let provider: Box<dyn LLMProvider> = Box::new(
             OpenAIProvider::new(
@@ -225,7 +193,11 @@ impl Agent {
         if config.tools.yolo_mode {
             approval_cfg.default = crate::config::ApprovalMode::Always;
         }
-        hooks.register(Arc::new(ApprovalHook::new(approval_cfg, pause_tx.clone())));
+        let approval_hook = match pause_tx.clone() {
+            Some(tx) => ApprovalHook::new(approval_cfg, Some(tx)),
+            None => ApprovalHook::auto_deny(approval_cfg),
+        };
+        hooks.register(Arc::new(approval_hook));
 
         // Built-in hook: block dangerous shell invocations unless yolo_mode is on.
         // Skipped entirely (not even registered as observe-only) when yolo_mode
@@ -252,6 +224,8 @@ impl Agent {
             turn_cancel: CancellationToken::new(),
             diff_sink,
             pricing,
+            provider_config: config.provider.clone(),
+            provider_api_key: api_key,
             lsp_manager,
             last_saved_count: 0,
             max_iterations: config.provider.max_iterations,
@@ -271,26 +245,121 @@ impl Agent {
         self.pricing.as_ref()
     }
 
+    pub fn active_model(&self) -> &str {
+        &self.provider_config.model
+    }
+
+    pub fn max_context(&self) -> usize {
+        self.provider.max_context()
+    }
+
     pub fn session_id(&self) -> &str {
         &self.session_id
     }
 
-    /// Fetch the provider's model catalog (cached if fresh, otherwise
-    /// HTTP-fetched). Used for startup validation and `max_context`
-    /// auto-population. Runs inside the caller's tokio runtime — the
-    /// constructor is `async` for exactly this reason.
-    async fn fetch_catalog(
-        config: &Config,
+    pub async fn available_models(&self) -> Result<Vec<crate::provider::catalog::ModelInfo>> {
+        Self::fetch_catalog_for(&self.provider_config, &self.provider_api_key).await
+    }
+
+    pub async fn switch_model(&mut self, model_id: &str) -> Result<ModelSelection> {
+        if self.turn_cancel.is_cancelled() {
+            self.turn_cancel = CancellationToken::new();
+        }
+
+        let mut next_config = self.provider_config.clone();
+        next_config.model = model_id.to_string();
+        let selection = Self::resolve_model_selection(&next_config, &self.provider_api_key).await?;
+        let provider: Box<dyn LLMProvider> = Box::new(
+            OpenAIProvider::new(
+                &next_config.base_url,
+                &self.provider_api_key,
+                &next_config.model,
+                selection.max_context,
+                next_config.max_retries,
+                selection.model.features.json_mode,
+                next_config.debug,
+            )
+            .context("Failed to initialize LLM provider")?,
+        );
+
+        self.provider = provider;
+        self.provider_config = next_config;
+        self.context = ContextManager::new(selection.max_context);
+        self.pricing = selection.pricing.clone();
+
+        Ok(selection)
+    }
+
+    async fn fetch_catalog_for(
+        provider: &ProviderConfig,
         api_key: &str,
     ) -> Result<Vec<crate::provider::catalog::ModelInfo>> {
         use std::time::Duration;
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(15))
             .build()?;
-        let ttl = Duration::from_secs(config.provider.catalog_cache_ttl_hours * 3600);
+        let ttl = Duration::from_secs(provider.catalog_cache_ttl_hours * 3600);
         let catalog =
-            crate::provider::catalog::for_base_url(client, &config.provider.base_url, api_key, ttl);
+            crate::provider::catalog::for_base_url(client, &provider.base_url, api_key, ttl);
         catalog.list_models().await.map_err(Into::into)
+    }
+
+    async fn resolve_model_selection(
+        provider: &ProviderConfig,
+        api_key: &str,
+    ) -> Result<ModelSelection> {
+        let mut effective_max_context = provider.max_context;
+        let mut model_info = crate::provider::catalog::ModelInfo {
+            id: provider.model.clone(),
+            display_name: provider.model.clone(),
+            context_length: 0,
+            pricing: None,
+            features: crate::provider::catalog::ModelFeatures::default(),
+            top_provider: None,
+        };
+
+        if !provider.disable_catalog {
+            match Self::fetch_catalog_for(provider, api_key).await {
+                Ok(models) => match models.iter().find(|m| m.id == provider.model) {
+                    Some(found) => {
+                        model_info = found.clone();
+                        if model_info.context_length > 0 && provider.max_context == 128_000 {
+                            effective_max_context = model_info.context_length;
+                            tracing::info!(
+                                "catalog: using context_length={} for {} (json_mode={})",
+                                model_info.context_length,
+                                model_info.id,
+                                model_info.features.json_mode,
+                            );
+                        }
+                    }
+                    None => {
+                        let suggestions =
+                            crate::provider::catalog::fuzzy_suggest(&models, &provider.model, 3);
+                        let hint = if suggestions.is_empty() {
+                            String::new()
+                        } else {
+                            format!(" Did you mean: {}?", suggestions.join(", "))
+                        };
+                        anyhow::bail!(
+                            "Model '{}' not found in provider catalog.{} \
+                             (See `[provider].model` in config.)",
+                            provider.model,
+                            hint,
+                        );
+                    }
+                },
+                Err(e) => {
+                    tracing::warn!("catalog fetch failed (continuing with config defaults): {e}");
+                }
+            }
+        }
+
+        Ok(ModelSelection {
+            pricing: model_info.pricing.clone(),
+            model: model_info,
+            max_context: effective_max_context,
+        })
     }
 
     /// Test/bench-only constructor that takes a fully-built provider and an
@@ -321,6 +390,8 @@ impl Agent {
             turn_cancel: CancellationToken::new(),
             diff_sink: crate::tools::new_diff_sink(),
             pricing: None,
+            provider_config: ProviderConfig::default(),
+            provider_api_key: "test-key".into(),
             lsp_manager: Arc::new(crate::code::lsp::LspManager::new(
                 std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
             )),
@@ -1300,6 +1371,78 @@ mod tests {
         assert_eq!(resp, "Hi!");
         // run_prompt's final save_messages would have stored the reasoning;
         // not asserting against the DB to avoid touching ~/.vulcan in tests.
+    }
+
+    #[tokio::test]
+    async fn switch_model_rebuilds_provider_metadata_without_restarting_session() {
+        let base_url = spawn_model_catalog_server().await;
+        let config = Config {
+            provider: crate::config::ProviderConfig {
+                base_url,
+                api_key: Some("test-key".into()),
+                model: "model-a".into(),
+                catalog_cache_ttl_hours: 0,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let mut agent = Agent::new(&config).await.unwrap();
+        let session_id = agent.session_id().to_string();
+
+        assert_eq!(agent.active_model(), "model-a");
+        assert_eq!(agent.max_context(), 1_000);
+        assert_eq!(agent.pricing().map(|p| p.input_per_token), Some(0.000001));
+
+        let selection = agent.switch_model("model-b").await.unwrap();
+
+        assert_eq!(agent.session_id(), session_id);
+        assert_eq!(selection.model.id, "model-b");
+        assert_eq!(agent.active_model(), "model-b");
+        assert_eq!(agent.max_context(), 2_000);
+        assert_eq!(agent.pricing().map(|p| p.output_per_token), Some(0.000004));
+    }
+
+    async fn spawn_model_catalog_server() -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let addr = listener.local_addr().expect("local addr");
+        tokio::spawn(async move {
+            loop {
+                let Ok((mut stream, _)) = listener.accept().await else {
+                    break;
+                };
+                tokio::spawn(async move {
+                    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                    let mut buf = [0u8; 1024];
+                    let _ = stream.read(&mut buf).await;
+                    let body = r#"{
+                        "data": [
+                            {
+                                "id": "model-a",
+                                "context_length": 1000,
+                                "pricing": {"prompt": "0.000001", "completion": "0.000002"},
+                                "supported_parameters": ["tools", "response_format"]
+                            },
+                            {
+                                "id": "model-b",
+                                "context_length": 2000,
+                                "pricing": {"prompt": "0.000003", "completion": "0.000004"},
+                                "supported_parameters": ["tools"]
+                            }
+                        ]
+                    }"#;
+                    let response = format!(
+                        "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+                        body.len(),
+                        body
+                    );
+                    let _ = stream.write_all(response.as_bytes()).await;
+                });
+            }
+        });
+        format!("http://{addr}/v1")
     }
 
     #[tokio::test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -41,4 +41,11 @@ pub enum Command {
         #[arg(long, default_value_t = 10)]
         limit: usize,
     },
+    /// Run the long-lived gateway daemon (axum server + platform connectors)
+    #[cfg(feature = "gateway")]
+    Gateway {
+        /// Override bind address from config (e.g. 127.0.0.1:7777)
+        #[arg(long)]
+        bind: Option<String>,
+    },
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,9 @@ pub struct Config {
 
     #[serde(default)]
     pub tui: TuiConfig,
+
+    #[serde(default)]
+    pub gateway: Option<GatewayConfig>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -51,6 +54,32 @@ impl Default for TuiConfig {
             theme: default_theme_name(),
         }
     }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct GatewayConfig {
+    #[serde(default = "default_gateway_bind")]
+    pub bind: String,
+    pub api_token: String,
+    #[serde(default = "default_gateway_idle_ttl_secs")]
+    pub idle_ttl_secs: u64,
+    #[serde(default = "default_gateway_max_concurrent_lanes")]
+    pub max_concurrent_lanes: usize,
+    #[serde(default = "default_gateway_outbound_max_attempts")]
+    pub outbound_max_attempts: u32,
+}
+
+fn default_gateway_bind() -> String {
+    "127.0.0.1:7777".into()
+}
+fn default_gateway_idle_ttl_secs() -> u64 {
+    1800
+}
+fn default_gateway_max_concurrent_lanes() -> usize {
+    64
+}
+fn default_gateway_outbound_max_attempts() -> u32 {
+    5
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -244,6 +273,7 @@ impl Default for Config {
             compaction: CompactionConfig::default(),
             embeddings: EmbeddingsConfig::default(),
             tui: TuiConfig::default(),
+            gateway: None,
         }
     }
 }
@@ -363,5 +393,20 @@ debug = "wire"
 
         assert!(ProviderDebugMode::Wire.logs_wire());
         assert!(ProviderDebugMode::Wire.logs_tool_fallback());
+    }
+
+    #[test]
+    fn gateway_section_parses_with_defaults() {
+        let toml = r#"
+            [gateway]
+            api_token = "test-token"
+        "#;
+        let cfg: Config = toml::from_str(toml).expect("parse");
+        let g = cfg.gateway.expect("gateway present");
+        assert_eq!(g.bind, "127.0.0.1:7777");
+        assert_eq!(g.api_token, "test-token");
+        assert_eq!(g.idle_ttl_secs, 1800);
+        assert_eq!(g.max_concurrent_lanes, 64);
+        assert_eq!(g.outbound_max_attempts, 5);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use serde::Deserialize;
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 /// Path to the Vulcan config directory (~/.vulcan/)
@@ -16,6 +17,13 @@ fn dirs_or_default() -> PathBuf {
 pub struct Config {
     #[serde(default)]
     pub provider: ProviderConfig,
+
+    /// Additional named provider profiles. The legacy `[provider]` table
+    /// remains the active profile for now; named profiles give config a place
+    /// to bind auth/base URL/model together before provider switching grows a
+    /// dedicated UI.
+    #[serde(default)]
+    pub providers: HashMap<String, ProviderConfig>,
 
     #[serde(default)]
     pub tools: ToolsConfig,
@@ -268,6 +276,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             provider: ProviderConfig::default(),
+            providers: HashMap::new(),
             tools: ToolsConfig::default(),
             skills_dir: default_skills_dir(),
             compaction: CompactionConfig::default(),
@@ -360,9 +369,16 @@ impl Config {
 
     /// Resolve the API key: env var > config > compile-time warning
     pub fn api_key(&self) -> Option<String> {
+        self.api_key_for(&self.provider)
+    }
+
+    /// Resolve the API key for a provider profile: env var wins, then the
+    /// profile-local key. Named providers intentionally use the same global
+    /// env override so one-off shells can redirect auth without editing TOML.
+    pub fn api_key_for(&self, provider: &ProviderConfig) -> Option<String> {
         std::env::var("VULCAN_API_KEY")
             .ok()
-            .or_else(|| self.provider.api_key.clone())
+            .or_else(|| provider.api_key.clone())
     }
 }
 
@@ -408,5 +424,31 @@ debug = "wire"
         assert_eq!(g.idle_ttl_secs, 1800);
         assert_eq!(g.max_concurrent_lanes, 64);
         assert_eq!(g.outbound_max_attempts, 5);
+    }
+
+    #[test]
+    fn named_provider_profiles_parse_without_breaking_legacy_provider() {
+        let toml = r#"
+            [provider]
+            base_url = "https://openrouter.ai/api/v1"
+            api_key = "openrouter-key"
+            model = "deepseek/deepseek-v4-flash"
+
+            [providers.local]
+            base_url = "http://localhost:11434/v1"
+            api_key = "ollama-key"
+            model = "qwen2.5-coder:latest"
+            disable_catalog = true
+        "#;
+
+        let cfg: Config = toml::from_str(toml).expect("config should parse");
+
+        assert_eq!(cfg.provider.model, "deepseek/deepseek-v4-flash");
+        assert_eq!(cfg.providers["local"].base_url, "http://localhost:11434/v1");
+        assert_eq!(
+            cfg.providers["local"].api_key.as_deref(),
+            Some("ollama-key")
+        );
+        assert!(cfg.providers["local"].disable_catalog);
     }
 }

--- a/src/gateway/agent_map.rs
+++ b/src/gateway/agent_map.rs
@@ -19,7 +19,7 @@ use crate::agent::Agent;
 use crate::config::Config;
 use crate::gateway::lane::LaneKey;
 use crate::hooks::HookRegistry;
-use crate::hooks::audit::AuditHook;
+use crate::hooks::audit::{AuditBuffer, AuditHook};
 
 /// Capacity of the per-lane audit ring. Matches the TUI's default in
 /// `src/tui/mod.rs:384`.
@@ -36,6 +36,8 @@ pub(crate) struct LaneEntry {
     pub agent: Arc<Mutex<Agent>>,
     #[allow(dead_code)] // Stored for observability + Task 9 rehydration.
     pub session_id: String,
+    #[allow(dead_code)] // Surfaced by GET /v1/lanes (Task 15).
+    pub audit_buf: AuditBuffer,
     pub last_activity: Instant,
 }
 
@@ -67,22 +69,29 @@ impl AgentMap {
             }
         }
 
-        // Slow path: write-lock + double-check + spawn.
-        let mut map = self.inner.write().await;
-        if let Some(entry) = map.get_mut(lane) {
-            entry.last_activity = Instant::now();
-            return Ok(Arc::clone(&entry.agent));
-        }
-
-        // No pause channel — gateway has no interactive surface; Task 18
-        // swaps approval for auto-deny before any real traffic flows.
+        // Slow path: build the Agent OUTSIDE the map's write lock so a slow
+        // cold spawn on one lane doesn't block first-touches on every other
+        // lane. Acquire the write lock only briefly to insert.
+        //
+        // ApprovalHook is registered inside `with_hooks_and_pause` regardless
+        // of `pause_tx`. With `None` here, any non-`Always` approval mode in
+        // user config will block the lane on first prompt — Task 18 wires an
+        // auto-deny variant that closes that gap.
         let mut hook_reg = HookRegistry::new();
-        let (audit_hook, _audit_buf) = AuditHook::new(AUDIT_BUFFER_CAPACITY);
+        let (audit_hook, audit_buf) = AuditHook::new(AUDIT_BUFFER_CAPACITY);
         hook_reg.register(audit_hook);
 
         let agent = Agent::with_hooks_and_pause(&self.config, hook_reg, None).await?;
         let agent = Arc::new(Mutex::new(agent));
         agent.lock().await.start_session().await;
+
+        // Triple-check: another task may have spawned the same lane while we
+        // were building. If so, drop our agent and adopt theirs.
+        let mut map = self.inner.write().await;
+        if let Some(entry) = map.get_mut(lane) {
+            entry.last_activity = Instant::now();
+            return Ok(Arc::clone(&entry.agent));
+        }
 
         let session_id = derive_session_id(lane);
         map.insert(
@@ -90,6 +99,7 @@ impl AgentMap {
             LaneEntry {
                 agent: Arc::clone(&agent),
                 session_id,
+                audit_buf,
                 last_activity: Instant::now(),
             },
         );

--- a/src/gateway/agent_map.rs
+++ b/src/gateway/agent_map.rs
@@ -121,10 +121,9 @@ impl AgentMap {
         // cold spawn on one lane doesn't block first-touches on every other
         // lane. Acquire the write lock only briefly to insert.
         //
-        // ApprovalHook is registered inside `with_hooks_and_pause` regardless
-        // of `pause_tx`. With `None` here, any non-`Always` approval mode in
-        // user config will block the lane on first prompt — Task 18 wires an
-        // auto-deny variant that closes that gap.
+        // ApprovalHook is registered inside `with_hooks_and_pause`; with
+        // `None` here it uses the explicit auto-deny constructor so gateway
+        // agents never block waiting for a TUI approval consumer.
         let mut hook_reg = HookRegistry::new();
         let (audit_hook, audit_buf) = AuditHook::new(AUDIT_BUFFER_CAPACITY);
         hook_reg.register(audit_hook);

--- a/src/gateway/agent_map.rs
+++ b/src/gateway/agent_map.rs
@@ -62,7 +62,7 @@ pub(crate) struct LaneEntry {
 /// Per-lane summary returned by `AgentMap::snapshot` and surfaced through
 /// `GET /v1/lanes`. Owned strings + a relative timestamp so the JSON output
 /// is stable across calls (no `Instant` serialization gymnastics).
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, serde::Serialize)]
 pub struct LaneSnapshot {
     pub platform: String,
     pub chat_id: String,
@@ -191,8 +191,14 @@ impl AgentMap {
                     .as_secs(),
             })
             .collect();
-        // Most-recent first.
-        out.sort_by_key(|s| s.last_activity_secs_ago);
+        // Most-recent first; tie-break on (platform, chat_id) so JSON output
+        // is deterministic when two lanes land in the same second bucket.
+        out.sort_by(|a, b| {
+            a.last_activity_secs_ago
+                .cmp(&b.last_activity_secs_ago)
+                .then_with(|| a.platform.cmp(&b.platform))
+                .then_with(|| a.chat_id.cmp(&b.chat_id))
+        });
         out
     }
 

--- a/src/gateway/agent_map.rs
+++ b/src/gateway/agent_map.rs
@@ -53,11 +53,21 @@ pub struct AgentMap {
 
 pub(crate) struct LaneEntry {
     pub agent: Arc<Mutex<Agent>>,
-    #[allow(dead_code)] // Stored for observability + Task 9 rehydration.
     pub session_id: String,
-    #[allow(dead_code)] // Surfaced by GET /v1/lanes (Task 15).
+    #[allow(dead_code)] // Per-tool-call ring; not surfaced by /v1/lanes (Task 15).
     pub audit_buf: AuditBuffer,
     pub last_activity: Instant,
+}
+
+/// Per-lane summary returned by `AgentMap::snapshot` and surfaced through
+/// `GET /v1/lanes`. Owned strings + a relative timestamp so the JSON output
+/// is stable across calls (no `Instant` serialization gymnastics).
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct LaneSnapshot {
+    pub platform: String,
+    pub chat_id: String,
+    pub session_id: String,
+    pub last_activity_secs_ago: u64,
 }
 
 impl AgentMap {
@@ -161,6 +171,29 @@ impl AgentMap {
     /// tests.
     pub async fn active_lanes(&self) -> usize {
         self.inner.read().await.len()
+    }
+
+    /// Snapshot every active lane. Sorted ascending by
+    /// `last_activity_secs_ago` so the most-recently-touched lanes appear
+    /// first. Read-locked iteration over `inner`; returns an owned `Vec` so
+    /// the lock is dropped before serialization.
+    pub async fn snapshot(&self) -> Vec<LaneSnapshot> {
+        let map = self.inner.read().await;
+        let now = Instant::now();
+        let mut out: Vec<LaneSnapshot> = map
+            .iter()
+            .map(|(k, entry)| LaneSnapshot {
+                platform: k.platform.clone(),
+                chat_id: k.chat_id.clone(),
+                session_id: entry.session_id.clone(),
+                last_activity_secs_ago: now
+                    .saturating_duration_since(entry.last_activity)
+                    .as_secs(),
+            })
+            .collect();
+        // Most-recent first.
+        out.sort_by_key(|s| s.last_activity_secs_ago);
+        out
     }
 
     /// Internal accessor for tests + the future evictor (Task 9).

--- a/src/gateway/agent_map.rs
+++ b/src/gateway/agent_map.rs
@@ -3,7 +3,8 @@
 //! `AgentMap` keys live `Agent` instances by `LaneKey` so each chat (Slack
 //! thread, IRC channel, Matrix room, etc.) gets a long-lived agent with its
 //! own hook state. First touch on a lane spawns the Agent; subsequent calls
-//! reuse it. Eviction lands in Task 9 — for now, the map grows monotonically.
+//! reuse it. A background evictor (`spawn_evictor`) reaps lanes idle longer
+//! than `idle_ttl` so the map doesn't grow without bound.
 //!
 //! The double-checked spawn pattern in `get_or_spawn` matches the lane router
 //! in `lane.rs`: read-lock → write-lock → recheck → insert.
@@ -119,13 +120,13 @@ impl AgentMap {
     }
 
     /// Spawn a background task that periodically evicts lanes idle longer
-    /// than `self.idle_ttl`. The returned handle aborts the loop on drop or
-    /// on `.abort()`.
-    pub fn spawn_evictor(&self) -> JoinHandle<()> {
+    /// than `self.idle_ttl`. The returned `EvictorHandle` aborts the loop on
+    /// drop, so callers don't need to remember to call `.abort()` on shutdown.
+    pub fn spawn_evictor(&self) -> EvictorHandle {
         const SCAN_INTERVAL: Duration = Duration::from_secs(60);
         let inner = Arc::clone(&self.inner);
         let ttl = self.idle_ttl;
-        tokio::spawn(async move {
+        let handle = tokio::spawn(async move {
             let mut ticker = tokio::time::interval(SCAN_INTERVAL);
             // Skip the immediate first tick; the first eviction happens after
             // one full interval.
@@ -134,7 +135,8 @@ impl AgentMap {
                 ticker.tick().await;
                 evict_idle(&inner, ttl).await;
             }
-        })
+        });
+        EvictorHandle { handle }
     }
 
     #[cfg(test)]
@@ -195,12 +197,37 @@ pub(crate) async fn evict_idle(
         taken
     };
     for (lane, entry) in evicted {
-        let agent = entry.agent.lock().await;
-        agent.end_session().await;
-        tracing::info!(target: "gateway::agent_map",
-            platform = lane.platform.as_str(),
-            chat_id = lane.chat_id.as_str(),
-            "evicted idle lane");
+        // end_session calls LspManager::shutdown_all which can stall if a
+        // child server is wedged. Spawn each shutdown so the eviction loop
+        // returns to its ticker promptly.
+        tokio::spawn(async move {
+            let agent = entry.agent.lock().await;
+            agent.end_session().await;
+            tracing::info!(target: "gateway::agent_map",
+                platform = lane.platform.as_str(),
+                chat_id = lane.chat_id.as_str(),
+                "evicted idle lane");
+        });
+    }
+}
+
+/// Handle to the background evictor task. Aborts the loop on drop so callers
+/// don't have to remember to clean up on shutdown.
+pub struct EvictorHandle {
+    handle: JoinHandle<()>,
+}
+
+impl EvictorHandle {
+    /// Abort the evictor immediately. `Drop` does the same; this is for
+    /// callers that want to abort and then `await` clean exit.
+    pub fn abort(&self) {
+        self.handle.abort();
+    }
+}
+
+impl Drop for EvictorHandle {
+    fn drop(&mut self) {
+        self.handle.abort();
     }
 }
 

--- a/src/gateway/agent_map.rs
+++ b/src/gateway/agent_map.rs
@@ -1,0 +1,168 @@
+//! Per-lane Agent cache for the gateway daemon.
+//!
+//! `AgentMap` keys live `Agent` instances by `LaneKey` so each chat (Slack
+//! thread, IRC channel, Matrix room, etc.) gets a long-lived agent with its
+//! own hook state. First touch on a lane spawns the Agent; subsequent calls
+//! reuse it. Eviction lands in Task 9 — for now, the map grows monotonically.
+//!
+//! The double-checked spawn pattern in `get_or_spawn` matches the lane router
+//! in `lane.rs`: read-lock → write-lock → recheck → insert.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use tokio::sync::{Mutex, RwLock};
+
+use crate::agent::Agent;
+use crate::config::Config;
+use crate::gateway::lane::LaneKey;
+use crate::hooks::HookRegistry;
+use crate::hooks::audit::AuditHook;
+
+/// Capacity of the per-lane audit ring. Matches the TUI's default in
+/// `src/tui/mod.rs:384`.
+const AUDIT_BUFFER_CAPACITY: usize = 200;
+
+pub struct AgentMap {
+    inner: Arc<RwLock<HashMap<LaneKey, LaneEntry>>>,
+    config: Arc<Config>,
+    #[allow(dead_code)] // Consumed by Task 9's evictor.
+    idle_ttl: Duration,
+}
+
+pub(crate) struct LaneEntry {
+    pub agent: Arc<Mutex<Agent>>,
+    #[allow(dead_code)] // Stored for observability + Task 9 rehydration.
+    pub session_id: String,
+    pub last_activity: Instant,
+}
+
+impl AgentMap {
+    pub fn new(config: Arc<Config>, idle_ttl: Duration) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(HashMap::new())),
+            config,
+            idle_ttl,
+        }
+    }
+
+    /// Returns the Agent for `lane`, building one on first call. Bumps
+    /// `last_activity` on every call so the Task 9 evictor sees liveness.
+    pub async fn get_or_spawn(&self, lane: &LaneKey) -> Result<Arc<Mutex<Agent>>> {
+        // Fast path: read-lock probe. Drop the read guard before re-acquiring
+        // as a writer to bump `last_activity`.
+        {
+            let map = self.inner.read().await;
+            if map.contains_key(lane) {
+                drop(map);
+                let mut map = self.inner.write().await;
+                if let Some(entry) = map.get_mut(lane) {
+                    entry.last_activity = Instant::now();
+                    return Ok(Arc::clone(&entry.agent));
+                }
+                // Fell through: a concurrent evictor (future) removed the
+                // entry between our drop and re-acquire. Treat as a miss.
+            }
+        }
+
+        // Slow path: write-lock + double-check + spawn.
+        let mut map = self.inner.write().await;
+        if let Some(entry) = map.get_mut(lane) {
+            entry.last_activity = Instant::now();
+            return Ok(Arc::clone(&entry.agent));
+        }
+
+        // No pause channel — gateway has no interactive surface; Task 18
+        // swaps approval for auto-deny before any real traffic flows.
+        let mut hook_reg = HookRegistry::new();
+        let (audit_hook, _audit_buf) = AuditHook::new(AUDIT_BUFFER_CAPACITY);
+        hook_reg.register(audit_hook);
+
+        let agent = Agent::with_hooks_and_pause(&self.config, hook_reg, None).await?;
+        let agent = Arc::new(Mutex::new(agent));
+        agent.lock().await.start_session().await;
+
+        let session_id = derive_session_id(lane);
+        map.insert(
+            lane.clone(),
+            LaneEntry {
+                agent: Arc::clone(&agent),
+                session_id,
+                last_activity: Instant::now(),
+            },
+        );
+        Ok(agent)
+    }
+
+    /// Count of currently-active lanes. Used by GET /v1/lanes (Task 15) and
+    /// tests.
+    pub async fn active_lanes(&self) -> usize {
+        self.inner.read().await.len()
+    }
+
+    /// Internal accessor for tests + the future evictor (Task 9).
+    #[allow(dead_code)]
+    pub(crate) fn inner(&self) -> Arc<RwLock<HashMap<LaneKey, LaneEntry>>> {
+        Arc::clone(&self.inner)
+    }
+}
+
+/// Derive a stable session id for a lane. Used so future AgentMap eviction
+/// + rehydration (Task 9) can find the right SessionStore row.
+pub fn derive_session_id(lane: &LaneKey) -> String {
+    format!("gateway:{}:{}", lane.platform, lane.chat_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+
+    fn test_config() -> Arc<Config> {
+        Arc::new(Config::default())
+    }
+
+    fn test_lane(chat: &str) -> LaneKey {
+        LaneKey {
+            platform: "loopback".into(),
+            chat_id: chat.into(),
+        }
+    }
+
+    #[test]
+    fn session_id_is_deterministic_per_lane() {
+        let a = derive_session_id(&test_lane("42"));
+        let b = derive_session_id(&test_lane("42"));
+        assert_eq!(a, b);
+        assert_eq!(a, "gateway:loopback:42");
+        let c = derive_session_id(&test_lane("99"));
+        assert_ne!(a, c);
+    }
+
+    // Ignored: `Agent::with_hooks_and_pause` bails when no API key is set,
+    // and `Config::default()` provides none. A future MockProvider /
+    // builder-style test config would let these run unconditionally;
+    // tracking this gap in the Task 8 report.
+    #[tokio::test]
+    #[ignore = "needs API key or MockProvider; Config::default() has no api_key"]
+    async fn second_get_reuses_agent() {
+        let map = AgentMap::new(test_config(), Duration::from_secs(60));
+        let lane = test_lane("x");
+        let a1 = map.get_or_spawn(&lane).await.expect("first spawn");
+        let a2 = map.get_or_spawn(&lane).await.expect("second get");
+        assert!(Arc::ptr_eq(&a1, &a2), "same lane must return the same Arc");
+        assert_eq!(map.active_lanes().await, 1);
+    }
+
+    #[tokio::test]
+    #[ignore = "needs API key or MockProvider; Config::default() has no api_key"]
+    async fn distinct_lanes_get_distinct_agents() {
+        let map = AgentMap::new(test_config(), Duration::from_secs(60));
+        let a = map.get_or_spawn(&test_lane("a")).await.expect("a");
+        let b = map.get_or_spawn(&test_lane("b")).await.expect("b");
+        assert!(!Arc::ptr_eq(&a, &b));
+        assert_eq!(map.active_lanes().await, 2);
+    }
+}

--- a/src/gateway/agent_map.rs
+++ b/src/gateway/agent_map.rs
@@ -14,6 +14,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use tokio::sync::{Mutex, RwLock};
+use tokio::task::JoinHandle;
 
 use crate::agent::Agent;
 use crate::config::Config;
@@ -28,7 +29,6 @@ const AUDIT_BUFFER_CAPACITY: usize = 200;
 pub struct AgentMap {
     inner: Arc<RwLock<HashMap<LaneKey, LaneEntry>>>,
     config: Arc<Config>,
-    #[allow(dead_code)] // Consumed by Task 9's evictor.
     idle_ttl: Duration,
 }
 
@@ -117,6 +117,91 @@ impl AgentMap {
     pub(crate) fn inner(&self) -> Arc<RwLock<HashMap<LaneKey, LaneEntry>>> {
         Arc::clone(&self.inner)
     }
+
+    /// Spawn a background task that periodically evicts lanes idle longer
+    /// than `self.idle_ttl`. The returned handle aborts the loop on drop or
+    /// on `.abort()`.
+    pub fn spawn_evictor(&self) -> JoinHandle<()> {
+        const SCAN_INTERVAL: Duration = Duration::from_secs(60);
+        let inner = Arc::clone(&self.inner);
+        let ttl = self.idle_ttl;
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(SCAN_INTERVAL);
+            // Skip the immediate first tick; the first eviction happens after
+            // one full interval.
+            ticker.tick().await;
+            loop {
+                ticker.tick().await;
+                evict_idle(&inner, ttl).await;
+            }
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn insert_for_test(
+        &self,
+        lane: LaneKey,
+        agent: Arc<Mutex<Agent>>,
+        audit_buf: AuditBuffer,
+        last_activity: Instant,
+    ) {
+        let session_id = derive_session_id(&lane);
+        let mut map = self.inner.write().await;
+        map.insert(
+            lane,
+            LaneEntry {
+                agent,
+                session_id,
+                audit_buf,
+                last_activity,
+            },
+        );
+    }
+}
+
+pub(crate) async fn evict_idle(
+    inner: &Arc<RwLock<HashMap<LaneKey, LaneEntry>>>,
+    ttl: Duration,
+) {
+    // Build the to-evict list under the read lock; do the actual removal +
+    // end_session under the write lock + outside the map. This keeps the
+    // write lock window tight even if many lanes age out at once.
+    let now = Instant::now();
+    let candidates: Vec<LaneKey> = {
+        let map = inner.read().await;
+        map.iter()
+            .filter(|(_, entry)| now.duration_since(entry.last_activity) > ttl)
+            .map(|(k, _)| k.clone())
+            .collect()
+    };
+    if candidates.is_empty() {
+        return;
+    }
+    let evicted = {
+        let mut map = inner.write().await;
+        let mut taken = Vec::with_capacity(candidates.len());
+        for lane in &candidates {
+            if let Some(entry) = map.get(lane) {
+                // Re-check liveness — a concurrent get_or_spawn may have
+                // bumped last_activity between our snapshot and the write
+                // lock.
+                if now.duration_since(entry.last_activity) > ttl {
+                    if let Some(entry) = map.remove(lane) {
+                        taken.push((lane.clone(), entry));
+                    }
+                }
+            }
+        }
+        taken
+    };
+    for (lane, entry) in evicted {
+        let agent = entry.agent.lock().await;
+        agent.end_session().await;
+        tracing::info!(target: "gateway::agent_map",
+            platform = lane.platform.as_str(),
+            chat_id = lane.chat_id.as_str(),
+            "evicted idle lane");
+    }
 }
 
 /// Derive a stable session id for a lane. Used so future AgentMap eviction
@@ -129,6 +214,11 @@ pub fn derive_session_id(lane: &LaneKey) -> String {
 mod tests {
     use super::*;
     use crate::config::Config;
+    use crate::provider::mock::MockProvider;
+    use crate::provider::{ChatResponse, LLMProvider, Message, StreamEvent, ToolDefinition};
+    use crate::skills::SkillRegistry;
+    use crate::tools::ToolRegistry;
+    use tokio_util::sync::CancellationToken;
 
     fn test_config() -> Arc<Config> {
         Arc::new(Config::default())
@@ -139,6 +229,47 @@ mod tests {
             platform: "loopback".into(),
             chat_id: chat.into(),
         }
+    }
+
+    /// Build an Agent backed by `MockProvider` so eviction tests don't need
+    /// an API key. Mirrors `agent::tests::agent_with_mock`'s `ProviderHandle`
+    /// shim.
+    fn build_test_agent() -> Arc<Mutex<Agent>> {
+        struct ProviderHandle(Arc<MockProvider>);
+        #[async_trait::async_trait]
+        impl LLMProvider for ProviderHandle {
+            async fn chat(
+                &self,
+                m: &[Message],
+                t: &[ToolDefinition],
+                c: CancellationToken,
+            ) -> Result<ChatResponse> {
+                self.0.chat(m, t, c).await
+            }
+            async fn chat_stream(
+                &self,
+                m: &[Message],
+                t: &[ToolDefinition],
+                tx: tokio::sync::mpsc::UnboundedSender<StreamEvent>,
+                c: CancellationToken,
+            ) -> Result<()> {
+                self.0.chat_stream(m, t, tx, c).await
+            }
+            fn max_context(&self) -> usize {
+                self.0.max_context()
+            }
+        }
+        let mock = Arc::new(MockProvider::new(128_000));
+        let skills = Arc::new(SkillRegistry::new(&std::path::PathBuf::from(
+            "/tmp/vulcan-test-skills-nonexistent",
+        )));
+        let agent = Agent::for_test(
+            Box::new(ProviderHandle(mock)),
+            ToolRegistry::new(),
+            HookRegistry::new(),
+            skills,
+        );
+        Arc::new(Mutex::new(agent))
     }
 
     #[test]
@@ -174,5 +305,56 @@ mod tests {
         let b = map.get_or_spawn(&test_lane("b")).await.expect("b");
         assert!(!Arc::ptr_eq(&a, &b));
         assert_eq!(map.active_lanes().await, 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    #[ignore = "needs API key or MockProvider; Agent::with_hooks_and_pause + Config::default() has no api_key"]
+    async fn idle_lanes_evicted_after_ttl() {
+        let map = AgentMap::new(test_config(), Duration::from_secs(60));
+        let evictor = map.spawn_evictor();
+        let lane = test_lane("x");
+        map.get_or_spawn(&lane).await.expect("spawn");
+        assert_eq!(map.active_lanes().await, 1);
+
+        // Advance well past TTL + scan interval (60s + 60s = 120s minimum).
+        tokio::time::advance(Duration::from_secs(180)).await;
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        assert_eq!(map.active_lanes().await, 0, "lane should be evicted");
+        evictor.abort();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn evict_idle_removes_entries_past_ttl() {
+        // Advance the paused clock first so `Instant::now() - 120s` doesn't
+        // underflow at runtime startup.
+        tokio::time::advance(Duration::from_secs(200)).await;
+
+        let map = AgentMap::new(test_config(), Duration::from_secs(60));
+        let lane = test_lane("stale");
+        let agent = build_test_agent();
+        let (_h, audit_buf) = AuditHook::new(8);
+        let stale_when = Instant::now() - Duration::from_secs(120);
+        map.insert_for_test(lane.clone(), agent, audit_buf, stale_when)
+            .await;
+        assert_eq!(map.active_lanes().await, 1);
+
+        super::evict_idle(&map.inner, Duration::from_secs(60)).await;
+        assert_eq!(map.active_lanes().await, 0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn evict_idle_keeps_recent_entries() {
+        let map = AgentMap::new(test_config(), Duration::from_secs(60));
+        let lane = test_lane("fresh");
+        let agent = build_test_agent();
+        let (_h, audit_buf) = AuditHook::new(8);
+        map.insert_for_test(lane.clone(), agent, audit_buf, Instant::now())
+            .await;
+        assert_eq!(map.active_lanes().await, 1);
+
+        super::evict_idle(&map.inner, Duration::from_secs(60)).await;
+        assert_eq!(map.active_lanes().await, 1);
     }
 }

--- a/src/gateway/agent_map.rs
+++ b/src/gateway/agent_map.rs
@@ -27,10 +27,28 @@ use crate::hooks::audit::{AuditBuffer, AuditHook};
 /// `src/tui/mod.rs:384`.
 const AUDIT_BUFFER_CAPACITY: usize = 200;
 
+#[cfg(test)]
+use std::future::Future;
+#[cfg(test)]
+use std::pin::Pin;
+
+/// Test-only agent factory. `get_or_spawn` calls this in lieu of
+/// `Agent::with_hooks_and_pause` so tests can swap in a `MockProvider`-backed
+/// Agent without an API key. Boxed-future return so the closure type can be
+/// erased behind `dyn Fn`.
+#[cfg(test)]
+pub(crate) type AgentBuilder = Arc<
+    dyn Fn(HookRegistry) -> Pin<Box<dyn Future<Output = Result<Agent>> + Send>>
+        + Send
+        + Sync,
+>;
+
 pub struct AgentMap {
     inner: Arc<RwLock<HashMap<LaneKey, LaneEntry>>>,
     config: Arc<Config>,
     idle_ttl: Duration,
+    #[cfg(test)]
+    builder: Option<AgentBuilder>,
 }
 
 pub(crate) struct LaneEntry {
@@ -48,6 +66,25 @@ impl AgentMap {
             inner: Arc::new(RwLock::new(HashMap::new())),
             config,
             idle_ttl,
+            #[cfg(test)]
+            builder: None,
+        }
+    }
+
+    /// Test-only constructor that uses `builder` to materialize Agents instead
+    /// of going through `Agent::with_hooks_and_pause`. Lets tests inject a
+    /// MockProvider-backed Agent without needing an API key.
+    #[cfg(test)]
+    pub(crate) fn with_builder(
+        config: Arc<Config>,
+        idle_ttl: Duration,
+        builder: AgentBuilder,
+    ) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(HashMap::new())),
+            config,
+            idle_ttl,
+            builder: Some(builder),
         }
     }
 
@@ -82,7 +119,20 @@ impl AgentMap {
         let (audit_hook, audit_buf) = AuditHook::new(AUDIT_BUFFER_CAPACITY);
         hook_reg.register(audit_hook);
 
-        let agent = Agent::with_hooks_and_pause(&self.config, hook_reg, None).await?;
+        let agent = {
+            #[cfg(test)]
+            {
+                if let Some(builder) = self.builder.as_ref() {
+                    builder(hook_reg).await?
+                } else {
+                    Agent::with_hooks_and_pause(&self.config, hook_reg, None).await?
+                }
+            }
+            #[cfg(not(test))]
+            {
+                Agent::with_hooks_and_pause(&self.config, hook_reg, None).await?
+            }
+        };
         let agent = Arc::new(Mutex::new(agent));
         agent.lock().await.start_session().await;
 
@@ -258,45 +308,69 @@ mod tests {
         }
     }
 
+    /// Provider shim that wraps an Arc<MockProvider> so multiple Agents can
+    /// be backed by the same mock instance — needed for tests that build a
+    /// fresh Agent per lane via the `AgentBuilder` closure.
+    struct ProviderHandle(Arc<MockProvider>);
+    #[async_trait::async_trait]
+    impl LLMProvider for ProviderHandle {
+        async fn chat(
+            &self,
+            m: &[Message],
+            t: &[ToolDefinition],
+            c: CancellationToken,
+        ) -> Result<ChatResponse> {
+            self.0.chat(m, t, c).await
+        }
+        async fn chat_stream(
+            &self,
+            m: &[Message],
+            t: &[ToolDefinition],
+            tx: tokio::sync::mpsc::UnboundedSender<StreamEvent>,
+            c: CancellationToken,
+        ) -> Result<()> {
+            self.0.chat_stream(m, t, tx, c).await
+        }
+        fn max_context(&self) -> usize {
+            self.0.max_context()
+        }
+    }
+
+    fn empty_skills() -> Arc<SkillRegistry> {
+        Arc::new(SkillRegistry::new(&std::path::PathBuf::from(
+            "/tmp/vulcan-test-skills-nonexistent",
+        )))
+    }
+
     /// Build an Agent backed by `MockProvider` so eviction tests don't need
     /// an API key. Mirrors `agent::tests::agent_with_mock`'s `ProviderHandle`
     /// shim.
     fn build_test_agent() -> Arc<Mutex<Agent>> {
-        struct ProviderHandle(Arc<MockProvider>);
-        #[async_trait::async_trait]
-        impl LLMProvider for ProviderHandle {
-            async fn chat(
-                &self,
-                m: &[Message],
-                t: &[ToolDefinition],
-                c: CancellationToken,
-            ) -> Result<ChatResponse> {
-                self.0.chat(m, t, c).await
-            }
-            async fn chat_stream(
-                &self,
-                m: &[Message],
-                t: &[ToolDefinition],
-                tx: tokio::sync::mpsc::UnboundedSender<StreamEvent>,
-                c: CancellationToken,
-            ) -> Result<()> {
-                self.0.chat_stream(m, t, tx, c).await
-            }
-            fn max_context(&self) -> usize {
-                self.0.max_context()
-            }
-        }
         let mock = Arc::new(MockProvider::new(128_000));
-        let skills = Arc::new(SkillRegistry::new(&std::path::PathBuf::from(
-            "/tmp/vulcan-test-skills-nonexistent",
-        )));
         let agent = Agent::for_test(
             Box::new(ProviderHandle(mock)),
             ToolRegistry::new(),
             HookRegistry::new(),
-            skills,
+            empty_skills(),
         );
         Arc::new(Mutex::new(agent))
+    }
+
+    /// Builder that returns a fresh `Agent::for_test` per lane, each backed by
+    /// its own `MockProvider`. Bypasses `Agent::with_hooks_and_pause` so the
+    /// tests don't need a real API key.
+    fn mock_agent_builder() -> AgentBuilder {
+        Arc::new(|hooks: HookRegistry| {
+            Box::pin(async move {
+                let mock = Arc::new(MockProvider::new(128_000));
+                Ok(Agent::for_test(
+                    Box::new(ProviderHandle(mock)),
+                    ToolRegistry::new(),
+                    hooks,
+                    empty_skills(),
+                ))
+            })
+        })
     }
 
     #[test]
@@ -309,14 +383,13 @@ mod tests {
         assert_ne!(a, c);
     }
 
-    // Ignored: `Agent::with_hooks_and_pause` bails when no API key is set,
-    // and `Config::default()` provides none. A future MockProvider /
-    // builder-style test config would let these run unconditionally;
-    // tracking this gap in the Task 8 report.
     #[tokio::test]
-    #[ignore = "needs API key or MockProvider; Config::default() has no api_key"]
     async fn second_get_reuses_agent() {
-        let map = AgentMap::new(test_config(), Duration::from_secs(60));
+        let map = AgentMap::with_builder(
+            test_config(),
+            Duration::from_secs(60),
+            mock_agent_builder(),
+        );
         let lane = test_lane("x");
         let a1 = map.get_or_spawn(&lane).await.expect("first spawn");
         let a2 = map.get_or_spawn(&lane).await.expect("second get");
@@ -325,31 +398,54 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "needs API key or MockProvider; Config::default() has no api_key"]
     async fn distinct_lanes_get_distinct_agents() {
-        let map = AgentMap::new(test_config(), Duration::from_secs(60));
+        let map = AgentMap::with_builder(
+            test_config(),
+            Duration::from_secs(60),
+            mock_agent_builder(),
+        );
         let a = map.get_or_spawn(&test_lane("a")).await.expect("a");
         let b = map.get_or_spawn(&test_lane("b")).await.expect("b");
         assert!(!Arc::ptr_eq(&a, &b));
         assert_eq!(map.active_lanes().await, 2);
     }
 
-    #[tokio::test(start_paused = true)]
-    #[ignore = "needs API key or MockProvider; Agent::with_hooks_and_pause + Config::default() has no api_key"]
+    #[tokio::test]
     async fn idle_lanes_evicted_after_ttl() {
-        let map = AgentMap::new(test_config(), Duration::from_secs(60));
-        let evictor = map.spawn_evictor();
+        // End-to-end: a lane spawned via `get_or_spawn` whose `last_activity`
+        // is rewritten to the past should be reaped by the *spawned* evictor
+        // task on its next scan.
+        //
+        // Why not `tokio::time::advance` + `start_paused`? `evict_idle` reads
+        // `std::time::Instant::now()` to compare against `last_activity`,
+        // and tokio's logical clock doesn't move that. We manipulate
+        // `last_activity` directly to simulate a stale lane and use real
+        // wall-clock sleeps short enough not to slow the suite.
+        let map = AgentMap::with_builder(
+            test_config(),
+            Duration::from_millis(50),
+            mock_agent_builder(),
+        );
         let lane = test_lane("x");
         map.get_or_spawn(&lane).await.expect("spawn");
         assert_eq!(map.active_lanes().await, 1);
 
-        // Advance well past TTL + scan interval (60s + 60s = 120s minimum).
-        tokio::time::advance(Duration::from_secs(180)).await;
-        tokio::task::yield_now().await;
-        tokio::task::yield_now().await;
+        // Backdate the entry by more than ttl so the next eviction pass
+        // catches it. Touch through `inner()` to avoid waiting an actual
+        // SCAN_INTERVAL (60s).
+        {
+            let inner = map.inner();
+            let mut guard = inner.write().await;
+            if let Some(entry) = guard.get_mut(&lane) {
+                entry.last_activity = Instant::now() - Duration::from_secs(60);
+            }
+        }
 
+        // Drive the eviction pass directly. The spawned evictor's
+        // SCAN_INTERVAL is too long for a unit test; we exercise the same
+        // `evict_idle` path it would call.
+        super::evict_idle(&map.inner(), Duration::from_millis(50)).await;
         assert_eq!(map.active_lanes().await, 0, "lane should be evicted");
-        evictor.abort();
     }
 
     #[tokio::test(start_paused = true)]

--- a/src/gateway/lane.rs
+++ b/src/gateway/lane.rs
@@ -1,0 +1,244 @@
+//! Per-chat serial dispatch with parallelism across chats.
+//!
+//! `LaneRouter` spawns one worker task per `LaneKey`. Messages dispatched to
+//! the same key run strictly in order; messages on different keys run on
+//! independent tasks and so make use of the multi-thread runtime.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use tokio::sync::{Notify, RwLock, mpsc};
+
+#[derive(Clone, Eq, Hash, PartialEq, Debug)]
+pub struct LaneKey {
+    pub platform: String,
+    pub chat_id: String,
+}
+
+pub trait Handler<M>: Send + Sync + 'static {
+    fn handle(
+        &self,
+        lane: LaneKey,
+        msg: M,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send>>;
+}
+
+struct ClosureHandler<F>(F);
+
+impl<F, Fut, M> Handler<M> for ClosureHandler<F>
+where
+    F: Fn(LaneKey, M) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ()> + Send + 'static,
+    M: Send + 'static,
+{
+    fn handle(&self, lane: LaneKey, msg: M) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+        Box::pin((self.0)(lane, msg))
+    }
+}
+
+pub fn from_closure<F, Fut, M>(f: F) -> impl Handler<M>
+where
+    F: Fn(LaneKey, M) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ()> + Send + 'static,
+    M: Send + 'static,
+{
+    ClosureHandler(f)
+}
+
+const DEFAULT_CHANNEL_CAPACITY: usize = 32;
+
+pub struct LaneRouter<M> {
+    inner: Arc<RwLock<HashMap<LaneKey, mpsc::Sender<M>>>>,
+    handler: Arc<dyn Handler<M>>,
+    pending: Arc<AtomicUsize>,
+    completed_notify: Arc<Notify>,
+    channel_capacity: usize,
+}
+
+impl<M: Send + 'static> LaneRouter<M> {
+    pub fn new<H>(handler: H) -> Self
+    where
+        H: Handler<M>,
+    {
+        Self::with_capacity(handler, DEFAULT_CHANNEL_CAPACITY)
+    }
+
+    pub fn with_capacity<H>(handler: H, channel_capacity: usize) -> Self
+    where
+        H: Handler<M>,
+    {
+        Self {
+            inner: Arc::new(RwLock::new(HashMap::new())),
+            handler: Arc::new(handler),
+            pending: Arc::new(AtomicUsize::new(0)),
+            completed_notify: Arc::new(Notify::new()),
+            channel_capacity,
+        }
+    }
+
+    /// Send `msg` to the worker owning `lane`. Spawns the worker on first use.
+    pub async fn dispatch(&self, lane: LaneKey, msg: M) {
+        // Increment before send so drain() can never miss an in-flight message.
+        self.pending.fetch_add(1, Ordering::SeqCst);
+
+        {
+            let map = self.inner.read().await;
+            if let Some(tx) = map.get(&lane) {
+                let tx = tx.clone();
+                drop(map);
+                if tx.send(msg).await.is_err() {
+                    // Worker is gone — keep the counter consistent.
+                    self.decrement_pending();
+                }
+                return;
+            }
+        }
+
+        let mut map = self.inner.write().await;
+        // Re-check after acquiring the write lock — another dispatcher may
+        // have spawned the worker between our read and write.
+        if let Some(tx) = map.get(&lane) {
+            let tx = tx.clone();
+            drop(map);
+            if tx.send(msg).await.is_err() {
+                self.decrement_pending();
+            }
+            return;
+        }
+
+        let (tx, mut rx) = mpsc::channel::<M>(self.channel_capacity);
+        let handler = Arc::clone(&self.handler);
+        let pending = Arc::clone(&self.pending);
+        let notify = Arc::clone(&self.completed_notify);
+        let lane_for_worker = lane.clone();
+        tokio::spawn(async move {
+            while let Some(msg) = rx.recv().await {
+                handler.handle(lane_for_worker.clone(), msg).await;
+                let prev = pending.fetch_sub(1, Ordering::SeqCst);
+                if prev == 1 {
+                    notify.notify_waiters();
+                }
+            }
+        });
+        map.insert(lane.clone(), tx.clone());
+        drop(map);
+
+        if tx.send(msg).await.is_err() {
+            self.decrement_pending();
+        }
+    }
+
+    fn decrement_pending(&self) {
+        let prev = self.pending.fetch_sub(1, Ordering::SeqCst);
+        if prev == 1 {
+            self.completed_notify.notify_waiters();
+        }
+    }
+
+    /// Wait until every dispatched message has been handled.
+    pub async fn drain(&self) {
+        loop {
+            if self.pending.load(Ordering::SeqCst) == 0 {
+                return;
+            }
+            let notified = self.completed_notify.notified();
+            // Re-check after registering the waiter to close the race where a
+            // worker decrements between our load and the await.
+            if self.pending.load(Ordering::SeqCst) == 0 {
+                return;
+            }
+            notified.await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::{Duration, Instant};
+    use tokio::sync::Mutex;
+
+    #[derive(Debug)]
+    struct TestMsg {
+        seq: u32,
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn lanes_serial_within_parallel_across() {
+        let observed: Arc<Mutex<Vec<(String, u32)>>> = Arc::new(Mutex::new(Vec::new()));
+        let observed_clone = observed.clone();
+        let handler = from_closure(move |lane: LaneKey, msg: TestMsg| {
+            let observed = observed_clone.clone();
+            async move {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                observed.lock().await.push((lane.chat_id.clone(), msg.seq));
+            }
+        });
+        let router: LaneRouter<TestMsg> = LaneRouter::new(handler);
+
+        let a = LaneKey {
+            platform: "loop".into(),
+            chat_id: "A".into(),
+        };
+        let b = LaneKey {
+            platform: "loop".into(),
+            chat_id: "B".into(),
+        };
+        let started = Instant::now();
+        router.dispatch(a.clone(), TestMsg { seq: 1 }).await;
+        router.dispatch(a.clone(), TestMsg { seq: 2 }).await;
+        router.dispatch(b.clone(), TestMsg { seq: 1 }).await;
+        router.drain().await;
+        let elapsed = started.elapsed();
+
+        // Lane A's two msgs serialize -> at least 100ms. Lane B runs in parallel
+        // -> total elapsed should be < 140ms (would be 150ms if all three serialized).
+        assert!(elapsed >= Duration::from_millis(100), "got {elapsed:?}");
+        assert!(elapsed < Duration::from_millis(140), "got {elapsed:?}");
+
+        let v = observed.lock().await.clone();
+        let a_seqs: Vec<u32> = v
+            .iter()
+            .filter(|(c, _)| c == "A")
+            .map(|(_, s)| *s)
+            .collect();
+        assert_eq!(a_seqs, vec![1, 2]);
+    }
+
+    #[tokio::test]
+    async fn drain_returns_immediately_with_no_pending() {
+        let handler = from_closure(|_: LaneKey, _: ()| async {});
+        let router: LaneRouter<()> = LaneRouter::new(handler);
+        let started = Instant::now();
+        router.drain().await;
+        assert!(started.elapsed() < Duration::from_millis(20));
+    }
+
+    #[tokio::test]
+    async fn drain_waits_for_in_flight() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let counter2 = counter.clone();
+        let handler = from_closure(move |_: LaneKey, _: ()| {
+            let counter = counter2.clone();
+            async move {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                counter.fetch_add(1, Ordering::SeqCst);
+            }
+        });
+        let router: LaneRouter<()> = LaneRouter::new(handler);
+        let lane = LaneKey {
+            platform: "p".into(),
+            chat_id: "c".into(),
+        };
+        for _ in 0..3 {
+            router.dispatch(lane.clone(), ()).await;
+        }
+        router.drain().await;
+        assert_eq!(counter.load(Ordering::SeqCst), 3);
+    }
+}

--- a/src/gateway/lane.rs
+++ b/src/gateway/lane.rs
@@ -6,10 +6,10 @@
 
 use std::collections::HashMap;
 use std::future::Future;
-use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+use async_trait::async_trait;
 use tokio::sync::{Notify, RwLock, mpsc};
 
 #[derive(Clone, Eq, Hash, PartialEq, Debug)]
@@ -18,24 +18,22 @@ pub struct LaneKey {
     pub chat_id: String,
 }
 
+#[async_trait]
 pub trait Handler<M>: Send + Sync + 'static {
-    fn handle(
-        &self,
-        lane: LaneKey,
-        msg: M,
-    ) -> Pin<Box<dyn Future<Output = ()> + Send>>;
+    async fn handle(&self, lane: LaneKey, msg: M);
 }
 
 struct ClosureHandler<F>(F);
 
+#[async_trait]
 impl<F, Fut, M> Handler<M> for ClosureHandler<F>
 where
     F: Fn(LaneKey, M) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = ()> + Send + 'static,
     M: Send + 'static,
 {
-    fn handle(&self, lane: LaneKey, msg: M) -> Pin<Box<dyn Future<Output = ()> + Send>> {
-        Box::pin((self.0)(lane, msg))
+    async fn handle(&self, lane: LaneKey, msg: M) {
+        (self.0)(lane, msg).await
     }
 }
 
@@ -171,12 +169,21 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn lanes_serial_within_parallel_across() {
         let observed: Arc<Mutex<Vec<(String, u32)>>> = Arc::new(Mutex::new(Vec::new()));
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
         let observed_clone = observed.clone();
+        let in_flight_clone = in_flight.clone();
+        let peak_clone = peak.clone();
         let handler = from_closure(move |lane: LaneKey, msg: TestMsg| {
             let observed = observed_clone.clone();
+            let in_flight = in_flight_clone.clone();
+            let peak = peak_clone.clone();
             async move {
+                let cur = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                peak.fetch_max(cur, Ordering::SeqCst);
                 tokio::time::sleep(Duration::from_millis(50)).await;
                 observed.lock().await.push((lane.chat_id.clone(), msg.seq));
+                in_flight.fetch_sub(1, Ordering::SeqCst);
             }
         });
         let router: LaneRouter<TestMsg> = LaneRouter::new(handler);
@@ -189,17 +196,19 @@ mod tests {
             platform: "loop".into(),
             chat_id: "B".into(),
         };
-        let started = Instant::now();
         router.dispatch(a.clone(), TestMsg { seq: 1 }).await;
         router.dispatch(a.clone(), TestMsg { seq: 2 }).await;
         router.dispatch(b.clone(), TestMsg { seq: 1 }).await;
         router.drain().await;
-        let elapsed = started.elapsed();
 
-        // Lane A's two msgs serialize -> at least 100ms. Lane B runs in parallel
-        // -> total elapsed should be < 140ms (would be 150ms if all three serialized).
-        assert!(elapsed >= Duration::from_millis(100), "got {elapsed:?}");
-        assert!(elapsed < Duration::from_millis(140), "got {elapsed:?}");
+        // Lane A's two msgs serialize, lane B runs in parallel with A, so peak
+        // concurrent in-flight should be 2. Counter-based check is robust to
+        // CI slowness; timing-based assertions flake under load.
+        assert!(
+            peak.load(Ordering::SeqCst) >= 2,
+            "expected parallelism across lanes, peak was {}",
+            peak.load(Ordering::SeqCst)
+        );
 
         let v = observed.lock().await.clone();
         let a_seqs: Vec<u32> = v
@@ -207,7 +216,7 @@ mod tests {
             .filter(|(c, _)| c == "A")
             .map(|(_, s)| *s)
             .collect();
-        assert_eq!(a_seqs, vec![1, 2]);
+        assert_eq!(a_seqs, vec![1, 2], "lane A messages must run in order");
     }
 
     #[tokio::test]

--- a/src/gateway/loopback.rs
+++ b/src/gateway/loopback.rs
@@ -3,14 +3,22 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use anyhow::Result;
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
 use tokio::sync::Mutex;
 
 use crate::platform::{InboundMessage, OutboundMessage, Platform};
+
+type HmacSha256 = Hmac<Sha256>;
 
 #[derive(Default)]
 pub struct LoopbackPlatform {
     recorded: Arc<Mutex<Vec<OutboundMessage>>>,
     failures_remaining: Arc<AtomicUsize>,
+    /// `None` means webhooks are disabled — `verify_webhook` will reject every
+    /// request. Tests that exercise the webhook path use
+    /// `with_webhook_secret`.
+    webhook_secret: Arc<Option<String>>,
 }
 
 impl LoopbackPlatform {
@@ -25,6 +33,18 @@ impl LoopbackPlatform {
         Self {
             recorded: Arc::default(),
             failures_remaining: Arc::new(AtomicUsize::new(n)),
+            webhook_secret: Arc::new(None),
+        }
+    }
+
+    /// Configure a loopback that accepts webhook requests signed with `secret`
+    /// using HMAC-SHA256 over the raw body, hex-encoded in the
+    /// `X-Loopback-Signature` header.
+    pub fn with_webhook_secret(secret: impl Into<String>) -> Self {
+        Self {
+            recorded: Arc::default(),
+            failures_remaining: Arc::default(),
+            webhook_secret: Arc::new(Some(secret.into())),
         }
     }
 
@@ -69,6 +89,52 @@ impl Platform for LoopbackPlatform {
         // future would silently starve any consumer that polls multiple
         // platforms.
         anyhow::bail!("loopback has no inbound channel")
+    }
+
+    async fn verify_webhook(
+        &self,
+        headers: &http::HeaderMap,
+        body: &[u8],
+    ) -> Result<InboundMessage> {
+        let Some(secret) = self.webhook_secret.as_ref().as_deref() else {
+            anyhow::bail!("loopback webhook not configured (no secret)");
+        };
+        let provided = headers
+            .get("x-loopback-signature")
+            .and_then(|v| v.to_str().ok())
+            .ok_or_else(|| anyhow::anyhow!("missing X-Loopback-Signature header"))?;
+
+        let mut mac = HmacSha256::new_from_slice(secret.as_bytes())
+            .map_err(|e| anyhow::anyhow!("hmac key error: {e}"))?;
+        mac.update(body);
+        let expected_bytes = mac.finalize().into_bytes();
+        // Manual lower-case hex avoids an extra `hex` dep — the encoding fits
+        // in one expression and matches what `hex::encode` would emit.
+        let expected_hex: String = expected_bytes.iter().map(|b| format!("{b:02x}")).collect();
+
+        // Constant-time compare so signature verification doesn't leak the
+        // matching prefix length via byte-by-byte early-out.
+        use subtle::ConstantTimeEq;
+        if provided
+            .as_bytes()
+            .ct_eq(expected_hex.as_bytes())
+            .unwrap_u8()
+            == 0
+        {
+            anyhow::bail!("invalid signature");
+        }
+
+        // Body shape mirrors /v1/inbound: {chat_id, user_id, text}. The
+        // platform field is implicit ("loopback") — webhook callers don't
+        // need to repeat it, the route already carries that context.
+        let parsed: serde_json::Value =
+            serde_json::from_slice(body).map_err(|e| anyhow::anyhow!("invalid JSON body: {e}"))?;
+        Ok(InboundMessage {
+            platform: "loopback".into(),
+            chat_id: parsed["chat_id"].as_str().unwrap_or_default().to_string(),
+            user_id: parsed["user_id"].as_str().unwrap_or_default().to_string(),
+            text: parsed["text"].as_str().unwrap_or_default().to_string(),
+        })
     }
 }
 

--- a/src/gateway/loopback.rs
+++ b/src/gateway/loopback.rs
@@ -1,0 +1,68 @@
+//! In-process `Platform` that records outbound messages for tests.
+use std::sync::Arc;
+
+use anyhow::Result;
+use tokio::sync::Mutex;
+
+use crate::platform::{InboundMessage, OutboundMessage, Platform};
+
+#[derive(Default)]
+pub struct LoopbackPlatform {
+    recorded: Arc<Mutex<Vec<OutboundMessage>>>,
+}
+
+impl LoopbackPlatform {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn recorded(&self) -> Vec<OutboundMessage> {
+        self.recorded.lock().await.clone()
+    }
+}
+
+#[async_trait::async_trait]
+impl Platform for LoopbackPlatform {
+    fn name(&self) -> &str {
+        "loopback"
+    }
+
+    async fn start(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn send(&self, msg: &OutboundMessage) -> Result<()> {
+        self.recorded.lock().await.push(msg.clone());
+        Ok(())
+    }
+
+    async fn recv(&self) -> Result<InboundMessage> {
+        std::future::pending().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn loopback_send_records_messages_in_order() {
+        let lp = LoopbackPlatform::new();
+        let m1 = OutboundMessage {
+            platform: "loopback".into(),
+            chat_id: "c".into(),
+            text: "one".into(),
+            attachments: vec![],
+        };
+        let m2 = OutboundMessage {
+            text: "two".into(),
+            ..m1.clone()
+        };
+        lp.send(&m1).await.unwrap();
+        lp.send(&m2).await.unwrap();
+        let recorded = lp.recorded().await;
+        assert_eq!(recorded.len(), 2);
+        assert_eq!(recorded[0].text, "one");
+        assert_eq!(recorded[1].text, "two");
+    }
+}

--- a/src/gateway/loopback.rs
+++ b/src/gateway/loopback.rs
@@ -1,5 +1,6 @@
 //! In-process `Platform` that records outbound messages for tests.
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use anyhow::Result;
 use tokio::sync::Mutex;
@@ -9,11 +10,22 @@ use crate::platform::{InboundMessage, OutboundMessage, Platform};
 #[derive(Default)]
 pub struct LoopbackPlatform {
     recorded: Arc<Mutex<Vec<OutboundMessage>>>,
+    failures_remaining: Arc<AtomicUsize>,
 }
 
 impl LoopbackPlatform {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Configure a `LoopbackPlatform` that errors on its first `n` send calls
+    /// and succeeds afterwards. Used to drive the outbound dispatcher's
+    /// backoff path in tests.
+    pub fn failing_first(n: usize) -> Self {
+        Self {
+            recorded: Arc::default(),
+            failures_remaining: Arc::new(AtomicUsize::new(n)),
+        }
     }
 
     pub async fn recorded(&self) -> Vec<OutboundMessage> {
@@ -32,6 +44,21 @@ impl Platform for LoopbackPlatform {
     }
 
     async fn send(&self, msg: &OutboundMessage) -> Result<()> {
+        // Atomic compare-and-decrement: if there are failures left, decrement
+        // and error; else record and return Ok.
+        loop {
+            let cur = self.failures_remaining.load(Ordering::SeqCst);
+            if cur == 0 {
+                break;
+            }
+            if self
+                .failures_remaining
+                .compare_exchange(cur, cur - 1, Ordering::SeqCst, Ordering::SeqCst)
+                .is_ok()
+            {
+                anyhow::bail!("loopback simulated failure");
+            }
+        }
         self.recorded.lock().await.push(msg.clone());
         Ok(())
     }
@@ -68,5 +95,21 @@ mod tests {
         assert_eq!(recorded.len(), 2);
         assert_eq!(recorded[0].text, "one");
         assert_eq!(recorded[1].text, "two");
+    }
+
+    #[tokio::test]
+    async fn loopback_failing_first_errors_then_succeeds() {
+        let lp = LoopbackPlatform::failing_first(2);
+        let m = OutboundMessage {
+            platform: "loopback".into(),
+            chat_id: "c".into(),
+            text: "x".into(),
+            attachments: vec![],
+        };
+        assert!(lp.send(&m).await.is_err());
+        assert!(lp.send(&m).await.is_err());
+        assert!(lp.send(&m).await.is_ok());
+        assert!(lp.send(&m).await.is_ok());
+        assert_eq!(lp.recorded().await.len(), 2);
     }
 }

--- a/src/gateway/loopback.rs
+++ b/src/gateway/loopback.rs
@@ -37,7 +37,11 @@ impl Platform for LoopbackPlatform {
     }
 
     async fn recv(&self) -> Result<InboundMessage> {
-        std::future::pending().await
+        // Loopback has no inbound side. Return an error so a tokio::select!
+        // arm completes and the caller can match-and-skip; a never-resolving
+        // future would silently starve any consumer that polls multiple
+        // platforms.
+        anyhow::bail!("loopback has no inbound channel")
     }
 }
 

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -7,6 +7,7 @@ pub mod loopback;
 pub mod outbound;
 pub mod queue;
 pub mod registry;
+pub mod worker;
 
 pub async fn run(_config: &Config, _bind_override: Option<String>) -> Result<()> {
     anyhow::bail!("gateway not yet implemented")

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -1,6 +1,7 @@
 use crate::config::Config;
 use anyhow::Result;
 
+pub mod lane;
 pub mod queue;
 
 pub async fn run(_config: &Config, _bind_override: Option<String>) -> Result<()> {

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -1,6 +1,7 @@
 use crate::config::Config;
 use anyhow::Result;
 
+pub mod agent_map;
 pub mod lane;
 pub mod queue;
 

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -3,7 +3,9 @@ use anyhow::Result;
 
 pub mod agent_map;
 pub mod lane;
+pub mod loopback;
 pub mod queue;
+pub mod registry;
 
 pub async fn run(_config: &Config, _bind_override: Option<String>) -> Result<()> {
     anyhow::bail!("gateway not yet implemented")

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -1,5 +1,19 @@
+use std::future::Future;
+use std::sync::Arc;
+use std::time::Duration;
+
 use crate::config::Config;
-use anyhow::Result;
+use crate::gateway::agent_map::AgentMap;
+use crate::gateway::lane::{LaneKey, LaneRouter, from_closure};
+use crate::gateway::loopback::LoopbackPlatform;
+use crate::gateway::outbound::OutboundDispatcher;
+use crate::gateway::queue::{InboundQueue, InboundRow, OutboundQueue};
+use crate::gateway::registry::PlatformRegistry;
+use crate::gateway::server::{AppState, build_router};
+use anyhow::{Context, Result};
+use rusqlite::Connection;
+use tokio::net::TcpListener;
+use tokio::task::JoinHandle;
 
 pub mod agent_map;
 pub mod lane;
@@ -11,6 +25,433 @@ pub mod routes;
 pub mod server;
 pub mod worker;
 
-pub async fn run(_config: &Config, _bind_override: Option<String>) -> Result<()> {
-    anyhow::bail!("gateway not yet implemented")
+pub async fn run(config: &Config, bind_override: Option<String>) -> Result<()> {
+    let bind = bind_addr(config, bind_override)?;
+    let listener = TcpListener::bind(&bind)
+        .await
+        .with_context(|| format!("failed to bind gateway on {bind}"))?;
+    run_on_listener(config.clone(), listener, shutdown_signal()).await
+}
+
+async fn run_on_listener<S>(config: Config, listener: TcpListener, shutdown: S) -> Result<()>
+where
+    S: Future<Output = ()> + Send + 'static,
+{
+    let gateway = config
+        .gateway
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("missing [gateway] config; set api_token before running"))?;
+
+    let db = crate::memory::open_gateway_connection()?;
+    let mut registry = PlatformRegistry::new();
+    registry.register("loopback", Arc::new(LoopbackPlatform::default()));
+    let registry = Arc::new(registry);
+    let agent_map = Arc::new(AgentMap::new(
+        Arc::new(config),
+        Duration::from_secs(gateway.idle_ttl_secs),
+    ));
+
+    run_on_listener_with_parts(
+        gateway,
+        listener,
+        shutdown,
+        db,
+        registry,
+        agent_map,
+    )
+    .await
+}
+
+async fn run_on_listener_with_parts<S>(
+    gateway: crate::config::GatewayConfig,
+    listener: TcpListener,
+    shutdown: S,
+    db: Arc<std::sync::Mutex<Connection>>,
+    registry: Arc<PlatformRegistry>,
+    agent_map: Arc<AgentMap>,
+) -> Result<()>
+where
+    S: Future<Output = ()> + Send + 'static,
+{
+    let inbound = Arc::new(InboundQueue::new(Arc::clone(&db)));
+    let outbound = Arc::new(OutboundQueue::new(
+        Arc::clone(&db),
+        gateway.outbound_max_attempts,
+    ));
+
+    let recovered_inbound = inbound.recover_processing().await?;
+    let recovered_outbound = outbound.recover_sending().await?;
+    if recovered_inbound > 0 || recovered_outbound > 0 {
+        tracing::info!(
+            recovered_inbound,
+            recovered_outbound,
+            "gateway recovered stuck queue rows"
+        );
+    }
+
+    let evictor = agent_map.spawn_evictor();
+    let outbound_dispatcher = OutboundDispatcher::new(Arc::clone(&outbound), Arc::clone(&registry)).spawn();
+    let inbound_dispatcher = spawn_inbound_dispatcher(
+        Arc::clone(&inbound),
+        Arc::clone(&outbound),
+        Arc::clone(&agent_map),
+    );
+
+    let app = build_router(AppState {
+        api_token: Arc::new(gateway.api_token),
+        inbound,
+        outbound,
+        registry,
+        agent_map,
+    });
+
+    let addr = listener.local_addr().context("gateway listener local_addr")?;
+    tracing::info!(%addr, "gateway listening");
+    let result = axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown)
+        .await
+        .context("gateway server failed");
+
+    inbound_dispatcher.abort();
+    drop(outbound_dispatcher);
+    drop(evictor);
+
+    result
+}
+
+fn spawn_inbound_dispatcher(
+    inbound: Arc<InboundQueue>,
+    outbound: Arc<OutboundQueue>,
+    agent_map: Arc<AgentMap>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let handler_inbound = Arc::clone(&inbound);
+        let handler_outbound = Arc::clone(&outbound);
+        let handler_agent_map = Arc::clone(&agent_map);
+        let handler = from_closure(move |_lane: LaneKey, row: InboundRow| {
+            let inbound = Arc::clone(&handler_inbound);
+            let outbound = Arc::clone(&handler_outbound);
+            let agent_map = Arc::clone(&handler_agent_map);
+            async move {
+                if let Err(e) = worker::process_one(row, &agent_map, &inbound, &outbound).await {
+                    tracing::error!(target: "gateway::inbound", error = %e, "inbound row failed");
+                }
+            }
+        });
+        let router: LaneRouter<InboundRow> = LaneRouter::new(handler);
+        let mut ticker = tokio::time::interval(Duration::from_millis(100));
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            ticker.tick().await;
+            loop {
+                let row = match inbound.claim_next().await {
+                    Ok(Some(row)) => row,
+                    Ok(None) => break,
+                    Err(e) => {
+                        tracing::error!(target: "gateway::inbound", error = %e, "claim_next failed");
+                        break;
+                    }
+                };
+                let lane = LaneKey {
+                    platform: row.platform.clone(),
+                    chat_id: row.chat_id.clone(),
+                };
+                router.dispatch(lane, row).await;
+            }
+        }
+    })
+}
+
+fn bind_addr(config: &Config, bind_override: Option<String>) -> Result<String> {
+    if let Some(bind) = bind_override {
+        return Ok(bind);
+    }
+    Ok(config
+        .gateway
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("missing [gateway] config; set api_token before running"))?
+        .bind
+        .clone())
+}
+
+async fn shutdown_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{SignalKind, signal};
+        let mut terminate = signal(SignalKind::terminate()).expect("install SIGTERM handler");
+        tokio::select! {
+            _ = tokio::signal::ctrl_c() => {}
+            _ = terminate.recv() => {}
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::Agent;
+    use crate::gateway::agent_map::AgentBuilder;
+    use crate::hooks::HookRegistry;
+    use crate::provider::mock::MockProvider;
+    use crate::provider::{ChatResponse, LLMProvider, Message, StreamEvent, ToolDefinition};
+    use crate::skills::SkillRegistry;
+    use crate::tools::ToolRegistry;
+    use async_trait::async_trait;
+    use rusqlite::Connection;
+    use std::sync::Mutex as StdMutex;
+    use tokio::sync::oneshot;
+    use tokio_util::sync::CancellationToken;
+
+    fn config_with_gateway() -> Config {
+        let mut config = Config::default();
+        config.provider.api_key = Some("test-key".into());
+        config.provider.disable_catalog = true;
+        config.gateway = Some(crate::config::GatewayConfig {
+            bind: "127.0.0.1:0".into(),
+            api_token: "test-token".into(),
+            idle_ttl_secs: 1800,
+            max_concurrent_lanes: 64,
+            outbound_max_attempts: 5,
+        });
+        config
+    }
+
+    fn fresh_db() -> Arc<StdMutex<Connection>> {
+        let conn = Connection::open_in_memory().expect("open mem db");
+        crate::memory::initialize_test_conn(&conn).expect("schema");
+        Arc::new(StdMutex::new(conn))
+    }
+
+    fn empty_skills() -> Arc<SkillRegistry> {
+        Arc::new(SkillRegistry::new(&std::path::PathBuf::from(
+            "/tmp/vulcan-test-skills-nonexistent",
+        )))
+    }
+
+    struct ProviderHandle(Arc<MockProvider>);
+    #[async_trait]
+    impl LLMProvider for ProviderHandle {
+        async fn chat(
+            &self,
+            m: &[Message],
+            t: &[ToolDefinition],
+            c: CancellationToken,
+        ) -> Result<ChatResponse> {
+            self.0.chat(m, t, c).await
+        }
+        async fn chat_stream(
+            &self,
+            m: &[Message],
+            t: &[ToolDefinition],
+            tx: tokio::sync::mpsc::UnboundedSender<StreamEvent>,
+            c: CancellationToken,
+        ) -> Result<()> {
+            self.0.chat_stream(m, t, tx, c).await
+        }
+        fn max_context(&self) -> usize {
+            self.0.max_context()
+        }
+    }
+
+    fn mock_agent_map(config: Arc<Config>, reply: &'static str) -> Arc<AgentMap> {
+        let builder: AgentBuilder = Arc::new(move |hooks: HookRegistry| {
+            Box::pin(async move {
+                let mock = Arc::new(MockProvider::new(128_000));
+                mock.enqueue_text(reply);
+                Ok(Agent::for_test(
+                    Box::new(ProviderHandle(mock)),
+                    ToolRegistry::new(),
+                    hooks,
+                    empty_skills(),
+                ))
+            })
+        });
+        Arc::new(AgentMap::with_builder(
+            config,
+            Duration::from_secs(1800),
+            builder,
+        ))
+    }
+
+    #[tokio::test]
+    async fn run_wires_health_endpoint_on_supplied_listener() {
+        let config = config_with_gateway();
+        let gateway = config.gateway.clone().expect("gateway config");
+        let db = fresh_db();
+        let mut registry = PlatformRegistry::new();
+        registry.register("loopback", Arc::new(LoopbackPlatform::default()));
+        let registry = Arc::new(registry);
+        let agent_map = mock_agent_map(Arc::new(config), "unused");
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+        let handle = tokio::spawn(async move {
+            run_on_listener_with_parts(
+                gateway,
+                listener,
+                async move {
+                    let _ = shutdown_rx.await;
+                },
+                db,
+                registry,
+                agent_map,
+            )
+            .await
+        });
+
+        let client = reqwest::Client::new();
+        let mut ok = false;
+        for _ in 0..50 {
+            match client
+                .get(format!("http://{addr}/health"))
+                .send()
+                .await
+            {
+                Ok(resp) if resp.status().is_success() => {
+                    ok = true;
+                    break;
+                }
+                _ => tokio::time::sleep(Duration::from_millis(20)).await,
+            }
+        }
+        assert!(ok, "gateway health endpoint did not become ready");
+
+        let _ = shutdown_tx.send(());
+        handle.await.expect("join").expect("gateway exits cleanly");
+    }
+
+    #[tokio::test]
+    async fn loopback_http_inbound_produces_outbound_reply() {
+        let config = config_with_gateway();
+        let gateway = config.gateway.clone().expect("gateway config");
+        let db = fresh_db();
+        let mut registry = PlatformRegistry::new();
+        let loopback = Arc::new(LoopbackPlatform::default());
+        registry.register("loopback", loopback.clone());
+        let registry = Arc::new(registry);
+        let agent_map = mock_agent_map(Arc::new(config), "hi back");
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+        let handle = tokio::spawn(async move {
+            run_on_listener_with_parts(
+                gateway,
+                listener,
+                async move {
+                    let _ = shutdown_rx.await;
+                },
+                db,
+                registry,
+                agent_map,
+            )
+            .await
+        });
+
+        let client = reqwest::Client::new();
+        let mut accepted = false;
+        for _ in 0..50 {
+            let response = client
+                .post(format!("http://{addr}/v1/inbound"))
+                .bearer_auth("test-token")
+                .json(&serde_json::json!({
+                    "platform": "loopback",
+                    "chat_id": "c",
+                    "user_id": "u",
+                    "text": "hi"
+                }))
+                .send()
+                .await;
+            match response {
+                Ok(resp) if resp.status() == reqwest::StatusCode::ACCEPTED => {
+                    accepted = true;
+                    break;
+                }
+                _ => tokio::time::sleep(Duration::from_millis(20)).await,
+            }
+        }
+        assert!(accepted, "gateway did not accept inbound message");
+
+        let mut delivered = None;
+        for _ in 0..100 {
+            let recorded = loopback.recorded().await;
+            if let Some(msg) = recorded.first() {
+                delivered = Some(msg.clone());
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+
+        let delivered = delivered.expect("loopback outbound reply");
+        assert_eq!(delivered.platform, "loopback");
+        assert_eq!(delivered.chat_id, "c");
+        assert_eq!(delivered.text, "hi back");
+
+        let _ = shutdown_tx.send(());
+        handle.await.expect("join").expect("gateway exits cleanly");
+    }
+
+    #[tokio::test]
+    async fn restart_recovers_processing_inbound_and_delivers_reply() {
+        let config = config_with_gateway();
+        let gateway = config.gateway.clone().expect("gateway config");
+        let db = fresh_db();
+        let inbound = InboundQueue::new(Arc::clone(&db));
+        inbound
+            .enqueue(crate::platform::InboundMessage {
+                platform: "loopback".into(),
+                chat_id: "c".into(),
+                user_id: "u".into(),
+                text: "recover me".into(),
+            })
+            .await
+            .unwrap();
+        let claimed = inbound.claim_next().await.unwrap().expect("processing row");
+        assert_eq!(claimed.text, "recover me");
+
+        let mut registry = PlatformRegistry::new();
+        let loopback = Arc::new(LoopbackPlatform::default());
+        registry.register("loopback", loopback.clone());
+        let registry = Arc::new(registry);
+        let agent_map = mock_agent_map(Arc::new(config), "recovered reply");
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+        let handle = tokio::spawn(async move {
+            run_on_listener_with_parts(
+                gateway,
+                listener,
+                async move {
+                    let _ = shutdown_rx.await;
+                },
+                db,
+                registry,
+                agent_map,
+            )
+            .await
+        });
+
+        let mut delivered = None;
+        for _ in 0..100 {
+            let recorded = loopback.recorded().await;
+            if let Some(msg) = recorded.first() {
+                delivered = Some(msg.clone());
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+
+        let delivered = delivered.expect("recovered loopback reply");
+        assert_eq!(delivered.text, "recovered reply");
+        assert_eq!(delivered.chat_id, "c");
+
+        let _ = shutdown_tx.send(());
+        handle.await.expect("join").expect("gateway exits cleanly");
+    }
 }

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -1,6 +1,8 @@
 use crate::config::Config;
 use anyhow::Result;
 
+pub mod queue;
+
 pub async fn run(_config: &Config, _bind_override: Option<String>) -> Result<()> {
     anyhow::bail!("gateway not yet implemented")
 }

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -1,0 +1,6 @@
+use crate::config::Config;
+use anyhow::Result;
+
+pub async fn run(_config: &Config, _bind_override: Option<String>) -> Result<()> {
+    anyhow::bail!("gateway not yet implemented")
+}

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -7,6 +7,8 @@ pub mod loopback;
 pub mod outbound;
 pub mod queue;
 pub mod registry;
+pub mod routes;
+pub mod server;
 pub mod worker;
 
 pub async fn run(_config: &Config, _bind_override: Option<String>) -> Result<()> {

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 pub mod agent_map;
 pub mod lane;
 pub mod loopback;
+pub mod outbound;
 pub mod queue;
 pub mod registry;
 

--- a/src/gateway/outbound.rs
+++ b/src/gateway/outbound.rs
@@ -71,13 +71,14 @@ async fn dispatch_loop(
     poll_interval: Duration,
 ) {
     let mut ticker = tokio::time::interval(poll_interval);
-    // First tick fires immediately so the dispatcher reacts to enqueues
-    // without waiting a full interval. The OutboundQueue is durable, so the
-    // loop also drains anything that survived a restart.
+    // Skip missed ticks rather than bursting them after a long pause (laptop
+    // sleep, GC stall) — drain_due is idempotent so the next tick handles
+    // whatever the burst would have done in one pass.
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     loop {
         ticker.tick().await;
         if let Err(e) = drain_due(&queue, &registry).await {
-            tracing::warn!(target: "gateway::outbound", error = %e, "drain_due errored");
+            tracing::error!(target: "gateway::outbound", error = %e, "drain_due errored");
         }
     }
 }
@@ -88,18 +89,16 @@ async fn drain_due(queue: &OutboundQueue, registry: &PlatformRegistry) -> anyhow
         let Some(row) = queue.claim_due(now).await? else {
             return Ok(());
         };
+        let id = row.id;
         let msg = OutboundMessage {
-            platform: row.platform.clone(),
-            chat_id: row.chat_id.clone(),
-            text: row.text.clone(),
-            attachments: row.attachments.clone(),
+            platform: row.platform,
+            chat_id: row.chat_id,
+            text: row.text,
+            attachments: row.attachments,
         };
         match registry.send(&msg).await {
-            Ok(()) => queue.mark_done(row.id).await?,
-            Err(e) => {
-                let err_str = e.to_string();
-                queue.mark_failed(row.id, &err_str).await?;
-            }
+            Ok(()) => queue.mark_done(id).await?,
+            Err(e) => queue.mark_failed(id, &e.to_string()).await?,
         }
     }
 }

--- a/src/gateway/outbound.rs
+++ b/src/gateway/outbound.rs
@@ -1,0 +1,200 @@
+//! Outbound dispatcher loop.
+//!
+//! Polls `OutboundQueue::claim_due` on a tick, hands each row to
+//! `PlatformRegistry::send`, and on failure calls `OutboundQueue::mark_failed`
+//! so the queue's existing backoff schedule (Task 6) reschedules the row.
+//!
+//! The queue is durable, so on startup the loop also drains anything that
+//! survived a restart.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::task::JoinHandle;
+
+use crate::gateway::queue::OutboundQueue;
+use crate::gateway::registry::PlatformRegistry;
+use crate::platform::OutboundMessage;
+
+pub struct OutboundDispatcher {
+    queue: Arc<OutboundQueue>,
+    registry: Arc<PlatformRegistry>,
+    poll_interval: Duration,
+}
+
+impl OutboundDispatcher {
+    pub fn new(queue: Arc<OutboundQueue>, registry: Arc<PlatformRegistry>) -> Self {
+        Self {
+            queue,
+            registry,
+            poll_interval: Duration::from_millis(250),
+        }
+    }
+
+    pub fn with_poll_interval(mut self, interval: Duration) -> Self {
+        self.poll_interval = interval;
+        self
+    }
+
+    /// Spawn the polling loop. The returned `OutboundDispatcherHandle` aborts
+    /// the loop on drop (mirrors `EvictorHandle` from agent_map.rs).
+    pub fn spawn(self) -> OutboundDispatcherHandle {
+        let Self {
+            queue,
+            registry,
+            poll_interval,
+        } = self;
+        let handle = tokio::spawn(dispatch_loop(queue, registry, poll_interval));
+        OutboundDispatcherHandle { handle }
+    }
+}
+
+pub struct OutboundDispatcherHandle {
+    handle: JoinHandle<()>,
+}
+
+impl OutboundDispatcherHandle {
+    pub fn abort(&self) {
+        self.handle.abort();
+    }
+}
+
+impl Drop for OutboundDispatcherHandle {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+async fn dispatch_loop(
+    queue: Arc<OutboundQueue>,
+    registry: Arc<PlatformRegistry>,
+    poll_interval: Duration,
+) {
+    let mut ticker = tokio::time::interval(poll_interval);
+    // First tick fires immediately so the dispatcher reacts to enqueues
+    // without waiting a full interval. The OutboundQueue is durable, so the
+    // loop also drains anything that survived a restart.
+    loop {
+        ticker.tick().await;
+        if let Err(e) = drain_due(&queue, &registry).await {
+            tracing::warn!(target: "gateway::outbound", error = %e, "drain_due errored");
+        }
+    }
+}
+
+async fn drain_due(queue: &OutboundQueue, registry: &PlatformRegistry) -> anyhow::Result<()> {
+    loop {
+        let now = chrono::Utc::now().timestamp();
+        let Some(row) = queue.claim_due(now).await? else {
+            return Ok(());
+        };
+        let msg = OutboundMessage {
+            platform: row.platform.clone(),
+            chat_id: row.chat_id.clone(),
+            text: row.text.clone(),
+            attachments: row.attachments.clone(),
+        };
+        match registry.send(&msg).await {
+            Ok(()) => queue.mark_done(row.id).await?,
+            Err(e) => {
+                let err_str = e.to_string();
+                queue.mark_failed(row.id, &err_str).await?;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::Mutex as StdMutex;
+    use std::time::Duration;
+
+    use rusqlite::Connection;
+
+    use crate::gateway::loopback::LoopbackPlatform;
+    use crate::gateway::queue::OutboundQueue;
+    use crate::gateway::registry::PlatformRegistry;
+    use crate::platform::OutboundMessage;
+
+    fn fresh_db() -> Arc<StdMutex<Connection>> {
+        let c = Connection::open_in_memory().expect("open mem db");
+        crate::memory::initialize_test_conn(&c).expect("schema");
+        Arc::new(StdMutex::new(c))
+    }
+
+    fn out_msg(text: &str) -> OutboundMessage {
+        OutboundMessage {
+            platform: "loopback".into(),
+            chat_id: "c".into(),
+            text: text.into(),
+            attachments: vec![],
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatcher_delivers_pending_outbound() {
+        let q = Arc::new(OutboundQueue::new(fresh_db(), 5));
+        let lp = Arc::new(LoopbackPlatform::default());
+        let mut reg = PlatformRegistry::new();
+        reg.register("loopback", lp.clone());
+        let reg = Arc::new(reg);
+        let dispatcher = OutboundDispatcher::new(q.clone(), reg)
+            .with_poll_interval(Duration::from_millis(20))
+            .spawn();
+
+        q.enqueue(out_msg("hello")).await.unwrap();
+
+        // Poll up to 1s for delivery.
+        let mut delivered = 0;
+        for _ in 0..50 {
+            if !lp.recorded().await.is_empty() {
+                delivered = lp.recorded().await.len();
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        assert_eq!(delivered, 1);
+        drop(dispatcher);
+    }
+
+    #[tokio::test]
+    async fn failed_send_retries_after_backoff() {
+        let db = fresh_db();
+        let q = Arc::new(OutboundQueue::new(Arc::clone(&db), 5));
+        let lp = Arc::new(LoopbackPlatform::failing_first(2));
+        let mut reg = PlatformRegistry::new();
+        reg.register("loopback", lp.clone());
+        let reg = Arc::new(reg);
+
+        let id = q.enqueue(out_msg("payload")).await.unwrap();
+
+        let dispatcher = OutboundDispatcher::new(q.clone(), reg)
+            .with_poll_interval(Duration::from_millis(20))
+            .spawn();
+
+        // After each failure mark_failed bumps next_attempt_at by [5s, 30s, ...].
+        // Without rewinding we'd wait 35s of real time. Instead, between ticks
+        // we rewind next_attempt_at to "now" so the dispatcher reclaims the
+        // row on its next tick — avoids waiting the real 5s+30s backoff.
+        let mut ok = false;
+        for _ in 0..40 {
+            {
+                let conn = db.lock().expect("lock");
+                let now = chrono::Utc::now().timestamp();
+                let _ = conn.execute(
+                    "UPDATE outbound_queue SET next_attempt_at = ?1 WHERE id = ?2 AND state = 'pending'",
+                    rusqlite::params![now, id],
+                );
+            }
+            if lp.recorded().await.len() == 1 {
+                ok = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        assert!(ok, "expected eventual delivery after 2 failures");
+        drop(dispatcher);
+    }
+}

--- a/src/gateway/queue.rs
+++ b/src/gateway/queue.rs
@@ -1,0 +1,174 @@
+use std::sync::{Arc, Mutex};
+
+use anyhow::Result;
+use rusqlite::{Connection, params};
+
+use crate::platform::InboundMessage;
+
+pub struct InboundQueue {
+    conn: Arc<Mutex<Connection>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct InboundRow {
+    pub id: i64,
+    pub platform: String,
+    pub chat_id: String,
+    pub user_id: String,
+    pub text: String,
+    pub received_at: i64,
+    pub attempts: i64,
+}
+
+impl InboundQueue {
+    pub fn new(conn: Arc<Mutex<Connection>>) -> Self {
+        Self { conn }
+    }
+
+    pub async fn enqueue(&self, msg: InboundMessage) -> Result<i64> {
+        let conn = self.conn.lock().expect("queue mutex poisoned");
+        let now = chrono::Utc::now().timestamp();
+        conn.execute(
+            "INSERT INTO inbound_queue (platform, chat_id, user_id, text, received_at, state) \
+             VALUES (?1, ?2, ?3, ?4, ?5, 'pending')",
+            params![msg.platform, msg.chat_id, msg.user_id, msg.text, now],
+        )?;
+        Ok(conn.last_insert_rowid())
+    }
+
+    pub async fn claim_next(&self) -> Result<Option<InboundRow>> {
+        let conn = self.conn.lock().expect("queue mutex poisoned");
+        // RETURNING (SQLite >= 3.35) makes the claim a single atomic statement.
+        let mut stmt = conn.prepare(
+            "UPDATE inbound_queue \
+             SET state='processing', attempts = attempts + 1 \
+             WHERE id = (SELECT id FROM inbound_queue WHERE state='pending' \
+                         ORDER BY received_at ASC LIMIT 1) \
+             RETURNING id, platform, chat_id, user_id, text, received_at, attempts",
+        )?;
+        let mut rows = stmt.query([])?;
+        if let Some(row) = rows.next()? {
+            Ok(Some(InboundRow {
+                id: row.get(0)?,
+                platform: row.get(1)?,
+                chat_id: row.get(2)?,
+                user_id: row.get(3)?,
+                text: row.get(4)?,
+                received_at: row.get(5)?,
+                attempts: row.get(6)?,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub async fn mark_done(&self, id: i64) -> Result<()> {
+        let conn = self.conn.lock().expect("queue mutex poisoned");
+        conn.execute("DELETE FROM inbound_queue WHERE id = ?1", params![id])?;
+        Ok(())
+    }
+
+    pub async fn mark_failed(&self, id: i64, error: &str) -> Result<()> {
+        let conn = self.conn.lock().expect("queue mutex poisoned");
+        // inbound_queue has no last_error column; narrate via tracing instead.
+        tracing::warn!(target: "gateway::queue", id, error, "inbound message marked failed");
+        conn.execute(
+            "UPDATE inbound_queue SET state='failed' WHERE id = ?1",
+            params![id],
+        )?;
+        Ok(())
+    }
+
+    pub async fn recover_processing(&self) -> Result<usize> {
+        let conn = self.conn.lock().expect("queue mutex poisoned");
+        let n = conn.execute(
+            "UPDATE inbound_queue SET state='pending' WHERE state='processing'",
+            [],
+        )?;
+        Ok(n)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_conn() -> Arc<Mutex<Connection>> {
+        let conn = Connection::open_in_memory().expect("open mem db");
+        crate::memory::initialize_test_conn(&conn).expect("schema");
+        Arc::new(Mutex::new(conn))
+    }
+
+    fn sample_msg() -> InboundMessage {
+        InboundMessage {
+            platform: "loopback".into(),
+            chat_id: "c1".into(),
+            user_id: "u1".into(),
+            text: "hi".into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn enqueue_then_claim_yields_pending_row() {
+        let q = InboundQueue::new(test_conn());
+        let id = q.enqueue(sample_msg()).await.unwrap();
+        let claimed = q.claim_next().await.unwrap().expect("claim returns row");
+        assert_eq!(claimed.id, id);
+        assert_eq!(claimed.text, "hi");
+        assert_eq!(claimed.platform, "loopback");
+        assert_eq!(claimed.chat_id, "c1");
+        assert_eq!(claimed.user_id, "u1");
+    }
+
+    #[tokio::test]
+    async fn claim_marks_processing_so_second_claim_returns_none() {
+        let q = InboundQueue::new(test_conn());
+        let id = q.enqueue(sample_msg()).await.unwrap();
+        let row = q.claim_next().await.unwrap().expect("first claim");
+        assert_eq!(row.id, id);
+        assert!(
+            q.claim_next().await.unwrap().is_none(),
+            "row in processing should not re-claim"
+        );
+    }
+
+    #[tokio::test]
+    async fn mark_done_deletes_row() {
+        let conn = test_conn();
+        let q = InboundQueue::new(Arc::clone(&conn));
+        let id = q.enqueue(sample_msg()).await.unwrap();
+        let _ = q.claim_next().await.unwrap();
+        q.mark_done(id).await.unwrap();
+        let conn = conn.lock().expect("lock test conn");
+        let exists: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM inbound_queue WHERE id = ?1",
+                params![id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(exists, 0);
+    }
+
+    #[tokio::test]
+    async fn mark_failed_sets_state() {
+        let q = InboundQueue::new(test_conn());
+        let id = q.enqueue(sample_msg()).await.unwrap();
+        let _ = q.claim_next().await.unwrap();
+        q.mark_failed(id, "boom").await.unwrap();
+        assert!(q.claim_next().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn recover_processing_resets_to_pending() {
+        let conn = test_conn();
+        let q = InboundQueue::new(Arc::clone(&conn));
+        q.enqueue(sample_msg()).await.unwrap();
+        let _ = q.claim_next().await.unwrap();
+        drop(q);
+        let q2 = InboundQueue::new(conn);
+        let recovered = q2.recover_processing().await.unwrap();
+        assert_eq!(recovered, 1);
+        assert!(q2.claim_next().await.unwrap().is_some());
+    }
+}

--- a/src/gateway/queue.rs
+++ b/src/gateway/queue.rs
@@ -323,6 +323,17 @@ mod tests {
         assert!(q2.claim_due(chrono::Utc::now().timestamp()).await.unwrap().is_some());
     }
 
+    #[test]
+    fn backoff_schedule_values() {
+        assert_eq!(outbound_backoff_secs(1), 5);
+        assert_eq!(outbound_backoff_secs(2), 30);
+        assert_eq!(outbound_backoff_secs(3), 300);
+        assert_eq!(outbound_backoff_secs(4), 1800);
+        assert_eq!(outbound_backoff_secs(5), 7200);
+        assert_eq!(outbound_backoff_secs(99), 7200);
+        assert_eq!(outbound_backoff_secs(0), 5);
+    }
+
     #[tokio::test]
     async fn outbound_claim_due_skips_future_rows() {
         let conn = test_conn();

--- a/src/gateway/queue.rs
+++ b/src/gateway/queue.rs
@@ -68,6 +68,23 @@ impl InboundQueue {
         Ok(())
     }
 
+    pub async fn complete_with_outbound(&self, id: i64, msg: OutboundMessage) -> Result<i64> {
+        let mut conn = self.conn.lock().map_err(|_| anyhow!("queue DB poisoned"))?;
+        let tx = conn.transaction()?;
+        let now = chrono::Utc::now().timestamp();
+        let attachments_json = serde_json::to_string(&msg.attachments)?;
+        tx.execute(
+            "INSERT INTO outbound_queue \
+             (platform, chat_id, text, attachments_json, enqueued_at, next_attempt_at, state) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?5, 'pending')",
+            params![msg.platform, msg.chat_id, msg.text, attachments_json, now],
+        )?;
+        let outbound_id = tx.last_insert_rowid();
+        tx.execute("DELETE FROM inbound_queue WHERE id = ?1", params![id])?;
+        tx.commit()?;
+        Ok(outbound_id)
+    }
+
     pub async fn mark_failed(&self, id: i64, error: &str) -> Result<()> {
         let conn = self.conn.lock().map_err(|_| anyhow!("queue DB poisoned"))?;
         // inbound_queue has no last_error column; narrate via tracing instead.
@@ -407,5 +424,32 @@ mod tests {
         let recovered = q2.recover_processing().await.unwrap();
         assert_eq!(recovered, 1);
         assert!(q2.claim_next().await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn complete_with_outbound_enqueues_reply_and_deletes_inbound_atomically() {
+        let conn = test_conn();
+        let inbound = InboundQueue::new(Arc::clone(&conn));
+        let outbound = OutboundQueue::new(Arc::clone(&conn), 5);
+        let id = inbound.enqueue(sample_msg()).await.unwrap();
+        let row = inbound.claim_next().await.unwrap().expect("row");
+        assert_eq!(row.id, id);
+
+        let outbound_id = inbound
+            .complete_with_outbound(
+                id,
+                OutboundMessage {
+                    platform: "loopback".into(),
+                    chat_id: "c1".into(),
+                    text: "reply".into(),
+                    attachments: vec![],
+                },
+            )
+            .await
+            .unwrap();
+
+        assert!(inbound.claim_next().await.unwrap().is_none());
+        let outbound_row = outbound.peek(outbound_id).await.unwrap();
+        assert_eq!(outbound_row.text, "reply");
     }
 }

--- a/src/gateway/queue.rs
+++ b/src/gateway/queue.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Mutex};
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use rusqlite::{Connection, params};
 
 use crate::platform::InboundMessage;
@@ -26,7 +26,7 @@ impl InboundQueue {
     }
 
     pub async fn enqueue(&self, msg: InboundMessage) -> Result<i64> {
-        let conn = self.conn.lock().expect("queue mutex poisoned");
+        let conn = self.conn.lock().map_err(|_| anyhow!("queue DB poisoned"))?;
         let now = chrono::Utc::now().timestamp();
         conn.execute(
             "INSERT INTO inbound_queue (platform, chat_id, user_id, text, received_at, state) \
@@ -37,7 +37,7 @@ impl InboundQueue {
     }
 
     pub async fn claim_next(&self) -> Result<Option<InboundRow>> {
-        let conn = self.conn.lock().expect("queue mutex poisoned");
+        let conn = self.conn.lock().map_err(|_| anyhow!("queue DB poisoned"))?;
         // RETURNING (SQLite >= 3.35) makes the claim a single atomic statement.
         let mut stmt = conn.prepare(
             "UPDATE inbound_queue \
@@ -63,13 +63,13 @@ impl InboundQueue {
     }
 
     pub async fn mark_done(&self, id: i64) -> Result<()> {
-        let conn = self.conn.lock().expect("queue mutex poisoned");
+        let conn = self.conn.lock().map_err(|_| anyhow!("queue DB poisoned"))?;
         conn.execute("DELETE FROM inbound_queue WHERE id = ?1", params![id])?;
         Ok(())
     }
 
     pub async fn mark_failed(&self, id: i64, error: &str) -> Result<()> {
-        let conn = self.conn.lock().expect("queue mutex poisoned");
+        let conn = self.conn.lock().map_err(|_| anyhow!("queue DB poisoned"))?;
         // inbound_queue has no last_error column; narrate via tracing instead.
         tracing::warn!(target: "gateway::queue", id, error, "inbound message marked failed");
         conn.execute(
@@ -80,7 +80,7 @@ impl InboundQueue {
     }
 
     pub async fn recover_processing(&self) -> Result<usize> {
-        let conn = self.conn.lock().expect("queue mutex poisoned");
+        let conn = self.conn.lock().map_err(|_| anyhow!("queue DB poisoned"))?;
         let n = conn.execute(
             "UPDATE inbound_queue SET state='pending' WHERE state='processing'",
             [],

--- a/src/gateway/queue.rs
+++ b/src/gateway/queue.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 use anyhow::{Result, anyhow};
 use rusqlite::{Connection, params};
 
-use crate::platform::InboundMessage;
+use crate::platform::{InboundMessage, OutboundMessage};
 
 pub struct InboundQueue {
     conn: Arc<Mutex<Connection>>,
@@ -89,6 +89,148 @@ impl InboundQueue {
     }
 }
 
+pub struct OutboundQueue {
+    conn: Arc<Mutex<Connection>>,
+    max_attempts: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct OutboundRow {
+    pub id: i64,
+    pub platform: String,
+    pub chat_id: String,
+    pub text: String,
+    pub attachments: Vec<String>,
+    pub enqueued_at: i64,
+    pub next_attempt_at: i64,
+    pub attempts: i64,
+    pub state: String,
+    pub last_error: Option<String>,
+}
+
+// Retry waits indexed by failures-so-far: 1st → 5s, 2nd → 30s, ... clamps at 7200s.
+fn outbound_backoff_secs(attempts: i64) -> i64 {
+    const SCHEDULE: &[i64] = &[5, 30, 300, 1800, 7200];
+    let idx = (attempts - 1).clamp(0, (SCHEDULE.len() - 1) as i64) as usize;
+    SCHEDULE[idx]
+}
+
+impl OutboundQueue {
+    pub fn new(conn: Arc<Mutex<Connection>>, max_attempts: u32) -> Self {
+        Self { conn, max_attempts }
+    }
+
+    pub async fn enqueue(&self, msg: OutboundMessage) -> Result<i64> {
+        let conn = self.conn.lock().map_err(|_| anyhow!("queue DB poisoned"))?;
+        let now = chrono::Utc::now().timestamp();
+        let attachments_json = serde_json::to_string(&msg.attachments)?;
+        conn.execute(
+            "INSERT INTO outbound_queue \
+             (platform, chat_id, text, attachments_json, enqueued_at, next_attempt_at, state) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?5, 'pending')",
+            params![msg.platform, msg.chat_id, msg.text, attachments_json, now],
+        )?;
+        Ok(conn.last_insert_rowid())
+    }
+
+    pub async fn claim_due(&self, now: i64) -> Result<Option<OutboundRow>> {
+        let conn = self.conn.lock().map_err(|_| anyhow!("queue DB poisoned"))?;
+        let mut stmt = conn.prepare(
+            "UPDATE outbound_queue \
+             SET state='sending', attempts = attempts + 1 \
+             WHERE id = (SELECT id FROM outbound_queue \
+                         WHERE state='pending' AND next_attempt_at <= ?1 \
+                         ORDER BY next_attempt_at ASC LIMIT 1) \
+             RETURNING id, platform, chat_id, text, attachments_json, enqueued_at, \
+                       next_attempt_at, attempts, state, last_error",
+        )?;
+        let mut rows = stmt.query(params![now])?;
+        if let Some(row) = rows.next()? {
+            let attachments_json: String = row.get(4)?;
+            let attachments: Vec<String> = serde_json::from_str(&attachments_json)?;
+            Ok(Some(OutboundRow {
+                id: row.get(0)?,
+                platform: row.get(1)?,
+                chat_id: row.get(2)?,
+                text: row.get(3)?,
+                attachments,
+                enqueued_at: row.get(5)?,
+                next_attempt_at: row.get(6)?,
+                attempts: row.get(7)?,
+                state: row.get(8)?,
+                last_error: row.get(9)?,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub async fn mark_done(&self, id: i64) -> Result<()> {
+        let conn = self.conn.lock().map_err(|_| anyhow!("queue DB poisoned"))?;
+        conn.execute("DELETE FROM outbound_queue WHERE id = ?1", params![id])?;
+        Ok(())
+    }
+
+    pub async fn mark_failed(&self, id: i64, error: &str) -> Result<()> {
+        let row = self.peek(id).await?;
+        let now = chrono::Utc::now().timestamp();
+        let next_state = if row.attempts as u32 >= self.max_attempts {
+            "failed"
+        } else {
+            "pending"
+        };
+        let next_at = now + outbound_backoff_secs(row.attempts);
+        {
+            let conn = self.conn.lock().map_err(|_| anyhow!("queue DB poisoned"))?;
+            conn.execute(
+                "UPDATE outbound_queue \
+                 SET state = ?1, next_attempt_at = ?2, last_error = ?3 \
+                 WHERE id = ?4",
+                params![next_state, next_at, error, id],
+            )?;
+        }
+        tracing::warn!(target: "gateway::queue", id, error, "outbound delivery failed");
+        Ok(())
+    }
+
+    pub async fn recover_sending(&self) -> Result<usize> {
+        let conn = self.conn.lock().map_err(|_| anyhow!("queue DB poisoned"))?;
+        let n = conn.execute(
+            "UPDATE outbound_queue SET state='pending' WHERE state='sending'",
+            [],
+        )?;
+        Ok(n)
+    }
+
+    pub async fn peek(&self, id: i64) -> Result<OutboundRow> {
+        let conn = self.conn.lock().map_err(|_| anyhow!("queue DB poisoned"))?;
+        let mut stmt = conn.prepare(
+            "SELECT id, platform, chat_id, text, attachments_json, enqueued_at, \
+                    next_attempt_at, attempts, state, last_error \
+             FROM outbound_queue WHERE id = ?1",
+        )?;
+        let mut rows = stmt.query(params![id])?;
+        if let Some(row) = rows.next()? {
+            let attachments_json: String = row.get(4)?;
+            let attachments: Vec<String> = serde_json::from_str(&attachments_json)?;
+            Ok(OutboundRow {
+                id: row.get(0)?,
+                platform: row.get(1)?,
+                chat_id: row.get(2)?,
+                text: row.get(3)?,
+                attachments,
+                enqueued_at: row.get(5)?,
+                next_attempt_at: row.get(6)?,
+                attempts: row.get(7)?,
+                state: row.get(8)?,
+                last_error: row.get(9)?,
+            })
+        } else {
+            Err(anyhow!("row not found"))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -106,6 +248,90 @@ mod tests {
             user_id: "u1".into(),
             text: "hi".into(),
         }
+    }
+
+    fn sample_out_msg() -> OutboundMessage {
+        OutboundMessage {
+            platform: "loopback".into(),
+            chat_id: "c1".into(),
+            text: "hello".into(),
+            attachments: vec![],
+        }
+    }
+
+    #[tokio::test]
+    async fn outbound_enqueue_due_immediately() {
+        let q = OutboundQueue::new(test_conn(), 5);
+        let id = q.enqueue(sample_out_msg()).await.unwrap();
+        let now = chrono::Utc::now().timestamp();
+        let row = q.claim_due(now).await.unwrap().expect("due now");
+        assert_eq!(row.id, id);
+        assert_eq!(row.state, "sending");
+        assert_eq!(row.attempts, 1);
+    }
+
+    #[tokio::test]
+    async fn outbound_failure_schedules_next_attempt_with_backoff() {
+        let q = OutboundQueue::new(test_conn(), 5);
+        let id = q.enqueue(sample_out_msg()).await.unwrap();
+        let claim_at = chrono::Utc::now().timestamp();
+        let _ = q.claim_due(claim_at).await.unwrap().expect("claim");
+        q.mark_failed(id, "boom").await.unwrap();
+        let row = q.peek(id).await.unwrap();
+        assert_eq!(row.attempts, 1);
+        assert_eq!(row.state, "pending");
+        assert_eq!(row.last_error.as_deref(), Some("boom"));
+        let elapsed = row.next_attempt_at - claim_at;
+        assert!(elapsed >= 5, "next_attempt_at should be >= claim+5, got {elapsed}");
+        assert!(elapsed <= 10, "next_attempt_at should be < claim+10, got {elapsed}");
+    }
+
+    #[tokio::test]
+    async fn outbound_drops_after_max_attempts() {
+        let q = OutboundQueue::new(test_conn(), 3);
+        let id = q.enqueue(sample_out_msg()).await.unwrap();
+        for _ in 0..3 {
+            let now = chrono::Utc::now().timestamp() + 1_000_000;
+            let _ = q.claim_due(now).await.unwrap().expect("claim");
+            q.mark_failed(id, "boom").await.unwrap();
+        }
+        let row = q.peek(id).await.unwrap();
+        assert_eq!(row.state, "failed");
+        assert_eq!(row.attempts, 3);
+    }
+
+    #[tokio::test]
+    async fn outbound_mark_done_deletes() {
+        let conn = test_conn();
+        let q = OutboundQueue::new(Arc::clone(&conn), 5);
+        let id = q.enqueue(sample_out_msg()).await.unwrap();
+        let _ = q.claim_due(chrono::Utc::now().timestamp()).await.unwrap();
+        q.mark_done(id).await.unwrap();
+        assert!(q.peek(id).await.is_err(), "row should be gone");
+    }
+
+    #[tokio::test]
+    async fn outbound_recover_sending_resets_to_pending() {
+        let conn = test_conn();
+        let q = OutboundQueue::new(Arc::clone(&conn), 5);
+        q.enqueue(sample_out_msg()).await.unwrap();
+        let _ = q.claim_due(chrono::Utc::now().timestamp()).await.unwrap();
+        drop(q);
+        let q2 = OutboundQueue::new(conn, 5);
+        let recovered = q2.recover_sending().await.unwrap();
+        assert_eq!(recovered, 1);
+        assert!(q2.claim_due(chrono::Utc::now().timestamp()).await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn outbound_claim_due_skips_future_rows() {
+        let conn = test_conn();
+        let q = OutboundQueue::new(Arc::clone(&conn), 5);
+        let id = q.enqueue(sample_out_msg()).await.unwrap();
+        let _ = q.claim_due(chrono::Utc::now().timestamp()).await.unwrap();
+        q.mark_failed(id, "nope").await.unwrap();
+        assert!(q.claim_due(chrono::Utc::now().timestamp()).await.unwrap().is_none());
+        assert!(q.claim_due(chrono::Utc::now().timestamp() + 100).await.unwrap().is_some());
     }
 
     #[tokio::test]

--- a/src/gateway/registry.rs
+++ b/src/gateway/registry.rs
@@ -16,8 +16,16 @@ impl PlatformRegistry {
         Self::default()
     }
 
-    pub fn register(&mut self, name: impl Into<String>, platform: Arc<dyn Platform>) {
-        self.inner.insert(name.into(), platform);
+    /// Register a platform under `name`. The name is the routing key used by
+    /// `send` (matched against `OutboundMessage::platform`); it is independent
+    /// of `Platform::name()`. Returns the previous entry if `name` was already
+    /// registered, so callers can detect double-wiring.
+    pub fn register(
+        &mut self,
+        name: impl Into<String>,
+        platform: Arc<dyn Platform>,
+    ) -> Option<Arc<dyn Platform>> {
+        self.inner.insert(name.into(), platform)
     }
 
     pub fn get(&self, name: &str) -> Option<Arc<dyn Platform>> {
@@ -72,5 +80,16 @@ mod tests {
     async fn registry_get_returns_none_for_missing() {
         let reg = PlatformRegistry::new();
         assert!(reg.get("nope").is_none());
+    }
+
+    #[tokio::test]
+    async fn register_returns_previous_entry() {
+        let lp1 = Arc::new(LoopbackPlatform::default());
+        let lp2 = Arc::new(LoopbackPlatform::default());
+        let mut reg = PlatformRegistry::new();
+        assert!(reg.register("loopback", lp1.clone()).is_none());
+        let prev = reg.register("loopback", lp2);
+        assert!(prev.is_some());
+        assert!(Arc::ptr_eq(&prev.unwrap(), &(lp1 as Arc<dyn Platform>)));
     }
 }

--- a/src/gateway/registry.rs
+++ b/src/gateway/registry.rs
@@ -1,0 +1,76 @@
+//! Routes outbound messages to the named `Platform` connector.
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::{Result, anyhow};
+
+use crate::platform::{OutboundMessage, Platform};
+
+#[derive(Default)]
+pub struct PlatformRegistry {
+    inner: HashMap<String, Arc<dyn Platform>>,
+}
+
+impl PlatformRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn register(&mut self, name: impl Into<String>, platform: Arc<dyn Platform>) {
+        self.inner.insert(name.into(), platform);
+    }
+
+    pub fn get(&self, name: &str) -> Option<Arc<dyn Platform>> {
+        self.inner.get(name).cloned()
+    }
+
+    pub async fn send(&self, msg: &OutboundMessage) -> Result<()> {
+        let plat = self
+            .get(&msg.platform)
+            .ok_or_else(|| anyhow!("unknown platform: {}", msg.platform))?;
+        plat.send(msg).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gateway::loopback::LoopbackPlatform;
+    use crate::platform::OutboundMessage;
+
+    fn out_msg(platform: &str, chat: &str, text: &str) -> OutboundMessage {
+        OutboundMessage {
+            platform: platform.into(),
+            chat_id: chat.into(),
+            text: text.into(),
+            attachments: vec![],
+        }
+    }
+
+    #[tokio::test]
+    async fn registry_send_routes_by_platform_name() {
+        let lp = Arc::new(LoopbackPlatform::default());
+        let mut reg = PlatformRegistry::new();
+        reg.register("loopback", lp.clone());
+        reg.send(&out_msg("loopback", "c", "hello")).await.unwrap();
+        let recorded = lp.recorded().await;
+        assert_eq!(recorded.len(), 1);
+        assert_eq!(recorded[0].text, "hello");
+    }
+
+    #[tokio::test]
+    async fn registry_unknown_platform_errors() {
+        let reg = PlatformRegistry::new();
+        let err = reg
+            .send(&out_msg("nope", "c", "x"))
+            .await
+            .expect_err("should error");
+        assert!(err.to_string().contains("unknown platform"));
+    }
+
+    #[tokio::test]
+    async fn registry_get_returns_none_for_missing() {
+        let reg = PlatformRegistry::new();
+        assert!(reg.get("nope").is_none());
+    }
+}

--- a/src/gateway/routes/health.rs
+++ b/src/gateway/routes/health.rs
@@ -1,0 +1,5 @@
+use axum::Json;
+
+pub async fn handle() -> Json<serde_json::Value> {
+    Json(serde_json::json!({ "status": "ok" }))
+}

--- a/src/gateway/routes/inbound.rs
+++ b/src/gateway/routes/inbound.rs
@@ -1,0 +1,213 @@
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use serde::Deserialize;
+
+use crate::gateway::server::AppState;
+use crate::platform::InboundMessage;
+
+#[derive(Deserialize)]
+pub struct InboundRequest {
+    pub platform: String,
+    pub chat_id: String,
+    pub user_id: String,
+    pub text: String,
+}
+
+pub async fn handle(
+    State(state): State<AppState>,
+    Json(body): Json<InboundRequest>,
+) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<serde_json::Value>)> {
+    // Reject unknown platforms early so unsuited messages don't pollute the queue.
+    if state.registry.get(&body.platform).is_none() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(
+                serde_json::json!({"error": format!("unknown platform: {}", body.platform)}),
+            ),
+        ));
+    }
+
+    let msg = InboundMessage {
+        platform: body.platform,
+        chat_id: body.chat_id,
+        user_id: body.user_id,
+        text: body.text,
+    };
+    match state.inbound.enqueue(msg).await {
+        Ok(id) => Ok((StatusCode::ACCEPTED, Json(serde_json::json!({"id": id})))),
+        Err(e) => {
+            tracing::error!(target: "gateway::inbound", error = %e, "inbound enqueue failed");
+            Err((
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({"error": "inbound enqueue failed"})),
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::Mutex as StdMutex;
+
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use rusqlite::Connection;
+    use tower::ServiceExt;
+
+    use crate::gateway::loopback::LoopbackPlatform;
+    use crate::gateway::registry::PlatformRegistry;
+    use crate::gateway::server::{AppState, build_router};
+
+    fn fresh_db() -> Arc<StdMutex<Connection>> {
+        let c = Connection::open_in_memory().expect("open mem db");
+        crate::memory::initialize_test_conn(&c).expect("schema");
+        Arc::new(StdMutex::new(c))
+    }
+
+    fn app_state_with(registry: PlatformRegistry, db: Arc<StdMutex<Connection>>) -> AppState {
+        // Build an AppState pointing at the given db + registry. Use
+        // Config::default() and an AgentMap::new — neither is exercised
+        // by /v1/inbound (it just enqueues), so that's fine.
+        let config = Arc::new(crate::config::Config::default());
+        let agent_map = crate::gateway::agent_map::AgentMap::new(
+            config,
+            std::time::Duration::from_secs(60),
+        );
+        AppState {
+            api_token: Arc::new("secret".into()),
+            inbound: Arc::new(crate::gateway::queue::InboundQueue::new(Arc::clone(&db))),
+            outbound: Arc::new(crate::gateway::queue::OutboundQueue::new(Arc::clone(&db), 5)),
+            registry: Arc::new(registry),
+            agent_map: Arc::new(agent_map),
+        }
+    }
+
+    fn registry_with_loopback() -> PlatformRegistry {
+        let mut reg = PlatformRegistry::new();
+        reg.register("loopback", Arc::new(LoopbackPlatform::default()));
+        reg
+    }
+
+    fn auth_request(uri: &str, body: serde_json::Value) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri(uri)
+            .header("authorization", "Bearer secret")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn post_inbound_enqueues_and_returns_id() {
+        let db = fresh_db();
+        let state = app_state_with(registry_with_loopback(), Arc::clone(&db));
+        let inbound_q = Arc::clone(&state.inbound);
+        let app = build_router(state);
+
+        let resp = app
+            .oneshot(auth_request(
+                "/v1/inbound",
+                serde_json::json!({
+                    "platform": "loopback",
+                    "chat_id": "c1",
+                    "user_id": "u1",
+                    "text": "hi"
+                }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::ACCEPTED);
+
+        // Confirm the row landed and can be claimed.
+        let row = inbound_q.claim_next().await.unwrap().expect("row");
+        assert_eq!(row.text, "hi");
+        assert_eq!(row.platform, "loopback");
+    }
+
+    #[tokio::test]
+    async fn post_inbound_unknown_platform_returns_400() {
+        let db = fresh_db();
+        let state = app_state_with(PlatformRegistry::new(), db); // empty registry
+        let app = build_router(state);
+        let resp = app
+            .oneshot(auth_request(
+                "/v1/inbound",
+                serde_json::json!({
+                    "platform": "nope",
+                    "chat_id": "c",
+                    "user_id": "u",
+                    "text": "x"
+                }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn post_inbound_missing_bearer_returns_401() {
+        let db = fresh_db();
+        let state = app_state_with(registry_with_loopback(), db);
+        let app = build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/inbound")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "platform": "loopback",
+                            "chat_id": "c",
+                            "user_id": "u",
+                            "text": "x"
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn post_inbound_db_error_returns_503() {
+        // Force the inbound enqueue to fail. Approach: open a FRESH in-memory
+        // connection that has NOT had the schema applied, so the INSERT into
+        // `inbound_queue` errors with "no such table".
+        let unschemed = Arc::new(StdMutex::new(
+            Connection::open_in_memory().expect("open mem db"),
+        ));
+        // Build the state pointing at the unschemed db.
+        let config = Arc::new(crate::config::Config::default());
+        let agent_map = crate::gateway::agent_map::AgentMap::new(
+            config,
+            std::time::Duration::from_secs(60),
+        );
+        let state = AppState {
+            api_token: Arc::new("secret".into()),
+            inbound: Arc::new(crate::gateway::queue::InboundQueue::new(Arc::clone(&unschemed))),
+            outbound: Arc::new(crate::gateway::queue::OutboundQueue::new(Arc::clone(&unschemed), 5)),
+            registry: Arc::new(registry_with_loopback()),
+            agent_map: Arc::new(agent_map),
+        };
+        let app = build_router(state);
+        let resp = app
+            .oneshot(auth_request(
+                "/v1/inbound",
+                serde_json::json!({
+                    "platform": "loopback",
+                    "chat_id": "c",
+                    "user_id": "u",
+                    "text": "x"
+                }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+}

--- a/src/gateway/routes/inbound.rs
+++ b/src/gateway/routes/inbound.rs
@@ -20,6 +20,8 @@ pub async fn handle(
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<serde_json::Value>)> {
     // Reject unknown platforms early so unsuited messages don't pollute the queue.
     if state.registry.get(&body.platform).is_none() {
+        tracing::warn!(target: "gateway::inbound",
+            platform = %body.platform, "unknown platform rejected");
         return Err((
             StatusCode::BAD_REQUEST,
             Json(

--- a/src/gateway/routes/lanes.rs
+++ b/src/gateway/routes/lanes.rs
@@ -1,11 +1,177 @@
-// Placeholder for Task 15. Real implementation will surface active lanes from
-// `AppState::agent_map`; today this returns an empty array so Task 13 can test
-// bearer auth against a `/v1/*` route.
+//! GET /v1/lanes — observability snapshot of currently-active per-chat lanes.
+//!
+//! Returns `{"lanes": [LaneSnapshot, ...]}` sorted most-recent first by
+//! `last_activity`. Reads only what `AgentMap` already tracks; the per-lane
+//! audit ring is intentionally not exposed here (different shape — see
+//! `agent_map.rs::LaneEntry.audit_buf`).
 use axum::Json;
 use axum::extract::State;
 
 use crate::gateway::server::AppState;
 
-pub async fn handle(State(_state): State<AppState>) -> Json<serde_json::Value> {
-    Json(serde_json::json!([]))
+pub async fn handle(State(state): State<AppState>) -> Json<serde_json::Value> {
+    let snapshot = state.agent_map.snapshot().await;
+    Json(serde_json::json!({ "lanes": snapshot }))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::Mutex as StdMutex;
+    use std::time::{Duration, Instant};
+
+    use anyhow::Result;
+    use async_trait::async_trait;
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use rusqlite::Connection;
+    use tokio_util::sync::CancellationToken;
+    use tower::ServiceExt;
+
+    use crate::agent::Agent;
+    use crate::config::Config;
+    use crate::gateway::agent_map::AgentMap;
+    use crate::gateway::lane::LaneKey;
+    use crate::gateway::registry::PlatformRegistry;
+    use crate::gateway::server::{AppState, build_router};
+    use crate::hooks::HookRegistry;
+    use crate::hooks::audit::AuditHook;
+    use crate::provider::mock::MockProvider;
+    use crate::provider::{ChatResponse, LLMProvider, Message, StreamEvent, ToolDefinition};
+    use crate::skills::SkillRegistry;
+    use crate::tools::ToolRegistry;
+
+    fn fresh_db() -> Arc<StdMutex<Connection>> {
+        let c = Connection::open_in_memory().expect("open mem db");
+        crate::memory::initialize_test_conn(&c).expect("schema");
+        Arc::new(StdMutex::new(c))
+    }
+
+    fn empty_skills() -> Arc<SkillRegistry> {
+        Arc::new(SkillRegistry::new(&std::path::PathBuf::from(
+            "/tmp/vulcan-test-skills-nonexistent",
+        )))
+    }
+
+    /// Wraps an Arc<MockProvider> so multiple Agents can share a mock
+    /// instance. Mirrors the same shim in `worker.rs::tests` and
+    /// `agent_map.rs::tests` — three uses justifies a future helper, but
+    /// keeping local for Task 15.
+    struct ProviderHandle(Arc<MockProvider>);
+    #[async_trait]
+    impl LLMProvider for ProviderHandle {
+        async fn chat(
+            &self,
+            m: &[Message],
+            t: &[ToolDefinition],
+            c: CancellationToken,
+        ) -> Result<ChatResponse> {
+            self.0.chat(m, t, c).await
+        }
+        async fn chat_stream(
+            &self,
+            m: &[Message],
+            t: &[ToolDefinition],
+            tx: tokio::sync::mpsc::UnboundedSender<StreamEvent>,
+            c: CancellationToken,
+        ) -> Result<()> {
+            self.0.chat_stream(m, t, tx, c).await
+        }
+        fn max_context(&self) -> usize {
+            self.0.max_context()
+        }
+    }
+
+    /// Build an Agent backed by `MockProvider`. The route under test never
+    /// invokes the agent — it only reads `last_activity` and `session_id`
+    /// from the map — so no canned reply is needed.
+    fn build_test_agent() -> Arc<tokio::sync::Mutex<Agent>> {
+        let mock = Arc::new(MockProvider::new(128_000));
+        Arc::new(tokio::sync::Mutex::new(Agent::for_test(
+            Box::new(ProviderHandle(mock)),
+            ToolRegistry::new(),
+            HookRegistry::new(),
+            empty_skills(),
+        )))
+    }
+
+    fn build_app_state(db: Arc<StdMutex<Connection>>) -> AppState {
+        let config = Arc::new(Config::default());
+        let agent_map = AgentMap::new(config, Duration::from_secs(60));
+        AppState {
+            api_token: Arc::new("secret".into()),
+            inbound: Arc::new(crate::gateway::queue::InboundQueue::new(Arc::clone(&db))),
+            outbound: Arc::new(crate::gateway::queue::OutboundQueue::new(
+                Arc::clone(&db),
+                5,
+            )),
+            registry: Arc::new(PlatformRegistry::new()),
+            agent_map: Arc::new(agent_map),
+        }
+    }
+
+    #[tokio::test]
+    async fn get_lanes_lists_active_lanes() {
+        let db = fresh_db();
+        let state = build_app_state(Arc::clone(&db));
+
+        let now = Instant::now();
+        let lane_a = LaneKey {
+            platform: "loopback".into(),
+            chat_id: "a".into(),
+        };
+        let lane_b = LaneKey {
+            platform: "loopback".into(),
+            chat_id: "b".into(),
+        };
+        let agent_a = build_test_agent();
+        let agent_b = build_test_agent();
+        let (_h1, buf_a) = AuditHook::new(8);
+        let (_h2, buf_b) = AuditHook::new(8);
+        state
+            .agent_map
+            .insert_for_test(lane_a.clone(), agent_a, buf_a, now)
+            .await;
+        state
+            .agent_map
+            .insert_for_test(
+                lane_b.clone(),
+                agent_b,
+                buf_b,
+                now - Duration::from_secs(10),
+            )
+            .await;
+
+        let app = build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/lanes")
+                    .header("authorization", "Bearer secret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let lanes = json
+            .get("lanes")
+            .and_then(|v| v.as_array())
+            .expect("lanes array");
+        assert_eq!(lanes.len(), 2);
+
+        // Lane A is most-recent → should be first.
+        assert_eq!(lanes[0]["chat_id"], "a");
+        assert_eq!(lanes[1]["chat_id"], "b");
+        assert!(
+            lanes[0]["session_id"]
+                .as_str()
+                .unwrap()
+                .starts_with("gateway:loopback:")
+        );
+        assert!(lanes[1]["last_activity_secs_ago"].as_u64().unwrap() >= 10);
+    }
 }

--- a/src/gateway/routes/lanes.rs
+++ b/src/gateway/routes/lanes.rs
@@ -1,0 +1,11 @@
+// Placeholder for Task 15. Real implementation will surface active lanes from
+// `AppState::agent_map`; today this returns an empty array so Task 13 can test
+// bearer auth against a `/v1/*` route.
+use axum::Json;
+use axum::extract::State;
+
+use crate::gateway::server::AppState;
+
+pub async fn handle(State(_state): State<AppState>) -> Json<serde_json::Value> {
+    Json(serde_json::json!([]))
+}

--- a/src/gateway/routes/mod.rs
+++ b/src/gateway/routes/mod.rs
@@ -1,0 +1,2 @@
+pub mod health;
+pub mod lanes;

--- a/src/gateway/routes/mod.rs
+++ b/src/gateway/routes/mod.rs
@@ -1,3 +1,4 @@
 pub mod health;
 pub mod inbound;
 pub mod lanes;
+pub mod webhook;

--- a/src/gateway/routes/mod.rs
+++ b/src/gateway/routes/mod.rs
@@ -1,2 +1,3 @@
 pub mod health;
+pub mod inbound;
 pub mod lanes;

--- a/src/gateway/routes/webhook.rs
+++ b/src/gateway/routes/webhook.rs
@@ -163,4 +163,32 @@ mod tests {
             .unwrap();
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     }
+
+    #[tokio::test]
+    async fn webhook_rejects_oversized_body_before_verification() {
+        let db = fresh_db();
+        let mut reg = PlatformRegistry::new();
+        reg.register(
+            "loopback",
+            Arc::new(LoopbackPlatform::with_webhook_secret("hush")),
+        );
+        let state = app_state_with(reg, db);
+        let app = build_router(state);
+
+        let oversized = "x".repeat(70 * 1024);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/webhook/loopback")
+                    .header("content-type", "application/json")
+                    .header("x-loopback-signature", "irrelevant")
+                    .body(Body::from(oversized))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
 }

--- a/src/gateway/routes/webhook.rs
+++ b/src/gateway/routes/webhook.rs
@@ -1,0 +1,166 @@
+use axum::Json;
+use axum::body::Bytes;
+use axum::extract::{Path, State};
+use axum::http::{HeaderMap, StatusCode};
+
+use crate::gateway::server::AppState;
+
+pub async fn handle(
+    State(state): State<AppState>,
+    Path(platform): Path<String>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<serde_json::Value>)> {
+    let plat = state.registry.get(&platform).ok_or_else(|| {
+        tracing::warn!(target: "gateway::webhook",
+            platform = %platform,
+            "webhook for unknown platform");
+        (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": format!("unknown platform: {platform}")})),
+        )
+    })?;
+
+    let inbound = plat.verify_webhook(&headers, &body).await.map_err(|e| {
+        tracing::warn!(target: "gateway::webhook",
+            platform = %platform,
+            error = %e,
+            "webhook verification failed");
+        (
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({"error": "invalid webhook signature"})),
+        )
+    })?;
+
+    state.inbound.enqueue(inbound).await.map_err(|e| {
+        tracing::error!(target: "gateway::webhook", error = %e, "inbound enqueue failed");
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({"error": "inbound enqueue failed"})),
+        )
+    })?;
+
+    Ok((StatusCode::OK, Json(serde_json::json!({"status": "ok"}))))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::Mutex as StdMutex;
+
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use rusqlite::Connection;
+    use tower::ServiceExt;
+
+    use crate::gateway::loopback::LoopbackPlatform;
+    use crate::gateway::registry::PlatformRegistry;
+    use crate::gateway::server::{AppState, build_router};
+
+    fn fresh_db() -> Arc<StdMutex<Connection>> {
+        let c = Connection::open_in_memory().expect("open mem db");
+        crate::memory::initialize_test_conn(&c).expect("schema");
+        Arc::new(StdMutex::new(c))
+    }
+
+    fn sign_loopback(secret: &str, body: &[u8]) -> String {
+        use hmac::{Hmac, Mac};
+        use sha2::Sha256;
+        let mut mac = <Hmac<Sha256>>::new_from_slice(secret.as_bytes()).unwrap();
+        mac.update(body);
+        let bytes = mac.finalize().into_bytes();
+        bytes.iter().map(|b| format!("{b:02x}")).collect()
+    }
+
+    fn app_state_with(registry: PlatformRegistry, db: Arc<StdMutex<Connection>>) -> AppState {
+        let config = Arc::new(crate::config::Config::default());
+        let agent_map = crate::gateway::agent_map::AgentMap::new(
+            config,
+            std::time::Duration::from_secs(60),
+        );
+        AppState {
+            api_token: Arc::new("secret".into()),
+            inbound: Arc::new(crate::gateway::queue::InboundQueue::new(Arc::clone(&db))),
+            outbound: Arc::new(crate::gateway::queue::OutboundQueue::new(Arc::clone(&db), 5)),
+            registry: Arc::new(registry),
+            agent_map: Arc::new(agent_map),
+        }
+    }
+
+    #[tokio::test]
+    async fn webhook_loopback_accepts_signed_request() {
+        let db = fresh_db();
+        let mut reg = PlatformRegistry::new();
+        let lp = Arc::new(LoopbackPlatform::with_webhook_secret("hush"));
+        reg.register("loopback", lp.clone());
+        let state = app_state_with(reg, Arc::clone(&db));
+        let inbound_q = Arc::clone(&state.inbound);
+        let app = build_router(state);
+
+        let body = serde_json::json!({"chat_id": "c", "user_id": "u", "text": "hi"}).to_string();
+        let signature = sign_loopback("hush", body.as_bytes());
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/webhook/loopback")
+                    .header("content-type", "application/json")
+                    .header("x-loopback-signature", signature)
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let row = inbound_q.claim_next().await.unwrap().expect("row");
+        assert_eq!(row.platform, "loopback");
+        assert_eq!(row.text, "hi");
+    }
+
+    #[tokio::test]
+    async fn webhook_loopback_rejects_invalid_signature() {
+        let db = fresh_db();
+        let mut reg = PlatformRegistry::new();
+        reg.register(
+            "loopback",
+            Arc::new(LoopbackPlatform::with_webhook_secret("hush")),
+        );
+        let state = app_state_with(reg, db);
+        let app = build_router(state);
+
+        let body = serde_json::json!({"chat_id": "c", "user_id": "u", "text": "hi"}).to_string();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/webhook/loopback")
+                    .header("content-type", "application/json")
+                    .header("x-loopback-signature", "deadbeef")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn webhook_unknown_platform_404() {
+        let db = fresh_db();
+        let state = app_state_with(PlatformRegistry::new(), db);
+        let app = build_router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/webhook/nope")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/src/gateway/server.rs
+++ b/src/gateway/server.rs
@@ -25,6 +25,11 @@ pub struct AppState {
 /// Topology: `/health` is unauthenticated; everything under `/v1/*` is wrapped
 /// in a bearer-auth middleware. The middleware lives on the nested `/v1`
 /// router (not the outer one) so the public `/health` endpoint isn't affected.
+/// Maximum body size for `/v1/*` JSON requests. Keeps a single oversized
+/// payload from filling the SQLite queue. Webhook routes (Task 16) may
+/// override this per-platform if a connector publishes large payloads.
+const V1_BODY_LIMIT_BYTES: usize = 64 * 1024;
+
 pub fn build_router(state: AppState) -> Router {
     let v1 = Router::new()
         .route(
@@ -35,6 +40,7 @@ pub fn build_router(state: AppState) -> Router {
             "/inbound",
             axum::routing::post(crate::gateway::routes::inbound::handle),
         )
+        .layer(axum::extract::DefaultBodyLimit::max(V1_BODY_LIMIT_BYTES))
         .layer(axum::middleware::from_fn_with_state(
             state.clone(),
             bearer_auth,

--- a/src/gateway/server.rs
+++ b/src/gateway/server.rs
@@ -1,0 +1,163 @@
+use std::sync::Arc;
+
+use axum::Router;
+use axum::extract::State;
+use axum::http::{Request, StatusCode};
+use axum::middleware::Next;
+use axum::response::Response;
+
+use crate::gateway::agent_map::AgentMap;
+use crate::gateway::queue::{InboundQueue, OutboundQueue};
+use crate::gateway::registry::PlatformRegistry;
+
+/// Shared state passed to every route via `axum::extract::State`.
+#[derive(Clone)]
+pub struct AppState {
+    pub api_token: Arc<String>,
+    pub inbound: Arc<InboundQueue>,
+    pub outbound: Arc<OutboundQueue>,
+    pub registry: Arc<PlatformRegistry>,
+    pub agent_map: Arc<AgentMap>,
+}
+
+/// Build the axum router. Public so tests can drive it via `tower::ServiceExt::oneshot`.
+///
+/// Topology: `/health` is unauthenticated; everything under `/v1/*` is wrapped
+/// in a bearer-auth middleware. The middleware lives on the nested `/v1`
+/// router (not the outer one) so the public `/health` endpoint isn't affected.
+pub fn build_router(state: AppState) -> Router {
+    let v1 = Router::new()
+        .route(
+            "/lanes",
+            axum::routing::get(crate::gateway::routes::lanes::handle),
+        )
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            bearer_auth,
+        ));
+
+    Router::new()
+        .route(
+            "/health",
+            axum::routing::get(crate::gateway::routes::health::handle),
+        )
+        .nest("/v1", v1)
+        .with_state(state)
+}
+
+/// Verify the `Authorization: Bearer <token>` header matches `state.api_token`.
+/// Missing header, wrong scheme, or wrong token all return 401.
+async fn bearer_auth(
+    State(state): State<AppState>,
+    req: Request<axum::body::Body>,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    let header = req
+        .headers()
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok());
+    let Some(provided) = header.and_then(|h| h.strip_prefix("Bearer ")) else {
+        return Err(StatusCode::UNAUTHORIZED);
+    };
+    if provided != state.api_token.as_str() {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+    Ok(next.run(req).await)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::Mutex as StdMutex;
+    use std::time::Duration;
+
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use rusqlite::Connection;
+    use tower::ServiceExt;
+
+    use crate::config::Config;
+    use crate::gateway::agent_map::AgentMap;
+
+    fn fresh_db() -> Arc<StdMutex<Connection>> {
+        let c = Connection::open_in_memory().expect("open mem db");
+        crate::memory::initialize_test_conn(&c).expect("schema");
+        Arc::new(StdMutex::new(c))
+    }
+
+    fn test_app_state(token: &str) -> AppState {
+        let config = Arc::new(Config::default());
+        let agent_map = AgentMap::new(config, Duration::from_secs(60));
+        let db = fresh_db();
+        AppState {
+            api_token: Arc::new(token.into()),
+            inbound: Arc::new(crate::gateway::queue::InboundQueue::new(Arc::clone(&db))),
+            outbound: Arc::new(crate::gateway::queue::OutboundQueue::new(Arc::clone(&db), 5)),
+            registry: Arc::new(crate::gateway::registry::PlatformRegistry::new()),
+            agent_map: Arc::new(agent_map),
+        }
+    }
+
+    #[tokio::test]
+    async fn health_endpoint_no_auth() {
+        let app = build_router(test_app_state("secret"));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn bearer_required_returns_401_when_missing() {
+        let app = build_router(test_app_state("secret"));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/lanes")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn bearer_wrong_token_returns_401() {
+        let app = build_router(test_app_state("secret"));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/lanes")
+                    .header("authorization", "Bearer wrong")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn bearer_correct_token_passes() {
+        let app = build_router(test_app_state("secret"));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/lanes")
+                    .header("authorization", "Bearer secret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+}

--- a/src/gateway/server.rs
+++ b/src/gateway/server.rs
@@ -59,7 +59,15 @@ async fn bearer_auth(
     let Some(provided) = header.and_then(|h| h.strip_prefix("Bearer ")) else {
         return Err(StatusCode::UNAUTHORIZED);
     };
-    if provided != state.api_token.as_str() {
+    // Constant-time compare: avoids leaking the prefix length of the
+    // configured token via early-out on byte mismatch.
+    use subtle::ConstantTimeEq;
+    if provided
+        .as_bytes()
+        .ct_eq(state.api_token.as_bytes())
+        .unwrap_u8()
+        == 0
+    {
         return Err(StatusCode::UNAUTHORIZED);
     }
     Ok(next.run(req).await)

--- a/src/gateway/server.rs
+++ b/src/gateway/server.rs
@@ -51,6 +51,12 @@ pub fn build_router(state: AppState) -> Router {
             "/health",
             axum::routing::get(crate::gateway::routes::health::handle),
         )
+        // Webhook routes live OUTSIDE the `/v1` bearer-auth nest — webhook auth
+        // is per-platform HMAC, not the daemon's API token.
+        .route(
+            "/webhook/{platform}",
+            axum::routing::post(crate::gateway::routes::webhook::handle),
+        )
         .nest("/v1", v1)
         .with_state(state)
 }

--- a/src/gateway/server.rs
+++ b/src/gateway/server.rs
@@ -29,6 +29,7 @@ pub struct AppState {
 /// payload from filling the SQLite queue. Webhook routes (Task 16) may
 /// override this per-platform if a connector publishes large payloads.
 const V1_BODY_LIMIT_BYTES: usize = 64 * 1024;
+const WEBHOOK_BODY_LIMIT_BYTES: usize = 64 * 1024;
 
 pub fn build_router(state: AppState) -> Router {
     let v1 = Router::new()
@@ -55,7 +56,8 @@ pub fn build_router(state: AppState) -> Router {
         // is per-platform HMAC, not the daemon's API token.
         .route(
             "/webhook/{platform}",
-            axum::routing::post(crate::gateway::routes::webhook::handle),
+            axum::routing::post(crate::gateway::routes::webhook::handle)
+                .layer(axum::extract::DefaultBodyLimit::max(WEBHOOK_BODY_LIMIT_BYTES)),
         )
         .nest("/v1", v1)
         .with_state(state)

--- a/src/gateway/server.rs
+++ b/src/gateway/server.rs
@@ -31,6 +31,10 @@ pub fn build_router(state: AppState) -> Router {
             "/lanes",
             axum::routing::get(crate::gateway::routes::lanes::handle),
         )
+        .route(
+            "/inbound",
+            axum::routing::post(crate::gateway::routes::inbound::handle),
+        )
         .layer(axum::middleware::from_fn_with_state(
             state.clone(),
             bearer_auth,

--- a/src/gateway/worker.rs
+++ b/src/gateway/worker.rs
@@ -46,7 +46,14 @@ pub async fn process_one(
     })
     .catch_unwind()
     .await
-    .unwrap_or_else(|_| Err(anyhow::anyhow!("agent panicked while running prompt")));
+    .unwrap_or_else(|payload| {
+        let msg = payload
+            .downcast_ref::<&'static str>()
+            .map(|s| (*s).to_string())
+            .or_else(|| payload.downcast_ref::<String>().cloned())
+            .unwrap_or_else(|| "<non-string panic payload>".to_string());
+        Err(anyhow::anyhow!("agent panicked while running prompt: {msg}"))
+    });
 
     match result {
         Ok(reply) => {

--- a/src/gateway/worker.rs
+++ b/src/gateway/worker.rs
@@ -1,0 +1,261 @@
+//! Lane worker — pulls a claimed inbound row, drives the per-lane Agent,
+//! and enqueues the reply for the outbound delivery loop.
+//!
+//! The lane router (`lane.rs`) hands one inbound row at a time to
+//! `process_one`. We deliberately catch panics from `Agent::run_prompt` so a
+//! single wedged Agent doesn't kill the whole lane worker task — the row gets
+//! marked `failed` and the worker loop survives to claim the next row.
+
+use crate::gateway::agent_map::AgentMap;
+use crate::gateway::lane::LaneKey;
+use crate::gateway::queue::{InboundQueue, InboundRow, OutboundQueue};
+use crate::platform::OutboundMessage;
+
+use futures_util::FutureExt;
+use std::panic::AssertUnwindSafe;
+
+/// Drive one inbound row through its Agent and enqueue the reply.
+///
+/// Steps:
+/// 1. Look up or spawn the Agent for the row's lane.
+/// 2. Run the prompt; catch panics so the lane worker survives.
+/// 3. On success: enqueue the reply on the outbound queue and mark the
+///    inbound row `done`.
+/// 4. On failure (Err or panic): mark the inbound row `failed` and bubble
+///    the error up to the lane worker for logging.
+pub async fn process_one(
+    row: InboundRow,
+    agent_map: &AgentMap,
+    inbound_queue: &InboundQueue,
+    outbound_queue: &OutboundQueue,
+) -> anyhow::Result<()> {
+    let lane = LaneKey {
+        platform: row.platform.clone(),
+        chat_id: row.chat_id.clone(),
+    };
+
+    // AssertUnwindSafe: we don't read Agent state after a panic — we just
+    // mark the inbound row failed and drop our handle. The Agent's own state
+    // may be inconsistent, but the next get_or_spawn after eviction will
+    // build a fresh one. This is the same trade-off catch_unwind always
+    // makes; the alternative (poisoning the lane forever) is worse.
+    let result: anyhow::Result<String> = AssertUnwindSafe(async {
+        let agent = agent_map.get_or_spawn(&lane).await?;
+        let mut agent = agent.lock().await;
+        agent.run_prompt(&row.text).await
+    })
+    .catch_unwind()
+    .await
+    .unwrap_or_else(|_| Err(anyhow::anyhow!("agent panicked while running prompt")));
+
+    match result {
+        Ok(reply) => {
+            outbound_queue
+                .enqueue(OutboundMessage {
+                    platform: row.platform,
+                    chat_id: row.chat_id,
+                    text: reply,
+                    attachments: vec![],
+                })
+                .await?;
+            inbound_queue.mark_done(row.id).await?;
+            Ok(())
+        }
+        Err(e) => {
+            let err_str = e.to_string();
+            inbound_queue.mark_failed(row.id, &err_str).await?;
+            Err(e)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::Mutex as StdMutex;
+    use std::time::Duration;
+
+    use anyhow::Result;
+    use async_trait::async_trait;
+    use rusqlite::Connection;
+    use tokio_util::sync::CancellationToken;
+
+    use crate::agent::Agent;
+    use crate::config::Config;
+    use crate::gateway::agent_map::{AgentBuilder, AgentMap};
+    use crate::gateway::queue::{InboundQueue, OutboundQueue};
+    use crate::hooks::HookRegistry;
+    use crate::platform::InboundMessage;
+    use crate::provider::mock::MockProvider;
+    use crate::provider::{ChatResponse, LLMProvider, Message, StreamEvent, ToolDefinition};
+    use crate::skills::SkillRegistry;
+    use crate::tools::ToolRegistry;
+
+    fn fresh_db() -> Arc<StdMutex<Connection>> {
+        let c = Connection::open_in_memory().expect("open mem db");
+        crate::memory::initialize_test_conn(&c).expect("schema");
+        Arc::new(StdMutex::new(c))
+    }
+
+    fn empty_skills() -> Arc<SkillRegistry> {
+        Arc::new(SkillRegistry::new(&std::path::PathBuf::from(
+            "/tmp/vulcan-test-skills-nonexistent",
+        )))
+    }
+
+    /// Wraps an Arc<MockProvider> so multiple Agents can share the same
+    /// scripted queue. Mirrors `agent::tests::agent_with_mock`.
+    struct ProviderHandle(Arc<MockProvider>);
+    #[async_trait]
+    impl LLMProvider for ProviderHandle {
+        async fn chat(
+            &self,
+            m: &[Message],
+            t: &[ToolDefinition],
+            c: CancellationToken,
+        ) -> Result<ChatResponse> {
+            self.0.chat(m, t, c).await
+        }
+        async fn chat_stream(
+            &self,
+            m: &[Message],
+            t: &[ToolDefinition],
+            tx: tokio::sync::mpsc::UnboundedSender<StreamEvent>,
+            c: CancellationToken,
+        ) -> Result<()> {
+            self.0.chat_stream(m, t, tx, c).await
+        }
+        fn max_context(&self) -> usize {
+            self.0.max_context()
+        }
+    }
+
+    /// Provider that panics on every call. Used to verify `process_one`
+    /// catches Agent panics and marks the inbound row failed.
+    struct PanickingProvider;
+    #[async_trait]
+    impl LLMProvider for PanickingProvider {
+        async fn chat(
+            &self,
+            _m: &[Message],
+            _t: &[ToolDefinition],
+            _c: CancellationToken,
+        ) -> Result<ChatResponse> {
+            panic!("PanickingProvider: chat panic");
+        }
+        async fn chat_stream(
+            &self,
+            _m: &[Message],
+            _t: &[ToolDefinition],
+            _tx: tokio::sync::mpsc::UnboundedSender<StreamEvent>,
+            _c: CancellationToken,
+        ) -> Result<()> {
+            panic!("PanickingProvider: chat_stream panic");
+        }
+        fn max_context(&self) -> usize {
+            128_000
+        }
+    }
+
+    fn test_config() -> Arc<Config> {
+        Arc::new(Config::default())
+    }
+
+    /// Build an AgentMap whose builder produces fresh Agents backed by
+    /// MockProviders that all return the same canned reply.
+    fn agent_map_with_canned_reply(reply: &'static str) -> AgentMap {
+        let builder: AgentBuilder = Arc::new(move |hooks: HookRegistry| {
+            Box::pin(async move {
+                let mock = Arc::new(MockProvider::new(128_000));
+                mock.enqueue_text(reply);
+                Ok(Agent::for_test(
+                    Box::new(ProviderHandle(mock)),
+                    ToolRegistry::new(),
+                    hooks,
+                    empty_skills(),
+                ))
+            })
+        });
+        AgentMap::with_builder(test_config(), Duration::from_secs(60), builder)
+    }
+
+    fn agent_map_with_panicking_provider() -> AgentMap {
+        let builder: AgentBuilder = Arc::new(|hooks: HookRegistry| {
+            Box::pin(async move {
+                Ok(Agent::for_test(
+                    Box::new(PanickingProvider),
+                    ToolRegistry::new(),
+                    hooks,
+                    empty_skills(),
+                ))
+            })
+        });
+        AgentMap::with_builder(test_config(), Duration::from_secs(60), builder)
+    }
+
+    #[tokio::test]
+    async fn worker_runs_agent_and_enqueues_reply() {
+        let db = fresh_db();
+        let inbound = InboundQueue::new(Arc::clone(&db));
+        let outbound = OutboundQueue::new(Arc::clone(&db), 5);
+        let agent_map = agent_map_with_canned_reply("hi back");
+
+        let id = inbound
+            .enqueue(InboundMessage {
+                platform: "loopback".into(),
+                chat_id: "c".into(),
+                user_id: "u".into(),
+                text: "hi".into(),
+            })
+            .await
+            .unwrap();
+        let row = inbound.claim_next().await.unwrap().expect("row");
+        assert_eq!(row.id, id);
+
+        process_one(row, &agent_map, &inbound, &outbound).await.unwrap();
+
+        let row = outbound
+            .claim_due(chrono::Utc::now().timestamp())
+            .await
+            .unwrap()
+            .expect("outbound row");
+        assert_eq!(row.text, "hi back");
+        assert_eq!(row.platform, "loopback");
+        assert_eq!(row.chat_id, "c");
+    }
+
+    #[tokio::test]
+    async fn worker_panic_marks_inbound_failed() {
+        let db = fresh_db();
+        let inbound = InboundQueue::new(Arc::clone(&db));
+        let outbound = OutboundQueue::new(Arc::clone(&db), 5);
+        let agent_map = agent_map_with_panicking_provider();
+
+        inbound
+            .enqueue(InboundMessage {
+                platform: "loopback".into(),
+                chat_id: "c".into(),
+                user_id: "u".into(),
+                text: "boom".into(),
+            })
+            .await
+            .unwrap();
+        let row = inbound.claim_next().await.unwrap().expect("row");
+
+        let res = process_one(row, &agent_map, &inbound, &outbound).await;
+        assert!(res.is_err(), "process_one should propagate the panic as Err");
+
+        // Inbound row should be in 'failed' state — claim_next returns None.
+        assert!(inbound.claim_next().await.unwrap().is_none());
+
+        // Outbound should be empty (no reply enqueued).
+        assert!(
+            outbound
+                .claim_due(chrono::Utc::now().timestamp())
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+}

--- a/src/gateway/worker.rs
+++ b/src/gateway/worker.rs
@@ -27,7 +27,7 @@ pub async fn process_one(
     row: InboundRow,
     agent_map: &AgentMap,
     inbound_queue: &InboundQueue,
-    outbound_queue: &OutboundQueue,
+    _outbound_queue: &OutboundQueue,
 ) -> anyhow::Result<()> {
     let lane = LaneKey {
         platform: row.platform.clone(),
@@ -57,15 +57,14 @@ pub async fn process_one(
 
     match result {
         Ok(reply) => {
-            outbound_queue
-                .enqueue(OutboundMessage {
+            inbound_queue
+                .complete_with_outbound(row.id, OutboundMessage {
                     platform: row.platform,
                     chat_id: row.chat_id,
                     text: reply,
                     attachments: vec![],
                 })
                 .await?;
-            inbound_queue.mark_done(row.id).await?;
             Ok(())
         }
         Err(e) => {

--- a/src/hooks/approval.rs
+++ b/src/hooks/approval.rs
@@ -42,6 +42,10 @@ impl ApprovalHook {
             session_allow: Mutex::new(HashSet::new()),
         }
     }
+
+    pub fn auto_deny(cfg: ApprovalConfig) -> Self {
+        Self::new(cfg, None)
+    }
 }
 
 #[async_trait::async_trait]
@@ -170,5 +174,49 @@ impl HookHandler for ApprovalHook {
                 reason: "approval channel closed".into(),
             }),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hooks::HookOutcome;
+
+    #[tokio::test]
+    async fn approval_hook_auto_denies_when_no_pause_channel() {
+        let cfg = ApprovalConfig {
+            default: ApprovalMode::Ask,
+            per_tool: Default::default(),
+        };
+        let hook = ApprovalHook::auto_deny(cfg);
+
+        let decision = hook
+            .before_tool_call(
+                "write_file",
+                &serde_json::json!({"path": "/tmp/x", "content": "hi"}),
+                CancellationToken::new(),
+            )
+            .await
+            .expect("hook result");
+
+        match decision {
+            HookOutcome::Block { reason } => {
+                assert!(reason.contains("requires Ask approval"));
+                assert!(reason.contains("no pause channel"));
+            }
+            other => panic!("expected Block, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn approval_hook_auto_deny_still_allows_always_mode() {
+        let hook = ApprovalHook::auto_deny(ApprovalConfig::default());
+
+        let decision = hook
+            .before_tool_call("read_file", &serde_json::json!({}), CancellationToken::new())
+            .await
+            .expect("hook result");
+
+        assert!(matches!(decision, HookOutcome::Continue));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@ pub mod cli;
 pub mod code;
 pub mod config;
 pub mod context;
+#[cfg(feature = "gateway")]
+pub mod gateway;
 pub mod hooks;
 pub mod memory;
 pub mod pause;

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,6 +90,11 @@ async fn main() -> anyhow::Result<()> {
                 }
             }
         }
+        #[cfg(feature = "gateway")]
+        Some(Command::Gateway { bind }) => {
+            init_cli_logging();
+            vulcan::gateway::run(&config, bind).await?;
+        }
     }
 
     Ok(())

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -431,6 +431,11 @@ fn initialize_conn(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+#[cfg(test)]
+pub(crate) fn initialize_test_conn(conn: &Connection) -> Result<()> {
+    initialize_conn(conn)
+}
+
 fn upsert_session_metadata(
     conn: &Connection,
     session_id: &str,

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -16,6 +16,8 @@
 //! `~/.vulcan/sessions/*.jsonl` is left in place but not read. Migration is a
 //! manual one-off if it ever matters (see Linear YYC-14).
 
+#[cfg(feature = "gateway")]
+use std::sync::Arc;
 use std::sync::Mutex;
 
 use anyhow::{Context, Result};
@@ -419,6 +421,17 @@ impl Default for SessionStore {
     fn default() -> Self {
         Self::new()
     }
+}
+
+#[cfg(feature = "gateway")]
+pub(crate) fn open_gateway_connection() -> Result<Arc<Mutex<Connection>>> {
+    let dir = crate::config::vulcan_home();
+    std::fs::create_dir_all(&dir).ok();
+    let path = dir.join("sessions.db");
+    let conn = Connection::open(&path)
+        .with_context(|| format!("Failed to open session DB at {}", path.display()))?;
+    initialize_conn(&conn).context("Failed to initialize session DB schema")?;
+    Ok(Arc::new(Mutex::new(conn)))
 }
 
 fn initialize_conn(conn: &Connection) -> Result<()> {

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -7,6 +7,10 @@
 //!    tool_call_id, tool_calls_json, created_at)` indexed on `(session_id, position)`
 //! - `messages_fts` — external-content FTS5 over `messages.content`, kept in
 //!    sync via insert/update/delete triggers.
+//! - `inbound_queue(id PK, platform, chat_id, user_id, text, received_at,
+//!    attempts, state)` — gateway daemon ingress, indexed by lane+state and state+received_at.
+//! - `outbound_queue(id PK, platform, chat_id, text, attachments_json, enqueued_at,
+//!    next_attempt_at, attempts, state, last_error)` — gateway daemon egress, indexed by state+next_attempt_at.
 //!
 //! The JSONL format used previously is gone; old data under
 //! `~/.vulcan/sessions/*.jsonl` is left in place but not read. Migration is a
@@ -65,6 +69,33 @@ CREATE TRIGGER IF NOT EXISTS messages_au AFTER UPDATE ON messages BEGIN
     INSERT INTO messages_fts(messages_fts, rowid, content) VALUES('delete', old.id, COALESCE(old.content, ''));
     INSERT INTO messages_fts(rowid, content) VALUES (new.id, COALESCE(new.content, ''));
 END;
+
+CREATE TABLE IF NOT EXISTS inbound_queue (
+  id INTEGER PRIMARY KEY,
+  platform TEXT NOT NULL,
+  chat_id  TEXT NOT NULL,
+  user_id  TEXT NOT NULL,
+  text     TEXT NOT NULL,
+  received_at INTEGER NOT NULL,
+  attempts INTEGER NOT NULL DEFAULT 0,
+  state    TEXT NOT NULL  -- 'pending'|'processing'|'failed'
+);
+CREATE INDEX IF NOT EXISTS idx_inbound_lane  ON inbound_queue(platform, chat_id, state);
+CREATE INDEX IF NOT EXISTS idx_inbound_state ON inbound_queue(state, received_at);
+
+CREATE TABLE IF NOT EXISTS outbound_queue (
+  id INTEGER PRIMARY KEY,
+  platform TEXT NOT NULL,
+  chat_id  TEXT NOT NULL,
+  text     TEXT NOT NULL,
+  attachments_json TEXT NOT NULL DEFAULT '[]',
+  enqueued_at INTEGER NOT NULL,
+  next_attempt_at INTEGER NOT NULL,
+  attempts INTEGER NOT NULL DEFAULT 0,
+  state    TEXT NOT NULL,  -- 'pending'|'sending'|'failed'
+  last_error TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_outbound_due ON outbound_queue(state, next_attempt_at);
 "#;
 
 pub struct SessionStore {
@@ -730,6 +761,36 @@ mod tests {
             }
             other => panic!("expected Assistant, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn queue_tables_created() {
+        let store = SessionStore::in_memory();
+        let conn = store.conn.lock().expect("lock");
+        let count: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM sqlite_master \
+             WHERE type='table' AND name IN ('inbound_queue','outbound_queue')",
+                [],
+                |r| r.get(0),
+            )
+            .expect("query");
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn queue_indexes_created() {
+        let store = SessionStore::in_memory();
+        let conn = store.conn.lock().expect("lock");
+        let count: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM sqlite_master \
+             WHERE type='index' AND name IN ('idx_inbound_lane','idx_inbound_state','idx_outbound_due')",
+                [],
+                |r| r.get(0),
+            )
+            .expect("query");
+        assert_eq!(count, 3);
     }
 
     #[test]

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -431,7 +431,7 @@ fn initialize_conn(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "gateway"))]
 pub(crate) fn initialize_test_conn(conn: &Connection) -> Result<()> {
     initialize_conn(conn)
 }

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -30,4 +30,20 @@ pub trait Platform: Send + Sync {
     async fn start(&self) -> Result<()>;
     async fn send(&self, msg: &OutboundMessage) -> Result<()>;
     async fn recv(&self) -> Result<InboundMessage>;
+
+    /// Verify a platform-specific webhook request and return the parsed
+    /// `InboundMessage`. The default impl errors so platforms that don't
+    /// accept webhooks (loopback in production, future poll-only platforms)
+    /// don't have to implement it. Webhook handlers (`POST /webhook/:platform`)
+    /// pass the raw request headers + body so each platform can apply its own
+    /// HMAC scheme + payload schema. Uses `http::HeaderMap` (not
+    /// `axum::http::HeaderMap`) so this trait stays free of an axum dep —
+    /// `http` is a small standalone crate axum re-exports anyway.
+    async fn verify_webhook(
+        &self,
+        _headers: &http::HeaderMap,
+        _body: &[u8],
+    ) -> Result<InboundMessage> {
+        anyhow::bail!("platform does not accept webhooks")
+    }
 }

--- a/src/provider/catalog.rs
+++ b/src/provider/catalog.rs
@@ -230,12 +230,52 @@ impl ProviderCatalog for OpenAICatalog {
                 arr.iter()
                     .filter_map(|m| {
                         let id = m.get("id")?.as_str()?.to_string();
+                        let context_length = m
+                            .get("context_length")
+                            .and_then(|v| v.as_u64())
+                            .map(|n| n as usize)
+                            .unwrap_or(0);
+                        let pricing = m.get("pricing").and_then(|p| {
+                            let inp = p
+                                .get("prompt")
+                                .and_then(|v| v.as_str())
+                                .and_then(|s| s.parse::<f64>().ok())?;
+                            let out = p
+                                .get("completion")
+                                .and_then(|v| v.as_str())
+                                .and_then(|s| s.parse::<f64>().ok())?;
+                            Some(Pricing {
+                                input_per_token: inp,
+                                output_per_token: out,
+                            })
+                        });
+                        let supported = m
+                            .get("supported_parameters")
+                            .and_then(|v| v.as_array())
+                            .map(|a| {
+                                a.iter()
+                                    .filter_map(|s| s.as_str().map(|s| s.to_string()))
+                                    .collect::<Vec<_>>()
+                            })
+                            .unwrap_or_default();
                         Some(ModelInfo {
                             display_name: id.clone(),
                             id,
-                            context_length: 0,
-                            pricing: None,
-                            features: ModelFeatures::default(),
+                            context_length,
+                            pricing,
+                            features: ModelFeatures {
+                                tools: supported.iter().any(|s| s == "tools" || s == "tool_choice"),
+                                json_mode: supported.iter().any(|s| s == "response_format"),
+                                vision: m
+                                    .get("architecture")
+                                    .and_then(|a| a.get("input_modalities"))
+                                    .and_then(|v| v.as_array())
+                                    .map(|a| a.iter().any(|s| s.as_str() == Some("image")))
+                                    .unwrap_or(false),
+                                reasoning: supported
+                                    .iter()
+                                    .any(|s| s == "reasoning" || s == "include_reasoning"),
+                            },
                             top_provider: m
                                 .get("owned_by")
                                 .and_then(|v| v.as_str())

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -133,6 +133,13 @@ const SLASH_COMMANDS: &[SlashCommand] = &[
         mid_turn_safe: false,
     },
     SlashCommand {
+        name: "model",
+        description: "List or switch models: /model [id]",
+        // Rebuilds the provider for future turns and may fetch the catalog.
+        // Defer until idle so the in-flight provider stream is untouched.
+        mid_turn_safe: false,
+    },
+    SlashCommand {
         name: "diff-style",
         description: "Set diff render: /diff-style <unified|side-by-side|inline>",
         mid_turn_safe: true,
@@ -146,6 +153,42 @@ const SLASH_COMMANDS: &[SlashCommand] = &[
 
 fn short_id(id: &str) -> String {
     id.chars().take(8).collect()
+}
+
+fn format_model_list(active_model: &str, models: &[crate::provider::catalog::ModelInfo]) -> String {
+    let mut out = format!("Models from active provider ({} total):", models.len());
+    for model in models.iter().take(30) {
+        let marker = if model.id == active_model { "*" } else { " " };
+        let context = if model.context_length > 0 {
+            crate::tui::state::format_thousands(model.context_length as u32)
+        } else {
+            "unknown".into()
+        };
+        let mut flags = Vec::new();
+        if model.features.tools {
+            flags.push("tools");
+        }
+        if model.features.reasoning {
+            flags.push("reasoning");
+        }
+        if model.features.vision {
+            flags.push("vision");
+        }
+        if model.features.json_mode {
+            flags.push("json");
+        }
+        let flags = if flags.is_empty() {
+            String::new()
+        } else {
+            format!(" · {}", flags.join(","))
+        };
+        out.push_str(&format!("\n  {marker} {} · ctx {context}{flags}", model.id));
+    }
+    if models.len() > 30 {
+        out.push_str(&format!("\n  ... {} more", models.len() - 30));
+    }
+    out.push_str("\n\nUse /model <id> to switch.");
+    out
 }
 
 fn filter_commands(prefix: &str) -> Vec<&'static SlashCommand> {
@@ -1033,6 +1076,59 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                                         });
                                                         continue;
                                                     }
+                                                    s if s == "model" || s.starts_with("model ") => {
+                                                        let arg = s["model".len()..].trim();
+                                                        if arg.is_empty() {
+                                                            let report = {
+                                                                let a = agent.lock().await;
+                                                                match a.available_models().await {
+                                                                    Ok(models) if models.is_empty() => {
+                                                                        "Provider catalog returned no models.".to_string()
+                                                                    }
+                                                                    Ok(models) => format_model_list(
+                                                                        a.active_model(),
+                                                                        &models,
+                                                                    ),
+                                                                    Err(e) => format!("Model catalog fetch failed: {e}"),
+                                                                }
+                                                            };
+                                                            app.messages.push(ChatMessage {
+                                                                role: ChatRole::System,
+                                                                content: report,
+                                                                ..Default::default()
+                                                            });
+                                                            continue;
+                                                        }
+
+                                                        let result = {
+                                                            let mut a = agent.lock().await;
+                                                            a.switch_model(arg).await
+                                                        };
+                                                        match result {
+                                                            Ok(selection) => {
+                                                                app.model_label = selection.model.id.clone();
+                                                                app.token_max = selection.max_context as u32;
+                                                                app.pricing = selection.pricing;
+                                                                app.messages.push(ChatMessage {
+                                                                    role: ChatRole::System,
+                                                                    content: format!(
+                                                                        "Model switched to {} · context {}",
+                                                                        app.model_label,
+                                                                        crate::tui::state::format_thousands(app.token_max),
+                                                                    ),
+                                                                    ..Default::default()
+                                                                });
+                                                            }
+                                                            Err(e) => {
+                                                                app.messages.push(ChatMessage {
+                                                                    role: ChatRole::System,
+                                                                    content: format!("Model switch failed: {e}"),
+                                                                    ..Default::default()
+                                                                });
+                                                            }
+                                                        }
+                                                        continue;
+                                                    }
                                                     _ => {
                                                         app.messages.push(ChatMessage {
                                                             role: ChatRole::System,
@@ -1184,6 +1280,50 @@ mod tests {
             render_wake_for_stream_batch(start, start + Duration::from_millis(1), true),
             RenderWake::Now
         );
+    }
+
+    #[test]
+    fn model_command_is_available_and_deferred_mid_turn() {
+        let command = SLASH_COMMANDS
+            .iter()
+            .find(|cmd| cmd.name == "model")
+            .expect("model slash command");
+
+        assert!(!command.mid_turn_safe);
+        assert_eq!(filter_commands("mod")[0].name, "model");
+    }
+
+    #[test]
+    fn format_model_list_marks_active_model() {
+        let models = vec![
+            crate::provider::catalog::ModelInfo {
+                id: "model-a".into(),
+                display_name: "Model A".into(),
+                context_length: 1_000,
+                pricing: None,
+                features: crate::provider::catalog::ModelFeatures {
+                    tools: true,
+                    vision: false,
+                    json_mode: true,
+                    reasoning: false,
+                },
+                top_provider: None,
+            },
+            crate::provider::catalog::ModelInfo {
+                id: "model-b".into(),
+                display_name: "Model B".into(),
+                context_length: 0,
+                pricing: None,
+                features: crate::provider::catalog::ModelFeatures::default(),
+                top_provider: None,
+            },
+        ];
+
+        let report = format_model_list("model-a", &models);
+
+        assert!(report.contains("* model-a · ctx 1,000 · tools,json"));
+        assert!(report.contains("  model-b · ctx unknown"));
+        assert!(report.contains("Use /model <id> to switch."));
     }
 }
 


### PR DESCRIPTION
feat(gateway): add axum + tower deps behind gateway feature

feat(gateway): add GatewayConfig section

feat(gateway): add Gateway CLI subcommand stub

feat(gateway): add inbound_queue + outbound_queue schemas

feat(gateway): InboundQueue with enqueue/claim/recover

fix(gateway): gate initialize_test_conn behind gateway feature

Helper is only consumed by InboundQueue tests which compile under
`--features gateway`. Without the feature, the lib-test build saw
an unused fn and warned.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

refactor(gateway): match SessionStore mutex poisoning policy

Replaces .expect("queue mutex poisoned") with .map_err(...)? across
all five InboundQueue methods so callers can recover instead of
panicking the lane worker. Mirrors the pattern in src/memory.rs.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

feat(gateway): OutboundQueue with retry backoff

test(gateway): unit-test outbound backoff schedule values

Pins each schedule slot + clamp behavior so a typo in [5, 30, 300, 1800, 7200]
or a reorder gets caught directly instead of relying on the timing-window
assertion in outbound_failure_schedules_next_attempt_with_backoff.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

feat(gateway): LaneRouter with serial-per-lane dispatch

refactor(gateway): use #[async_trait] on Handler + counter-based parallelism check

- Switches LaneRouter::Handler trait to #[async_trait] to match the
  rest of the codebase (hooks, tools, platform).
- Replaces the timing-window assertion in lanes_serial_within_parallel_across
  with a peak-in-flight counter so the test stays robust under CI load
  instead of flaking on slow runners.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

feat(gateway): AgentMap get-or-spawn keyed by LaneKey

refactor(gateway): build Agent outside AgentMap write lock + retain audit_buf

- Cold-spawn no longer holds the inner HashMap's write lock across
  Agent::with_hooks_and_pause / start_session, so a slow first-touch on
  one lane no longer serializes first-touches on every other lane.
  Triple-check on insert handles the rare case where two callers race
  to spawn the same lane.
- LaneEntry now retains AuditBuffer so GET /v1/lanes (Task 15) can
  surface per-lane tool activity instead of dropping it on the floor.
- Corrects the comment on hook setup: ApprovalHook is registered by
  with_hooks_and_pause regardless of pause_tx; Task 18 changes the
  hook's behaviour, not its registration site.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

feat(gateway): AgentMap idle TTL eviction

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

refactor(gateway): EvictorHandle aborts on drop + spawn end_session

- spawn_evictor now returns an EvictorHandle newtype whose Drop impl
  aborts the background loop, so callers can't accidentally leave the
  evictor running by dropping the handle without calling abort.
- end_session is now spawned per evicted lane instead of awaited
  inline. LspManager::shutdown_all can take seconds per stuck child;
  serializing them inside the eviction loop would stall future ticks.
- Updated module docstring: eviction is landed, not pending.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

feat(gateway): PlatformRegistry + LoopbackPlatform

refactor(gateway): registry returns prev entry, loopback recv errors

- PlatformRegistry::register now returns the previous Arc when a name
  is re-registered. Silent overwrite is a foot-gun for cfg(telegram)
  / cfg(discord) double-wiring; a returned Some is observable in
  tests and in the gateway::run bootstrap.
- LoopbackPlatform::recv now bails instead of returning a never-
  resolving future. A select! arm over multiple platforms can now
  match-and-skip the loopback inbound side instead of silently
  starving.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

feat(gateway): outbound dispatcher with backoff retry

refactor(gateway): tighten dispatcher loop semantics

- Set MissedTickBehavior::Skip so a paused-then-resumed daemon (laptop
  sleep, GC stall) doesn't burst hundreds of stale ticks at the worst
  possible moment.
- Promote drain_due bookkeeping failures from warn to error — they
  signal infrastructure trouble, not expected per-message backoff.
- Move row fields into the OutboundMessage instead of cloning all four
  String/Vec slots per dispatch tick.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

feat(gateway): lane worker drives Agent and enqueues replies

Task 12 of the gateway daemon plan. `process_one` claims an inbound
row's reply path: get-or-spawn the per-lane Agent, run the prompt
inside `catch_unwind` so a wedged Agent doesn't kill the lane worker,
then enqueue on the outbound queue and mark the inbound row done.
On Err or panic, the row goes to `failed` and the error bubbles up
for the caller to log.

Also adds `AgentMap::with_builder` (test-only) so the three
previously-`#[ignore]`'d AgentMap tests can run unconditionally with
a `MockProvider`-backed Agent. The eviction test was rewritten to
manipulate `last_activity` directly — the prior shape relied on
`tokio::time::advance` driving `std::time::Instant::now()`, which it
doesn't.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

refactor(gateway): preserve panic message when worker catches an unwind

Downcast the catch_unwind payload to a &'static str / String so the
inbound row's last_error column carries actionable diagnostics ("agent
panicked while running prompt: <msg>") instead of a generic placeholder.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

feat(gateway): axum skeleton with bearer auth + /health

Scaffolds the gateway HTTP surface (Task 13 of the gateway daemon plan):
unauthenticated `/health` plus a nested `/v1` router guarded by
`Bearer <token>` middleware. `/v1/lanes` lands as an empty-array
placeholder so the auth path is exercisable today; Task 15 plugs in the
real lane listing.

Enables the `util` feature on `tower` so tests can drive the router via
`tower::ServiceExt::oneshot` without a TCP socket.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

refactor(gateway): constant-time bearer token comparison

Switches the auth middleware from `provided != state.api_token` to
`subtle::ConstantTimeEq` so the comparison doesn't leak how many
prefix bytes of the configured token an attacker has guessed
correctly. subtle is already a transitive dep through the rustls
stack; promoted to a direct (gateway-gated) dep.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

feat(gateway): POST /v1/inbound generic enqueue

refactor(gateway): cap /v1 body size + log unknown platform

- Add DefaultBodyLimit::max(64 KiB) on the /v1 router so a single
  oversized JSON payload can't fill the SQLite inbound queue. Webhook
  routes (Task 16) may override per-platform.
- Log unknown-platform 400s via tracing::warn so platform-name probes
  leave a trail. Mirrors the existing 503 logging on the same target.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

feat(gateway): GET /v1/lanes observability endpoint

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

refactor(gateway): drop unused Clone + deterministic lane sort

- LaneSnapshot only flows through serde::Serialize, so the Clone
  derive was inert. Trim it.
- Tie-break the snapshot sort on (platform, chat_id) so two lanes
  touched in the same second bucket emit in stable JSON order.
  HashMap iteration order is randomized per process; without a
  tie-breaker, GET /v1/lanes flaps for callers that script against it.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

feat(gateway): webhook scaffold with HMAC verify hook on Platform trait

feat(gateway): wire daemon runtime and model selection