### PR TITLE
YYC-85: Tool descriptions name the bash command they replace

### DIFF
--- a/src/tools/cargo.rs
+++ b/src/tools/cargo.rs
@@ -24,7 +24,7 @@ impl Tool for CargoCheckTool {
         "cargo_check"
     }
     fn description(&self) -> &str {
-        "Run `cargo check --message-format=json` in the cwd and return the parsed compiler diagnostics. Works without rust-analyzer indexed; complements the LSP `diagnostics` tool."
+        "Run `cargo check --message-format=json` in the cwd and return the parsed compiler diagnostics. Works without rust-analyzer indexed; complements the LSP `diagnostics` tool. Use this instead of `cargo check` or `cargo build` via bash — structured errors with paths, lines, and rendered messages."
     }
     fn schema(&self) -> Value {
         json!({

--- a/src/tools/code.rs
+++ b/src/tools/code.rs
@@ -40,7 +40,7 @@ impl Tool for CodeOutlineTool {
         "code_outline"
     }
     fn description(&self) -> &str {
-        "Structural outline of a source file: top-level functions/types/etc with line ranges. JSON. Cheaper than read_file when the agent only needs the shape of a file."
+        "Structural outline of a source file: top-level functions/types/etc with line ranges. JSON. Cheaper than read_file when the agent only needs the shape of a file. Use this instead of `grep '^fn\\|^pub'` via bash."
     }
     fn schema(&self) -> Value {
         json!({
@@ -93,7 +93,7 @@ impl Tool for CodeExtractTool {
         "code_extract"
     }
     fn description(&self) -> &str {
-        "Return the source body of a single named symbol (function / class / type). When the agent already knows what it wants and shouldn't pay for surrounding code."
+        "Return the source body of a single named symbol (function / class / type). When the agent already knows what it wants and shouldn't pay for surrounding code. Use this instead of `awk '/fn name/,/^}/'` or `sed` ranges via bash."
     }
     fn schema(&self) -> Value {
         json!({
@@ -156,7 +156,7 @@ impl Tool for CodeQueryTool {
         "code_query"
     }
     fn description(&self) -> &str {
-        "Run a tree-sitter S-expression query against one source file. Strictly more expressive than ripgrep for structural patterns: '(function_item name: (identifier) @name)' to find all Rust fn names."
+        "Run a tree-sitter S-expression query against one source file. Strictly more expressive than ripgrep for structural patterns: '(function_item name: (identifier) @name)' to find all Rust fn names. Use this instead of `grep` for structural code patterns via bash."
     }
     fn schema(&self) -> Value {
         json!({

--- a/src/tools/file.rs
+++ b/src/tools/file.rs
@@ -12,7 +12,7 @@ impl Tool for ReadFile {
         "read_file"
     }
     fn description(&self) -> &str {
-        "Read a file from the filesystem. Returns content with line numbers."
+        "Read a file from the filesystem. Returns content with line numbers. Use this instead of `cat`, `head`, `tail`, or `sed -n` via bash."
     }
     fn schema(&self) -> Value {
         json!({
@@ -65,7 +65,7 @@ impl Tool for ListFiles {
         "list_files"
     }
     fn description(&self) -> &str {
-        "List files + directories under a path as a structured tree (JSON). Respects .gitignore. Cheaper than shelling out to `ls` or `tree` and won't drown in target/ or node_modules/."
+        "List files + directories under a path as a structured tree (JSON). Respects .gitignore. Use this instead of `ls`, `tree`, or `find -type f` via bash — won't drown in target/ or node_modules/."
     }
     fn schema(&self) -> Value {
         json!({
@@ -214,7 +214,7 @@ impl Tool for WriteFile {
         "write_file"
     }
     fn description(&self) -> &str {
-        "Write content to a file. Creates parent directories if needed. OVERWRITES existing content."
+        "Write content to a file. Creates parent directories if needed. OVERWRITES existing content. Use this instead of `echo > file` or `cat <<EOF` via bash."
     }
     fn schema(&self) -> Value {
         json!({
@@ -281,7 +281,7 @@ impl Tool for SearchFiles {
         "search_files"
     }
     fn description(&self) -> &str {
-        "Search file contents using regex patterns. Ripgrep-style. Fast for large codebases."
+        "Search file contents using regex patterns. Ripgrep-style, gitignore-aware. Use this instead of `rg`, `grep -r`, or `grep -rn` via bash."
     }
     fn schema(&self) -> Value {
         json!({
@@ -346,7 +346,7 @@ impl Tool for PatchFile {
         "edit_file"
     }
     fn description(&self) -> &str {
-        "Find and replace text in a file. Uses fuzzy matching so minor whitespace differences won't break it."
+        "Find and replace text in a file. Uses fuzzy matching so minor whitespace differences won't break it. Use this instead of `sed -i` via bash."
     }
     fn schema(&self) -> Value {
         json!({

--- a/src/tools/git.rs
+++ b/src/tools/git.rs
@@ -90,7 +90,7 @@ impl Tool for GitStatusTool {
         "git_status"
     }
     fn description(&self) -> &str {
-        "Show working tree status (staged, unstaged, untracked). Compact porcelain format."
+        "Show working tree status (staged, unstaged, untracked). Compact porcelain format. Use this instead of `git status` via bash."
     }
     fn schema(&self) -> Value {
         json!({ "type": "object", "properties": {} })
@@ -110,7 +110,7 @@ impl Tool for GitDiffTool {
         "git_diff"
     }
     fn description(&self) -> &str {
-        "Show diff for staged, unstaged, or specific path changes. Defaults to unstaged worktree changes."
+        "Show diff for staged, unstaged, or specific path changes. Defaults to unstaged worktree changes. Use this instead of `git diff` via bash."
     }
     fn schema(&self) -> Value {
         json!({
@@ -158,7 +158,7 @@ impl Tool for GitCommitTool {
         "git_commit"
     }
     fn description(&self) -> &str {
-        "Create a commit with the given message. Set `all=true` to stage all tracked changes first."
+        "Create a commit with the given message. Set `all=true` to stage all tracked changes first. Use this instead of `git commit -m` via bash."
     }
     fn schema(&self) -> Value {
         json!({
@@ -204,7 +204,7 @@ impl Tool for GitPushTool {
         "git_push"
     }
     fn description(&self) -> &str {
-        "Push the current branch to its remote tracking branch. Set `set_upstream=true` to push and create the upstream link in one go."
+        "Push the current branch to its remote tracking branch. Set `set_upstream=true` to push and create the upstream link in one go. Use this instead of `git push` via bash."
     }
     fn schema(&self) -> Value {
         json!({
@@ -253,7 +253,7 @@ impl Tool for GitBranchTool {
         "git_branch"
     }
     fn description(&self) -> &str {
-        "List, create, or switch branches. Default action lists local branches with the current one starred."
+        "List, create, or switch branches. Default action lists local branches with the current one starred. Use this instead of `git branch` / `git checkout` via bash."
     }
     fn schema(&self) -> Value {
         json!({
@@ -310,7 +310,7 @@ impl Tool for GitLogTool {
         "git_log"
     }
     fn description(&self) -> &str {
-        "Show recent commit history (oneline format). Defaults to last 10 commits."
+        "Show recent commit history (oneline format). Defaults to last 10 commits. Use this instead of `git log` via bash."
     }
     fn schema(&self) -> Value {
         json!({

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -369,6 +369,44 @@ mod tests {
         assert_eq!(missing, "b");
     }
 
+    /// YYC-85: every native tool that has a clear bash equivalent must
+    /// state it in its description, so the model sees the redirect on
+    /// every turn (descriptions ship in the tool spec). Failing here
+    /// means a tool was added without the "instead of" hint.
+    #[test]
+    fn native_tool_descriptions_call_out_bash_equivalents() {
+        let registry = ToolRegistry::new();
+        let must_redirect = [
+            "read_file",
+            "write_file",
+            "list_files",
+            "search_files",
+            "edit_file",
+            "cargo_check",
+            "code_outline",
+            "code_query",
+            "code_extract",
+            "git_status",
+            "git_diff",
+            "git_commit",
+            "git_push",
+            "git_branch",
+            "git_log",
+        ];
+        let defs = registry.definitions();
+        for name in must_redirect {
+            let def = defs
+                .iter()
+                .find(|d| d.function.name == name)
+                .unwrap_or_else(|| panic!("expected `{name}` in registry"));
+            let desc = &def.function.description;
+            assert!(
+                desc.contains("instead of"),
+                "{name} description missing 'instead of <bash>' clause: {desc:?}"
+            );
+        }
+    }
+
     #[tokio::test]
     async fn non_object_arguments_fail_before_tool_dispatch() {
         let registry = ToolRegistry::new();


### PR DESCRIPTION
Adds an explicit "Use this instead of <bash>" clause to every native
tool that has a clear shell equivalent: read_file, write_file,
list_files, search_files, edit_file, cargo_check, code_outline,
code_extract, code_query, and the six git_* tools. The model reads
descriptions every turn, so this is the highest-leverage low-cost
nudge under the YYC-84 native-tool preference epic.

A snapshot test in tools::tests asserts every tool in the redirect
set ships an "instead of" clause, so adding a future tool without one
fails CI.