### PR TITLE
YYC-89: Config knob — [tools].native_enforcement = off|warn|block

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -45,6 +45,13 @@ catalog_cache_ttl_hours = 24
 # Enable dangerous tools (file overwrite, shell exec) without confirmation
 yolo_mode = false
 
+# How aggressively to redirect bash invocations to native-tool equivalents
+# (YYC-84 / YYC-89). The PreferNativeTools hook reads this:
+#   off   — hook disabled, no redirects.
+#   warn  — log + count via the audit hook (YYC-88), pass through.
+#   block — return Block with a redirect message (default).
+native_enforcement = "block"
+
 # Per-tool approval gate (YYC-76). Default is "always" (no prompts) so
 # the gate is opt-in. Set entries to "ask" or "session" for per-tool
 # granularity — TUI will pause on the gate and render inline pills.

--- a/src/config.rs
+++ b/src/config.rs
@@ -200,6 +200,26 @@ pub struct ToolsConfig {
     /// without prompting (matches pre-YYC-76 behavior).
     #[serde(default)]
     pub approval: ApprovalConfig,
+    /// How aggressively to redirect bash invocations to native-tool
+    /// equivalents (YYC-84 / YYC-89). The `PreferNativeTools` hook
+    /// reads this to decide whether to block, warn, or stay out of the
+    /// way entirely.
+    #[serde(default)]
+    pub native_enforcement: NativeEnforcement,
+}
+
+/// Native-tool redirect aggressiveness.
+///
+/// * `Off`   — hook disabled.
+/// * `Warn`  — log + count via the audit hook (YYC-88), but pass through.
+/// * `Block` — return `HookOutcome::Block` with a redirect message (default).
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum NativeEnforcement {
+    Off,
+    Warn,
+    #[default]
+    Block,
 }
 
 /// Per-tool approval gate (YYC-76).
@@ -270,6 +290,7 @@ impl Default for ToolsConfig {
         Self {
             yolo_mode: false,
             approval: ApprovalConfig::default(),
+            native_enforcement: NativeEnforcement::default(),
         }
     }
 }
@@ -409,6 +430,27 @@ debug = "wire"
         .expect("config should parse");
 
         assert!(matches!(config.provider.debug, ProviderDebugMode::Wire));
+    }
+
+    #[test]
+    fn native_enforcement_round_trips_each_mode() {
+        for (raw, expected) in [
+            ("off", NativeEnforcement::Off),
+            ("warn", NativeEnforcement::Warn),
+            ("block", NativeEnforcement::Block),
+        ] {
+            let toml = format!("[tools]\nnative_enforcement = \"{raw}\"\n");
+            let cfg: Config = toml::from_str(&toml).expect("should parse");
+            assert_eq!(cfg.tools.native_enforcement, expected);
+        }
+    }
+
+    #[test]
+    fn native_enforcement_defaults_to_block_when_missing() {
+        let cfg: Config = toml::from_str("").expect("empty parses");
+        assert_eq!(cfg.tools.native_enforcement, NativeEnforcement::Block);
+        let cfg: Config = toml::from_str("[tools]\n").expect("empty tools parses");
+        assert_eq!(cfg.tools.native_enforcement, NativeEnforcement::Block);
     }
 
     #[test]


### PR DESCRIPTION
Adds NativeEnforcement enum and the corresponding [tools] field that
selects how the (forthcoming) PreferNativeTools hook treats bash
invocations matching native-tool equivalents.

Default is `block`, matching the epic's default. Omitting the field
in config.toml resolves to the default; an empty `[tools]` section
also picks up the default. Two serde round-trip tests cover each
mode and the missing-field paths.

Documents the knob in config.example.toml. The hook itself lands in
the next stack entry (YYC-87) and reads this setting at startup.