### PR TITLE
YYC-90: Configurable TUI keybindings — bind keys, not just labels

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -108,3 +108,17 @@ theme = "system"
 # enabled = false
 # bot_token = "..."
 # allow_bots = false
+
+[keybinds]
+# TUI key bindings (YYC-90). Strings are parsed at startup; unparseable
+# values fall back to the defaults shown here with a tracing warning.
+# Recognised forms:
+#   - "Ctrl+K" / "Alt+T" / "Shift+F4"
+#   - Caret sigils:  "⌃K" (Ctrl), "⌥T" (Alt), "⇧F4" (Shift)
+#   - Function keys: "F1" .. "F24"
+#   - Named keys:    "Esc", "Enter", "Tab", "Backspace", "Up"/"Down"/"Left"/"Right"
+toggle_sessions  = "Ctrl+K"        # open the session picker (Insert mode)
+toggle_tools     = "Ctrl+T"        # switch to the trading-floor tool log
+toggle_reasoning = "Ctrl+R"        # show/hide reasoning traces
+cancel           = "Ctrl+C"        # cancel current turn / quit
+queue_drop       = "Ctrl+Backspace" # pop the most recent queued submission

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,6 +42,9 @@ pub struct Config {
 
     #[serde(default)]
     pub gateway: Option<GatewayConfig>,
+
+    #[serde(default)]
+    pub keybinds: KeybindsConfig,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -60,6 +63,37 @@ impl Default for TuiConfig {
     fn default() -> Self {
         Self {
             theme: default_theme_name(),
+        }
+    }
+}
+
+/// Raw, unparsed key-binding strings the user can override in
+/// `~/.vulcan/config.toml`. The TUI parses these into
+/// `crate::tui::keybinds::Keybinds` at startup; unparseable values fall
+/// back to defaults with a tracing warning, so a typo never silently
+/// drops a binding (YYC-90).
+#[derive(Debug, Deserialize, Clone)]
+pub struct KeybindsConfig {
+    #[serde(default = "default_key_sessions")]
+    pub toggle_sessions: String,
+    #[serde(default = "default_key_tools")]
+    pub toggle_tools: String,
+    #[serde(default = "default_key_reasoning")]
+    pub toggle_reasoning: String,
+    #[serde(default = "default_key_cancel")]
+    pub cancel: String,
+    #[serde(default = "default_key_queue_drop")]
+    pub queue_drop: String,
+}
+
+impl Default for KeybindsConfig {
+    fn default() -> Self {
+        Self {
+            toggle_sessions: default_key_sessions(),
+            toggle_tools: default_key_tools(),
+            toggle_reasoning: default_key_reasoning(),
+            cancel: default_key_cancel(),
+            queue_drop: default_key_queue_drop(),
         }
     }
 }
@@ -100,6 +134,22 @@ fn default_gateway_max_concurrent_lanes() -> usize {
 }
 fn default_gateway_outbound_max_attempts() -> u32 {
     5
+}
+
+fn default_key_sessions() -> String {
+    "Ctrl+K".into()
+}
+fn default_key_tools() -> String {
+    "Ctrl+T".into()
+}
+fn default_key_reasoning() -> String {
+    "Ctrl+R".into()
+}
+fn default_key_cancel() -> String {
+    "Ctrl+C".into()
+}
+fn default_key_queue_drop() -> String {
+    "Ctrl+Backspace".into()
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -316,6 +366,7 @@ impl Default for Config {
             embeddings: EmbeddingsConfig::default(),
             tui: TuiConfig::default(),
             gateway: None,
+            keybinds: KeybindsConfig::default(),
         }
     }
 }
@@ -451,6 +502,29 @@ debug = "wire"
         assert_eq!(cfg.tools.native_enforcement, NativeEnforcement::Block);
         let cfg: Config = toml::from_str("[tools]\n").expect("empty tools parses");
         assert_eq!(cfg.tools.native_enforcement, NativeEnforcement::Block);
+    }
+
+    #[test]
+    fn keybinds_block_parses_with_overrides() {
+        let config: Config = toml::from_str(
+            r#"
+[keybinds]
+toggle_tools = "F2"
+"#,
+        )
+        .expect("config should parse");
+
+        assert_eq!(config.keybinds.toggle_tools, "F2");
+        assert_eq!(config.keybinds.toggle_sessions, "Ctrl+K");
+        assert_eq!(config.keybinds.cancel, "Ctrl+C");
+    }
+
+    #[test]
+    fn keybinds_default_when_section_missing() {
+        let config: Config = toml::from_str("").expect("empty toml is valid");
+        let defaults = KeybindsConfig::default();
+        assert_eq!(config.keybinds.toggle_tools, defaults.toggle_tools);
+        assert_eq!(config.keybinds.toggle_sessions, defaults.toggle_sessions);
     }
 
     #[test]

--- a/src/tui/keybinds.rs
+++ b/src/tui/keybinds.rs
@@ -1,0 +1,339 @@
+//! Configurable key bindings for the TUI (YYC-90).
+//!
+//! Owns the parser that turns user-facing strings like `"Ctrl+K"` / `"⌃K"` /
+//! `"F2"` / `"Esc"` into a `KeyBinding`, and the bag (`Keybinds`) the input
+//! handler matches against and the prompt-row reads its hint labels from.
+
+use std::str::FromStr;
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use crate::config::KeybindsConfig;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct KeyBinding {
+    pub code: KeyCode,
+    pub mods: KeyModifiers,
+}
+
+impl KeyBinding {
+    pub fn matches(&self, ev: &KeyEvent) -> bool {
+        ev.code == self.code && ev.modifiers == self.mods
+    }
+
+    /// Caret-prefixed label suited for prompt-row footer (e.g. `⌃K`, `F2`,
+    /// `Esc`). Stable regardless of how the user spelled it in config.
+    pub fn label(&self) -> String {
+        let mut out = String::new();
+        if self.mods.contains(KeyModifiers::CONTROL) {
+            out.push('⌃');
+        }
+        if self.mods.contains(KeyModifiers::ALT) {
+            out.push('⌥');
+        }
+        if self.mods.contains(KeyModifiers::SHIFT) {
+            out.push('⇧');
+        }
+        match self.code {
+            KeyCode::Char(c) => out.push(c.to_ascii_uppercase()),
+            KeyCode::F(n) => out.push_str(&format!("F{n}")),
+            KeyCode::Esc => out.push_str("Esc"),
+            KeyCode::Enter => out.push('↵'),
+            KeyCode::Tab => out.push_str("Tab"),
+            KeyCode::Backspace => out.push('⌫'),
+            KeyCode::Up => out.push('↑'),
+            KeyCode::Down => out.push('↓'),
+            KeyCode::Left => out.push('←'),
+            KeyCode::Right => out.push('→'),
+            other => out.push_str(&format!("{other:?}")),
+        }
+        out
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct KeyParseError(pub String);
+
+impl std::fmt::Display for KeyParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "unrecognised key binding: {}", self.0)
+    }
+}
+
+impl std::error::Error for KeyParseError {}
+
+impl FromStr for KeyBinding {
+    type Err = KeyParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let trimmed = s.trim();
+        if trimmed.is_empty() {
+            return Err(KeyParseError(s.to_string()));
+        }
+
+        let mut mods = KeyModifiers::NONE;
+        let mut rest = trimmed.to_string();
+
+        loop {
+            // Caret-style sigils first (⌃, ⌥, ⇧).
+            let mut consumed = false;
+            for (sigil, modifier) in [
+                ('⌃', KeyModifiers::CONTROL),
+                ('⌥', KeyModifiers::ALT),
+                ('⇧', KeyModifiers::SHIFT),
+            ] {
+                if let Some(stripped) = rest.strip_prefix(sigil) {
+                    mods.insert(modifier);
+                    rest = stripped.to_string();
+                    consumed = true;
+                    break;
+                }
+            }
+            if consumed {
+                continue;
+            }
+
+            // `Ctrl+`, `Alt+`, `Shift+` prefixes (case-insensitive).
+            let lower = rest.to_ascii_lowercase();
+            if let Some(after) = lower.strip_prefix("ctrl+") {
+                mods.insert(KeyModifiers::CONTROL);
+                rest = rest[rest.len() - after.len()..].to_string();
+                continue;
+            }
+            if let Some(after) = lower.strip_prefix("alt+") {
+                mods.insert(KeyModifiers::ALT);
+                rest = rest[rest.len() - after.len()..].to_string();
+                continue;
+            }
+            if let Some(after) = lower.strip_prefix("shift+") {
+                mods.insert(KeyModifiers::SHIFT);
+                rest = rest[rest.len() - after.len()..].to_string();
+                continue;
+            }
+            break;
+        }
+
+        if rest.is_empty() {
+            return Err(KeyParseError(s.to_string()));
+        }
+
+        let code = match rest.as_str() {
+            "Esc" | "esc" | "ESC" => KeyCode::Esc,
+            "Enter" | "enter" | "Return" | "return" | "↵" => KeyCode::Enter,
+            "Tab" | "tab" => KeyCode::Tab,
+            "Backspace" | "backspace" | "⌫" => KeyCode::Backspace,
+            "Up" | "up" | "↑" => KeyCode::Up,
+            "Down" | "down" | "↓" => KeyCode::Down,
+            "Left" | "left" | "←" => KeyCode::Left,
+            "Right" | "right" | "→" => KeyCode::Right,
+            other => {
+                if let Some(n) = other
+                    .strip_prefix('F')
+                    .or_else(|| other.strip_prefix('f'))
+                    .and_then(|d| d.parse::<u8>().ok())
+                {
+                    if (1..=24).contains(&n) {
+                        KeyCode::F(n)
+                    } else {
+                        return Err(KeyParseError(s.to_string()));
+                    }
+                } else {
+                    let mut chars = other.chars();
+                    let first = chars.next().ok_or_else(|| KeyParseError(s.to_string()))?;
+                    if chars.next().is_some() {
+                        return Err(KeyParseError(s.to_string()));
+                    }
+                    // Ctrl-shorthand keys are conventionally lowercased.
+                    let ch = if mods.contains(KeyModifiers::CONTROL) {
+                        first.to_ascii_lowercase()
+                    } else {
+                        first
+                    };
+                    KeyCode::Char(ch)
+                }
+            }
+        };
+
+        Ok(Self { code, mods })
+    }
+}
+
+/// Parsed binding bag — built once at TUI startup from `KeybindsConfig`.
+#[derive(Clone, Debug)]
+pub struct Keybinds {
+    pub toggle_sessions: KeyBinding,
+    pub toggle_tools: KeyBinding,
+    pub toggle_reasoning: KeyBinding,
+    pub cancel: KeyBinding,
+    pub queue_drop: KeyBinding,
+}
+
+impl Keybinds {
+    /// Build from config strings, falling back to the in-code default if a
+    /// user-supplied value fails to parse. Reports each fallback via tracing
+    /// so misconfigurations are visible.
+    pub fn from_config(cfg: &KeybindsConfig) -> Self {
+        let parse = |raw: &str, action: &str, fallback: KeyBinding| match raw.parse::<KeyBinding>() {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::warn!(
+                    "keybinds: failed to parse `{}` for `{action}` ({e}); using default {}",
+                    raw,
+                    fallback.label()
+                );
+                fallback
+            }
+        };
+
+        Self {
+            toggle_sessions: parse(
+                &cfg.toggle_sessions,
+                "toggle_sessions",
+                Self::defaults().toggle_sessions,
+            ),
+            toggle_tools: parse(
+                &cfg.toggle_tools,
+                "toggle_tools",
+                Self::defaults().toggle_tools,
+            ),
+            toggle_reasoning: parse(
+                &cfg.toggle_reasoning,
+                "toggle_reasoning",
+                Self::defaults().toggle_reasoning,
+            ),
+            cancel: parse(&cfg.cancel, "cancel", Self::defaults().cancel),
+            queue_drop: parse(&cfg.queue_drop, "queue_drop", Self::defaults().queue_drop),
+        }
+    }
+
+    pub fn defaults() -> Self {
+        Self {
+            toggle_sessions: KeyBinding {
+                code: KeyCode::Char('k'),
+                mods: KeyModifiers::CONTROL,
+            },
+            toggle_tools: KeyBinding {
+                code: KeyCode::Char('t'),
+                mods: KeyModifiers::CONTROL,
+            },
+            toggle_reasoning: KeyBinding {
+                code: KeyCode::Char('r'),
+                mods: KeyModifiers::CONTROL,
+            },
+            cancel: KeyBinding {
+                code: KeyCode::Char('c'),
+                mods: KeyModifiers::CONTROL,
+            },
+            queue_drop: KeyBinding {
+                code: KeyCode::Backspace,
+                mods: KeyModifiers::CONTROL,
+            },
+        }
+    }
+}
+
+impl Default for Keybinds {
+    fn default() -> Self {
+        Self::defaults()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_ctrl_plus_letter() {
+        let b: KeyBinding = "Ctrl+K".parse().unwrap();
+        assert_eq!(b.code, KeyCode::Char('k'));
+        assert!(b.mods.contains(KeyModifiers::CONTROL));
+    }
+
+    #[test]
+    fn parses_caret_sigil() {
+        let b: KeyBinding = "⌃K".parse().unwrap();
+        assert_eq!(b.code, KeyCode::Char('k'));
+        assert!(b.mods.contains(KeyModifiers::CONTROL));
+    }
+
+    #[test]
+    fn parses_function_key() {
+        let b: KeyBinding = "F2".parse().unwrap();
+        assert_eq!(b.code, KeyCode::F(2));
+        assert!(b.mods.is_empty());
+    }
+
+    #[test]
+    fn parses_named_keys() {
+        assert_eq!("Esc".parse::<KeyBinding>().unwrap().code, KeyCode::Esc);
+        assert_eq!("Tab".parse::<KeyBinding>().unwrap().code, KeyCode::Tab);
+        assert_eq!(
+            "Backspace".parse::<KeyBinding>().unwrap().code,
+            KeyCode::Backspace
+        );
+    }
+
+    #[test]
+    fn parses_ctrl_backspace() {
+        let b: KeyBinding = "Ctrl+Backspace".parse().unwrap();
+        assert_eq!(b.code, KeyCode::Backspace);
+        assert!(b.mods.contains(KeyModifiers::CONTROL));
+    }
+
+    #[test]
+    fn rejects_empty_and_garbage() {
+        assert!("".parse::<KeyBinding>().is_err());
+        assert!("Ctrl+".parse::<KeyBinding>().is_err());
+        assert!("nonsense".parse::<KeyBinding>().is_err());
+        assert!("F99".parse::<KeyBinding>().is_err());
+    }
+
+    #[test]
+    fn label_uses_caret_for_ctrl_letters() {
+        let b = KeyBinding {
+            code: KeyCode::Char('k'),
+            mods: KeyModifiers::CONTROL,
+        };
+        assert_eq!(b.label(), "⌃K");
+    }
+
+    #[test]
+    fn label_function_and_esc() {
+        let b = KeyBinding {
+            code: KeyCode::F(2),
+            mods: KeyModifiers::NONE,
+        };
+        assert_eq!(b.label(), "F2");
+        let b = KeyBinding {
+            code: KeyCode::Esc,
+            mods: KeyModifiers::NONE,
+        };
+        assert_eq!(b.label(), "Esc");
+    }
+
+    #[test]
+    fn matches_key_event() {
+        let b: KeyBinding = "Ctrl+T".parse().unwrap();
+        let ev = KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL);
+        assert!(b.matches(&ev));
+        let ev = KeyEvent::new(KeyCode::Char('t'), KeyModifiers::NONE);
+        assert!(!b.matches(&ev));
+    }
+
+    #[test]
+    fn keybinds_from_config_uses_defaults_for_unparseable() {
+        let mut cfg = KeybindsConfig::default();
+        cfg.toggle_tools = "garbage-string".into();
+        let kb = Keybinds::from_config(&cfg);
+        assert_eq!(kb.toggle_tools, Keybinds::defaults().toggle_tools);
+    }
+
+    #[test]
+    fn keybinds_from_config_parses_overrides() {
+        let mut cfg = KeybindsConfig::default();
+        cfg.toggle_tools = "F2".into();
+        let kb = Keybinds::from_config(&cfg);
+        assert_eq!(kb.toggle_tools.code, KeyCode::F(2));
+        assert!(kb.toggle_tools.mods.is_empty());
+    }
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -21,6 +21,7 @@ use crate::pause::{self, AgentResume, PauseKind};
 use crate::provider::StreamEvent;
 
 pub mod chat_render;
+pub mod keybinds;
 pub mod markdown;
 pub mod state;
 pub mod theme;
@@ -469,7 +470,8 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
         config.provider.model.clone(),
         config.provider.max_context as u32,
     )
-    .with_theme(Theme::from_name(&config.tui.theme));
+    .with_theme(Theme::from_name(&config.tui.theme))
+    .with_keybinds(keybinds::Keybinds::from_config(&config.keybinds));
     app.audit_log = Some(audit_buf);
     // YYC-66: clone the agent's diff sink so the TUI can render real edits.
     // YYC-67: pull catalog pricing for the cost estimate.
@@ -806,6 +808,33 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                     }
                                 }
 
+                                // ── configurable bindings (YYC-90).
+                                // Run before the legacy Ctrl-modifier match
+                                // so user overrides win. The session-picker
+                                // bind only fires when the slash menu isn't
+                                // active, so Ctrl+K nav still works while
+                                // typing a `/command`. Cancel and queue_drop
+                                // stay in the hardcoded match below because
+                                // they carry compound behavior (pending_quit,
+                                // Shift-to-clear) that doesn't reduce to a
+                                // simple binding.
+                                if app.keybinds.toggle_tools.matches(&key) {
+                                    app.view = View::TradingFloor;
+                                    continue;
+                                }
+                                if app.keybinds.toggle_sessions.matches(&key)
+                                    && !app.input.starts_with('/')
+                                {
+                                    refresh_sessions(&agent, &mut app).await;
+                                    app.show_session_picker = true;
+                                    app.session_picker_selection = 0;
+                                    continue;
+                                }
+                                if app.keybinds.toggle_reasoning.matches(&key) {
+                                    app.show_reasoning = !app.show_reasoning;
+                                    continue;
+                                }
+
                                 // ── view switching: Ctrl+1..5
                                 if key.modifiers.contains(KeyModifiers::CONTROL) {
                                     match key.code {
@@ -844,10 +873,6 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                                     continue;
                                                 }
                                             }
-                                        }
-                                        KeyCode::Char('r') => {
-                                            app.show_reasoning = !app.show_reasoning;
-                                            continue;
                                         }
                                         KeyCode::Char('c') => {
                                             if pending_quit {

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -1,6 +1,8 @@
 use std::cell::{Cell, RefCell};
 use std::collections::VecDeque;
 
+use super::keybinds::Keybinds;
+
 /// Format a u32 with comma thousands separators (YYC-60).
 /// `18402 → "18,402"`. Pure utility, no allocation beyond the result.
 pub fn format_thousands(n: u32) -> String {
@@ -529,6 +531,51 @@ pub struct AppState {
     /// callers inherit terminal palette; production wires the real config-derived
     /// theme via `.with_theme(...)` post-construction.
     pub theme: Theme,
+
+    /// Active key bindings — drives both the input handler in `tui::mod`
+    /// and the prompt-row hint cache below (YYC-90).
+    pub keybinds: Keybinds,
+    /// Pre-formatted hint pairs per `PromptMode`. Built once in
+    /// `with_keybinds`; `prompt_hints()` returns a slice into one of
+    /// these vectors so the render hot path never allocates.
+    prompt_hints_cache: PromptHintsCache,
+}
+
+#[derive(Clone, Debug)]
+struct PromptHintsCache {
+    insert: Vec<(String, String)>,
+    command: Vec<(String, String)>,
+    ask: Vec<(String, String)>,
+    busy: Vec<(String, String)>,
+}
+
+impl PromptHintsCache {
+    fn build(kb: &Keybinds) -> Self {
+        Self {
+            insert: vec![
+                ("↵".into(), "send".into()),
+                (kb.toggle_tools.label(), "tools".into()),
+                (kb.toggle_sessions.label(), "sessions".into()),
+                ("/".into(), "cmds".into()),
+            ],
+            command: vec![
+                ("↵".into(), "run".into()),
+                ("↑↓".into(), "select".into()),
+                ("Tab".into(), "complete".into()),
+                ("Esc".into(), "cancel".into()),
+            ],
+            ask: vec![
+                ("y".into(), "proceed".into()),
+                ("n".into(), "deny".into()),
+                ("Esc".into(), "cancel".into()),
+            ],
+            busy: vec![
+                ("↵".into(), "queue".into()),
+                (kb.cancel.label(), "cancel".into()),
+                (kb.queue_drop.label(), "drop last".into()),
+            ],
+        }
+    }
 }
 
 impl AppState {
@@ -574,6 +621,8 @@ impl AppState {
             session_picker_selection: 0,
 
             theme: Theme::system(),
+            keybinds: Keybinds::default(),
+            prompt_hints_cache: PromptHintsCache::build(&Keybinds::default()),
         }
     }
 
@@ -581,6 +630,15 @@ impl AppState {
     /// default `Theme::system()` for the user's configured theme.
     pub fn with_theme(mut self, theme: Theme) -> Self {
         self.theme = theme;
+        self
+    }
+
+    /// Replace the active key bindings and rebuild the prompt-row hint
+    /// cache (YYC-90). Builder-style so existing `AppState::new` call
+    /// sites don't change.
+    pub fn with_keybinds(mut self, keybinds: Keybinds) -> Self {
+        self.prompt_hints_cache = PromptHintsCache::build(&keybinds);
+        self.keybinds = keybinds;
         self
     }
 
@@ -623,25 +681,15 @@ impl AppState {
         self.prompt_mode.badge()
     }
 
-    /// Per-mode hint pairs for the prompt-row footer (YYC-58). Centralized
-    /// so call sites in views don't drift apart on the bindings each mode
-    /// advertises.
-    pub fn prompt_hints(&self) -> &'static [(&'static str, &'static str)] {
+    /// Per-mode hint pairs for the prompt-row footer (YYC-58, YYC-90).
+    /// Returns a slice into the cached, pre-formatted vector so the
+    /// render hot path never allocates. Bindings come from `self.keybinds`.
+    pub fn prompt_hints(&self) -> &[(String, String)] {
         match self.prompt_mode {
-            PromptMode::Insert => &[
-                ("↵", "send"),
-                ("⌃T", "tools"),
-                ("⌃K", "sessions"),
-                ("/", "cmds"),
-            ],
-            PromptMode::Command => &[
-                ("↵", "run"),
-                ("↑↓", "select"),
-                ("Tab", "complete"),
-                ("Esc", "cancel"),
-            ],
-            PromptMode::Ask => &[("y", "proceed"), ("n", "deny"), ("Esc", "cancel")],
-            PromptMode::Busy => &[("↵", "queue"), ("⌃C", "cancel"), ("⌃⌫", "drop last")],
+            PromptMode::Insert => &self.prompt_hints_cache.insert,
+            PromptMode::Command => &self.prompt_hints_cache.command,
+            PromptMode::Ask => &self.prompt_hints_cache.ask,
+            PromptMode::Busy => &self.prompt_hints_cache.busy,
         }
     }
 
@@ -1216,6 +1264,54 @@ mod tests {
         app.input = "/queue".into();
         app.refresh_prompt_mode();
         assert_eq!(app.prompt_mode, PromptMode::Busy);
+    }
+
+    #[test]
+    fn prompt_hints_default_keybinds_match_legacy_labels() {
+        // Default Keybinds should produce the exact static labels the
+        // pre-config code shipped: ⌃T for tools, ⌃K for sessions, etc.
+        let app = AppState::new("test".into(), 100);
+        let hints = app.prompt_hints();
+        let pairs: Vec<(String, String)> = hints.iter().cloned().collect();
+        assert!(
+            pairs.contains(&("⌃T".into(), "tools".into())),
+            "expected ⌃T tools in {pairs:?}"
+        );
+        assert!(
+            pairs.contains(&("⌃K".into(), "sessions".into())),
+            "expected ⌃K sessions in {pairs:?}"
+        );
+    }
+
+    #[test]
+    fn prompt_hints_reflect_overridden_keybind() {
+        use super::super::keybinds::{KeyBinding, Keybinds};
+        use crossterm::event::{KeyCode, KeyModifiers};
+        let mut kb = Keybinds::defaults();
+        kb.toggle_tools = KeyBinding {
+            code: KeyCode::F(2),
+            mods: KeyModifiers::NONE,
+        };
+        let app = AppState::new("test".into(), 100).with_keybinds(kb);
+        let pairs: Vec<(String, String)> = app.prompt_hints().iter().cloned().collect();
+        assert!(
+            pairs.contains(&("F2".into(), "tools".into())),
+            "expected F2 tools in {pairs:?}"
+        );
+        assert!(
+            !pairs.iter().any(|(k, _)| k == "⌃T"),
+            "stale ⌃T label leaked into {pairs:?}"
+        );
+    }
+
+    #[test]
+    fn prompt_hints_returns_borrowed_slice_no_alloc() {
+        // Two consecutive calls in the same mode must return slices to
+        // the same cached storage — proves we're not allocating per call.
+        let app = AppState::new("test".into(), 100);
+        let first = app.prompt_hints().as_ptr();
+        let second = app.prompt_hints().as_ptr();
+        assert_eq!(first, second, "prompt_hints reallocated between calls");
     }
 
     #[test]

--- a/src/tui/widgets.rs
+++ b/src/tui/widgets.rs
@@ -328,7 +328,7 @@ pub fn prompt_row(
     area: Rect,
     mode: &str,
     input: &str,
-    hints: &[(&str, &str)],
+    hints: &[(String, String)],
     model_status: &str,
     // capacity_ratio (YYC-60): current context / max. Drives the
     // model_status fg color: ≤70% body_fg, 70-90% yellow, >90% red.


### PR DESCRIPTION
Adds a config-driven binding layer that drives both the input handler
and the prompt-row hint labels.

* `KeyBinding` parser accepts `Ctrl+K` / `⌃K` / `F2` / `Esc` /
  `Ctrl+Backspace` and rejects empty / out-of-range / multi-char input.
* `KeybindsConfig` in `[keybinds]` carries raw strings; `Keybinds::from_config`
  parses them at TUI startup, falling back to defaults with a tracing
  warning when a user value fails to parse so a typo is never silent.
* `AppState::with_keybinds` is a builder so existing `AppState::new`
  call sites keep their two-arg signature. Hint labels are pre-formatted
  into a per-mode cache; `prompt_hints()` returns a borrowed slice into
  it so the render hot path doesn't reallocate (covered by a
  pointer-stability test).
* Input handler matches `toggle_tools`, `toggle_sessions`, and
  `toggle_reasoning` against config bindings. `cancel` and `queue_drop`
  stay hardcoded because their compound behavior (pending_quit,
  Shift+Backspace = clear queue) doesn't reduce to a simple binding —
  but their labels are still config-driven.
* `config.example.toml` documents the section with the recognised
  string forms.