### PR TITLE
YYC-93: Strip backgrounds from themes — terminal-native fg/bg only

### DIFF
--- a/src/tui/chat_render.rs
+++ b/src/tui/chat_render.rs
@@ -157,7 +157,7 @@ impl ChatRenderStore {
     ) -> RenderedMessageBlock {
         let (role_label, accent) = match message.role {
             ChatRole::User => ("you", Palette::RED),
-            ChatRole::Agent => ("agent", Palette::INK),
+            ChatRole::Agent => ("agent", theme.body_fg),
             ChatRole::System => ("system", Palette::YELLOW),
         };
         let is_agent = matches!(message.role, ChatRole::Agent);

--- a/src/tui/keybinds.rs
+++ b/src/tui/keybinds.rs
@@ -21,30 +21,32 @@ impl KeyBinding {
         ev.code == self.code && ev.modifiers == self.mods
     }
 
-    /// Caret-prefixed label suited for prompt-row footer (e.g. `⌃K`, `F2`,
-    /// `Esc`). Stable regardless of how the user spelled it in config.
+    /// ASCII-safe label suited for the prompt-row footer (e.g. `Ctrl+K`,
+    /// `Alt+T`, `F2`, `Esc`). Stable regardless of how the user spelled it
+    /// in config; avoids glyphs that fall back to tofu in many terminal
+    /// fonts.
     pub fn label(&self) -> String {
         let mut out = String::new();
         if self.mods.contains(KeyModifiers::CONTROL) {
-            out.push('⌃');
+            out.push_str("Ctrl+");
         }
         if self.mods.contains(KeyModifiers::ALT) {
-            out.push('⌥');
+            out.push_str("Alt+");
         }
         if self.mods.contains(KeyModifiers::SHIFT) {
-            out.push('⇧');
+            out.push_str("Shift+");
         }
         match self.code {
             KeyCode::Char(c) => out.push(c.to_ascii_uppercase()),
             KeyCode::F(n) => out.push_str(&format!("F{n}")),
             KeyCode::Esc => out.push_str("Esc"),
-            KeyCode::Enter => out.push('↵'),
+            KeyCode::Enter => out.push_str("Enter"),
             KeyCode::Tab => out.push_str("Tab"),
-            KeyCode::Backspace => out.push('⌫'),
-            KeyCode::Up => out.push('↑'),
-            KeyCode::Down => out.push('↓'),
-            KeyCode::Left => out.push('←'),
-            KeyCode::Right => out.push('→'),
+            KeyCode::Backspace => out.push_str("Bksp"),
+            KeyCode::Up => out.push_str("Up"),
+            KeyCode::Down => out.push_str("Down"),
+            KeyCode::Left => out.push_str("Left"),
+            KeyCode::Right => out.push_str("Right"),
             other => out.push_str(&format!("{other:?}")),
         }
         out
@@ -289,12 +291,12 @@ mod tests {
     }
 
     #[test]
-    fn label_uses_caret_for_ctrl_letters() {
+    fn label_uses_ascii_for_ctrl_letters() {
         let b = KeyBinding {
             code: KeyCode::Char('k'),
             mods: KeyModifiers::CONTROL,
         };
-        assert_eq!(b.label(), "⌃K");
+        assert_eq!(b.label(), "Ctrl+K");
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -29,7 +29,7 @@ pub mod views;
 pub mod widgets;
 
 use state::{AppState, ChatMessage, ChatRole, SessionStatus};
-use theme::{Palette, Theme, body};
+use theme::{Theme, body};
 use views::{View, render_view};
 
 const STREAM_FRAME_BUDGET: Duration = Duration::from_millis(16);
@@ -1396,14 +1396,8 @@ fn draw_palette(
             // YYC-70: highlight the active row by swapping fg/bg of accent
             // (gives a visible selection bar regardless of active theme).
             let (prefix, name_style, desc_style) = if is_active {
-                let active_fg = theme.accent.bg.unwrap_or(theme.body_bg);
-                let active_bg = theme.accent.fg.unwrap_or(theme.body_fg);
-                let active_style = Style::default().fg(active_fg).bg(active_bg);
-                (
-                    "▸ ",
-                    active_style.add_modifier(Modifier::BOLD),
-                    active_style,
-                )
+                let active_style = theme.accent.add_modifier(Modifier::BOLD);
+                ("▸ ", active_style, active_style)
             } else {
                 (
                     "  ",
@@ -1436,13 +1430,6 @@ fn draw_session_picker(f: &mut ratatui::Frame, area: Rect, app: &AppState) {
     if box_area.height < 4 {
         return;
     }
-
-    // Fill the box with solid theme-bg to obscure the view behind.
-    let fill_bg = rect_with_border(box_area, 0);
-    f.render_widget(
-        Paragraph::new(Line::from("")).style(Style::default().bg(theme.body_bg)),
-        fill_bg,
-    );
 
     // Title bar
     let bar = Rect {
@@ -1490,13 +1477,6 @@ fn draw_session_picker(f: &mut ratatui::Frame, area: Rect, app: &AppState) {
             .min(app.sessions.len().saturating_sub(1));
         for (i, s) in app.sessions.iter().enumerate() {
             let is_active = i == active;
-            // YYC-52: active rows get a subtle highlight bg via FAINT;
-            // inactive rows sit on the theme body bg.
-            let bg = if is_active {
-                Palette::FAINT
-            } else {
-                theme.body_bg
-            };
             let marker = if is_active { "▸ " } else { "  " };
             let status_style = match s.status {
                 SessionStatus::Live => theme.success,
@@ -1507,7 +1487,6 @@ fn draw_session_picker(f: &mut ratatui::Frame, area: Rect, app: &AppState) {
                 SessionStatus::Saved => "saved",
             };
 
-            // Format the date/time
             let dt = chrono::DateTime::from_timestamp(s.last_active, 0)
                 .map(|d| {
                     d.with_timezone(&chrono::Local)
@@ -1518,41 +1497,30 @@ fn draw_session_picker(f: &mut ratatui::Frame, area: Rect, app: &AppState) {
 
             let name_style = Style::default()
                 .fg(theme.body_fg)
-                .bg(bg)
                 .add_modifier(if is_active {
                     Modifier::BOLD
                 } else {
                     Modifier::empty()
                 });
-            let meta_style = theme.muted.bg(bg);
 
             lines.push(Line::from(vec![
                 Span::styled(marker, name_style.add_modifier(Modifier::BOLD)),
-                Span::styled("█ ", status_style.bg(bg)),
-                Span::styled(format!("{:<12}", short_id(&s.id)), name_style.clone()),
-                Span::styled(format!("{:>4}m", s.message_count), meta_style),
-                Span::styled(
-                    format!("  {} ", dt),
-                    theme.muted.bg(bg),
-                ),
+                Span::styled("█ ", status_style),
+                Span::styled(format!("{:<12}", short_id(&s.id)), name_style),
+                Span::styled(format!("{:>4}m", s.message_count), theme.muted),
+                Span::styled(format!("  {} ", dt), theme.muted),
                 Span::styled(
                     status_label,
-                    status_style.bg(bg).add_modifier(Modifier::BOLD),
+                    status_style.add_modifier(Modifier::BOLD),
                 ),
             ]));
 
-            // Preview synopsis from first user message, if available.
             if let Some(preview) = &s.preview {
                 lines.push(Line::from(vec![
-                    // Invisible spacer — fg=bg so the marker column stays
-                    // blank but the row keeps its background fill.
-                    Span::styled(
-                        if is_active { "▸ " } else { "  " },
-                        Style::default().fg(bg).bg(bg),
-                    ),
+                    Span::raw("  "),
                     Span::styled(
                         format!("  {}", preview),
-                        theme.muted.bg(bg).add_modifier(Modifier::DIM),
+                        theme.muted.add_modifier(Modifier::DIM),
                     ),
                 ]));
             }
@@ -1571,16 +1539,6 @@ fn draw_session_picker(f: &mut ratatui::Frame, area: Rect, app: &AppState) {
 
     // Draw a border around the whole thing
     draw_picker_border(f, box_area, theme);
-}
-
-/// Fill the interior of a bordered rect. `border_w` pixels from each edge.
-fn rect_with_border(r: Rect, border_w: u16) -> Rect {
-    Rect {
-        x: r.x + border_w,
-        y: r.y + border_w,
-        width: r.width.saturating_sub(border_w * 2),
-        height: r.height.saturating_sub(border_w * 2),
-    }
 }
 
 /// Simple border drawn with box-drawing characters.

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -553,14 +553,14 @@ impl PromptHintsCache {
     fn build(kb: &Keybinds) -> Self {
         Self {
             insert: vec![
-                ("↵".into(), "send".into()),
+                ("Enter".into(), "send".into()),
                 (kb.toggle_tools.label(), "tools".into()),
                 (kb.toggle_sessions.label(), "sessions".into()),
                 ("/".into(), "cmds".into()),
             ],
             command: vec![
-                ("↵".into(), "run".into()),
-                ("↑↓".into(), "select".into()),
+                ("Enter".into(), "run".into()),
+                ("Up/Dn".into(), "select".into()),
                 ("Tab".into(), "complete".into()),
                 ("Esc".into(), "cancel".into()),
             ],
@@ -570,7 +570,7 @@ impl PromptHintsCache {
                 ("Esc".into(), "cancel".into()),
             ],
             busy: vec![
-                ("↵".into(), "queue".into()),
+                ("Enter".into(), "queue".into()),
                 (kb.cancel.label(), "cancel".into()),
                 (kb.queue_drop.label(), "drop last".into()),
             ],
@@ -1267,19 +1267,19 @@ mod tests {
     }
 
     #[test]
-    fn prompt_hints_default_keybinds_match_legacy_labels() {
-        // Default Keybinds should produce the exact static labels the
-        // pre-config code shipped: ⌃T for tools, ⌃K for sessions, etc.
+    fn prompt_hints_default_keybinds_match_ascii_labels() {
+        // Default Keybinds should produce ASCII-safe labels (Ctrl+T,
+        // Ctrl+K) so prompt-row chips render in any terminal font.
         let app = AppState::new("test".into(), 100);
         let hints = app.prompt_hints();
         let pairs: Vec<(String, String)> = hints.iter().cloned().collect();
         assert!(
-            pairs.contains(&("⌃T".into(), "tools".into())),
-            "expected ⌃T tools in {pairs:?}"
+            pairs.contains(&("Ctrl+T".into(), "tools".into())),
+            "expected Ctrl+T tools in {pairs:?}"
         );
         assert!(
-            pairs.contains(&("⌃K".into(), "sessions".into())),
-            "expected ⌃K sessions in {pairs:?}"
+            pairs.contains(&("Ctrl+K".into(), "sessions".into())),
+            "expected Ctrl+K sessions in {pairs:?}"
         );
     }
 
@@ -1299,8 +1299,8 @@ mod tests {
             "expected F2 tools in {pairs:?}"
         );
         assert!(
-            !pairs.iter().any(|(k, _)| k == "⌃T"),
-            "stale ⌃T label leaked into {pairs:?}"
+            !pairs.iter().any(|(k, _)| k == "Ctrl+T"),
+            "stale Ctrl+T label leaked into {pairs:?}"
         );
     }
 

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -19,24 +19,25 @@ impl Palette {
     pub const GREEN: Color = Color::Rgb(0x3F, 0x7A, 0x4F);
 }
 
-/// Default body style — ink on paper.
+/// Default body style — terminal-default background.
 pub fn body() -> Style {
-    Style::default().fg(Palette::INK).bg(Palette::PAPER)
+    Style::default().fg(Palette::INK)
 }
 
-/// Inverse — paper on ink (used for header bars, ticker, mode pill).
+/// Bold emphasis for header bars and chrome. No background paint so
+/// the active terminal theme shows through.
 pub fn inverse() -> Style {
-    Style::default().fg(Palette::PAPER).bg(Palette::INK)
+    Style::default().fg(Palette::INK).add_modifier(Modifier::BOLD)
 }
 
 /// Muted body text.
 pub fn muted() -> Style {
-    Style::default().fg(Palette::MUTED).bg(Palette::PAPER)
+    Style::default().fg(Palette::MUTED)
 }
 
-/// Faint backdrop — used for inactive rails and reasoning trace.
+/// Inset trace style (reasoning, side rails).
 pub fn faint_bg() -> Style {
-    Style::default().fg(Palette::INK).bg(Palette::FAINT)
+    Style::default().fg(Palette::MUTED).add_modifier(Modifier::ITALIC)
 }
 
 /// Centralized style table — one entry per theming role.
@@ -119,7 +120,7 @@ impl Theme {
             heading_4: bold,
             heading_5: bold,
             heading_6: bold,
-            code_block: Style::default().fg(Color::White).bg(Color::Black),
+            code_block: Style::default().fg(Color::White),
             inline_code: Style::default().fg(Color::Cyan),
             link: Style::default().fg(Color::Blue).add_modifier(Modifier::UNDERLINED),
             blockquote: italic,
@@ -131,23 +132,23 @@ impl Theme {
         }
     }
 
-    /// Bauhaus / brutalist palette — formalizes today's hardcoded look.
-    /// Cream paper, ink black, primary accents.
+    /// Bauhaus / brutalist foreground palette. Backgrounds inherit from the
+    /// terminal so copy-paste behaves naturally and OS theming wins.
     pub fn default_light() -> Self {
-        let body = Style::default().fg(Palette::INK).bg(Palette::PAPER);
+        let body = Style::default().fg(Palette::INK);
         let bold = body.add_modifier(Modifier::BOLD);
         let italic = body.add_modifier(Modifier::ITALIC);
         Self {
             user: body,
             assistant: body,
-            system: Style::default().fg(Palette::BLUE).bg(Palette::PAPER),
-            tool_call: Style::default().fg(Palette::YELLOW).bg(Palette::PAPER),
-            tool_result: Style::default().fg(Palette::GREEN).bg(Palette::PAPER),
-            error: Style::default().fg(Palette::RED).bg(Palette::PAPER).add_modifier(Modifier::BOLD),
-            success: Style::default().fg(Palette::GREEN).bg(Palette::PAPER),
-            muted: Style::default().fg(Palette::MUTED).bg(Palette::PAPER),
-            accent: Style::default().fg(Palette::RED).bg(Palette::PAPER),
-            border: Style::default().fg(Palette::INK).bg(Palette::PAPER),
+            system: Style::default().fg(Palette::BLUE),
+            tool_call: Style::default().fg(Palette::YELLOW),
+            tool_result: Style::default().fg(Palette::GREEN),
+            error: Style::default().fg(Palette::RED).add_modifier(Modifier::BOLD),
+            success: Style::default().fg(Palette::GREEN),
+            muted: Style::default().fg(Palette::MUTED),
+            accent: Style::default().fg(Palette::RED),
+            border: Style::default().fg(Palette::INK),
 
             heading_1: bold,
             heading_2: bold,
@@ -155,22 +156,21 @@ impl Theme {
             heading_4: bold,
             heading_5: bold,
             heading_6: bold,
-            code_block: Style::default().fg(Palette::INK).bg(Palette::FAINT),
-            inline_code: Style::default().fg(Palette::RED).bg(Palette::FAINT),
-            link: Style::default().fg(Palette::BLUE).bg(Palette::PAPER).add_modifier(Modifier::UNDERLINED),
+            code_block: Style::default().fg(Palette::INK),
+            inline_code: Style::default().fg(Palette::RED),
+            link: Style::default().fg(Palette::BLUE).add_modifier(Modifier::UNDERLINED),
             blockquote: italic,
-            list_marker: Style::default().fg(Palette::BLUE).bg(Palette::PAPER),
+            list_marker: Style::default().fg(Palette::BLUE),
             strikethrough: body.add_modifier(Modifier::CROSSED_OUT),
 
-            body_bg: Palette::PAPER,
+            body_bg: Color::Reset,
             body_fg: Palette::INK,
         }
     }
 
-    /// Canonical Dracula palette — https://draculatheme.com/contribute
+    /// Canonical Dracula foreground palette — https://draculatheme.com/contribute
+    /// Backgrounds inherit from the terminal so copy-paste behaves naturally.
     pub fn dracula() -> Self {
-        const BG: Color = Color::Rgb(0x28, 0x2a, 0x36);
-        const CURRENT_LINE: Color = Color::Rgb(0x44, 0x47, 0x5a);
         const FG: Color = Color::Rgb(0xf8, 0xf8, 0xf2);
         const COMMENT: Color = Color::Rgb(0x62, 0x72, 0xa4);
         const CYAN: Color = Color::Rgb(0x8b, 0xe9, 0xfd);
@@ -181,19 +181,19 @@ impl Theme {
         const RED: Color = Color::Rgb(0xff, 0x55, 0x55);
         const YELLOW: Color = Color::Rgb(0xf1, 0xfa, 0x8c);
 
-        let body = Style::default().fg(FG).bg(BG);
-        let bold_pink = Style::default().fg(PINK).bg(BG).add_modifier(Modifier::BOLD);
+        let body = Style::default().fg(FG);
+        let bold_pink = Style::default().fg(PINK).add_modifier(Modifier::BOLD);
         Self {
             user: body,
             assistant: body,
-            system: Style::default().fg(CYAN).bg(BG),
-            tool_call: Style::default().fg(YELLOW).bg(BG),
-            tool_result: Style::default().fg(GREEN).bg(BG),
-            error: Style::default().fg(RED).bg(BG).add_modifier(Modifier::BOLD),
-            success: Style::default().fg(GREEN).bg(BG),
-            muted: Style::default().fg(COMMENT).bg(BG),
-            accent: Style::default().fg(PURPLE).bg(BG),
-            border: Style::default().fg(COMMENT).bg(BG),
+            system: Style::default().fg(CYAN),
+            tool_call: Style::default().fg(YELLOW),
+            tool_result: Style::default().fg(GREEN),
+            error: Style::default().fg(RED).add_modifier(Modifier::BOLD),
+            success: Style::default().fg(GREEN),
+            muted: Style::default().fg(COMMENT),
+            accent: Style::default().fg(PURPLE),
+            border: Style::default().fg(COMMENT),
 
             heading_1: bold_pink,
             heading_2: bold_pink,
@@ -201,14 +201,14 @@ impl Theme {
             heading_4: bold_pink,
             heading_5: bold_pink,
             heading_6: bold_pink,
-            code_block: Style::default().fg(FG).bg(CURRENT_LINE),
-            inline_code: Style::default().fg(ORANGE).bg(CURRENT_LINE),
-            link: Style::default().fg(CYAN).bg(BG).add_modifier(Modifier::UNDERLINED),
-            blockquote: Style::default().fg(COMMENT).bg(BG).add_modifier(Modifier::ITALIC),
-            list_marker: Style::default().fg(PURPLE).bg(BG),
+            code_block: Style::default().fg(FG),
+            inline_code: Style::default().fg(ORANGE),
+            link: Style::default().fg(CYAN).add_modifier(Modifier::UNDERLINED),
+            blockquote: Style::default().fg(COMMENT).add_modifier(Modifier::ITALIC),
+            list_marker: Style::default().fg(PURPLE),
             strikethrough: body.add_modifier(Modifier::CROSSED_OUT),
 
-            body_bg: BG,
+            body_bg: Color::Reset,
             body_fg: FG,
         }
     }
@@ -226,16 +226,15 @@ mod theme_tests {
     }
 
     #[test]
-    fn from_name_default_light_returns_paper_bg() {
-        let t = Theme::from_name("default-light");
-        // default-light formalizes today's Bauhaus palette.
-        assert_eq!(t.body_bg, Palette::PAPER);
-    }
-
-    #[test]
-    fn from_name_dracula_returns_dracula_bg() {
-        let t = Theme::from_name("dracula");
-        assert_eq!(t.body_bg, Color::Rgb(0x28, 0x2a, 0x36));
+    fn all_themes_inherit_terminal_bg() {
+        for name in ["system", "default-light", "dracula"] {
+            let t = Theme::from_name(name);
+            assert_eq!(
+                t.body_bg,
+                Color::Reset,
+                "{name} must not paint a background"
+            );
+        }
     }
 
     #[test]

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -110,9 +110,9 @@ impl Theme {
             tool_result: Style::default().fg(Color::Green),
             error: Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
             success: Style::default().fg(Color::Green),
-            muted: Style::default().add_modifier(Modifier::DIM),
+            muted: Style::default().fg(Color::DarkGray),
             accent: Style::default().fg(Color::Magenta),
-            border: plain,
+            border: Style::default().fg(Color::DarkGray),
 
             heading_1: bold,
             heading_2: bold,
@@ -120,7 +120,7 @@ impl Theme {
             heading_4: bold,
             heading_5: bold,
             heading_6: bold,
-            code_block: Style::default().fg(Color::White),
+            code_block: Style::default(),
             inline_code: Style::default().fg(Color::Cyan),
             link: Style::default().fg(Color::Blue).add_modifier(Modifier::UNDERLINED),
             blockquote: italic,
@@ -132,8 +132,9 @@ impl Theme {
         }
     }
 
-    /// Bauhaus / brutalist foreground palette. Backgrounds inherit from the
-    /// terminal so copy-paste behaves naturally and OS theming wins.
+    /// Bauhaus / brutalist palette — ink text + colored accents on the
+    /// terminal's native background. Backgrounds always inherit so
+    /// copy-paste behaves naturally.
     pub fn default_light() -> Self {
         let body = Style::default().fg(Palette::INK);
         let bold = body.add_modifier(Modifier::BOLD);
@@ -148,7 +149,7 @@ impl Theme {
             success: Style::default().fg(Palette::GREEN),
             muted: Style::default().fg(Palette::MUTED),
             accent: Style::default().fg(Palette::RED),
-            border: Style::default().fg(Palette::INK),
+            border: Style::default().fg(Palette::MUTED),
 
             heading_1: bold,
             heading_2: bold,
@@ -156,7 +157,7 @@ impl Theme {
             heading_4: bold,
             heading_5: bold,
             heading_6: bold,
-            code_block: Style::default().fg(Palette::INK),
+            code_block: body,
             inline_code: Style::default().fg(Palette::RED),
             link: Style::default().fg(Palette::BLUE).add_modifier(Modifier::UNDERLINED),
             blockquote: italic,
@@ -168,8 +169,9 @@ impl Theme {
         }
     }
 
-    /// Canonical Dracula foreground palette — https://draculatheme.com/contribute
-    /// Backgrounds inherit from the terminal so copy-paste behaves naturally.
+    /// Canonical Dracula foreground palette on the terminal's native
+    /// background. Backgrounds always inherit so copy-paste behaves
+    /// naturally.
     pub fn dracula() -> Self {
         const FG: Color = Color::Rgb(0xf8, 0xf8, 0xf2);
         const COMMENT: Color = Color::Rgb(0x62, 0x72, 0xa4);
@@ -201,7 +203,7 @@ impl Theme {
             heading_4: bold_pink,
             heading_5: bold_pink,
             heading_6: bold_pink,
-            code_block: Style::default().fg(FG),
+            code_block: body,
             inline_code: Style::default().fg(ORANGE),
             link: Style::default().fg(CYAN).add_modifier(Modifier::UNDERLINED),
             blockquote: Style::default().fg(COMMENT).add_modifier(Modifier::ITALIC),
@@ -249,22 +251,33 @@ mod theme_tests {
 mod theme_swap_tests {
     use super::*;
 
-    // Pin the property that dracula and default-light differ on roles where
-    // a swap should be visible. If a future palette change accidentally
-    // aligns them, this test forces the change-author to acknowledge it.
+    // All themes share terminal-native body roles (assistant/user/code).
+    // What differentiates them is their semantic accent palette — pin
+    // those differences so a future palette change doesn't accidentally
+    // collapse the themes onto identical accents.
 
     #[test]
-    fn dracula_assistant_differs_from_default_light() {
+    fn dracula_accent_differs_from_default_light() {
         let light = Theme::default_light();
         let drac = Theme::dracula();
-        assert_ne!(light.assistant, drac.assistant);
+        assert_ne!(light.accent, drac.accent);
     }
 
     #[test]
-    fn dracula_code_block_differs_from_default_light() {
+    fn dracula_inline_code_differs_from_default_light() {
         let light = Theme::default_light();
         let drac = Theme::dracula();
-        assert_ne!(light.code_block, drac.code_block);
+        assert_ne!(light.inline_code, drac.inline_code);
+    }
+
+    #[test]
+    fn system_alone_inherits_terminal_body_fg() {
+        let system = Theme::from_name("system");
+        assert_eq!(system.body_fg, Color::Reset);
+        assert_eq!(system.assistant.fg, None);
+        // Painted themes intentionally stamp their own body fg.
+        assert_eq!(Theme::from_name("default-light").body_fg, Palette::INK);
+        assert_ne!(Theme::from_name("dracula").body_fg, Color::Reset);
     }
 
     #[test]

--- a/src/tui/views.rs
+++ b/src/tui/views.rs
@@ -177,7 +177,7 @@ fn build_chat_suffix_lines(app: &AppState) -> Vec<Line<'static>> {
                 }
                 let color = match opt.kind {
                     crate::pause::OptionKind::Primary => Palette::BLUE,
-                    crate::pause::OptionKind::Neutral => Palette::INK,
+                    crate::pause::OptionKind::Neutral => app.theme.body_fg,
                     crate::pause::OptionKind::Destructive => Palette::RED,
                 };
                 let filled = matches!(opt.kind, crate::pause::OptionKind::Primary);
@@ -322,12 +322,9 @@ fn split_sessions(f: &mut TuiFrame, area: Rect, app: &AppState) {
         .unwrap_or(app.messages.len());
     let header_text = format!(" {active_name}   · {lineage} · {turn_count} msgs",);
     let accent_bar = Style::default()
-        .fg(app.theme.body_bg)
-        .bg(app.theme.accent.fg.unwrap_or(Color::Reset));
-    let mut spans = vec![Span::styled(
-        header_text,
-        accent_bar.add_modifier(Modifier::BOLD),
-    )];
+        .fg(app.theme.accent.fg.unwrap_or(Color::Reset))
+        .add_modifier(Modifier::BOLD);
+    let mut spans = vec![Span::styled(header_text, accent_bar)];
     let used = spans
         .iter()
         .map(|s| s.content.chars().count() as u16)
@@ -335,11 +332,8 @@ fn split_sessions(f: &mut TuiFrame, area: Rect, app: &AppState) {
     let live_label = " ● LIVE ";
     if used + live_label.len() as u16 + 1 < main.width {
         let pad = " ".repeat((main.width - used - live_label.len() as u16) as usize);
-        spans.push(Span::styled(pad, accent_bar));
-        spans.push(Span::styled(
-            live_label.to_string(),
-            accent_bar.add_modifier(Modifier::BOLD),
-        ));
+        spans.push(Span::raw(pad));
+        spans.push(Span::styled(live_label.to_string(), accent_bar));
     }
     f.render_widget(Paragraph::new(Line::from(spans)), header);
 
@@ -403,40 +397,36 @@ fn render_session_rail(f: &mut TuiFrame, area: Rect, app: &AppState) {
         };
         let bar = if s.is_active { "▌" } else { " " };
         let bar_color = if s.is_active { accent_fg } else { muted_fg };
-        let bg = if s.is_active {
-            Palette::PAPER
+        let row_style = if s.is_active {
+            app.theme.assistant.add_modifier(Modifier::BOLD)
         } else {
-            Palette::FAINT
+            app.theme.assistant
         };
-        let row_style = app.theme.assistant.bg(bg);
         lines.push(Line::from(vec![
             Span::styled(
                 bar,
-                Style::default()
-                    .fg(bar_color)
-                    .bg(bg)
-                    .add_modifier(Modifier::BOLD),
+                Style::default().fg(bar_color).add_modifier(Modifier::BOLD),
             ),
-            Span::styled(" █ ", status_style.bg(bg)),
+            Span::styled(" █ ", status_style),
             Span::styled(s.label.clone(), row_style.add_modifier(Modifier::BOLD)),
         ]));
         lines.push(Line::from(vec![
-            Span::styled(bar, Style::default().fg(bar_color).bg(bg)),
+            Span::styled(bar, Style::default().fg(bar_color)),
             Span::styled(
                 format!(
                     " {:<6}    {:>4}m",
                     s.status.label().to_uppercase(),
                     s.message_count
                 ),
-                app.theme.muted.bg(bg),
+                app.theme.muted,
             ),
         ]));
         if let Some(lineage) = &s.lineage_label {
             lines.push(Line::from(vec![
-                Span::styled(bar, Style::default().fg(bar_color).bg(bg)),
+                Span::styled(bar, Style::default().fg(bar_color)),
                 Span::styled(
                     format!(" {}", lineage),
-                    app.theme.muted.bg(bg).add_modifier(Modifier::DIM),
+                    app.theme.muted.add_modifier(Modifier::DIM),
                 ),
             ]));
         }
@@ -565,11 +555,6 @@ fn tree_of_thought(f: &mut TuiFrame, area: Rect, app: &AppState) {
     let tree_accent_fg = app.theme.accent.fg.unwrap_or(Color::Reset);
     let tree_muted_fg = app.theme.muted.fg.unwrap_or(Color::Reset);
     for n in &tree_nodes {
-        let bg = if n.active {
-            Palette::PAPER
-        } else {
-            Palette::FAINT
-        };
         let bar = if n.active { "▌" } else { " " };
         let bar_color = if n.active {
             tree_accent_fg
@@ -579,21 +564,15 @@ fn tree_of_thought(f: &mut TuiFrame, area: Rect, app: &AppState) {
         lines.push(Line::from(vec![
             Span::styled(
                 bar,
-                Style::default()
-                    .fg(bar_color)
-                    .bg(bg)
-                    .add_modifier(Modifier::BOLD),
+                Style::default().fg(bar_color).add_modifier(Modifier::BOLD),
             ),
             Span::styled(
                 format!(" {} ", n.state),
-                Style::default()
-                    .fg(n.color)
-                    .bg(bg)
-                    .add_modifier(Modifier::BOLD),
+                Style::default().fg(n.color).add_modifier(Modifier::BOLD),
             ),
             Span::styled(
                 n.label.clone(),
-                app.theme.assistant.bg(bg).add_modifier(if n.depth == 0 {
+                app.theme.assistant.add_modifier(if n.depth == 0 {
                     Modifier::BOLD
                 } else {
                     Modifier::empty()
@@ -604,13 +583,13 @@ fn tree_of_thought(f: &mut TuiFrame, area: Rect, app: &AppState) {
     lines.push(Line::from(""));
     lines.push(Line::from(Span::styled(
         " Delegated branch runtime not enabled yet.",
-        app.theme.muted.bg(Palette::FAINT),
+        app.theme.muted,
     )));
     lines.push(Line::from(Span::styled(
         " This pane currently shows the root orchestrator state only.",
-        app.theme.muted.bg(Palette::FAINT),
+        app.theme.muted,
     )));
-    f.render_widget(Paragraph::new(lines).style(faint_bg()), inner);
+    f.render_widget(Paragraph::new(lines), inner);
 
     // Right: focused stream
     let focus_inner = section_header(f, h[1], "focused stream", Some(Palette::YELLOW));
@@ -783,11 +762,6 @@ fn trading_floor(f: &mut TuiFrame, area: Rect, app: &AppState) {
     }
     let floor_accent_fg = app.theme.accent.fg.unwrap_or(Color::Reset);
     for s in &app.sessions {
-        let bg = if s.is_active {
-            Palette::FAINT
-        } else {
-            Palette::PAPER
-        };
         let bar = if s.is_active { "▌" } else { " " };
         let status_style = match s.status {
             SessionStatus::Live => app.theme.success,
@@ -796,17 +770,14 @@ fn trading_floor(f: &mut TuiFrame, area: Rect, app: &AppState) {
         lines.push(Line::from(vec![
             Span::styled(
                 bar,
-                Style::default()
-                    .fg(floor_accent_fg)
-                    .bg(bg)
-                    .add_modifier(Modifier::BOLD),
+                Style::default().fg(floor_accent_fg).add_modifier(Modifier::BOLD),
             ),
-            Span::styled(" █ ", status_style.bg(bg)),
-            Span::styled(format!("{:<14}", s.label), app.theme.assistant.bg(bg)),
-            Span::styled(format!(" {}m", s.message_count), app.theme.muted.bg(bg)),
+            Span::styled(" █ ", status_style),
+            Span::styled(format!("{:<14}", s.label), app.theme.assistant),
+            Span::styled(format!(" {}m", s.message_count), app.theme.muted),
         ]));
     }
-    f.render_widget(Paragraph::new(lines).style(body()), ses_inner);
+    f.render_widget(Paragraph::new(lines), ses_inner);
 
     // ── tool log (bot-left) — live audit data when available
     let tl_inner = section_header(f, bot[0], "tool log", None);
@@ -925,7 +896,7 @@ fn trading_floor(f: &mut TuiFrame, area: Rect, app: &AppState) {
                     .add_modifier(Modifier::DIM),
                 DiffKind::Added => Style::default().fg(Palette::GREEN),
                 DiffKind::Removed => Style::default().fg(Palette::RED),
-                DiffKind::Ctx => Style::default().fg(Palette::INK),
+                DiffKind::Ctx => Style::default(),
             };
             lines.push(Line::from(Span::styled(ln.text.clone(), style)));
         }
@@ -966,12 +937,12 @@ fn trading_floor(f: &mut TuiFrame, area: Rect, app: &AppState) {
         (
             "input",
             super::state::format_thousands(app.prompt_tokens_total),
-            Palette::INK,
+            app.theme.body_fg,
         ),
         (
             "output",
             super::state::format_thousands(app.completion_tokens_total),
-            Palette::INK,
+            app.theme.body_fg,
         ),
         (
             "tools",
@@ -1008,7 +979,7 @@ fn trading_floor(f: &mut TuiFrame, area: Rect, app: &AppState) {
         };
         lines.push(Line::from(vec![
             Span::styled(format!(" {k}"), Style::default().fg(Palette::MUTED)),
-            Span::styled(middle, Style::default().fg(Palette::PAPER)),
+            Span::raw(middle),
             Span::styled(v, Style::default().fg(color).add_modifier(Modifier::BOLD)),
         ]));
     }
@@ -1027,7 +998,7 @@ fn trading_floor(f: &mut TuiFrame, area: Rect, app: &AppState) {
         let div_y = rows[0].y + rows[0].height - 1;
         let div = "─".repeat(v[0].width as usize);
         f.render_widget(
-            Paragraph::new(div).style(Style::default().fg(Palette::INK).bg(Palette::PAPER)),
+            Paragraph::new(div).style(app.theme.border),
             Rect {
                 x: v[0].x,
                 y: div_y,
@@ -1070,7 +1041,7 @@ fn render_empty_activity_tile(f: &mut TuiFrame, area: Rect, label: &str, msg: &s
                 .add_modifier(Modifier::BOLD),
         )),
         Line::from(""),
-        Line::from(Span::styled(msg, Style::default().fg(Palette::INK))),
+        Line::from(Span::raw(msg.to_string())),
         Line::from(Span::styled(
             "Delegation/runtime wiring has not been enabled yet.",
             Style::default().fg(Palette::MUTED),
@@ -1095,12 +1066,7 @@ fn draw_v_divider(f: &mut TuiFrame, area: Rect) {
     }
     let x = area.x + area.width - 1;
     let lines: Vec<Line<'static>> = (0..area.height)
-        .map(|_| {
-            Line::from(Span::styled(
-                "│",
-                Style::default().fg(Palette::INK).bg(Palette::PAPER),
-            ))
-        })
+        .map(|_| Line::from(Span::raw("│")))
         .collect();
     f.render_widget(
         Paragraph::new(lines),

--- a/src/tui/widgets.rs
+++ b/src/tui/widgets.rs
@@ -6,23 +6,18 @@ use ratatui::{
     widgets::{Block, BorderType, Borders, Paragraph, Wrap},
 };
 
-use super::theme::{Palette, Theme, inverse};
+use super::theme::{Palette, Theme};
 
-// YYC-52 (Task 9): widgets.rs hosts the structural Bauhaus shell of the
-// TUI — frames, section headers, the prompt row, the ticker, and the
-// tool-call card. Most "structural" styles (the inverse INK/PAPER title
-// bars, the SLATE tool-card header, the RED ticker pill, the mode pill
-// inverse) intentionally remain on `Palette::*` per the design canvas:
-// these elements are the brutalist chrome and don't follow the active
-// chat theme. Chat-role styles (border edges, body fill, muted hint
-// text, capacity-warning fg) are now read from the active `Theme` via
-// the `theme: &Theme` parameter threaded into each public widget.
+// widgets.rs hosts the structural shell of the TUI — frames, section
+// headers, the prompt row, the ticker, the tool-call card. Backgrounds
+// are deliberately omitted everywhere so the active terminal theme
+// shows through and copy-paste captures plain text. Emphasis is carried
+// by foreground color, bold, brackets, and box-drawing borders.
 
-/// Bauhaus framed window: thick double-line border, title bar with `▓▓` mark
-/// + uppercase title on left, status pill on right. Matches the design's
-/// `Frame` component (boxShadow handled with paper bg fill).
+/// Framed window: thick border, title bar with `▓▓` mark + uppercase
+/// title on left, status pill on right.
 ///
-/// `accent` overrides the title-bar background; default is ink black.
+/// `accent` recolors the title-bar foreground; default is `theme.border`.
 pub fn frame(
     f: &mut TuiFrame,
     area: Rect,
@@ -35,18 +30,13 @@ pub fn frame(
         return area;
     }
 
-    // Outer block — paint themed background and the themed border edge.
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Thick)
-        .border_style(theme.border)
-        .style(Style::default().fg(theme.body_fg).bg(theme.body_bg));
+        .border_style(theme.border);
     let inner = block.inner(area);
     f.render_widget(block, area);
 
-    // Title bar = first line inside the border. The title bar itself is
-    // structural inverse (INK on PAPER) — the design's brutalist chrome
-    // doesn't recolor with the active theme.
     if inner.height == 0 {
         return inner;
     }
@@ -56,16 +46,8 @@ pub fn frame(
         width: inner.width,
         height: 1,
     };
-    let bar_bg = accent.unwrap_or(Palette::INK);
-    let bar_fg = if accent.is_some() {
-        Palette::INK
-    } else {
-        Palette::PAPER
-    };
-    let bar_style = Style::default()
-        .fg(bar_fg)
-        .bg(bar_bg)
-        .add_modifier(Modifier::BOLD);
+    let bar_fg = accent.unwrap_or_else(|| theme.body_fg);
+    let bar_style = Style::default().fg(bar_fg).add_modifier(Modifier::BOLD);
 
     let mut spans = vec![
         Span::styled(" ▓▓ ", bar_style),
@@ -76,19 +58,12 @@ pub fn frame(
         let used: u16 = (4 + title.chars().count() + status_text.chars().count()) as u16;
         if used < bar.width {
             let pad = " ".repeat((bar.width - used) as usize);
-            spans.push(Span::styled(pad, bar_style));
+            spans.push(Span::raw(pad));
         }
         spans.push(Span::styled(status_text, bar_style));
-    } else {
-        let used: u16 = (4 + title.chars().count()) as u16;
-        if used < bar.width {
-            let pad = " ".repeat((bar.width - used) as usize);
-            spans.push(Span::styled(pad, bar_style));
-        }
     }
-    f.render_widget(Paragraph::new(Line::from(spans)).style(bar_style), bar);
+    f.render_widget(Paragraph::new(Line::from(spans)), bar);
 
-    // Body region = everything below the title bar.
     Rect {
         x: inner.x,
         y: inner.y + 1,
@@ -97,23 +72,14 @@ pub fn frame(
     }
 }
 
-/// Render a child "section" header inside a pane (one ink line, paper text).
-///
-/// Section headers are structural inverse chrome (INK/PAPER) per the
-/// Bauhaus design canvas — the bar itself doesn't recolor with the
-/// active theme. The optional `accent` arg lets callers stamp a
-/// theme-derived emphasis color (e.g. `theme.accent.fg`).
+/// Render a section header inside a pane: `▣ LABEL` plus an underline,
+/// foreground emphasis only so the terminal background shows through.
 pub fn section_header(f: &mut TuiFrame, area: Rect, label: &str, accent: Option<Color>) -> Rect {
     if area.height == 0 {
         return area;
     }
-    let bg = accent.unwrap_or(Palette::INK);
-    let fg = if accent.is_some() {
-        Palette::INK
-    } else {
-        Palette::PAPER
-    };
-    let style = Style::default().fg(fg).bg(bg).add_modifier(Modifier::BOLD);
+    let fg = accent.unwrap_or(Color::Reset);
+    let style = Style::default().fg(fg).add_modifier(Modifier::BOLD);
     let bar = Rect {
         x: area.x,
         y: area.y,
@@ -121,12 +87,7 @@ pub fn section_header(f: &mut TuiFrame, area: Rect, label: &str, accent: Option<
         height: 1,
     };
     let text = format!(" ▣ {} ", label.to_uppercase());
-    let pad_total = area.width as usize;
-    let mut display = text.clone();
-    if display.chars().count() < pad_total {
-        display.push_str(&" ".repeat(pad_total - display.chars().count()));
-    }
-    f.render_widget(Paragraph::new(display).style(style), bar);
+    f.render_widget(Paragraph::new(text).style(style), bar);
     Rect {
         x: area.x,
         y: area.y + 1,
@@ -135,24 +96,18 @@ pub fn section_header(f: &mut TuiFrame, area: Rect, label: &str, accent: Option<
     }
 }
 
-/// A status pill rendered inline as a Span (uppercase, padded).
-///
-/// Pills are structural design elements: when `filled` the foreground
-/// is the inverse PAPER (per the Bauhaus chrome), and the caller-
-/// supplied `color` is the background. The hollow variant uses the
-/// caller color as the foreground. Theme integration happens at the
-/// call site by passing e.g. `theme.error.fg.unwrap_or(Palette::RED)`.
+/// Status pill rendered inline. Foreground-only — bracketed when
+/// `filled` to keep emphasis without painting a background.
 pub fn pill(text: &str, color: Color, filled: bool) -> Span<'static> {
-    let body = format!(" {} ", text.to_uppercase());
-    let style = if filled {
-        Style::default()
-            .fg(Palette::PAPER)
-            .bg(color)
-            .add_modifier(Modifier::BOLD)
+    let body = if filled {
+        format!("[{}]", text.to_uppercase())
     } else {
-        Style::default().fg(color).add_modifier(Modifier::BOLD)
+        format!(" {} ", text.to_uppercase())
     };
-    Span::styled(body, style)
+    Span::styled(
+        body,
+        Style::default().fg(color).add_modifier(Modifier::BOLD),
+    )
 }
 
 /// Sparkline characters — 1 char per value.
@@ -185,26 +140,14 @@ pub fn tool_call_lines(
     let header = format!(" ┏ {name:<28}{label:>14} ");
     lines.push(Line::from(Span::styled(
         header,
-        Style::default()
-            .fg(color)
-            .bg(Palette::FAINT)
-            .add_modifier(Modifier::BOLD),
+        Style::default().fg(color).add_modifier(Modifier::BOLD),
     )));
     lines.push(Line::from(Span::styled(
         format!(" ┃ {}", args),
-        Style::default().fg(Palette::MUTED).bg(Palette::PAPER),
+        Style::default().fg(Palette::MUTED),
     )));
-    if let Some(r) = result {
-        lines.push(Line::from(Span::styled(
-            format!(" ┗ {}", r),
-            Style::default().fg(Palette::INK).bg(Palette::PAPER),
-        )));
-    } else {
-        lines.push(Line::from(Span::styled(
-            " ┗".to_string(),
-            Style::default().fg(Palette::INK).bg(Palette::PAPER),
-        )));
-    }
+    let tail = result.map(|r| format!(" ┗ {}", r)).unwrap_or_else(|| " ┗".to_string());
+    lines.push(Line::from(Span::raw(tail)));
     lines
 }
 
@@ -230,18 +173,12 @@ pub fn reasoning_lines(text: &str, hidden: bool, theme: &Theme) -> Vec<Line<'sta
     }
     let mut lines = vec![Line::from(Span::styled(
         " ▒ THINKING",
-        Style::default()
-            .fg(Palette::INK)
-            .bg(Palette::FAINT)
-            .add_modifier(Modifier::BOLD),
+        theme.muted.add_modifier(Modifier::BOLD),
     ))];
     for raw in text.lines() {
         lines.push(Line::from(Span::styled(
             format!(" ▒ {}", raw),
-            Style::default()
-                .fg(Palette::INK)
-                .bg(Palette::FAINT)
-                .add_modifier(Modifier::ITALIC),
+            theme.muted.add_modifier(Modifier::ITALIC),
         )));
     }
     lines
@@ -283,7 +220,7 @@ pub fn render_message_body(
     if area.width < 3 || area.height == 0 {
         return;
     }
-    let body_style = Style::default().fg(theme.body_fg).bg(theme.body_bg);
+    let body_style = Style::default().fg(theme.body_fg);
     let bar = Rect {
         x: area.x,
         y: area.y,
@@ -295,8 +232,7 @@ pub fn render_message_body(
             std::iter::repeat_with(|| Line::from(Span::styled("▎", Style::default().fg(accent))))
                 .take(area.height as usize)
                 .collect::<Vec<_>>(),
-        )
-        .style(body_style),
+        ),
         bar,
     );
     let body_area = Rect {
@@ -339,8 +275,7 @@ pub fn prompt_row(
     if area.height < 2 {
         return (area.x, area.y);
     }
-    let body_style = Style::default().fg(theme.body_fg).bg(theme.body_bg);
-    // Top divider — themed border edge across the prompt row.
+    let body_style = Style::default().fg(theme.body_fg);
     let layout = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
@@ -350,26 +285,18 @@ pub fn prompt_row(
         ])
         .split(area);
 
-    // Divider row
     let div = "─".repeat(area.width as usize);
     f.render_widget(Paragraph::new(div).style(theme.border), layout[0]);
 
-    // Mode pill is structural inverse (PAPER on INK) — design-locked
-    // so the active mode badge stays unmistakable across themes.
     let mode_pill = Span::styled(
-        format!(" {} ", mode),
+        format!("[{}]", mode),
         Style::default()
-            .fg(Palette::PAPER)
-            .bg(Palette::INK)
+            .fg(theme.body_fg)
             .add_modifier(Modifier::BOLD),
     );
-    // Caret is structural RED — always the "send" cue, regardless of theme.
     let caret = Span::styled(
         " ❯ ",
-        Style::default()
-            .fg(Palette::RED)
-            .bg(theme.body_bg)
-            .add_modifier(Modifier::BOLD),
+        Style::default().fg(Palette::RED).add_modifier(Modifier::BOLD),
     );
     let input_span = Span::styled(input.to_string(), body_style);
     let cursor_block = Span::styled(
@@ -381,28 +308,21 @@ pub fn prompt_row(
         }),
     );
     let line = Line::from(vec![mode_pill, caret, input_span, cursor_block]);
-    f.render_widget(Paragraph::new(line).style(body_style), layout[1]);
+    f.render_widget(Paragraph::new(line), layout[1]);
 
-    // Cursor position: after mode pill (mode width + 2 spaces) + caret (3) + input chars
     let mode_width = mode.chars().count() as u16 + 2;
     let cursor_x = layout[1].x + mode_width + 3 + input.chars().count() as u16;
     let cursor_y = layout[1].y;
 
-    // Hints row
     let muted_style = theme.muted;
     let mut hint_spans: Vec<Span<'static>> = Vec::new();
     for (i, (key, label)) in hints.iter().enumerate() {
         if i > 0 {
-            hint_spans.push(Span::styled("  ", muted_style));
+            hint_spans.push(Span::raw("  "));
         }
-        // Hint key chip — structural inverse (PAPER-on-INK) so the
-        // keybinding chip is visually consistent across themes.
         hint_spans.push(Span::styled(
-            format!(" {key} "),
-            Style::default()
-                .fg(Palette::PAPER)
-                .bg(Palette::INK)
-                .add_modifier(Modifier::BOLD),
+            format!("[{key}]"),
+            Style::default().fg(theme.body_fg).add_modifier(Modifier::BOLD),
         ));
         hint_spans.push(Span::styled(format!(" {label}"), muted_style));
     }
@@ -413,10 +333,7 @@ pub fn prompt_row(
     let model_len = model_status.chars().count() as u16;
     if hint_text_len + model_len + 2 < area.width {
         let pad = " ".repeat((area.width - hint_text_len - model_len - 1) as usize);
-        hint_spans.push(Span::styled(pad, muted_style));
-        // YYC-60: color the model_status span by context capacity ratio.
-        // ≤70% follows the active theme's body fg; 70-90% / >90% use the
-        // structural warn palette so the urgency cue is theme-agnostic.
+        hint_spans.push(Span::raw(pad));
         let status_fg = if capacity_ratio > 0.90 {
             Palette::RED
         } else if capacity_ratio > 0.70 {
@@ -426,71 +343,35 @@ pub fn prompt_row(
         };
         hint_spans.push(Span::styled(
             format!(" {model_status}"),
-            Style::default()
-                .fg(status_fg)
-                .bg(theme.body_bg)
-                .add_modifier(Modifier::BOLD),
+            Style::default().fg(status_fg).add_modifier(Modifier::BOLD),
         ));
     }
-    f.render_widget(
-        Paragraph::new(Line::from(hint_spans)).style(body_style),
-        layout[2],
-    );
+    f.render_widget(Paragraph::new(Line::from(hint_spans)), layout[2]);
 
     (cursor_x, cursor_y)
 }
 
-/// Bottom ticker strip — used in trading floor view. Scrolling text of recent
-/// sub-agent activity.
-///
-/// The ticker is structural inverse chrome (PAPER on INK) with a RED
-/// "TICKER" pill — the design canvas treats it as a fixed brutalist
-/// element, so it intentionally does not follow the active theme.
+/// Bottom ticker strip — used in trading floor view. Scrolling text of
+/// recent sub-agent activity. Foreground emphasis only.
 pub fn ticker(f: &mut TuiFrame, area: Rect, cells: &[(String, String, Color)]) {
     if area.height == 0 {
         return;
     }
     let mut spans = vec![Span::styled(
-        " TICKER ",
-        Style::default()
-            .fg(Palette::PAPER)
-            .bg(Palette::RED)
-            .add_modifier(Modifier::BOLD),
+        "[TICKER] ",
+        Style::default().fg(Palette::RED).add_modifier(Modifier::BOLD),
     )];
     for (sub, msg, color) in cells {
-        spans.push(Span::styled(
-            " ".to_string(),
-            Style::default().fg(Palette::PAPER).bg(Palette::INK),
-        ));
-        spans.push(Span::styled(
-            "█".to_string(),
-            Style::default().fg(*color).bg(Palette::INK),
-        ));
+        spans.push(Span::raw(" "));
+        spans.push(Span::styled("█", Style::default().fg(*color)));
         spans.push(Span::styled(
             format!(" #{sub} "),
-            Style::default()
-                .fg(Palette::PAPER)
-                .bg(Palette::INK)
-                .add_modifier(Modifier::BOLD),
+            Style::default().add_modifier(Modifier::BOLD),
         ));
-        spans.push(Span::styled(
-            format!("{msg} "),
-            Style::default().fg(Palette::PAPER).bg(Palette::INK),
-        ));
-        spans.push(Span::styled(
-            "│",
-            Style::default().fg(Palette::MUTED).bg(Palette::INK),
-        ));
+        spans.push(Span::raw(format!("{msg} ")));
+        spans.push(Span::styled("│", Style::default().fg(Palette::MUTED)));
     }
-    // Pad to full width with ink bg
-    let used: u16 = spans.iter().map(|s| s.content.chars().count() as u16).sum();
-    if used < area.width {
-        spans.push(Span::styled(
-            " ".repeat((area.width - used) as usize),
-            Style::default().bg(Palette::INK),
-        ));
-    }
-    f.render_widget(Paragraph::new(Line::from(spans)).style(inverse()), area);
+    f.render_widget(Paragraph::new(Line::from(spans)), area);
 }
 
 /// Render a structured tool-call card per the design canvas (YYC-74).
@@ -566,78 +447,55 @@ pub fn tool_card(
     }
     let gap = inner_w.saturating_sub(left_chars + right_chars);
 
-    // Continuous border around the whole card. Header rows sit on
-    // SLATE (including the top border row's bg); body rows sit on
-    // FAINT (which is darker than the TUI's PAPER but lighter than
-    // SLATE) so the title visually separates without ever breaking
-    // the outer rectangle.
-    let header_bg = Palette::SLATE;
-    let body_bg = Palette::FAINT;
-    let header_border = Style::default().fg(Palette::MUTED).bg(header_bg);
-    let body_border = Style::default().fg(Palette::MUTED).bg(body_bg);
+    // Border-only card. Foreground emphasis carries the visual hierarchy
+    // so the active terminal background shows through and copy-paste
+    // captures plain text.
+    let border = Style::default().fg(Palette::MUTED);
 
-    // ── Top border: ┌──...──┐ on SLATE so it merges with the header.
     let mut out = vec![Line::from(vec![
-        Span::styled("┌", header_border),
-        Span::styled("─".repeat(inner_w), header_border),
-        Span::styled("┐", header_border),
+        Span::styled("┌", border),
+        Span::styled("─".repeat(inner_w), border),
+        Span::styled("┐", border),
     ])];
 
-    // ── Header content: │ pill params  ...  status_pill │ on SLATE.
     let mut header: Vec<Span<'static>> = Vec::new();
-    header.push(Span::styled("│", header_border));
+    header.push(Span::styled("│", border));
     header.push(Span::styled(
         name_pill_text,
-        Style::default()
-            .fg(Palette::PAPER)
-            .bg(Palette::INK)
-            .add_modifier(Modifier::BOLD),
+        Style::default().add_modifier(Modifier::BOLD),
     ));
     if !params_text.is_empty() {
-        header.push(Span::styled(
-            params_text,
-            Style::default().fg(Palette::INK).bg(header_bg),
-        ));
+        header.push(Span::raw(params_text));
     }
     if gap > 0 {
-        header.push(Span::styled(
-            " ".repeat(gap),
-            Style::default().bg(header_bg),
-        ));
+        header.push(Span::raw(" ".repeat(gap)));
     }
     header.push(Span::styled(
         pill_body,
-        Style::default()
-            .fg(Palette::PAPER)
-            .bg(color)
-            .add_modifier(Modifier::BOLD),
+        Style::default().fg(color).add_modifier(Modifier::BOLD),
     ));
-    header.push(Span::styled("│", header_border));
+    header.push(Span::styled("│", border));
     out.push(Line::from(header));
 
-    // ── Body rows: │  text...padding  │ on FAINT.
     let body_indent = "  ";
     let body_inner = inner_w.saturating_sub(body_indent.chars().count());
 
     let render_body = |spans: &mut Vec<Span<'static>>, used: usize| {
         let pad = inner_w.saturating_sub(used);
         if pad > 0 {
-            spans.push(Span::styled(" ".repeat(pad), Style::default().bg(body_bg)));
+            spans.push(Span::raw(" ".repeat(pad)));
         }
-        spans.push(Span::styled("│", body_border));
+        spans.push(Span::styled("│", border));
     };
 
     if let Some(meta) = result_meta {
         let used = body_indent.chars().count() + meta.chars().count();
         let mut spans = vec![
-            Span::styled("│", body_border),
-            Span::styled(body_indent.to_string(), Style::default().bg(body_bg)),
+            Span::styled("│", border),
+            Span::raw(body_indent.to_string()),
             Span::styled(
                 meta.to_string(),
-                Style::default()
-                    .fg(Palette::MUTED)
-                    .bg(body_bg)
-                    .add_modifier(Modifier::BOLD),
+                Style::default().fg(Palette::MUTED).add_modifier(Modifier::BOLD),
             ),
         ];
         render_body(&mut spans, used);
@@ -652,33 +510,24 @@ pub fn tool_card(
                 chars.push('…');
             }
             let body: String = chars.iter().collect();
-            // YYC-74 bonus: diff coloring on lines that look like
-            // unified-diff entries (`+ ...` / `- ...`). Header lines
-            // (NEW FILE / MODIFIED / EDITED · path) get bold muted.
             let body_style = if body.starts_with("+ ") || body.starts_with("+") && body != "+" {
-                Style::default().fg(Palette::GREEN).bg(body_bg)
+                Style::default().fg(Palette::GREEN)
             } else if body.starts_with("- ") || body.starts_with("-") && body != "-" {
-                Style::default().fg(Palette::RED).bg(body_bg)
+                Style::default().fg(Palette::RED)
             } else if body.starts_with("NEW FILE")
                 || body.starts_with("MODIFIED")
                 || body.starts_with("EDITED")
             {
-                Style::default()
-                    .fg(Palette::MUTED)
-                    .bg(body_bg)
-                    .add_modifier(Modifier::BOLD)
+                Style::default().fg(Palette::MUTED).add_modifier(Modifier::BOLD)
             } else if body.starts_with("… ") {
-                Style::default()
-                    .fg(Palette::MUTED)
-                    .bg(body_bg)
-                    .add_modifier(Modifier::ITALIC)
+                Style::default().fg(Palette::MUTED).add_modifier(Modifier::ITALIC)
             } else {
-                Style::default().fg(Palette::INK).bg(body_bg)
+                Style::default()
             };
             let used = body_indent.chars().count() + body.chars().count();
             let mut spans = vec![
-                Span::styled("│", body_border),
-                Span::styled(body_indent.to_string(), Style::default().bg(body_bg)),
+                Span::styled("│", border),
+                Span::raw(body_indent.to_string()),
                 Span::styled(body, body_style),
             ];
             render_body(&mut spans, used);
@@ -686,7 +535,6 @@ pub fn tool_card(
         }
     }
 
-    // ── YYC-78: long-output footer when the result was clipped.
     if elided_lines > 0 {
         let footer = format!(
             "… {elided_lines} more line{} elided",
@@ -694,25 +542,21 @@ pub fn tool_card(
         );
         let used = body_indent.chars().count() + footer.chars().count();
         let mut spans = vec![
-            Span::styled("│", body_border),
-            Span::styled(body_indent.to_string(), Style::default().bg(body_bg)),
+            Span::styled("│", border),
+            Span::raw(body_indent.to_string()),
             Span::styled(
                 footer,
-                Style::default()
-                    .fg(Palette::MUTED)
-                    .bg(body_bg)
-                    .add_modifier(Modifier::ITALIC),
+                Style::default().fg(Palette::MUTED).add_modifier(Modifier::ITALIC),
             ),
         ];
         render_body(&mut spans, used);
         out.push(Line::from(spans));
     }
 
-    // ── Bottom border on FAINT, closing the rectangle.
     out.push(Line::from(vec![
-        Span::styled("└", body_border),
-        Span::styled("─".repeat(inner_w), body_border),
-        Span::styled("┘", body_border),
+        Span::styled("└", border),
+        Span::styled("─".repeat(inner_w), border),
+        Span::styled("┘", border),
     ]));
 
     out


### PR DESCRIPTION
Hardcoded bg fills (Palette::PAPER/INK/FAINT/SLATE) painted Bauhaus
chrome over the active terminal, breaking copy-paste and ignoring the
selected Theme. Drop bg from every role in system/default-light/dracula
and from widgets/views/mod call sites; pin body_bg = Color::Reset across
all themes. Replace hardcoded INK/PAPER foregrounds with theme.body_fg
so terminal text color also conforms. Re-emphasize chrome via bold,
brackets, and box-drawing borders.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>