### PR TITLE
YYC-94: /provider slash command + Agent runtime swap

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -51,6 +51,11 @@ pub struct Agent {
     /// Agent, hook registry, tools, memory, or session state.
     provider_config: ProviderConfig,
     provider_api_key: String,
+    /// Name of the active named provider profile from `[providers.<name>]`,
+    /// or `None` when running on the unnamed legacy `[provider]` block.
+    /// Set by `switch_provider`; surfaced via `active_profile()` so the
+    /// TUI can label which profile a turn will hit (YYC-94).
+    active_profile: Option<String>,
     /// LSP server pool (YYC-46). Lazy: servers spawn on first tool
     /// invocation that needs one. Reaped in `end_session`.
     lsp_manager: Arc<crate::code::lsp::LspManager>,
@@ -240,6 +245,7 @@ impl Agent {
             pricing,
             provider_config: config.provider.clone(),
             provider_api_key: api_key,
+            active_profile: None,
             lsp_manager,
             last_saved_count: 0,
             max_iterations: config.provider.max_iterations,
@@ -261,6 +267,12 @@ impl Agent {
 
     pub fn active_model(&self) -> &str {
         &self.provider_config.model
+    }
+
+    /// Name of the active named provider profile, or `None` when running
+    /// on the legacy unnamed `[provider]` block (YYC-94).
+    pub fn active_profile(&self) -> Option<&str> {
+        self.active_profile.as_deref()
     }
 
     pub fn max_context(&self) -> usize {
@@ -300,6 +312,61 @@ impl Agent {
         self.provider_config = next_config;
         self.context = ContextManager::new(selection.max_context);
         self.pricing = selection.pricing.clone();
+
+        Ok(selection)
+    }
+
+    /// Switch to a named provider profile from `Config.providers` (YYC-94).
+    /// Rebuilds the underlying `OpenAIProvider` against the chosen profile
+    /// (base URL, model, retries, debug mode), refreshes the model catalog,
+    /// and updates context window + pricing. Hooks, tools, memory, and the
+    /// in-flight session state are left untouched.
+    ///
+    /// Pass `None` to revert to the unnamed legacy `[provider]` block.
+    pub async fn switch_provider(
+        &mut self,
+        profile: Option<&str>,
+        config: &Config,
+    ) -> Result<ModelSelection> {
+        if self.turn_cancel.is_cancelled() {
+            self.turn_cancel = CancellationToken::new();
+        }
+
+        let next_config = match profile {
+            Some(name) => config
+                .providers
+                .get(name)
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("Provider profile '{name}' not found in config"))?,
+            None => config.provider.clone(),
+        };
+        let api_key = config.api_key_for(&next_config).ok_or_else(|| {
+            anyhow::anyhow!(
+                "No API key for provider '{}' (set VULCAN_API_KEY or supply api_key in config)",
+                profile.unwrap_or("[provider]"),
+            )
+        })?;
+
+        let selection = Self::resolve_model_selection(&next_config, &api_key).await?;
+        let provider: Box<dyn LLMProvider> = Box::new(
+            OpenAIProvider::new(
+                &next_config.base_url,
+                &api_key,
+                &next_config.model,
+                selection.max_context,
+                next_config.max_retries,
+                selection.model.features.json_mode,
+                next_config.debug,
+            )
+            .context("Failed to initialize LLM provider")?,
+        );
+
+        self.provider = provider;
+        self.provider_config = next_config;
+        self.provider_api_key = api_key;
+        self.context = ContextManager::new(selection.max_context);
+        self.pricing = selection.pricing.clone();
+        self.active_profile = profile.map(str::to_string);
 
         Ok(selection)
     }
@@ -406,6 +473,7 @@ impl Agent {
             pricing: None,
             provider_config: ProviderConfig::default(),
             provider_api_key: "test-key".into(),
+            active_profile: None,
             lsp_manager: Arc::new(crate::code::lsp::LspManager::new(
                 std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
             )),

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -141,6 +141,13 @@ const SLASH_COMMANDS: &[SlashCommand] = &[
         mid_turn_safe: false,
     },
     SlashCommand {
+        name: "provider",
+        description: "List or switch named providers: /provider [name|default]",
+        // Rebuilds the provider against a different profile; same idle
+        // requirement as /model.
+        mid_turn_safe: false,
+    },
+    SlashCommand {
         name: "diff-style",
         description: "Set diff render: /diff-style <unified|side-by-side|inline>",
         mid_turn_safe: true,
@@ -189,6 +196,31 @@ fn format_model_list(active_model: &str, models: &[crate::provider::catalog::Mod
         out.push_str(&format!("\n  ... {} more", models.len() - 30));
     }
     out.push_str("\n\nUse /model <id> to switch.");
+    out
+}
+
+fn format_provider_list(config: &Config, active: Option<&str>) -> String {
+    let mut out = String::from("Provider profiles:");
+    let default_marker = if active.is_none() { "*" } else { " " };
+    out.push_str(&format!(
+        "\n  {default_marker} default · {} · {}",
+        config.provider.base_url, config.provider.model,
+    ));
+
+    let mut names: Vec<&String> = config.providers.keys().collect();
+    names.sort();
+    for name in names {
+        let cfg = &config.providers[name];
+        let marker = if active == Some(name.as_str()) { "*" } else { " " };
+        out.push_str(&format!(
+            "\n  {marker} {name} · {} · {}",
+            cfg.base_url, cfg.model,
+        ));
+    }
+    if config.providers.is_empty() {
+        out.push_str("\n  (no named [providers.<name>] profiles configured)");
+    }
+    out.push_str("\n\nUse /provider <name> to switch, /provider default to revert.");
     out
 }
 
@@ -1101,6 +1133,56 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                                         });
                                                         continue;
                                                     }
+                                                    s if s == "provider" || s.starts_with("provider ") => {
+                                                        let arg = s["provider".len()..].trim();
+                                                        if arg.is_empty() {
+                                                            let report = {
+                                                                let a = agent.lock().await;
+                                                                format_provider_list(config, a.active_profile())
+                                                            };
+                                                            app.messages.push(ChatMessage {
+                                                                role: ChatRole::System,
+                                                                content: report,
+                                                                ..Default::default()
+                                                            });
+                                                            continue;
+                                                        }
+
+                                                        let target: Option<&str> = if arg.eq_ignore_ascii_case("default") {
+                                                            None
+                                                        } else {
+                                                            Some(arg)
+                                                        };
+                                                        let result = {
+                                                            let mut a = agent.lock().await;
+                                                            a.switch_provider(target, config).await
+                                                        };
+                                                        match result {
+                                                            Ok(selection) => {
+                                                                app.model_label = selection.model.id.clone();
+                                                                app.token_max = selection.max_context as u32;
+                                                                app.pricing = selection.pricing;
+                                                                let label = target.unwrap_or("default");
+                                                                app.messages.push(ChatMessage {
+                                                                    role: ChatRole::System,
+                                                                    content: format!(
+                                                                        "Provider switched to {label} · {} · context {}",
+                                                                        app.model_label,
+                                                                        crate::tui::state::format_thousands(app.token_max),
+                                                                    ),
+                                                                    ..Default::default()
+                                                                });
+                                                            }
+                                                            Err(e) => {
+                                                                app.messages.push(ChatMessage {
+                                                                    role: ChatRole::System,
+                                                                    content: format!("Provider switch failed: {e}"),
+                                                                    ..Default::default()
+                                                                });
+                                                            }
+                                                        }
+                                                        continue;
+                                                    }
                                                     s if s == "model" || s.starts_with("model ") => {
                                                         let arg = s["model".len()..].trim();
                                                         if arg.is_empty() {
@@ -1316,6 +1398,51 @@ mod tests {
 
         assert!(!command.mid_turn_safe);
         assert_eq!(filter_commands("mod")[0].name, "model");
+    }
+
+    #[test]
+    fn provider_command_is_available_and_deferred_mid_turn() {
+        let command = SLASH_COMMANDS
+            .iter()
+            .find(|cmd| cmd.name == "provider")
+            .expect("provider slash command");
+
+        assert!(!command.mid_turn_safe);
+        assert_eq!(filter_commands("prov")[0].name, "provider");
+    }
+
+    #[test]
+    fn format_provider_list_marks_active_profile_and_lists_named() {
+        use crate::config::{Config, ProviderConfig};
+        use std::collections::HashMap;
+
+        let mut providers = HashMap::new();
+        let mut local = ProviderConfig::default();
+        local.base_url = "http://localhost:11434/v1".into();
+        local.model = "qwen2.5".into();
+        providers.insert("local".into(), local);
+
+        let mut config = Config::default();
+        config.provider.base_url = "https://openrouter.ai/api/v1".into();
+        config.provider.model = "deepseek/v4".into();
+        config.providers = providers;
+
+        let active_default = format_provider_list(&config, None);
+        assert!(active_default.contains("* default · https://openrouter.ai/api/v1 · deepseek/v4"));
+        assert!(active_default.contains("  local · http://localhost:11434/v1 · qwen2.5"));
+
+        let active_local = format_provider_list(&config, Some("local"));
+        assert!(active_local.contains("  default · https://openrouter.ai/api/v1"));
+        assert!(active_local.contains("* local · http://localhost:11434/v1"));
+    }
+
+    #[test]
+    fn format_provider_list_handles_no_named_profiles() {
+        use crate::config::Config;
+        let config = Config::default();
+        let report = format_provider_list(&config, None);
+        assert!(report.contains("* default"));
+        assert!(report.contains("(no named [providers.<name>] profiles configured)"));
     }
 
     #[test]


### PR DESCRIPTION
Switch the active OpenAI-compatible provider profile at runtime
without rebuilding the long-lived Agent. Adds:

- Agent::switch_provider(profile, config): swaps the underlying
  OpenAIProvider, refetches the catalog, updates context window,
  pricing, and active_profile. Hooks, tools, memory, in-flight
  session state are preserved.
- Agent::active_profile(): None on the legacy [provider] block,
  Some(name) once a named profile is active.
- /provider slash command (mid_turn_safe = false):
    /provider           — list named profiles + legacy default,
                          mark active
    /provider <name>    — switch
    /provider default   — revert to legacy [provider]
- Confirmation system message on success; surfaces switch failures
  inline (missing profile, missing API key, catalog rejection).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>