### PR TITLE
YYC-96: Show active provider in prompt status line

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -519,12 +519,14 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
     // YYC-67: pull catalog pricing for the cost estimate.
     // YYC-95: if resume restored a provider profile the active model/context
     // window changed under us — sync the app surface from the agent.
+    // YYC-96: surface the active profile name in the prompt-row status.
     {
         let a = agent.lock().await;
         app.diff_sink = Some(a.diff_sink().clone());
         app.pricing = a.pricing().cloned();
         app.model_label = a.active_model().to_string();
         app.token_max = a.max_context() as u32;
+        app.provider_label = a.active_profile().map(str::to_string);
     }
     refresh_sessions(&agent, &mut app).await;
 
@@ -688,6 +690,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                                     app.model_label = a.active_model().to_string();
                                                     app.token_max = a.max_context() as u32;
                                                     app.pricing = a.pricing().cloned();
+                                                    app.provider_label = a.active_profile().map(str::to_string);
                                                 }
                                                 if let Some(n) = note {
                                                     app.messages.push(ChatMessage {
@@ -1187,6 +1190,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                                                 app.model_label = selection.model.id.clone();
                                                                 app.token_max = selection.max_context as u32;
                                                                 app.pricing = selection.pricing;
+                                                                app.provider_label = target.map(str::to_string);
                                                                 let label = target.unwrap_or("default");
                                                                 app.messages.push(ChatMessage {
                                                                     role: ChatRole::System,

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -506,6 +506,10 @@ pub struct AppState {
 
     cursor: Cell<(u16, u16)>,
     pub model_label: String,
+    /// Active named provider profile, if any (YYC-96). `None` means the
+    /// session is running on the legacy unnamed `[provider]` block —
+    /// `model_status()` omits the prefix in that case.
+    pub provider_label: Option<String>,
     /// Cumulative input tokens across the whole session (every turn's
     /// `usage.prompt_tokens` summed). Used by the cost telemetry pane
     /// (YYC-67).
@@ -611,6 +615,7 @@ impl AppState {
 
             cursor: Cell::new((0, 0)),
             model_label,
+            provider_label: None,
             prompt_tokens_total: 0,
             completion_tokens_total: 0,
             prompt_tokens_last: 0,
@@ -721,12 +726,24 @@ impl AppState {
         // grouping. `used` is the latest turn's prompt_tokens (current
         // context window size); the bar represents context capacity, not
         // lifetime cost.
-        format!(
-            "{} · {} / {}",
-            self.model_label,
-            format_thousands(self.prompt_tokens_last),
-            format_thousands(self.token_max),
-        )
+        // YYC-96: when running on a named provider profile, prefix the
+        // string with `{profile} · ` so the user can tell which provider
+        // any given turn will hit.
+        match &self.provider_label {
+            Some(profile) => format!(
+                "{} · {} · {} / {}",
+                profile,
+                self.model_label,
+                format_thousands(self.prompt_tokens_last),
+                format_thousands(self.token_max),
+            ),
+            None => format!(
+                "{} · {} / {}",
+                self.model_label,
+                format_thousands(self.prompt_tokens_last),
+                format_thousands(self.token_max),
+            ),
+        }
     }
 
     /// Estimated session cost in USD, computed from cumulative token
@@ -1220,6 +1237,24 @@ mod tests {
 
         m.finish_tool("bash", true);
         assert!(m.render_version() > after_tool_start);
+    }
+
+    #[test]
+    fn model_status_omits_prefix_when_no_provider_label() {
+        let mut app = AppState::new("deepseek/v4".into(), 128_000);
+        app.prompt_tokens_last = 18_402;
+        let status = app.model_status();
+        assert_eq!(status, "deepseek/v4 · 18,402 / 128,000");
+        assert!(!status.contains(" · deepseek/v4"));
+    }
+
+    #[test]
+    fn model_status_prefixes_active_provider_label() {
+        let mut app = AppState::new("deepseek/v4".into(), 128_000);
+        app.provider_label = Some("local".into());
+        app.prompt_tokens_last = 18_402;
+        let status = app.model_status();
+        assert_eq!(status, "local · deepseek/v4 · 18,402 / 128,000");
     }
 
     #[test]


### PR DESCRIPTION
Prompt-row right side now reads `{profile} · {model} · {used} / {max}`
when a named provider profile is active, falls back to the prior
`{model} · {used} / {max}` shape when running on the legacy [provider]
block. So users can tell at a glance which provider any given turn
will hit — same model id can route through different profiles.

- AppState gains provider_label: Option<String>; model_status() reads it.
- TUI sync points refreshed: startup, /provider switch, CLI-resume,
  picker-resume — all keep app.provider_label aligned with
  Agent::active_profile().
- Tests pin both formats (prefixed when label set, unprefixed when None).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>