### PR TITLE
YYC-99: Split ~/.vulcan/config.toml into config + keybinds + providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1163,7 +1163,7 @@ dependencies = [
  "bstr",
  "gix-date",
  "gix-error",
- "winnow",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -1278,7 +1278,7 @@ dependencies = [
  "smallvec",
  "thiserror 2.0.18",
  "unicode-bom",
- "winnow",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -1617,7 +1617,7 @@ dependencies = [
  "itoa",
  "smallvec",
  "thiserror 2.0.18",
- "winnow",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -1730,7 +1730,7 @@ dependencies = [
  "maybe-async",
  "nonempty",
  "thiserror 2.0.18",
- "winnow",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -1762,7 +1762,7 @@ dependencies = [
  "gix-validate",
  "memmap2",
  "thiserror 2.0.18",
- "winnow",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -4493,10 +4493,19 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.2",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -4509,12 +4518,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.23.10+spec-1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -4932,6 +4954,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml",
+ "toml_edit",
  "tower",
  "tower-http",
  "tracing",
@@ -5480,6 +5503,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ futures-util = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1"
+toml_edit = "0.23"
 
 # CLI + TUI
 clap = { version = "4", features = ["derive"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -48,4 +48,11 @@ pub enum Command {
         #[arg(long)]
         bind: Option<String>,
     },
+    /// Split monolithic ~/.vulcan/config.toml into config + keybinds +
+    /// providers fragment files (YYC-99). Idempotent. Existing fragment
+    /// files are preserved unless `--force` is passed.
+    MigrateConfig {
+        #[arg(long)]
+        force: bool,
+    },
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,17 @@
 use anyhow::{Context, Result};
 use serde::Deserialize;
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+/// Outcome of a `Config::migrate(dir, force)` run (YYC-99). Booleans
+/// flag which fragment files the run produced so the CLI can print a
+/// honest summary.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct MigrationReport {
+    pub keybinds_written: bool,
+    pub providers_written: bool,
+    pub main_rewritten: bool,
+}
 
 /// Path to the Vulcan config directory (~/.vulcan/)
 pub fn vulcan_home() -> PathBuf {
@@ -422,33 +432,184 @@ fn default_reserved_tokens() -> usize {
 }
 
 impl Config {
-    /// Load config from ~/.vulcan/config.toml, then checks project dir as fallback.
+    /// Load config from `~/.vulcan/`, falling back to project-dir
+    /// `./config.toml` for in-repo dev runs.
+    ///
+    /// YYC-99: the config now lives across three files in the dir:
+    /// `config.toml` (main), `keybinds.toml`, `providers.toml`.
+    /// Missing files are fine; legacy monolithic `config.toml` blocks
+    /// still work and are surfaced via a deprecation log.
     pub fn load() -> Result<Self> {
-        let primary = vulcan_home().join("config.toml");
+        let home = vulcan_home();
+        if home.join("config.toml").exists()
+            || home.join("keybinds.toml").exists()
+            || home.join("providers.toml").exists()
+        {
+            return Self::load_from_dir(&home);
+        }
 
-        // Check multiple locations in order of precedence
-        let candidates = [
-            ("~/.vulcan/config.toml", primary.clone()),
-            ("./config.toml", PathBuf::from("config.toml")),
-        ];
-
-        for (label, path) in &candidates {
-            if path.exists() {
-                let content = std::fs::read_to_string(path).with_context(|| {
-                    format!("Failed to read config at {label} ({})", path.display())
-                })?;
-                let config: Config =
-                    toml::from_str(&content).context("Failed to parse config.toml")?;
-                tracing::info!("Loaded config from {}", path.display());
-                return Ok(config);
+        // Repo-relative fallback for cargo-run dev workflows.
+        let proj = std::env::current_dir().ok();
+        if let Some(dir) = proj {
+            if dir.join("config.toml").exists() {
+                return Self::load_from_dir(&dir);
             }
         }
 
         tracing::info!(
-            "No config found at ~/.vulcan/config.toml or ./config.toml, using defaults. \
+            "No config found at ~/.vulcan/ or ./config.toml — using defaults. \
              Copy config.example.toml to ~/.vulcan/config.toml and set your API key."
         );
         Ok(Config::default())
+    }
+
+    /// Load every config fragment under `dir` (`config.toml` +
+    /// `keybinds.toml` + `providers.toml`) and merge into a single
+    /// `Config`. Each file is optional. Explicit fragment files take
+    /// precedence over the same blocks inlined in the legacy
+    /// `config.toml`.
+    pub fn load_from_dir(dir: &Path) -> Result<Self> {
+        let main_path = dir.join("config.toml");
+        let mut config = if main_path.exists() {
+            let raw = std::fs::read_to_string(&main_path)
+                .with_context(|| format!("Failed to read {}", main_path.display()))?;
+            let parsed: Config = toml::from_str(&raw).with_context(|| {
+                format!("Failed to parse {}", main_path.display())
+            })?;
+            tracing::info!("Loaded main config from {}", main_path.display());
+            parsed
+        } else {
+            Config::default()
+        };
+
+        let keybinds_path = dir.join("keybinds.toml");
+        if keybinds_path.exists() {
+            let raw = std::fs::read_to_string(&keybinds_path)
+                .with_context(|| format!("Failed to read {}", keybinds_path.display()))?;
+            let kb: KeybindsConfig = toml::from_str(&raw).with_context(|| {
+                format!("Failed to parse {}", keybinds_path.display())
+            })?;
+            config.keybinds = kb;
+            tracing::info!("Loaded keybinds from {}", keybinds_path.display());
+        }
+
+        let providers_path = dir.join("providers.toml");
+        if providers_path.exists() {
+            let raw = std::fs::read_to_string(&providers_path)
+                .with_context(|| format!("Failed to read {}", providers_path.display()))?;
+            let parsed: HashMap<String, ProviderConfig> = toml::from_str(&raw)
+                .with_context(|| format!("Failed to parse {}", providers_path.display()))?;
+            // Merge: explicit providers.toml takes precedence; entries
+            // also present in `config.toml`'s `[providers.*]` survive
+            // unless the same name appears in providers.toml.
+            for (name, profile) in parsed {
+                config.providers.insert(name, profile);
+            }
+            tracing::info!("Loaded providers from {}", providers_path.display());
+        }
+
+        if main_path.exists() {
+            let raw = std::fs::read_to_string(&main_path).unwrap_or_default();
+            if raw.contains("[keybinds]") && !keybinds_path.exists() {
+                tracing::warn!(
+                    "config.toml still contains [keybinds]; consider running \
+                     `vulcan migrate-config` to split it into keybinds.toml (YYC-99)."
+                );
+            }
+            if raw.contains("[providers.") && !providers_path.exists() {
+                tracing::warn!(
+                    "config.toml still contains [providers.<name>] blocks; consider running \
+                     `vulcan migrate-config` to split them into providers.toml (YYC-99)."
+                );
+            }
+        }
+
+        Ok(config)
+    }
+
+    /// Load a single legacy `config.toml` from a specific path. Used by
+    /// `vulcan provider` which writes into a per-fragment file —
+    /// callers that just need to read the *main* config block.
+    pub fn load_from(path: &Path) -> Result<Self> {
+        if !path.exists() {
+            return Ok(Config::default());
+        }
+        let raw = std::fs::read_to_string(path)
+            .with_context(|| format!("Failed to read {}", path.display()))?;
+        toml::from_str(&raw).with_context(|| format!("Failed to parse {}", path.display()))
+    }
+
+    /// One-shot migration for users still on the monolithic
+    /// `config.toml`: extract `[keybinds]` into `keybinds.toml` and
+    /// every `[providers.<name>]` into `providers.toml`. Existing
+    /// fragment files are not overwritten unless `force` is true.
+    /// Idempotent — safe to run repeatedly.
+    pub fn migrate(dir: &Path, force: bool) -> Result<MigrationReport> {
+        let main_path = dir.join("config.toml");
+        let mut report = MigrationReport::default();
+        if !main_path.exists() {
+            return Ok(report);
+        }
+        let raw = std::fs::read_to_string(&main_path)
+            .with_context(|| format!("Failed to read {}", main_path.display()))?;
+        let mut doc: toml_edit::DocumentMut = raw
+            .parse()
+            .with_context(|| format!("Failed to parse {}", main_path.display()))?;
+
+        // ── Keybinds.
+        let keybinds_path = dir.join("keybinds.toml");
+        if let Some(item) = doc.remove("keybinds") {
+            if keybinds_path.exists() && !force {
+                tracing::warn!(
+                    "keybinds.toml already exists; leaving [keybinds] in config.toml. \
+                     Use --force to overwrite."
+                );
+                doc.insert("keybinds", item);
+            } else {
+                let table = match item.as_table() {
+                    Some(t) => t.clone(),
+                    None => anyhow::bail!("[keybinds] in config.toml is not a table"),
+                };
+                let mut out = toml_edit::DocumentMut::new();
+                for (k, v) in table.iter() {
+                    out.insert(k, v.clone());
+                }
+                std::fs::write(&keybinds_path, out.to_string())
+                    .with_context(|| format!("Failed to write {}", keybinds_path.display()))?;
+                report.keybinds_written = true;
+            }
+        }
+
+        // ── Providers.
+        let providers_path = dir.join("providers.toml");
+        if let Some(item) = doc.remove("providers") {
+            if providers_path.exists() && !force {
+                tracing::warn!(
+                    "providers.toml already exists; leaving [providers.*] in config.toml. \
+                     Use --force to overwrite."
+                );
+                doc.insert("providers", item);
+            } else {
+                let table = match item.as_table() {
+                    Some(t) => t.clone(),
+                    None => anyhow::bail!("[providers] in config.toml is not a table"),
+                };
+                let mut out = toml_edit::DocumentMut::new();
+                for (name, sub) in table.iter() {
+                    out.insert(name, sub.clone());
+                }
+                std::fs::write(&providers_path, out.to_string())
+                    .with_context(|| format!("Failed to write {}", providers_path.display()))?;
+                report.providers_written = true;
+            }
+        }
+
+        if report.keybinds_written || report.providers_written {
+            std::fs::write(&main_path, doc.to_string())
+                .with_context(|| format!("Failed to write {}", main_path.display()))?;
+            report.main_rewritten = true;
+        }
+        Ok(report)
     }
 
     /// Resolve the API key: env var > config > compile-time warning
@@ -595,5 +756,106 @@ toggle_tools = "F2"
             Some("ollama-key")
         );
         assert!(cfg.providers["local"].disable_catalog);
+    }
+
+    #[test]
+    fn load_from_dir_handles_missing_files_with_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = Config::load_from_dir(dir.path()).expect("empty dir → defaults");
+        assert!(cfg.providers.is_empty());
+        assert_eq!(cfg.keybinds.toggle_tools, "Ctrl+T");
+    }
+
+    #[test]
+    fn load_from_dir_merges_three_files() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("config.toml"),
+            r#"
+[provider]
+type = "openai-compat"
+base_url = "https://main.example/v1"
+model = "main-1"
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("keybinds.toml"),
+            r#"
+toggle_tools = "F2"
+toggle_sessions = "Ctrl+P"
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("providers.toml"),
+            r#"
+[local]
+type = "openai-compat"
+base_url = "http://localhost:11434/v1"
+model = "qwen2.5-coder:latest"
+disable_catalog = true
+"#,
+        )
+        .unwrap();
+
+        let cfg = Config::load_from_dir(dir.path()).unwrap();
+        assert_eq!(cfg.provider.base_url, "https://main.example/v1");
+        assert_eq!(cfg.keybinds.toggle_tools, "F2");
+        assert_eq!(cfg.keybinds.toggle_sessions, "Ctrl+P");
+        assert_eq!(cfg.providers["local"].model, "qwen2.5-coder:latest");
+        assert!(cfg.providers["local"].disable_catalog);
+    }
+
+    #[test]
+    fn migrate_extracts_keybinds_and_providers() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("config.toml"),
+            r#"# top comment
+[provider]
+type = "openai-compat"
+base_url = "https://x.example/v1"
+model = "x-1"
+
+[keybinds]
+toggle_tools = "F4"
+
+[providers.local]
+type = "openai-compat"
+base_url = "http://localhost:11434/v1"
+model = "qwen2.5"
+"#,
+        )
+        .unwrap();
+
+        let report = Config::migrate(dir.path(), false).unwrap();
+        assert!(report.keybinds_written);
+        assert!(report.providers_written);
+        assert!(report.main_rewritten);
+
+        // After split: original config.toml should no longer contain
+        // [keybinds] or [providers.*], the fragment files should.
+        let main_after = std::fs::read_to_string(dir.path().join("config.toml")).unwrap();
+        assert!(!main_after.contains("[keybinds]"));
+        assert!(!main_after.contains("[providers"));
+
+        let keybinds_raw = std::fs::read_to_string(dir.path().join("keybinds.toml")).unwrap();
+        assert!(keybinds_raw.contains("toggle_tools = \"F4\""));
+
+        let providers_raw =
+            std::fs::read_to_string(dir.path().join("providers.toml")).unwrap();
+        assert!(providers_raw.contains("[local]"));
+
+        // Re-run is a no-op (idempotent).
+        let report2 = Config::migrate(dir.path(), false).unwrap();
+        assert!(!report2.keybinds_written);
+        assert!(!report2.providers_written);
+
+        // Round-trip: load the migrated layout and assert behavior matches
+        // pre-migration.
+        let cfg = Config::load_from_dir(dir.path()).unwrap();
+        assert_eq!(cfg.keybinds.toggle_tools, "F4");
+        assert_eq!(cfg.providers["local"].model, "qwen2.5");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,6 +95,22 @@ async fn main() -> anyhow::Result<()> {
             init_cli_logging();
             vulcan::gateway::run(&config, bind).await?;
         }
+        Some(Command::MigrateConfig { force }) => {
+            init_cli_logging();
+            let dir = vulcan::config::vulcan_home();
+            let report = vulcan::config::Config::migrate(&dir, force)?;
+            if !report.main_rewritten {
+                println!("Nothing to migrate — config.toml already split (or absent).");
+            } else {
+                if report.keybinds_written {
+                    println!("Wrote {}/keybinds.toml", dir.display());
+                }
+                if report.providers_written {
+                    println!("Wrote {}/providers.toml", dir.display());
+                }
+                println!("Updated {}/config.toml (sections removed).", dir.display());
+            }
+        }
     }
 
     Ok(())


### PR DESCRIPTION
The single config.toml was starting to mix concerns: provider defaults,
tools, compaction, embeddings, gateway, TUI theme, keybinds, and named
provider profiles. Split it across three files so future automated
edits (vulcan provider add, future /keybind set) own a single file
instead of churning unrelated sections.

Layout under ~/.vulcan/ (and project-dir fallback):

- config.toml      — [provider], [tools], [compaction], [embeddings],
                     [tui], [gateway]
- keybinds.toml    — top-level keys mirroring the legacy [keybinds] block
- providers.toml   — [<name>] blocks (was [providers.<name>])

Config::load_from_dir merges all three; missing files fall back to
defaults. Explicit fragment files take precedence over the same blocks
inlined in the legacy config.toml. Legacy monolithic configs still
parse — Config::load logs a deprecation warning suggesting the new
`vulcan migrate-config` subcommand.

Migration path:

- Config::migrate(dir, force) auto-extracts [keybinds] + [providers.*]
  into fragment files, rewrites the main config.toml without those
  sections. Idempotent. Existing fragment files preserved unless
  --force.
- New `vulcan migrate-config [--force]` CLI subcommand wraps the call
  and prints what was written.

Tests: 4 new — empty dir → defaults, full three-file merge, migration
round-trip with idempotency check, and verification that the
post-migration load produces identical Config to the pre-migration
inline parse.

Adds toml_edit (0.23) so the migration writer preserves comments and
key ordering across the source config.toml.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>