### PR TITLE
YYC-100: vulcan auth — guided interactive provider setup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,6 +480,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,6 +734,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
+dependencies = [
+ "console",
+ "fuzzy-matcher",
+ "shell-words",
+ "tempfile",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,6 +819,12 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -1033,6 +1064,15 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
 ]
 
 [[package]]
@@ -4931,6 +4971,7 @@ dependencies = [
  "clap",
  "crossterm",
  "dhat",
+ "dialoguer",
  "divan",
  "futures-util",
  "gix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,10 @@ toml_edit = "0.23"
 
 # CLI + TUI
 clap = { version = "4", features = ["derive"] }
+# Interactive prompts for `vulcan auth` (YYC-100). Fuzzy select +
+# password input + confirm modals. Optional dep — only the auth flow
+# uses it, but cheap enough to leave in default deps.
+dialoguer = { version = "0.12", features = ["fuzzy-select", "password"] }
 ratatui = "0.30"
 crossterm = "0.29"
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,6 @@
 use clap::{Parser, Subcommand};
 
+use crate::cli_auth::AuthArgs;
 use crate::cli_provider::ProviderCommand;
 
 /// vulcan — a Rust AI agent. Forged at the forge, tested by fire.
@@ -62,4 +63,7 @@ pub enum Command {
         #[command(subcommand)]
         cmd: ProviderCommand,
     },
+    /// Guided interactive provider setup (YYC-100). Picker + prompts for
+    /// name, API key, and default model; writes to providers.toml.
+    Auth(AuthArgs),
 }

--- a/src/cli_auth.rs
+++ b/src/cli_auth.rs
@@ -285,14 +285,72 @@ fn prompt_api_key(
 }
 
 /// Heuristic for "local" endpoints — used to default-skip the API key
-/// prompt and the catalog fetch. Matches the loopback hosts and `.local`.
+/// prompt and the catalog fetch. Matches loopback, link-local, mDNS
+/// `.local`, and the RFC1918 private IPv4 ranges (10/8, 172.16/12,
+/// 192.168/16). Hostnames that resolve to private IPs but aren't
+/// literally addresses won't be caught — that needs DNS, which is too
+/// slow for an interactive prompt.
 fn is_local_endpoint(base_url: &str) -> bool {
-    let lower = base_url.to_ascii_lowercase();
-    lower.contains("localhost")
-        || lower.contains("127.0.0.1")
-        || lower.contains("0.0.0.0")
-        || lower.contains("[::1]")
-        || lower.contains(".local")
+    let host = extract_host(base_url);
+    if host.is_empty() {
+        return false;
+    }
+    if host == "localhost" || host.ends_with(".local") {
+        return true;
+    }
+    // Loopback / unspecified.
+    if host == "127.0.0.1" || host == "0.0.0.0" || host == "::1" {
+        return true;
+    }
+    // RFC1918 + link-local IPv4.
+    if let Some(octets) = parse_ipv4(host) {
+        let [a, b, _, _] = octets;
+        if a == 10 || (a == 192 && b == 168) || (a == 172 && (16..=31).contains(&b)) {
+            return true;
+        }
+        if a == 169 && b == 254 {
+            return true; // 169.254/16 link-local
+        }
+        if a == 127 {
+            return true; // entire 127/8 loopback
+        }
+    }
+    false
+}
+
+/// Pull the bare host (no scheme, no port, no path) out of `base_url`.
+/// Lowercased. IPv6 brackets stripped. Returns "" on malformed input.
+fn extract_host(base_url: &str) -> &str {
+    let s = base_url.trim();
+    let after_scheme = s
+        .split_once("://")
+        .map(|(_, rest)| rest)
+        .unwrap_or(s);
+    // Strip path/query: everything before the first '/' (or '?').
+    let host_port = after_scheme
+        .split(|c| c == '/' || c == '?')
+        .next()
+        .unwrap_or("");
+    // IPv6 in brackets: [::1]:8080.
+    if let Some(rest) = host_port.strip_prefix('[') {
+        if let Some(end) = rest.find(']') {
+            return &rest[..end];
+        }
+    }
+    // Strip :port for IPv4 / hostname.
+    host_port.split(':').next().unwrap_or("")
+}
+
+fn parse_ipv4(host: &str) -> Option<[u8; 4]> {
+    let parts: Vec<&str> = host.split('.').collect();
+    if parts.len() != 4 {
+        return None;
+    }
+    let mut octets = [0u8; 4];
+    for (i, part) in parts.iter().enumerate() {
+        octets[i] = part.parse().ok()?;
+    }
+    Some(octets)
 }
 
 /// Fetch the provider's `/models` catalog and present a fuzzy picker;
@@ -354,6 +412,51 @@ async fn pick_or_input_model(
         .default(default_idx)
         .interact()?;
     Ok(models[pick].id.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_endpoint_detection_matches_rfc1918_and_loopback() {
+        let positives = [
+            "http://localhost:11434/v1",
+            "http://127.0.0.1/v1",
+            "http://10.0.5.7/v1",
+            "https://10.255.255.255",
+            "http://192.168.1.20:8080/v1",
+            "http://172.16.4.4/v1",
+            "http://172.31.0.1/v1",
+            "http://169.254.169.254",
+            "http://my-host.local/v1",
+            "http://[::1]:8000/v1",
+        ];
+        for u in positives {
+            assert!(is_local_endpoint(u), "{u} should be local");
+        }
+
+        let negatives = [
+            "https://api.openai.com/v1",
+            "https://openrouter.ai/api/v1",
+            "https://172.32.0.1/v1", // outside 172.16-31
+            "https://192.169.1.1/v1",
+            "https://8.8.8.8/v1",
+            "https://example.com/v1",
+        ];
+        for u in negatives {
+            assert!(!is_local_endpoint(u), "{u} should NOT be local");
+        }
+    }
+
+    #[test]
+    fn extract_host_strips_scheme_port_and_path() {
+        assert_eq!(extract_host("https://api.example.com/v1"), "api.example.com");
+        assert_eq!(extract_host("http://localhost:11434/v1"), "localhost");
+        assert_eq!(extract_host("http://[::1]:8080/x"), "::1");
+        assert_eq!(extract_host("https://10.0.0.5"), "10.0.0.5");
+        assert_eq!(extract_host(""), "");
+    }
 }
 
 async fn fetch_models_with_timeout(

--- a/src/cli_auth.rs
+++ b/src/cli_auth.rs
@@ -1,0 +1,249 @@
+//! `vulcan auth` — guided interactive provider setup (YYC-100).
+//!
+//! Pairs the YYC-98 preset catalog with `dialoguer` prompts: pick
+//! provider → name → API key → model → confirm → write. Front-end
+//! only; the actual writer is `cli_provider::add`.
+
+use anyhow::{Context, Result, bail};
+use clap::Args;
+use dialoguer::{Confirm, FuzzySelect, Input, Password};
+use std::io::IsTerminal;
+use std::path::Path;
+
+use crate::cli_provider::{AddArgs, Preset, add, lookup_preset, presets};
+
+#[derive(Args, Debug)]
+pub struct AuthArgs {
+    /// Skip the picker by naming a preset directly (e.g. `vulcan auth openrouter`).
+    pub preset: Option<String>,
+    /// Jump straight to the custom (non-preset) flow: prompts for base
+    /// URL, model, and API key without a preset shortcut.
+    #[arg(long)]
+    pub custom: bool,
+}
+
+pub async fn run(args: AuthArgs, dir: std::path::PathBuf) -> Result<()> {
+    if !std::io::stdin().is_terminal() {
+        bail!(
+            "vulcan auth requires an interactive terminal. \
+             For non-interactive flows use `vulcan provider add ...`."
+        );
+    }
+
+    let theme = dialoguer_theme();
+
+    if args.custom {
+        return run_custom(&theme, &dir);
+    }
+
+    if let Some(key) = args.preset.as_deref() {
+        let preset = lookup_preset(key)
+            .with_context(|| format!("unknown preset '{key}'. See `vulcan provider presets`."))?;
+        return run_preset(&theme, &dir, preset);
+    }
+
+    // No preset supplied → fuzzy picker.
+    let presets = presets();
+    let mut labels: Vec<String> = presets
+        .iter()
+        .map(|p| format!("{}  ({})", p.display, p.key))
+        .collect();
+    let custom_label = "Custom (enter base URL by hand)".to_string();
+    labels.push(custom_label);
+
+    let pick = FuzzySelect::with_theme(&theme)
+        .with_prompt("Pick a provider")
+        .items(&labels)
+        .default(0)
+        .interact()
+        .context("provider picker cancelled")?;
+
+    if pick == presets.len() {
+        run_custom(&theme, &dir)
+    } else {
+        run_preset(&theme, &dir, &presets[pick])
+    }
+}
+
+fn run_preset(theme: &dyn dialoguer::theme::Theme, dir: &Path, preset: &Preset) -> Result<()> {
+    println!();
+    println!("Selected: {} ({})", preset.display, preset.key);
+    println!("  base_url     : {}", preset.base_url);
+    println!("  default_model: {}", preset.model);
+    println!("  auth         : {}", preset.auth_hint);
+    if !preset.notes.is_empty() {
+        println!("  notes        : {}", preset.notes);
+    }
+    println!();
+
+    let name: String = Input::with_theme(theme)
+        .with_prompt("Profile name")
+        .default(preset.key.to_string())
+        .validate_with(|input: &String| -> Result<(), &str> {
+            if input.eq_ignore_ascii_case("default") {
+                Err("'default' is reserved for the legacy [provider] block")
+            } else if input.trim().is_empty() {
+                Err("name required")
+            } else {
+                Ok(())
+            }
+        })
+        .interact_text()?;
+
+    let api_key: String = Password::with_theme(theme)
+        .with_prompt(format!(
+            "API key (Press Enter to skip and rely on env var: {})",
+            preset.auth_hint
+        ))
+        .allow_empty_password(true)
+        .interact()?;
+
+    let model: String = Input::with_theme(theme)
+        .with_prompt("Default model id")
+        .default(preset.model.to_string())
+        .interact_text()?;
+
+    let force = if profile_exists(dir, &name)? {
+        Confirm::with_theme(theme)
+            .with_prompt(format!(
+                "Profile '{name}' already exists in providers.toml. Overwrite?"
+            ))
+            .default(false)
+            .interact()?
+    } else {
+        false
+    };
+
+    let confirm = Confirm::with_theme(theme)
+        .with_prompt(format!(
+            "Write [{}] to providers.toml (base_url={}, model={})?",
+            name, preset.base_url, model
+        ))
+        .default(true)
+        .interact()?;
+    if !confirm {
+        println!("Aborted — nothing written.");
+        return Ok(());
+    }
+
+    let api_key_opt = if api_key.trim().is_empty() {
+        None
+    } else {
+        Some(api_key)
+    };
+    add(
+        AddArgs {
+            name: name.clone(),
+            preset: Some(preset.key.to_string()),
+            base_url: None,
+            model: Some(model),
+            api_key: api_key_opt,
+            max_context: None,
+            disable_catalog: false,
+            force,
+        },
+        dir,
+    )?;
+    println!();
+    println!("Done. Switch into the new profile with `/provider {name}` in the TUI.");
+    Ok(())
+}
+
+fn run_custom(theme: &dyn dialoguer::theme::Theme, dir: &Path) -> Result<()> {
+    println!();
+    println!("Custom provider — enter the OpenAI-compatible endpoint by hand.");
+    println!();
+
+    let name: String = Input::with_theme(theme)
+        .with_prompt("Profile name")
+        .validate_with(|input: &String| -> Result<(), &str> {
+            if input.eq_ignore_ascii_case("default") {
+                Err("'default' is reserved for the legacy [provider] block")
+            } else if input.trim().is_empty() {
+                Err("name required")
+            } else {
+                Ok(())
+            }
+        })
+        .interact_text()?;
+
+    let base_url: String = Input::with_theme(theme)
+        .with_prompt("Base URL (must be OpenAI-compatible, e.g. https://example.com/v1)")
+        .validate_with(|input: &String| -> Result<(), &str> {
+            if input.starts_with("http://") || input.starts_with("https://") {
+                Ok(())
+            } else {
+                Err("must start with http:// or https://")
+            }
+        })
+        .interact_text()?;
+
+    let model: String = Input::with_theme(theme)
+        .with_prompt("Default model id")
+        .interact_text()?;
+
+    let api_key: String = Password::with_theme(theme)
+        .with_prompt("API key (Enter to skip — auth then resolves via VULCAN_API_KEY)")
+        .allow_empty_password(true)
+        .interact()?;
+
+    let disable_catalog = Confirm::with_theme(theme)
+        .with_prompt("Skip the /models catalog fetch at startup? (yes for self-hosted endpoints)")
+        .default(false)
+        .interact()?;
+
+    let force = if profile_exists(dir, &name)? {
+        Confirm::with_theme(theme)
+            .with_prompt(format!(
+                "Profile '{name}' already exists in providers.toml. Overwrite?"
+            ))
+            .default(false)
+            .interact()?
+    } else {
+        false
+    };
+
+    let confirm = Confirm::with_theme(theme)
+        .with_prompt(format!(
+            "Write [{}] to providers.toml (base_url={}, model={})?",
+            name, base_url, model
+        ))
+        .default(true)
+        .interact()?;
+    if !confirm {
+        println!("Aborted — nothing written.");
+        return Ok(());
+    }
+
+    let api_key_opt = if api_key.trim().is_empty() {
+        None
+    } else {
+        Some(api_key)
+    };
+
+    add(
+        AddArgs {
+            name: name.clone(),
+            preset: None,
+            base_url: Some(base_url),
+            model: Some(model),
+            api_key: api_key_opt,
+            max_context: None,
+            disable_catalog,
+            force,
+        },
+        dir,
+    )?;
+    println!();
+    println!("Done. Switch into the new profile with `/provider {name}` in the TUI.");
+    Ok(())
+}
+
+fn profile_exists(dir: &Path, name: &str) -> Result<bool> {
+    let cfg = crate::config::Config::load_from_dir(dir).unwrap_or_default();
+    Ok(cfg.providers.contains_key(name))
+}
+
+fn dialoguer_theme() -> dialoguer::theme::ColorfulTheme {
+    dialoguer::theme::ColorfulTheme::default()
+}

--- a/src/cli_auth.rs
+++ b/src/cli_auth.rs
@@ -9,8 +9,10 @@ use clap::Args;
 use dialoguer::{Confirm, FuzzySelect, Input, Password};
 use std::io::IsTerminal;
 use std::path::Path;
+use std::time::Duration;
 
 use crate::cli_provider::{AddArgs, Preset, add, lookup_preset, presets};
+use crate::provider::catalog::{self, ModelInfo};
 
 #[derive(Args, Debug)]
 pub struct AuthArgs {
@@ -33,13 +35,13 @@ pub async fn run(args: AuthArgs, dir: std::path::PathBuf) -> Result<()> {
     let theme = dialoguer_theme();
 
     if args.custom {
-        return run_custom(&theme, &dir);
+        return run_custom(&theme, &dir).await;
     }
 
     if let Some(key) = args.preset.as_deref() {
         let preset = lookup_preset(key)
             .with_context(|| format!("unknown preset '{key}'. See `vulcan provider presets`."))?;
-        return run_preset(&theme, &dir, preset);
+        return run_preset(&theme, &dir, preset).await;
     }
 
     // No preset supplied → fuzzy picker.
@@ -59,13 +61,17 @@ pub async fn run(args: AuthArgs, dir: std::path::PathBuf) -> Result<()> {
         .context("provider picker cancelled")?;
 
     if pick == presets.len() {
-        run_custom(&theme, &dir)
+        run_custom(&theme, &dir).await
     } else {
-        run_preset(&theme, &dir, &presets[pick])
+        run_preset(&theme, &dir, &presets[pick]).await
     }
 }
 
-fn run_preset(theme: &dyn dialoguer::theme::Theme, dir: &Path, preset: &Preset) -> Result<()> {
+async fn run_preset(
+    theme: &dyn dialoguer::theme::Theme,
+    dir: &Path,
+    preset: &Preset,
+) -> Result<()> {
     println!();
     println!("Selected: {} ({})", preset.display, preset.key);
     println!("  base_url     : {}", preset.base_url);
@@ -79,40 +85,21 @@ fn run_preset(theme: &dyn dialoguer::theme::Theme, dir: &Path, preset: &Preset) 
     let name: String = Input::with_theme(theme)
         .with_prompt("Profile name")
         .default(preset.key.to_string())
-        .validate_with(|input: &String| -> Result<(), &str> {
-            if input.eq_ignore_ascii_case("default") {
-                Err("'default' is reserved for the legacy [provider] block")
-            } else if input.trim().is_empty() {
-                Err("name required")
-            } else {
-                Ok(())
-            }
-        })
+        .validate_with(validate_profile_name)
         .interact_text()?;
 
-    let api_key: String = Password::with_theme(theme)
-        .with_prompt(format!(
-            "API key (Press Enter to skip and rely on env var: {})",
-            preset.auth_hint
-        ))
-        .allow_empty_password(true)
-        .interact()?;
+    let api_key_opt = prompt_api_key(theme, preset.base_url, preset.auth_hint)?;
 
-    let model: String = Input::with_theme(theme)
-        .with_prompt("Default model id")
-        .default(preset.model.to_string())
-        .interact_text()?;
+    let model = pick_or_input_model(
+        theme,
+        preset.base_url,
+        api_key_opt.as_deref().unwrap_or(""),
+        preset.model,
+        preset.disable_catalog,
+    )
+    .await?;
 
-    let force = if profile_exists(dir, &name)? {
-        Confirm::with_theme(theme)
-            .with_prompt(format!(
-                "Profile '{name}' already exists in providers.toml. Overwrite?"
-            ))
-            .default(false)
-            .interact()?
-    } else {
-        false
-    };
+    let force = profile_exists_prompt(theme, dir, &name)?;
 
     let confirm = Confirm::with_theme(theme)
         .with_prompt(format!(
@@ -126,11 +113,6 @@ fn run_preset(theme: &dyn dialoguer::theme::Theme, dir: &Path, preset: &Preset) 
         return Ok(());
     }
 
-    let api_key_opt = if api_key.trim().is_empty() {
-        None
-    } else {
-        Some(api_key)
-    };
     add(
         AddArgs {
             name: name.clone(),
@@ -149,22 +131,14 @@ fn run_preset(theme: &dyn dialoguer::theme::Theme, dir: &Path, preset: &Preset) 
     Ok(())
 }
 
-fn run_custom(theme: &dyn dialoguer::theme::Theme, dir: &Path) -> Result<()> {
+async fn run_custom(theme: &dyn dialoguer::theme::Theme, dir: &Path) -> Result<()> {
     println!();
     println!("Custom provider — enter the OpenAI-compatible endpoint by hand.");
     println!();
 
     let name: String = Input::with_theme(theme)
         .with_prompt("Profile name")
-        .validate_with(|input: &String| -> Result<(), &str> {
-            if input.eq_ignore_ascii_case("default") {
-                Err("'default' is reserved for the legacy [provider] block")
-            } else if input.trim().is_empty() {
-                Err("name required")
-            } else {
-                Ok(())
-            }
-        })
+        .validate_with(validate_profile_name)
         .interact_text()?;
 
     let base_url: String = Input::with_theme(theme)
@@ -178,30 +152,37 @@ fn run_custom(theme: &dyn dialoguer::theme::Theme, dir: &Path) -> Result<()> {
         })
         .interact_text()?;
 
-    let model: String = Input::with_theme(theme)
-        .with_prompt("Default model id")
-        .interact_text()?;
+    let api_key_opt = prompt_api_key(
+        theme,
+        &base_url,
+        "auth resolves via VULCAN_API_KEY when blank",
+    )?;
 
-    let api_key: String = Password::with_theme(theme)
-        .with_prompt("API key (Enter to skip — auth then resolves via VULCAN_API_KEY)")
-        .allow_empty_password(true)
-        .interact()?;
-
-    let disable_catalog = Confirm::with_theme(theme)
-        .with_prompt("Skip the /models catalog fetch at startup? (yes for self-hosted endpoints)")
-        .default(false)
-        .interact()?;
-
-    let force = if profile_exists(dir, &name)? {
+    let disable_catalog = if is_local_endpoint(&base_url) {
+        // Local endpoints (Ollama, llama.cpp, vLLM, etc.) frequently
+        // don't ship an OpenAI-shape `/models` route. Default to off
+        // so the agent doesn't fail at startup probing it.
         Confirm::with_theme(theme)
-            .with_prompt(format!(
-                "Profile '{name}' already exists in providers.toml. Overwrite?"
-            ))
-            .default(false)
+            .with_prompt("Local endpoint detected — skip the /models catalog fetch at startup?")
+            .default(true)
             .interact()?
     } else {
-        false
+        Confirm::with_theme(theme)
+            .with_prompt("Skip the /models catalog fetch at startup? (rare; mainly for self-hosted endpoints)")
+            .default(false)
+            .interact()?
     };
+
+    let model = pick_or_input_model(
+        theme,
+        &base_url,
+        api_key_opt.as_deref().unwrap_or(""),
+        "",
+        disable_catalog,
+    )
+    .await?;
+
+    let force = profile_exists_prompt(theme, dir, &name)?;
 
     let confirm = Confirm::with_theme(theme)
         .with_prompt(format!(
@@ -214,12 +195,6 @@ fn run_custom(theme: &dyn dialoguer::theme::Theme, dir: &Path) -> Result<()> {
         println!("Aborted — nothing written.");
         return Ok(());
     }
-
-    let api_key_opt = if api_key.trim().is_empty() {
-        None
-    } else {
-        Some(api_key)
-    };
 
     add(
         AddArgs {
@@ -237,6 +212,161 @@ fn run_custom(theme: &dyn dialoguer::theme::Theme, dir: &Path) -> Result<()> {
     println!();
     println!("Done. Switch into the new profile with `/provider {name}` in the TUI.");
     Ok(())
+}
+
+fn validate_profile_name(input: &String) -> Result<(), &'static str> {
+    if input.eq_ignore_ascii_case("default") {
+        Err("'default' is reserved for the legacy [provider] block")
+    } else if input.trim().is_empty() {
+        Err("name required")
+    } else {
+        Ok(())
+    }
+}
+
+fn profile_exists_prompt(
+    theme: &dyn dialoguer::theme::Theme,
+    dir: &Path,
+    name: &str,
+) -> Result<bool> {
+    if profile_exists(dir, name)? {
+        Ok(Confirm::with_theme(theme)
+            .with_prompt(format!(
+                "Profile '{name}' already exists in providers.toml. Overwrite?"
+            ))
+            .default(false)
+            .interact()?)
+    } else {
+        Ok(false)
+    }
+}
+
+/// Prompt for an API key, but skip the prompt entirely when the
+/// endpoint looks local — most self-hosted endpoints (Ollama, llama.cpp,
+/// vLLM in unauth mode) don't need one. Returns `None` when the user
+/// declines to set a key (or local + opted out), `Some(s)` otherwise.
+fn prompt_api_key(
+    theme: &dyn dialoguer::theme::Theme,
+    base_url: &str,
+    auth_hint: &str,
+) -> Result<Option<String>> {
+    if is_local_endpoint(base_url) {
+        let want = Confirm::with_theme(theme)
+            .with_prompt(
+                "Local endpoint detected — set an API key? (most self-hosted servers don't need one)",
+            )
+            .default(false)
+            .interact()?;
+        if !want {
+            return Ok(None);
+        }
+        let key: String = Password::with_theme(theme)
+            .with_prompt("API key (placeholder is fine, e.g. \"ollama\")")
+            .allow_empty_password(true)
+            .interact()?;
+        return Ok(if key.trim().is_empty() {
+            None
+        } else {
+            Some(key)
+        });
+    }
+
+    let key: String = Password::with_theme(theme)
+        .with_prompt(format!(
+            "API key (Press Enter to skip — {auth_hint})"
+        ))
+        .allow_empty_password(true)
+        .interact()?;
+    Ok(if key.trim().is_empty() {
+        None
+    } else {
+        Some(key)
+    })
+}
+
+/// Heuristic for "local" endpoints — used to default-skip the API key
+/// prompt and the catalog fetch. Matches the loopback hosts and `.local`.
+fn is_local_endpoint(base_url: &str) -> bool {
+    let lower = base_url.to_ascii_lowercase();
+    lower.contains("localhost")
+        || lower.contains("127.0.0.1")
+        || lower.contains("0.0.0.0")
+        || lower.contains("[::1]")
+        || lower.contains(".local")
+}
+
+/// Fetch the provider's `/models` catalog and present a fuzzy picker;
+/// fall back to a typed input pre-filled with `default_model` when the
+/// fetch is disabled, fails, or returns nothing.
+async fn pick_or_input_model(
+    theme: &dyn dialoguer::theme::Theme,
+    base_url: &str,
+    api_key: &str,
+    default_model: &str,
+    disable_catalog: bool,
+) -> Result<String> {
+    if disable_catalog {
+        let value: String = Input::with_theme(theme)
+            .with_prompt("Default model id")
+            .default(default_model.to_string())
+            .interact_text()?;
+        return Ok(value);
+    }
+
+    println!("Fetching models from {base_url} …");
+    let models = match fetch_models_with_timeout(base_url, api_key).await {
+        Ok(list) if !list.is_empty() => list,
+        Ok(_) => {
+            println!("  (catalog returned no models — typed input)");
+            let value: String = Input::with_theme(theme)
+                .with_prompt("Default model id")
+                .default(default_model.to_string())
+                .interact_text()?;
+            return Ok(value);
+        }
+        Err(e) => {
+            println!("  (catalog fetch failed: {e} — typed input)");
+            let value: String = Input::with_theme(theme)
+                .with_prompt("Default model id")
+                .default(default_model.to_string())
+                .interact_text()?;
+            return Ok(value);
+        }
+    };
+
+    let labels: Vec<String> = models
+        .iter()
+        .map(|m| {
+            if m.context_length > 0 {
+                format!("{}  · ctx {}", m.id, m.context_length)
+            } else {
+                m.id.clone()
+            }
+        })
+        .collect();
+    let default_idx = models
+        .iter()
+        .position(|m| m.id == default_model)
+        .unwrap_or(0);
+    let pick = FuzzySelect::with_theme(theme)
+        .with_prompt(format!("Pick default model ({} available)", models.len()))
+        .items(&labels)
+        .default(default_idx)
+        .interact()?;
+    Ok(models[pick].id.clone())
+}
+
+async fn fetch_models_with_timeout(
+    base_url: &str,
+    api_key: &str,
+) -> Result<Vec<ModelInfo>> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(8))
+        .build()?;
+    let cache_ttl = Duration::from_secs(0); // bypass cache during interactive setup
+    let cat = catalog::for_base_url(client, base_url, api_key, cache_ttl);
+    let models = cat.list_models().await.map_err(anyhow::Error::from)?;
+    Ok(models)
 }
 
 fn profile_exists(dir: &Path, name: &str) -> Result<bool> {

--- a/src/cli_provider.rs
+++ b/src/cli_provider.rs
@@ -205,7 +205,7 @@ fn print_presets() {
     println!("Add via:  vulcan provider add <name> --preset <key>");
 }
 
-fn add(args: AddArgs, dir: &Path) -> Result<()> {
+pub fn add(args: AddArgs, dir: &Path) -> Result<()> {
     if args.name.eq_ignore_ascii_case("default") {
         bail!("'default' is reserved for the legacy [provider] block in config.toml.");
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod agent;
 pub mod cli;
+pub mod cli_auth;
 pub mod cli_provider;
 pub mod code;
 pub mod config;

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,6 +116,11 @@ async fn main() -> anyhow::Result<()> {
             let dir = vulcan::config::vulcan_home();
             vulcan::cli_provider::run(cmd, dir).await?;
         }
+        Some(Command::Auth(args)) => {
+            init_cli_logging();
+            let dir = vulcan::config::vulcan_home();
+            vulcan::cli_auth::run(args, dir).await?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
Pairs the YYC-98 preset catalog with dialoguer prompts for a smooth
first-run flow:

  vulcan auth                    → fuzzy-pick a preset → name → API
                                   key → model → confirm → write.
  vulcan auth openrouter         → skips the picker.
  vulcan auth --custom           → custom base URL flow (validates
                                   http(s):// prefix, asks
                                   disable_catalog yes/no).

Behavior:

- Reuses cli_provider::add as the writer — auth is purely a front-end.
- API key prompt is a hidden Password input; pressing Enter skips and
  relies on the preset's auth env var hint.
- Default-name profile rejected (reserved for legacy [provider]).
- Detects existing profile collision and prompts to overwrite (sets
  the --force flag on the underlying writer).
- Bails with a clear error on non-TTY stdin so script users get
  pointed at `vulcan provider add` instead of getting silent stalls.

Adds dialoguer 0.12 (fuzzy-select + password features). 236 lib tests
pass; the interactive prompts themselves aren't covered by tests
(cli_provider::add already is).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>