### PR TITLE
YYC-101 (mvp): hierarchical /model picker — miller columns + hjkl

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -9,7 +9,7 @@ use ratatui::{
     prelude::Position,
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::Paragraph,
+    widgets::{Paragraph, Wrap},
 };
 use tokio::sync::{Mutex, mpsc};
 
@@ -23,6 +23,7 @@ use crate::provider::StreamEvent;
 pub mod chat_render;
 pub mod keybinds;
 pub mod markdown;
+pub mod model_picker;
 pub mod state;
 pub mod theme;
 pub mod views;
@@ -786,7 +787,8 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
             continue;
         }
 
-        // ── Model picker overlay (YYC-97): intercept input until dismissed.
+        // ── Hierarchical model picker (YYC-101): miller columns,
+        // hjkl drill-down. Intercepts input until dismissed.
         if app.show_model_picker {
             tokio::select! {
                 ev = key_rx.recv() => {
@@ -794,51 +796,76 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                         Some(KeyEv::Press(event)) => {
                             if let Event::Key(key) = event {
                                 if key.kind == KeyEventKind::Press {
+                                    let mut commit_id: Option<String> = None;
+                                    let mut close = false;
                                     match key.code {
                                         KeyCode::Up | KeyCode::Char('k') => {
-                                            app.model_picker_selection = app.model_picker_selection.saturating_sub(1);
+                                            picker_move(&mut app, -1);
                                         }
                                         KeyCode::Down | KeyCode::Char('j') => {
-                                            let max = app.model_picker_items.len().saturating_sub(1);
-                                            app.model_picker_selection = app.model_picker_selection.saturating_add(1).min(max);
+                                            picker_move(&mut app, 1);
+                                        }
+                                        KeyCode::Left | KeyCode::Char('h') => {
+                                            if app.model_picker_focus == 0 {
+                                                close = true;
+                                            } else {
+                                                app.model_picker_focus -= 1;
+                                                app.model_picker_path
+                                                    .truncate(app.model_picker_focus + 1);
+                                            }
+                                        }
+                                        KeyCode::Right | KeyCode::Char('l') => {
+                                            if let Some(id) = picker_drill_or_commit(&mut app)
+                                            {
+                                                commit_id = Some(id);
+                                            }
                                         }
                                         KeyCode::Enter => {
-                                            let idx = app.model_picker_selection.min(app.model_picker_items.len().saturating_sub(1));
-                                            if let Some(picked) = app.model_picker_items.get(idx).cloned() {
-                                                let result = {
-                                                    let mut a = agent.lock().await;
-                                                    a.switch_model(&picked.id).await
-                                                };
-                                                match result {
-                                                    Ok(selection) => {
-                                                        app.model_label = selection.model.id.clone();
-                                                        app.token_max = selection.max_context as u32;
-                                                        app.pricing = selection.pricing;
-                                                        app.messages.push(ChatMessage {
-                                                            role: ChatRole::System,
-                                                            content: format!(
-                                                                "Model switched to {} · context {}",
-                                                                app.model_label,
-                                                                crate::tui::state::format_thousands(app.token_max),
-                                                            ),
-                                                            ..Default::default()
-                                                        });
-                                                    }
-                                                    Err(e) => {
-                                                        app.messages.push(ChatMessage {
-                                                            role: ChatRole::System,
-                                                            content: format!("Model switch failed: {e}"),
-                                                            ..Default::default()
-                                                        });
-                                                    }
-                                                }
+                                            if let Some(id) = picker_commit_current(&app) {
+                                                commit_id = Some(id);
                                             }
-                                            app.show_model_picker = false;
                                         }
-                                        KeyCode::Esc => {
-                                            app.show_model_picker = false;
-                                        }
+                                        KeyCode::Esc | KeyCode::Char('q') => close = true,
                                         _ => {}
+                                    }
+                                    if let Some(id) = commit_id {
+                                        let result = {
+                                            let mut a = agent.lock().await;
+                                            a.switch_model(&id).await
+                                        };
+                                        match result {
+                                            Ok(selection) => {
+                                                app.model_label =
+                                                    selection.model.id.clone();
+                                                app.token_max =
+                                                    selection.max_context as u32;
+                                                app.pricing = selection.pricing;
+                                                app.messages.push(ChatMessage {
+                                                    role: ChatRole::System,
+                                                    content: format!(
+                                                        "Model switched to {} · context {}",
+                                                        app.model_label,
+                                                        crate::tui::state::format_thousands(
+                                                            app.token_max
+                                                        ),
+                                                    ),
+                                                    ..Default::default()
+                                                });
+                                            }
+                                            Err(e) => {
+                                                app.messages.push(ChatMessage {
+                                                    role: ChatRole::System,
+                                                    content: format!("Model switch failed: {e}"),
+                                                    ..Default::default()
+                                                });
+                                            }
+                                        }
+                                        close = true;
+                                    }
+                                    if close {
+                                        app.show_model_picker = false;
+                                        app.model_picker_path.clear();
+                                        app.model_picker_focus = 0;
                                     }
                                 }
                             }
@@ -1531,12 +1558,29 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                                                     });
                                                                 }
                                                                 Ok(models) => {
-                                                                    let active_idx = models
-                                                                        .iter()
-                                                                        .position(|m| m.id == active)
-                                                                        .unwrap_or(0);
+                                                                    let provider_label = {
+                                                                        let a = agent.lock().await;
+                                                                        a.active_profile()
+                                                                            .map(str::to_string)
+                                                                            .unwrap_or_else(|| "default".into())
+                                                                    };
+                                                                    let tree =
+                                                                        crate::tui::model_picker::build_model_tree(
+                                                                            &provider_label,
+                                                                            &models,
+                                                                        );
+                                                                    app.model_picker_path =
+                                                                        initial_path_for_active_model(
+                                                                            &tree,
+                                                                            &active,
+                                                                            &models,
+                                                                        );
+                                                                    app.model_picker_focus = app
+                                                                        .model_picker_path
+                                                                        .len()
+                                                                        .saturating_sub(1);
+                                                                    app.model_picker_tree = tree;
                                                                     app.model_picker_items = models;
-                                                                    app.model_picker_selection = active_idx;
                                                                     app.show_model_picker = true;
                                                                 }
                                                                 Err(e) => {
@@ -2079,77 +2123,330 @@ fn draw_model_picker(f: &mut ratatui::Frame, area: Rect, app: &AppState) {
         height: box_area.height.saturating_sub(2),
     };
 
-    let mut lines: Vec<Line<'static>> = Vec::new();
     if app.model_picker_items.is_empty() {
-        lines.push(Line::from(Span::styled(
-            "  No models in provider catalog.",
-            theme.muted,
-        )));
+        f.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                "  No models in provider catalog.",
+                theme.muted,
+            ))),
+            list_area,
+        );
+        draw_picker_border(f, box_area, theme);
+        return;
+    }
+
+    // Mini-files-style miller columns. The number of visible columns is
+    // capped to whatever the box width can fit (each column is roughly
+    // 20–28 chars). Always reserve the rightmost column for details.
+    let drilled_depth = app.model_picker_path.len();
+    let max_tree_depth = app.model_picker_tree.max_depth();
+    let total_columns = max_tree_depth.max(1) + 1; // +1 for details
+
+    let col_width = (list_area.width / total_columns as u16).max(16);
+    let cols: Vec<Rect> = (0..total_columns)
+        .map(|i| Rect {
+            x: list_area.x + i as u16 * col_width,
+            y: list_area.y,
+            width: col_width,
+            height: list_area.height,
+        })
+        .collect();
+
+    // Render each tree column.
+    for col_idx in 0..max_tree_depth {
+        let path_prefix: Vec<usize> = app
+            .model_picker_path
+            .iter()
+            .copied()
+            .take(col_idx)
+            .collect();
+        let nodes = app.model_picker_tree.column_at(col_idx, &path_prefix);
+        let selection = app
+            .model_picker_path
+            .get(col_idx)
+            .copied()
+            .unwrap_or(0)
+            .min(nodes.len().saturating_sub(1));
+        let is_focused = col_idx == app.model_picker_focus;
+        render_picker_column(f, cols[col_idx], nodes, selection, is_focused, theme);
+    }
+
+    // Details panel at the rightmost column.
+    let details_col = cols.last().copied().unwrap_or(list_area);
+    let detail_lines = build_picker_details(app);
+    f.render_widget(Paragraph::new(detail_lines).wrap(Wrap { trim: false }), details_col);
+
+    let hint = "  hjkl move · Enter select · Esc cancel  (drilled: column ";
+    let footer_line = format!(
+        "{hint}{}/{})",
+        app.model_picker_focus + 1,
+        max_tree_depth.max(1)
+    );
+    let footer_rect = Rect {
+        x: list_area.x,
+        y: list_area.y + list_area.height.saturating_sub(1),
+        width: list_area.width,
+        height: 1,
+    };
+    f.render_widget(
+        Paragraph::new(Line::from(Span::styled(footer_line, theme.muted))),
+        footer_rect,
+    );
+    let _ = drilled_depth; // reserved for future filter UI
+
+    draw_picker_border(f, box_area, theme);
+}
+
+fn render_picker_column(
+    f: &mut ratatui::Frame,
+    area: Rect,
+    nodes: &[crate::tui::model_picker::TreeNode],
+    selection: usize,
+    is_focused: bool,
+    theme: &Theme,
+) {
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    if nodes.is_empty() {
+        lines.push(Line::from(Span::styled("  ·", theme.muted)));
     } else {
-        let visible = list_area.height.saturating_sub(2) as usize;
-        let active = app
-            .model_picker_selection
-            .min(app.model_picker_items.len().saturating_sub(1));
-        let start = active.saturating_sub(visible.saturating_sub(1) / 2);
-        let end = (start + visible).min(app.model_picker_items.len());
-        for (i, m) in app.model_picker_items.iter().enumerate().take(end).skip(start) {
-            let is_active = i == active;
-            let marker = if is_active { "▸ " } else { "  " };
-            let context = if m.context_length > 0 {
-                crate::tui::state::format_thousands(m.context_length as u32)
+        let visible = area.height.saturating_sub(2) as usize;
+        let start = selection.saturating_sub(visible.saturating_sub(1) / 2);
+        let end = (start + visible).min(nodes.len());
+        for (i, node) in nodes.iter().enumerate().take(end).skip(start) {
+            let is_active = i == selection;
+            let marker = if is_active && is_focused {
+                "▸ "
+            } else if is_active {
+                "│ "
             } else {
-                "?".into()
+                "  "
             };
-            let mut flags = Vec::new();
-            if m.features.tools {
-                flags.push("tools");
+            let mut style = Style::default();
+            if is_active {
+                style = style.add_modifier(Modifier::BOLD);
+                if is_focused {
+                    style = if let Some(fg) = theme.accent.fg {
+                        style.fg(fg)
+                    } else {
+                        style.add_modifier(Modifier::REVERSED)
+                    };
+                }
             }
-            if m.features.reasoning {
-                flags.push("reasoning");
-            }
-            if m.features.vision {
-                flags.push("vision");
-            }
-            if m.features.json_mode {
-                flags.push("json");
-            }
-            let flag_str = if flags.is_empty() {
-                String::new()
+            let suffix = if node.children.is_empty() && node.model_index.is_some() {
+                ""
             } else {
-                format!(" · {}", flags.join(","))
+                "›"
             };
-            let row_style = Style::default()
-                .fg(theme.body_fg)
-                .add_modifier(if is_active {
-                    Modifier::BOLD
-                } else {
-                    Modifier::empty()
-                });
+            let label = trim_to_width(&node.label, area.width.saturating_sub(4) as usize);
             lines.push(Line::from(vec![
-                Span::styled(marker, row_style.add_modifier(Modifier::BOLD)),
-                Span::styled(m.id.clone(), row_style),
-                Span::styled(format!("  ctx {context}{flag_str}"), theme.muted),
+                Span::styled(marker, style),
+                Span::styled(label, style),
+                Span::styled(format!(" {suffix}"), theme.muted),
             ]));
         }
-        if start > 0 || end < app.model_picker_items.len() {
+        if start > 0 || end < nodes.len() {
             lines.push(Line::from(Span::styled(
-                format!(
-                    "  …showing {}–{} of {}",
-                    start + 1,
-                    end,
-                    app.model_picker_items.len()
-                ),
+                format!("  …{}/{}", end, nodes.len()),
                 theme.muted.add_modifier(Modifier::DIM),
             )));
         }
     }
+    f.render_widget(Paragraph::new(lines), area);
+}
 
-    let hint = "  ↑↓ navigate · Enter select · Esc cancel  ";
+fn build_picker_details(app: &AppState) -> Vec<Line<'static>> {
+    let theme = &app.theme;
+    let mut lines = Vec::new();
+    let leaf_idx = picker_current_leaf(&app.model_picker_tree, &app.model_picker_path);
+    let Some(idx) = leaf_idx else {
+        lines.push(Line::from(Span::styled(
+            "  drill in (l/→) for details",
+            theme.muted,
+        )));
+        return lines;
+    };
+    let Some(model) = app.model_picker_items.get(idx) else {
+        return lines;
+    };
+    lines.push(Line::from(Span::styled(
+        format!(" {}", model.id),
+        Style::default().add_modifier(Modifier::BOLD),
+    )));
     lines.push(Line::from(""));
-    lines.push(Line::from(Span::styled(hint, theme.muted)));
+    let ctx = if model.context_length > 0 {
+        crate::tui::state::format_thousands(model.context_length as u32)
+    } else {
+        "?".into()
+    };
+    lines.push(Line::from(Span::styled(
+        format!(" context  : {ctx}"),
+        theme.muted,
+    )));
+    let mut flags = Vec::new();
+    if model.features.tools {
+        flags.push("tools");
+    }
+    if model.features.reasoning {
+        flags.push("reasoning");
+    }
+    if model.features.vision {
+        flags.push("vision");
+    }
+    if model.features.json_mode {
+        flags.push("json");
+    }
+    let flag_str = if flags.is_empty() {
+        "(none reported)".to_string()
+    } else {
+        flags.join(", ")
+    };
+    lines.push(Line::from(Span::styled(
+        format!(" features : {flag_str}"),
+        theme.muted,
+    )));
+    if let Some(p) = &model.pricing {
+        lines.push(Line::from(Span::styled(
+            format!(
+                " pricing  : ${:.4}/1k in · ${:.4}/1k out",
+                p.input_per_token * 1000.0,
+                p.output_per_token * 1000.0,
+            ),
+            theme.muted,
+        )));
+    }
+    if let Some(top) = &model.top_provider {
+        lines.push(Line::from(Span::styled(
+            format!(" upstream : {top}"),
+            theme.muted,
+        )));
+    }
+    lines
+}
 
-    f.render_widget(Paragraph::new(lines), list_area);
-    draw_picker_border(f, box_area, theme);
+fn trim_to_width(s: &str, width: usize) -> String {
+    if width == 0 {
+        return String::new();
+    }
+    let chars: Vec<char> = s.chars().collect();
+    if chars.len() <= width {
+        return s.to_string();
+    }
+    let head: String = chars.iter().take(width.saturating_sub(1)).collect();
+    format!("{head}…")
+}
+
+fn picker_move(app: &mut AppState, delta: i32) {
+    let depth = app.model_picker_focus;
+    let path_prefix: Vec<usize> = app
+        .model_picker_path
+        .iter()
+        .copied()
+        .take(depth)
+        .collect();
+    let len = app
+        .model_picker_tree
+        .column_at(depth, &path_prefix)
+        .len();
+    if len == 0 {
+        return;
+    }
+    while app.model_picker_path.len() <= depth {
+        app.model_picker_path.push(0);
+    }
+    let cur = app.model_picker_path[depth] as i32 + delta;
+    let max = (len - 1) as i32;
+    app.model_picker_path[depth] = cur.clamp(0, max) as usize;
+    // Reset deeper selections — the active branch changed.
+    app.model_picker_path.truncate(depth + 1);
+}
+
+fn picker_drill_or_commit(app: &mut AppState) -> Option<String> {
+    let depth = app.model_picker_focus;
+    let path_prefix: Vec<usize> = app
+        .model_picker_path
+        .iter()
+        .copied()
+        .take(depth)
+        .collect();
+    let nodes = app
+        .model_picker_tree
+        .column_at(depth, &path_prefix)
+        .to_vec();
+    let sel = app.model_picker_path.get(depth).copied().unwrap_or(0);
+    let Some(node) = nodes.get(sel) else {
+        return None;
+    };
+    if node.children.is_empty() {
+        // Leaf — commit.
+        return node
+            .model_index
+            .and_then(|i| app.model_picker_items.get(i))
+            .map(|m| m.id.clone());
+    }
+    // Drill: focus next column, default selection 0.
+    while app.model_picker_path.len() <= depth + 1 {
+        app.model_picker_path.push(0);
+    }
+    app.model_picker_path[depth + 1] = 0;
+    app.model_picker_focus = depth + 1;
+    None
+}
+
+fn picker_commit_current(app: &AppState) -> Option<String> {
+    picker_current_leaf(&app.model_picker_tree, &app.model_picker_path)
+        .and_then(|i| app.model_picker_items.get(i))
+        .map(|m| m.id.clone())
+}
+
+fn picker_current_leaf(
+    tree: &crate::tui::model_picker::ModelTree,
+    path: &[usize],
+) -> Option<usize> {
+    let mut current: &[crate::tui::model_picker::TreeNode] = &tree.labs;
+    let mut leaf: Option<usize> = None;
+    for &idx in path {
+        let node = current.get(idx)?;
+        if node.children.is_empty() {
+            return node.model_index;
+        }
+        leaf = node.model_index;
+        current = &node.children;
+    }
+    // Path didn't reach a leaf — return last seen leaf marker (None for
+    // internal-only nodes).
+    leaf
+}
+
+fn initial_path_for_active_model(
+    tree: &crate::tui::model_picker::ModelTree,
+    active_id: &str,
+    items: &[crate::provider::catalog::ModelInfo],
+) -> Vec<usize> {
+    let target = items.iter().position(|m| m.id == active_id);
+    fn find_path(
+        nodes: &[crate::tui::model_picker::TreeNode],
+        target: Option<usize>,
+        path: &mut Vec<usize>,
+    ) -> bool {
+        for (i, node) in nodes.iter().enumerate() {
+            path.push(i);
+            if node.model_index.is_some() && node.model_index == target {
+                return true;
+            }
+            if find_path(&node.children, target, path) {
+                return true;
+            }
+            path.pop();
+        }
+        false
+    }
+    let mut path = Vec::new();
+    if !find_path(&tree.labs, target, &mut path) {
+        // No exact match — start from column 0 with no drilled selection.
+        path.clear();
+        path.push(0);
+    }
+    path
 }
 
 fn draw_provider_picker(f: &mut ratatui::Frame, area: Rect, app: &AppState) {

--- a/src/tui/model_picker.rs
+++ b/src/tui/model_picker.rs
@@ -1,0 +1,284 @@
+//! Unified model picker tree builder (YYC-101).
+//!
+//! Turns a flat catalog (`Vec<ModelInfo>`) into a hierarchy that mini.files-
+//! style columns can render: provider → lab → series → version. Pure
+//! helper module — render and key dispatch live in `tui::mod`.
+
+use crate::provider::catalog::ModelInfo;
+use std::collections::BTreeMap;
+
+/// One node in the model tree. Leaves point at a `ModelInfo` index in
+/// the source catalog so the caller can resolve full metadata when the
+/// user lands on a leaf.
+#[derive(Debug, Clone, Default)]
+pub struct ModelTree {
+    pub provider_label: String,
+    /// Top-level entries (one per "lab" — the segment before the first
+    /// `/` in OpenRouter-style ids, or "default" for flat slugs).
+    pub labs: Vec<TreeNode>,
+}
+
+#[derive(Debug, Clone)]
+pub struct TreeNode {
+    pub label: String,
+    pub children: Vec<TreeNode>,
+    /// Some(index) when this node is a leaf pointing at a model in the
+    /// source catalog. Internal nodes carry None.
+    pub model_index: Option<usize>,
+}
+
+impl ModelTree {
+    /// Walk the tree to reach the column at depth `depth`, taking the
+    /// `selection_path[i]` index at each level. Returns the column's
+    /// nodes, or empty if depth exceeds the path.
+    pub fn column_at(&self, depth: usize, path: &[usize]) -> &[TreeNode] {
+        if depth == 0 {
+            return &self.labs;
+        }
+        let mut current: &[TreeNode] = &self.labs;
+        for &idx in path.iter().take(depth) {
+            let Some(node) = current.get(idx) else {
+                return &[];
+            };
+            current = &node.children;
+        }
+        current
+    }
+
+    /// Number of columns the tree exposes given a fully-drilled path.
+    pub fn max_depth(&self) -> usize {
+        fn dive(nodes: &[TreeNode], current: usize, best: &mut usize) {
+            if current > *best {
+                *best = current;
+            }
+            for n in nodes {
+                if !n.children.is_empty() {
+                    dive(&n.children, current + 1, best);
+                }
+            }
+        }
+        let mut best = 0;
+        dive(&self.labs, 1, &mut best);
+        best
+    }
+}
+
+/// Build a column-friendly tree from a flat catalog.
+///
+/// `provider_label` is the display name for the active provider profile
+/// — used as the root row in column 0 and as the synthetic "lab" for
+/// flat (non-slash) model ids.
+pub fn build_model_tree(provider_label: &str, models: &[ModelInfo]) -> ModelTree {
+    let mut grouped: BTreeMap<String, Vec<(usize, &str)>> = BTreeMap::new();
+    for (i, m) in models.iter().enumerate() {
+        let (lab, rest) = split_lab(&m.id, provider_label);
+        grouped
+            .entry(lab.to_string())
+            .or_default()
+            .push((i, rest));
+    }
+    let mut labs: Vec<TreeNode> = grouped
+        .into_iter()
+        .map(|(lab, entries)| build_lab_node(&lab, &entries))
+        .collect();
+    // Sort labs alphabetically with a couple of usual suspects pinned
+    // toward the front.
+    labs.sort_by(|a, b| a.label.cmp(&b.label));
+    ModelTree {
+        provider_label: provider_label.to_string(),
+        labs,
+    }
+}
+
+fn split_lab<'a>(id: &'a str, fallback_lab: &'a str) -> (&'a str, &'a str) {
+    if let Some((lab, rest)) = id.split_once('/') {
+        (lab, rest)
+    } else {
+        (fallback_lab, id)
+    }
+}
+
+/// One pass through a lab's models: split each remaining id by
+/// `-` / `:` / `.` into series / version components and group.
+fn build_lab_node(lab: &str, entries: &[(usize, &str)]) -> TreeNode {
+    // Build a tree of (series-tokens) → leaves.
+    // For most ids the first token is a coherent series (`gpt`, `claude`,
+    // `kimi`, `qwen2.5`); subsequent tokens describe the variant.
+    let mut node = TreeNode {
+        label: lab.to_string(),
+        children: Vec::new(),
+        model_index: None,
+    };
+    let mut by_series: BTreeMap<String, Vec<(usize, Vec<String>)>> = BTreeMap::new();
+    for (idx, rest) in entries {
+        let toks = tokenize(rest);
+        let series = toks.first().cloned().unwrap_or_else(|| rest.to_string());
+        let tail: Vec<String> = toks.into_iter().skip(1).collect();
+        by_series
+            .entry(series)
+            .or_default()
+            .push((*idx, tail));
+    }
+    for (series, leaves) in by_series {
+        node.children.push(build_series_node(&series, &leaves));
+    }
+    node
+}
+
+fn build_series_node(series: &str, leaves: &[(usize, Vec<String>)]) -> TreeNode {
+    let mut node = TreeNode {
+        label: series.to_string(),
+        children: Vec::new(),
+        model_index: None,
+    };
+    if leaves.len() == 1 {
+        let (idx, _) = leaves[0];
+        node.children.push(TreeNode {
+            label: "(only)".to_string(),
+            children: Vec::new(),
+            model_index: Some(idx),
+        });
+        return node;
+    }
+    // Group leaves by the first remaining token (= "version") so users
+    // can drill one more layer down. Anything past that is collapsed
+    // into the leaf label.
+    let mut by_version: BTreeMap<String, Vec<(usize, Vec<String>)>> = BTreeMap::new();
+    for (idx, tail) in leaves {
+        let (head, rest) = match tail.split_first() {
+            Some((h, r)) => (h.clone(), r.to_vec()),
+            None => ("(base)".to_string(), Vec::new()),
+        };
+        by_version.entry(head).or_default().push((*idx, rest));
+    }
+    for (version, group) in by_version {
+        if group.len() == 1 {
+            let (idx, rest) = &group[0];
+            let label = if rest.is_empty() {
+                version.clone()
+            } else {
+                format!("{} {}", version, rest.join(" "))
+            };
+            node.children.push(TreeNode {
+                label,
+                children: Vec::new(),
+                model_index: Some(*idx),
+            });
+            continue;
+        }
+        // Multiple variants share the same version prefix → expose them
+        // as siblings under the version node.
+        let mut version_node = TreeNode {
+            label: version.clone(),
+            children: Vec::new(),
+            model_index: None,
+        };
+        for (idx, rest) in &group {
+            let label = if rest.is_empty() {
+                "(base)".to_string()
+            } else {
+                rest.join(" ")
+            };
+            version_node.children.push(TreeNode {
+                label,
+                children: Vec::new(),
+                model_index: Some(*idx),
+            });
+        }
+        node.children.push(version_node);
+    }
+    node
+}
+
+fn tokenize(rest: &str) -> Vec<String> {
+    rest.split(|c: char| c == '-' || c == ':')
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::catalog::{ModelFeatures, ModelInfo};
+
+    fn mi(id: &str) -> ModelInfo {
+        ModelInfo {
+            id: id.into(),
+            display_name: id.into(),
+            context_length: 128_000,
+            pricing: None,
+            features: ModelFeatures::default(),
+            top_provider: None,
+        }
+    }
+
+    #[test]
+    fn slash_ids_split_lab_then_series() {
+        let models = vec![
+            mi("moonshot/kimi-k2.6"),
+            mi("moonshot/kimi-k2.5"),
+            mi("openai/gpt-5"),
+        ];
+        let tree = build_model_tree("openrouter", &models);
+        let lab_labels: Vec<&str> = tree.labs.iter().map(|n| n.label.as_str()).collect();
+        assert_eq!(lab_labels, vec!["moonshot", "openai"]);
+
+        let moonshot = tree.labs.iter().find(|n| n.label == "moonshot").unwrap();
+        let series_labels: Vec<&str> = moonshot
+            .children
+            .iter()
+            .map(|n| n.label.as_str())
+            .collect();
+        assert_eq!(series_labels, vec!["kimi"]);
+
+        let kimi = &moonshot.children[0];
+        let versions: Vec<&str> = kimi.children.iter().map(|n| n.label.as_str()).collect();
+        // Two leaves k2.5 and k2.6.
+        assert_eq!(versions.len(), 2);
+        assert!(versions.contains(&"k2.5"));
+        assert!(versions.contains(&"k2.6"));
+    }
+
+    #[test]
+    fn flat_ids_use_provider_label_as_lab() {
+        let models = vec![mi("gpt-5"), mi("gpt-5-mini"), mi("o3")];
+        let tree = build_model_tree("openai", &models);
+        let labs: Vec<&str> = tree.labs.iter().map(|n| n.label.as_str()).collect();
+        assert_eq!(labs, vec!["openai"]);
+
+        let lab = &tree.labs[0];
+        let series: Vec<&str> = lab.children.iter().map(|n| n.label.as_str()).collect();
+        // gpt + o3
+        assert!(series.contains(&"gpt"));
+        assert!(series.contains(&"o3"));
+    }
+
+    #[test]
+    fn single_model_in_lab_collapses_to_only_leaf() {
+        let models = vec![mi("anthropic/claude-opus-4-7")];
+        let tree = build_model_tree("openrouter", &models);
+        let lab = &tree.labs[0];
+        assert_eq!(lab.label, "anthropic");
+        let claude = &lab.children[0];
+        assert_eq!(claude.label, "claude");
+        assert_eq!(claude.children.len(), 1);
+        assert_eq!(claude.children[0].label, "(only)");
+        assert_eq!(claude.children[0].model_index, Some(0));
+    }
+
+    #[test]
+    fn column_at_walks_path() {
+        let models = vec![mi("moonshot/kimi-k2.6"), mi("openai/gpt-5")];
+        let tree = build_model_tree("openrouter", &models);
+        // Column 0: labs.
+        assert_eq!(tree.column_at(0, &[]).len(), 2);
+        // Column 1: series under moonshot (idx 0).
+        let series = tree.column_at(1, &[0]);
+        assert_eq!(series.len(), 1);
+        assert_eq!(series[0].label, "kimi");
+        // Column 2: versions under moonshot/kimi.
+        let versions = tree.column_at(2, &[0, 0]);
+        assert!(!versions.is_empty());
+    }
+}

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -540,12 +540,19 @@ pub struct AppState {
     /// Index into `sessions` for the highlighted row in the picker.
     pub session_picker_selection: usize,
 
-    /// Model picker overlay (YYC-97). Opened by `/model` with no args;
-    /// items are populated from the active provider's catalog at open
-    /// time. Selecting a row triggers `Agent::switch_model`.
+    /// Model picker overlay (YYC-97 → YYC-101 hierarchical). Opened by
+    /// `/model` with no args; items are populated from the active
+    /// provider's catalog at open time. Tree columns drill
+    /// lab → series → version. `Enter` triggers `Agent::switch_model`.
     pub show_model_picker: bool,
-    pub model_picker_selection: usize,
+    /// Source catalog for the picker; rebuilt each open.
     pub model_picker_items: Vec<crate::provider::catalog::ModelInfo>,
+    /// Hierarchical tree built from `model_picker_items`.
+    pub model_picker_tree: super::model_picker::ModelTree,
+    /// Selection index per drilled column.
+    pub model_picker_path: Vec<usize>,
+    /// Which column currently has focus (0 = column 0, etc.).
+    pub model_picker_focus: usize,
 
     /// Provider picker overlay (YYC-97). Opened by `/provider` with no
     /// args; items are the legacy `[provider]` block followed by named
@@ -663,8 +670,10 @@ impl AppState {
             session_picker_selection: 0,
 
             show_model_picker: false,
-            model_picker_selection: 0,
             model_picker_items: Vec::new(),
+            model_picker_tree: super::model_picker::ModelTree::default(),
+            model_picker_path: Vec::new(),
+            model_picker_focus: 0,
 
             show_provider_picker: false,
             provider_picker_selection: 0,


### PR DESCRIPTION
Replaces the flat 350-row scroll list with a mini.files-style miller-
columns overlay drilled by Vim keys. Tractable for OpenRouter-shape
catalogs where the model id encodes lab → series → version.

Tree builder (src/tui/model_picker.rs):
- build_model_tree(provider_label, models) splits each id at `/` for
  the lab, then `-`/`:` for series and version. Flat slugs (gpt-5,
  o3) bucket under the provider profile name.
- ModelTree::column_at(depth, path) is the column accessor.
- 4 unit tests fix the slash, flat, single-leaf, and walk paths.

TUI (src/tui/state.rs, src/tui/mod.rs):
- AppState gains model_picker_tree / path / focus; the old single
  selection index is gone.
- /model (no arg) builds the tree, picks the column path that
  matches the active model, and opens the overlay.
- draw_diff scrubber stays untouched. draw_model_picker is rewritten
  to render N tree columns + a final details pane (id, ctx, features,
  pricing, upstream).
- Active column row gets the theme accent (or REVERSED fallback
  when accent has no fg).
- Key dispatch (modal):
  ↑/k ↓/j move within the focused column,
  →/l drill into the child column or commit a leaf,
  ←/h focus the parent column or close on column 0,
  Enter commits when the path lands on a leaf,
  Esc / q close without changing.

Out of scope, follow-ups:
- Provider column merge: /provider stays as its own flat picker for
  now. Doing a real merge needs async catalog refetch on column-0
  navigation; deferred.
- Incremental `/` filter and `g`/`G`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>