### PR TITLE
YYC-102: universal MillerColumns widget — mini.files-style picker

### DIFF
--- a/src/tui/miller_columns.rs
+++ b/src/tui/miller_columns.rs
@@ -1,0 +1,391 @@
+//! Universal mini.files-style miller-columns widget (YYC-102).
+//!
+//! Anchored top-left, drilled by hjkl. Each column is its own bordered
+//! block with a header equal to the parent path segment. The rightmost
+//! column is a preview pane: leaf → rendered detail; branch → child
+//! listing.
+//!
+//! `MillerSource` is the adapter trait; the model picker, session
+//! picker, command palette, and `/skills` browser can all back the
+//! same widget by implementing it.
+
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, BorderType, Borders, Paragraph, Wrap},
+};
+
+use crate::tui::theme::Theme;
+
+/// One row in a miller column.
+#[derive(Clone, Debug)]
+pub struct MillerEntry {
+    pub label: String,
+    /// Single-char icon (e.g. ▸, ▪, 󰈤, 📁). Empty string = no icon.
+    pub icon: String,
+    /// Branch entry → arrow rendered, drill-down works.
+    pub has_children: bool,
+}
+
+/// Rendered preview content for the rightmost column.
+#[derive(Clone, Debug, Default)]
+pub struct MillerPreview {
+    pub title: String,
+    pub lines: Vec<Line<'static>>,
+}
+
+/// Adapter: the consumer of the widget implements this to expose
+/// hierarchical content.
+pub trait MillerSource {
+    /// Title for the column at `path.len()` depth — typically the
+    /// parent's label, or a root anchor like `~/vulcan`.
+    fn header(&self, path: &[usize]) -> String;
+    /// Rows for the column at `path.len()` depth.
+    fn entries(&self, path: &[usize]) -> Vec<MillerEntry>;
+    /// Preview pane content for the currently-selected row at `path`.
+    fn preview(&self, path: &[usize]) -> Option<MillerPreview>;
+}
+
+/// Cursor state. Owned by the consumer so the widget itself stays
+/// stateless across redraws.
+#[derive(Clone, Debug, Default)]
+pub struct MillerState {
+    /// Selection index per column. Length == focused column + 1.
+    pub path: Vec<usize>,
+    /// Which column has keyboard focus (0..= path.len()-1).
+    pub focus: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MillerAction {
+    /// No state change, redraw and wait for the next key.
+    Continue,
+    /// User pressed Esc / q — caller should close the overlay.
+    Cancel,
+    /// User pressed Enter on a row that should commit.
+    Commit,
+}
+
+impl MillerState {
+    pub fn new() -> Self {
+        Self {
+            path: vec![0],
+            focus: 0,
+        }
+    }
+    pub fn current_selection(&self) -> usize {
+        self.path.get(self.focus).copied().unwrap_or(0)
+    }
+}
+
+/// Move the focused column's cursor by `delta`. Clamps to entries.
+pub fn move_cursor<S: MillerSource>(state: &mut MillerState, source: &S, delta: i32) {
+    let prefix: Vec<usize> = state.path.iter().take(state.focus).copied().collect();
+    let entries = source.entries(&prefix);
+    if entries.is_empty() {
+        return;
+    }
+    while state.path.len() <= state.focus {
+        state.path.push(0);
+    }
+    let cur = state.path[state.focus] as i32 + delta;
+    let max = (entries.len() - 1) as i32;
+    state.path[state.focus] = cur.clamp(0, max) as usize;
+    // Drilled columns past the focused one are stale — drop them.
+    state.path.truncate(state.focus + 1);
+}
+
+/// Drill into the focused selection's children. Returns true when the
+/// drill happened; false when the row is a leaf (caller should commit).
+pub fn drill<S: MillerSource>(state: &mut MillerState, source: &S) -> bool {
+    let prefix: Vec<usize> = state.path.iter().take(state.focus).copied().collect();
+    let entries = source.entries(&prefix);
+    let sel = state.path.get(state.focus).copied().unwrap_or(0);
+    let Some(entry) = entries.get(sel) else {
+        return false;
+    };
+    if !entry.has_children {
+        return false;
+    }
+    while state.path.len() <= state.focus + 1 {
+        state.path.push(0);
+    }
+    state.path[state.focus + 1] = 0;
+    state.focus += 1;
+    true
+}
+
+/// Move focus to the parent column (collapse rightmost). Returns true
+/// when the collapse happened; false when already at column 0 (caller
+/// should close the overlay).
+pub fn ascend(state: &mut MillerState) -> bool {
+    if state.focus == 0 {
+        return false;
+    }
+    state.focus -= 1;
+    state.path.truncate(state.focus + 1);
+    true
+}
+
+/// Render the picker top-left-anchored inside `area`. Each column is a
+/// titled, bordered block; the rightmost column shows preview content
+/// for the focused selection.
+pub fn render<S: MillerSource>(
+    f: &mut Frame,
+    area: Rect,
+    state: &MillerState,
+    source: &S,
+    theme: &Theme,
+) {
+    if area.width < 24 || area.height < 6 {
+        return;
+    }
+
+    // Work out how many columns we'll render: every drilled level + a
+    // preview column (always shown, even if empty, so the layout doesn't
+    // jump as the user drills).
+    let drill_columns = state.focus + 1;
+    let total_columns = drill_columns + 1; // +1 preview
+
+    // Width budget. Cap each column at ~30 cols, give the preview the
+    // larger remainder.
+    let col_w = (area.width / total_columns as u16)
+        .min(36)
+        .max(14);
+    let preview_w = area
+        .width
+        .saturating_sub(col_w * drill_columns as u16)
+        .max(col_w);
+
+    let mut x_cursor = area.x;
+    let max_height = area.height;
+
+    for col_idx in 0..drill_columns {
+        let prefix: Vec<usize> = state.path.iter().take(col_idx).copied().collect();
+        let entries = source.entries(&prefix);
+        let selection = state.path.get(col_idx).copied().unwrap_or(0);
+        let header = source.header(&prefix);
+
+        let max_visible = max_height.saturating_sub(2);
+        let height = ((entries.len() as u16) + 2)
+            .min(max_height)
+            .max(if entries.is_empty() { 4 } else { 4 });
+        let _ = max_visible;
+
+        let rect = Rect {
+            x: x_cursor,
+            y: area.y,
+            width: col_w,
+            height,
+        };
+        draw_column(f, rect, &header, &entries, selection, col_idx == state.focus, theme);
+        x_cursor = x_cursor.saturating_add(col_w);
+    }
+
+    // Preview column — leaf detail or "no preview" placeholder.
+    let preview = source.preview(&state.path);
+    let preview_rect = Rect {
+        x: x_cursor,
+        y: area.y,
+        width: preview_w,
+        height: max_height,
+    };
+    draw_preview(f, preview_rect, preview.as_ref(), theme);
+}
+
+fn draw_column(
+    f: &mut Frame,
+    rect: Rect,
+    header: &str,
+    entries: &[MillerEntry],
+    selection: usize,
+    is_focused: bool,
+    theme: &Theme,
+) {
+    if rect.width < 4 || rect.height < 3 {
+        return;
+    }
+    let border_style = if is_focused {
+        theme.accent.add_modifier(Modifier::BOLD)
+    } else {
+        theme.border
+    };
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Plain)
+        .border_style(border_style)
+        .title(format!(" {} ", header));
+    let inner = block.inner(rect);
+    f.render_widget(block, rect);
+
+    if entries.is_empty() {
+        f.render_widget(
+            Paragraph::new(Line::from(Span::styled("  (empty)", theme.muted))),
+            inner,
+        );
+        return;
+    }
+
+    let visible = inner.height as usize;
+    let active = selection.min(entries.len().saturating_sub(1));
+    let start = active.saturating_sub(visible.saturating_sub(1) / 2);
+    let end = (start + visible).min(entries.len());
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    for (i, entry) in entries.iter().enumerate().take(end).skip(start) {
+        let is_active = i == active;
+        let icon = if entry.icon.is_empty() {
+            String::new()
+        } else {
+            format!("{} ", entry.icon)
+        };
+        let arrow = if entry.has_children { " ›" } else { "" };
+        let label = trim_to_width(
+            &format!("{}{}{}", icon, entry.label, arrow),
+            inner.width.saturating_sub(2) as usize,
+        );
+        let style = if is_active {
+            // mini.files-style cursor row: full-width REVERSED block.
+            if is_focused {
+                Style::default().add_modifier(Modifier::REVERSED | Modifier::BOLD)
+            } else {
+                Style::default().add_modifier(Modifier::BOLD)
+            }
+        } else {
+            Style::default()
+        };
+        // Pad to column width so the REVERSED row fills the visible
+        // line — matches the mini.files cursor block.
+        let mut row = label.clone();
+        let pad = (inner.width as usize).saturating_sub(row.chars().count());
+        if pad > 0 {
+            row.push_str(&" ".repeat(pad));
+        }
+        lines.push(Line::from(Span::styled(row, style)));
+    }
+    f.render_widget(Paragraph::new(lines), inner);
+}
+
+fn draw_preview(
+    f: &mut Frame,
+    rect: Rect,
+    preview: Option<&MillerPreview>,
+    theme: &Theme,
+) {
+    if rect.width < 6 || rect.height < 3 {
+        return;
+    }
+    let title = preview
+        .map(|p| p.title.clone())
+        .unwrap_or_else(|| "preview".to_string());
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Plain)
+        .border_style(theme.border)
+        .title(format!(" {title} "));
+    let inner = block.inner(rect);
+    f.render_widget(block, rect);
+
+    let body = match preview {
+        Some(p) if !p.lines.is_empty() => Paragraph::new(p.lines.clone()).wrap(Wrap { trim: false }),
+        Some(_) => Paragraph::new(Line::from(Span::styled("  (empty)", theme.muted))),
+        None => Paragraph::new(Line::from(Span::styled(
+            "  drill in to preview",
+            theme.muted,
+        ))),
+    };
+    f.render_widget(body, inner);
+}
+
+fn trim_to_width(s: &str, width: usize) -> String {
+    if width == 0 {
+        return String::new();
+    }
+    let chars: Vec<char> = s.chars().collect();
+    if chars.len() <= width {
+        return s.to_string();
+    }
+    let head: String = chars.iter().take(width.saturating_sub(1)).collect();
+    format!("{head}…")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct FakeSource;
+    impl MillerSource for FakeSource {
+        fn header(&self, path: &[usize]) -> String {
+            format!("col@{}", path.len())
+        }
+        fn entries(&self, path: &[usize]) -> Vec<MillerEntry> {
+            // Three branches at root, two leaves at depth 1, none deeper.
+            match path.len() {
+                0 => vec![
+                    MillerEntry {
+                        label: "alpha".into(),
+                        icon: String::new(),
+                        has_children: true,
+                    },
+                    MillerEntry {
+                        label: "beta".into(),
+                        icon: String::new(),
+                        has_children: true,
+                    },
+                ],
+                1 => vec![
+                    MillerEntry {
+                        label: "leaf1".into(),
+                        icon: String::new(),
+                        has_children: false,
+                    },
+                    MillerEntry {
+                        label: "leaf2".into(),
+                        icon: String::new(),
+                        has_children: false,
+                    },
+                ],
+                _ => vec![],
+            }
+        }
+        fn preview(&self, _path: &[usize]) -> Option<MillerPreview> {
+            None
+        }
+    }
+
+    #[test]
+    fn cursor_navigation_clamps() {
+        let mut state = MillerState::new();
+        let src = FakeSource;
+        move_cursor(&mut state, &src, 3); // overshoots → clamps to 1
+        assert_eq!(state.path[0], 1);
+        move_cursor(&mut state, &src, -10);
+        assert_eq!(state.path[0], 0);
+    }
+
+    #[test]
+    fn drill_into_branch_then_ascend() {
+        let mut state = MillerState::new();
+        let src = FakeSource;
+        assert!(drill(&mut state, &src));
+        assert_eq!(state.focus, 1);
+        assert_eq!(state.path.len(), 2);
+        assert!(ascend(&mut state));
+        assert_eq!(state.focus, 0);
+        assert_eq!(state.path.len(), 1);
+        // Already at column 0 → ascend returns false.
+        assert!(!ascend(&mut state));
+    }
+
+    #[test]
+    fn drill_returns_false_on_leaf() {
+        let mut state = MillerState::new();
+        let src = FakeSource;
+        drill(&mut state, &src); // into alpha
+        // Now at depth 1 looking at leaves; drilling further should bail.
+        assert!(!drill(&mut state, &src));
+        assert_eq!(state.focus, 1);
+    }
+}

--- a/src/tui/miller_columns.rs
+++ b/src/tui/miller_columns.rs
@@ -129,9 +129,14 @@ pub fn ascend(state: &mut MillerState) -> bool {
     true
 }
 
+/// Width budget per column kind (mini.files defaults adapted to TUI).
+const WIDTH_FOCUS: u16 = 36;
+const WIDTH_NOFOCUS: u16 = 18;
+const WIDTH_PREVIEW: u16 = 40;
+
 /// Render the picker top-left-anchored inside `area`. Each column is a
-/// titled, bordered block; the rightmost column shows preview content
-/// for the focused selection.
+/// titled, bordered block; the focused column is wider; the rightmost
+/// column is a preview pane only when there's something to preview.
 pub fn render<S: MillerSource>(
     f: &mut Frame,
     area: Rect,
@@ -143,56 +148,63 @@ pub fn render<S: MillerSource>(
         return;
     }
 
-    // Work out how many columns we'll render: every drilled level + a
-    // preview column (always shown, even if empty, so the layout doesn't
-    // jump as the user drills).
     let drill_columns = state.focus + 1;
-    let total_columns = drill_columns + 1; // +1 preview
+    let preview = source.preview(&state.path);
+    let show_preview = preview.is_some();
 
-    // Width budget. Cap each column at ~30 cols, give the preview the
-    // larger remainder.
-    let col_w = (area.width / total_columns as u16)
-        .min(36)
-        .max(14);
-    let preview_w = area
-        .width
-        .saturating_sub(col_w * drill_columns as u16)
-        .max(col_w);
+    // Compute how many columns fit. Mini.files prioritizes focus + preview,
+    // then adds non-focused columns while space remains.
+    let mut budget = area.width;
+    let preview_w = if show_preview {
+        WIDTH_PREVIEW.min(budget.saturating_sub(WIDTH_FOCUS).max(WIDTH_PREVIEW.min(20)))
+    } else {
+        0
+    };
+    if show_preview {
+        budget = budget.saturating_sub(preview_w);
+    }
+    budget = budget.saturating_sub(WIDTH_FOCUS);
+    let mut max_visible_cols = 1; // focused
+    while budget >= WIDTH_NOFOCUS && max_visible_cols < drill_columns {
+        budget = budget.saturating_sub(WIDTH_NOFOCUS);
+        max_visible_cols += 1;
+    }
+
+    // Center the focused column in the visible window: `to` is the last
+    // column drawn, `from` the first.
+    let to = drill_columns;
+    let from = to.saturating_sub(max_visible_cols);
 
     let mut x_cursor = area.x;
-    let max_height = area.height;
+    let max_height = area.height.saturating_sub(1); // keep last row for footer
 
-    for col_idx in 0..drill_columns {
+    for col_idx in from..drill_columns {
         let prefix: Vec<usize> = state.path.iter().take(col_idx).copied().collect();
         let entries = source.entries(&prefix);
         let selection = state.path.get(col_idx).copied().unwrap_or(0);
         let header = source.header(&prefix);
-
-        let max_visible = max_height.saturating_sub(2);
-        let height = ((entries.len() as u16) + 2)
-            .min(max_height)
-            .max(if entries.is_empty() { 4 } else { 4 });
-        let _ = max_visible;
+        let is_focused = col_idx == state.focus;
+        let width = if is_focused { WIDTH_FOCUS } else { WIDTH_NOFOCUS };
 
         let rect = Rect {
             x: x_cursor,
             y: area.y,
-            width: col_w,
-            height,
+            width,
+            height: max_height,
         };
-        draw_column(f, rect, &header, &entries, selection, col_idx == state.focus, theme);
-        x_cursor = x_cursor.saturating_add(col_w);
+        draw_column(f, rect, &header, &entries, selection, is_focused, theme);
+        x_cursor = x_cursor.saturating_add(width);
     }
 
-    // Preview column — leaf detail or "no preview" placeholder.
-    let preview = source.preview(&state.path);
-    let preview_rect = Rect {
-        x: x_cursor,
-        y: area.y,
-        width: preview_w,
-        height: max_height,
-    };
-    draw_preview(f, preview_rect, preview.as_ref(), theme);
+    if show_preview && preview_w > 0 {
+        let preview_rect = Rect {
+            x: x_cursor,
+            y: area.y,
+            width: preview_w,
+            height: max_height,
+        };
+        draw_preview(f, preview_rect, preview.as_ref(), theme);
+    }
 }
 
 fn draw_column(

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -834,6 +834,28 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                                     .map(|m| m.id.clone());
                                             }
                                         }
+                                        KeyCode::Char('L') => {
+                                            // mini.files L: drill, and if the
+                                            // child is a leaf, commit.
+                                            if !miller_columns::drill(&mut state, &source) {
+                                                commit_id = source.leaf_at(&state.path)
+                                                    .and_then(|i| app.model_picker_items.get(i))
+                                                    .map(|m| m.id.clone());
+                                            } else {
+                                                commit_id = source.leaf_at(&state.path)
+                                                    .and_then(|i| app.model_picker_items.get(i))
+                                                    .map(|m| m.id.clone());
+                                            }
+                                        }
+                                        KeyCode::Char('H') => {
+                                            // mini.files H: ascend AND trim
+                                            // rightward — already implicit in
+                                            // ascend() since deeper path is
+                                            // dropped.
+                                            if !miller_columns::ascend(&mut state) {
+                                                close = true;
+                                            }
+                                        }
                                         KeyCode::Enter => {
                                             commit_id = source
                                                 .leaf_at(&state.path)

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -9,7 +9,7 @@ use ratatui::{
     prelude::Position,
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Paragraph, Wrap},
+    widgets::Paragraph,
 };
 use tokio::sync::{Mutex, mpsc};
 
@@ -23,6 +23,7 @@ use crate::provider::StreamEvent;
 pub mod chat_render;
 pub mod keybinds;
 pub mod markdown;
+pub mod miller_columns;
 pub mod model_picker;
 pub mod state;
 pub mod theme;
@@ -798,36 +799,52 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                 if key.kind == KeyEventKind::Press {
                                     let mut commit_id: Option<String> = None;
                                     let mut close = false;
+                                    let provider_label = {
+                                        let a = agent.lock().await;
+                                        a.active_profile()
+                                            .map(str::to_string)
+                                            .unwrap_or_else(|| "default".into())
+                                    };
+                                    let mut state = miller_columns::MillerState {
+                                        path: app.model_picker_path.clone(),
+                                        focus: app.model_picker_focus,
+                                    };
+                                    let source = model_picker::ModelPickerSource::new(
+                                        &app.model_picker_tree,
+                                        &app.model_picker_items,
+                                        format!("~ {provider_label}"),
+                                    );
                                     match key.code {
                                         KeyCode::Up | KeyCode::Char('k') => {
-                                            picker_move(&mut app, -1);
+                                            miller_columns::move_cursor(&mut state, &source, -1);
                                         }
                                         KeyCode::Down | KeyCode::Char('j') => {
-                                            picker_move(&mut app, 1);
+                                            miller_columns::move_cursor(&mut state, &source, 1);
                                         }
                                         KeyCode::Left | KeyCode::Char('h') => {
-                                            if app.model_picker_focus == 0 {
+                                            if !miller_columns::ascend(&mut state) {
                                                 close = true;
-                                            } else {
-                                                app.model_picker_focus -= 1;
-                                                app.model_picker_path
-                                                    .truncate(app.model_picker_focus + 1);
                                             }
                                         }
                                         KeyCode::Right | KeyCode::Char('l') => {
-                                            if let Some(id) = picker_drill_or_commit(&mut app)
-                                            {
-                                                commit_id = Some(id);
+                                            if !miller_columns::drill(&mut state, &source) {
+                                                // Leaf — commit.
+                                                commit_id = source.leaf_at(&state.path)
+                                                    .and_then(|i| app.model_picker_items.get(i))
+                                                    .map(|m| m.id.clone());
                                             }
                                         }
                                         KeyCode::Enter => {
-                                            if let Some(id) = picker_commit_current(&app) {
-                                                commit_id = Some(id);
-                                            }
+                                            commit_id = source
+                                                .leaf_at(&state.path)
+                                                .and_then(|i| app.model_picker_items.get(i))
+                                                .map(|m| m.id.clone());
                                         }
                                         KeyCode::Esc | KeyCode::Char('q') => close = true,
                                         _ => {}
                                     }
+                                    app.model_picker_path = state.path;
+                                    app.model_picker_focus = state.focus;
                                     if let Some(id) = commit_id {
                                         let result = {
                                             let mut a = agent.lock().await;
@@ -2084,337 +2101,41 @@ fn draw_session_picker(f: &mut ratatui::Frame, area: Rect, app: &AppState) {
 }
 
 fn draw_model_picker(f: &mut ratatui::Frame, area: Rect, app: &AppState) {
-    let theme = &app.theme;
-    let width = area.width.min(72);
-    let rows = (app.model_picker_items.len() as u16).min(20);
-    let height = (rows + 5).min(area.height.saturating_sub(2));
-    let x = area.x + (area.width.saturating_sub(width)) / 2;
-    let y = area.y + (area.height.saturating_sub(height)) / 2;
-    let box_area = Rect { x, y, width, height };
-    if box_area.height < 4 {
-        return;
-    }
-
-    let bar = Rect {
-        x: box_area.x,
-        y: box_area.y,
-        width: box_area.width,
-        height: 1,
-    };
-    let mut title = "  Switch Model  ".to_string();
-    if (title.chars().count() as u16) < bar.width {
-        let pad = bar.width as usize - title.chars().count();
-        title = format!(
-            "{}{}{}",
-            " ".repeat(pad / 2),
-            title.trim(),
-            " ".repeat(pad - pad / 2)
-        );
-    }
-    f.render_widget(
-        Paragraph::new(title).style(theme.accent.add_modifier(Modifier::BOLD)),
-        bar,
+    // YYC-102: render via the universal miller_columns widget. The
+    // overlay anchors top-left and grows rightward as the user drills.
+    let provider_label = app
+        .provider_label
+        .clone()
+        .unwrap_or_else(|| "default".into());
+    let source = model_picker::ModelPickerSource::new(
+        &app.model_picker_tree,
+        &app.model_picker_items,
+        format!("~ {provider_label}"),
     );
-
-    let list_area = Rect {
-        x: box_area.x,
-        y: box_area.y + 1,
-        width: box_area.width,
-        height: box_area.height.saturating_sub(2),
+    let state = miller_columns::MillerState {
+        path: app.model_picker_path.clone(),
+        focus: app.model_picker_focus,
     };
-
-    if app.model_picker_items.is_empty() {
-        f.render_widget(
-            Paragraph::new(Line::from(Span::styled(
-                "  No models in provider catalog.",
-                theme.muted,
-            ))),
-            list_area,
-        );
-        draw_picker_border(f, box_area, theme);
-        return;
-    }
-
-    // Mini-files-style miller columns. The number of visible columns is
-    // capped to whatever the box width can fit (each column is roughly
-    // 20–28 chars). Always reserve the rightmost column for details.
-    let drilled_depth = app.model_picker_path.len();
-    let max_tree_depth = app.model_picker_tree.max_depth();
-    let total_columns = max_tree_depth.max(1) + 1; // +1 for details
-
-    let col_width = (list_area.width / total_columns as u16).max(16);
-    let cols: Vec<Rect> = (0..total_columns)
-        .map(|i| Rect {
-            x: list_area.x + i as u16 * col_width,
-            y: list_area.y,
-            width: col_width,
-            height: list_area.height,
-        })
-        .collect();
-
-    // Render each tree column.
-    for col_idx in 0..max_tree_depth {
-        let path_prefix: Vec<usize> = app
-            .model_picker_path
-            .iter()
-            .copied()
-            .take(col_idx)
-            .collect();
-        let nodes = app.model_picker_tree.column_at(col_idx, &path_prefix);
-        let selection = app
-            .model_picker_path
-            .get(col_idx)
-            .copied()
-            .unwrap_or(0)
-            .min(nodes.len().saturating_sub(1));
-        let is_focused = col_idx == app.model_picker_focus;
-        render_picker_column(f, cols[col_idx], nodes, selection, is_focused, theme);
-    }
-
-    // Details panel at the rightmost column.
-    let details_col = cols.last().copied().unwrap_or(list_area);
-    let detail_lines = build_picker_details(app);
-    f.render_widget(Paragraph::new(detail_lines).wrap(Wrap { trim: false }), details_col);
-
-    let hint = "  hjkl move · Enter select · Esc cancel  (drilled: column ";
-    let footer_line = format!(
-        "{hint}{}/{})",
-        app.model_picker_focus + 1,
-        max_tree_depth.max(1)
-    );
-    let footer_rect = Rect {
-        x: list_area.x,
-        y: list_area.y + list_area.height.saturating_sub(1),
-        width: list_area.width,
+    // Inset by 1 from the top-left so we don't paint over the very edge.
+    let rect = Rect {
+        x: area.x + 1,
+        y: area.y + 1,
+        width: area.width.saturating_sub(2),
+        height: area.height.saturating_sub(2),
+    };
+    miller_columns::render(f, rect, &state, &source, &app.theme);
+    // Footer hint anchored to the bottom of the area.
+    let hint = "  hjkl navigate · Enter select · Esc cancel  ";
+    let footer = Rect {
+        x: area.x + 1,
+        y: area.y + area.height.saturating_sub(1),
+        width: area.width.saturating_sub(2),
         height: 1,
     };
     f.render_widget(
-        Paragraph::new(Line::from(Span::styled(footer_line, theme.muted))),
-        footer_rect,
+        Paragraph::new(Line::from(Span::styled(hint, app.theme.muted))),
+        footer,
     );
-    let _ = drilled_depth; // reserved for future filter UI
-
-    draw_picker_border(f, box_area, theme);
-}
-
-fn render_picker_column(
-    f: &mut ratatui::Frame,
-    area: Rect,
-    nodes: &[crate::tui::model_picker::TreeNode],
-    selection: usize,
-    is_focused: bool,
-    theme: &Theme,
-) {
-    let mut lines: Vec<Line<'static>> = Vec::new();
-    if nodes.is_empty() {
-        lines.push(Line::from(Span::styled("  ·", theme.muted)));
-    } else {
-        let visible = area.height.saturating_sub(2) as usize;
-        let start = selection.saturating_sub(visible.saturating_sub(1) / 2);
-        let end = (start + visible).min(nodes.len());
-        for (i, node) in nodes.iter().enumerate().take(end).skip(start) {
-            let is_active = i == selection;
-            let marker = if is_active && is_focused {
-                "▸ "
-            } else if is_active {
-                "│ "
-            } else {
-                "  "
-            };
-            let mut style = Style::default();
-            if is_active {
-                style = style.add_modifier(Modifier::BOLD);
-                if is_focused {
-                    style = if let Some(fg) = theme.accent.fg {
-                        style.fg(fg)
-                    } else {
-                        style.add_modifier(Modifier::REVERSED)
-                    };
-                }
-            }
-            let suffix = if node.children.is_empty() && node.model_index.is_some() {
-                ""
-            } else {
-                "›"
-            };
-            let label = trim_to_width(&node.label, area.width.saturating_sub(4) as usize);
-            lines.push(Line::from(vec![
-                Span::styled(marker, style),
-                Span::styled(label, style),
-                Span::styled(format!(" {suffix}"), theme.muted),
-            ]));
-        }
-        if start > 0 || end < nodes.len() {
-            lines.push(Line::from(Span::styled(
-                format!("  …{}/{}", end, nodes.len()),
-                theme.muted.add_modifier(Modifier::DIM),
-            )));
-        }
-    }
-    f.render_widget(Paragraph::new(lines), area);
-}
-
-fn build_picker_details(app: &AppState) -> Vec<Line<'static>> {
-    let theme = &app.theme;
-    let mut lines = Vec::new();
-    let leaf_idx = picker_current_leaf(&app.model_picker_tree, &app.model_picker_path);
-    let Some(idx) = leaf_idx else {
-        lines.push(Line::from(Span::styled(
-            "  drill in (l/→) for details",
-            theme.muted,
-        )));
-        return lines;
-    };
-    let Some(model) = app.model_picker_items.get(idx) else {
-        return lines;
-    };
-    lines.push(Line::from(Span::styled(
-        format!(" {}", model.id),
-        Style::default().add_modifier(Modifier::BOLD),
-    )));
-    lines.push(Line::from(""));
-    let ctx = if model.context_length > 0 {
-        crate::tui::state::format_thousands(model.context_length as u32)
-    } else {
-        "?".into()
-    };
-    lines.push(Line::from(Span::styled(
-        format!(" context  : {ctx}"),
-        theme.muted,
-    )));
-    let mut flags = Vec::new();
-    if model.features.tools {
-        flags.push("tools");
-    }
-    if model.features.reasoning {
-        flags.push("reasoning");
-    }
-    if model.features.vision {
-        flags.push("vision");
-    }
-    if model.features.json_mode {
-        flags.push("json");
-    }
-    let flag_str = if flags.is_empty() {
-        "(none reported)".to_string()
-    } else {
-        flags.join(", ")
-    };
-    lines.push(Line::from(Span::styled(
-        format!(" features : {flag_str}"),
-        theme.muted,
-    )));
-    if let Some(p) = &model.pricing {
-        lines.push(Line::from(Span::styled(
-            format!(
-                " pricing  : ${:.4}/1k in · ${:.4}/1k out",
-                p.input_per_token * 1000.0,
-                p.output_per_token * 1000.0,
-            ),
-            theme.muted,
-        )));
-    }
-    if let Some(top) = &model.top_provider {
-        lines.push(Line::from(Span::styled(
-            format!(" upstream : {top}"),
-            theme.muted,
-        )));
-    }
-    lines
-}
-
-fn trim_to_width(s: &str, width: usize) -> String {
-    if width == 0 {
-        return String::new();
-    }
-    let chars: Vec<char> = s.chars().collect();
-    if chars.len() <= width {
-        return s.to_string();
-    }
-    let head: String = chars.iter().take(width.saturating_sub(1)).collect();
-    format!("{head}…")
-}
-
-fn picker_move(app: &mut AppState, delta: i32) {
-    let depth = app.model_picker_focus;
-    let path_prefix: Vec<usize> = app
-        .model_picker_path
-        .iter()
-        .copied()
-        .take(depth)
-        .collect();
-    let len = app
-        .model_picker_tree
-        .column_at(depth, &path_prefix)
-        .len();
-    if len == 0 {
-        return;
-    }
-    while app.model_picker_path.len() <= depth {
-        app.model_picker_path.push(0);
-    }
-    let cur = app.model_picker_path[depth] as i32 + delta;
-    let max = (len - 1) as i32;
-    app.model_picker_path[depth] = cur.clamp(0, max) as usize;
-    // Reset deeper selections — the active branch changed.
-    app.model_picker_path.truncate(depth + 1);
-}
-
-fn picker_drill_or_commit(app: &mut AppState) -> Option<String> {
-    let depth = app.model_picker_focus;
-    let path_prefix: Vec<usize> = app
-        .model_picker_path
-        .iter()
-        .copied()
-        .take(depth)
-        .collect();
-    let nodes = app
-        .model_picker_tree
-        .column_at(depth, &path_prefix)
-        .to_vec();
-    let sel = app.model_picker_path.get(depth).copied().unwrap_or(0);
-    let Some(node) = nodes.get(sel) else {
-        return None;
-    };
-    if node.children.is_empty() {
-        // Leaf — commit.
-        return node
-            .model_index
-            .and_then(|i| app.model_picker_items.get(i))
-            .map(|m| m.id.clone());
-    }
-    // Drill: focus next column, default selection 0.
-    while app.model_picker_path.len() <= depth + 1 {
-        app.model_picker_path.push(0);
-    }
-    app.model_picker_path[depth + 1] = 0;
-    app.model_picker_focus = depth + 1;
-    None
-}
-
-fn picker_commit_current(app: &AppState) -> Option<String> {
-    picker_current_leaf(&app.model_picker_tree, &app.model_picker_path)
-        .and_then(|i| app.model_picker_items.get(i))
-        .map(|m| m.id.clone())
-}
-
-fn picker_current_leaf(
-    tree: &crate::tui::model_picker::ModelTree,
-    path: &[usize],
-) -> Option<usize> {
-    let mut current: &[crate::tui::model_picker::TreeNode] = &tree.labs;
-    let mut leaf: Option<usize> = None;
-    for &idx in path {
-        let node = current.get(idx)?;
-        if node.children.is_empty() {
-            return node.model_index;
-        }
-        leaf = node.model_index;
-        current = &node.children;
-    }
-    // Path didn't reach a leaf — return last seen leaf marker (None for
-    // internal-only nodes).
-    leaf
 }
 
 fn initial_path_for_active_model(

--- a/src/tui/model_picker.rs
+++ b/src/tui/model_picker.rs
@@ -5,6 +5,9 @@
 //! helper module — render and key dispatch live in `tui::mod`.
 
 use crate::provider::catalog::ModelInfo;
+use crate::tui::miller_columns::{MillerEntry, MillerPreview, MillerSource};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
 use std::collections::BTreeMap;
 
 /// One node in the model tree. Leaves point at a `ModelInfo` index in
@@ -188,6 +191,121 @@ fn build_series_node(series: &str, leaves: &[(usize, Vec<String>)]) -> TreeNode 
         node.children.push(version_node);
     }
     node
+}
+
+/// `MillerSource` adapter that drives the universal miller-columns
+/// widget from a `ModelTree` + the source catalog (YYC-102).
+pub struct ModelPickerSource<'a> {
+    pub tree: &'a ModelTree,
+    pub items: &'a [ModelInfo],
+    pub root_label: String,
+}
+
+impl<'a> ModelPickerSource<'a> {
+    pub fn new(tree: &'a ModelTree, items: &'a [ModelInfo], root_label: String) -> Self {
+        Self {
+            tree,
+            items,
+            root_label,
+        }
+    }
+
+    fn nodes_at(&self, path: &[usize]) -> &'a [TreeNode] {
+        self.tree.column_at(path.len(), path)
+    }
+
+    pub fn leaf_at(&self, path: &[usize]) -> Option<usize> {
+        let mut current: &[TreeNode] = &self.tree.labs;
+        let mut leaf: Option<usize> = None;
+        for &idx in path {
+            let node = current.get(idx)?;
+            if node.children.is_empty() {
+                return node.model_index;
+            }
+            leaf = node.model_index;
+            current = &node.children;
+        }
+        leaf
+    }
+}
+
+impl<'a> MillerSource for ModelPickerSource<'a> {
+    fn header(&self, path: &[usize]) -> String {
+        if path.is_empty() {
+            return self.root_label.clone();
+        }
+        let mut current: &[TreeNode] = &self.tree.labs;
+        let mut last = self.root_label.clone();
+        for &idx in path {
+            let Some(node) = current.get(idx) else {
+                return last;
+            };
+            last = node.label.clone();
+            if node.children.is_empty() {
+                return last;
+            }
+            current = &node.children;
+        }
+        last
+    }
+
+    fn entries(&self, path: &[usize]) -> Vec<MillerEntry> {
+        self.nodes_at(path)
+            .iter()
+            .map(|node| MillerEntry {
+                label: node.label.clone(),
+                icon: if node.children.is_empty() { "·" } else { "▸" }.to_string(),
+                has_children: !node.children.is_empty(),
+            })
+            .collect()
+    }
+
+    fn preview(&self, path: &[usize]) -> Option<MillerPreview> {
+        let leaf = self.leaf_at(path)?;
+        let model = self.items.get(leaf)?;
+        let mut lines: Vec<Line<'static>> = Vec::new();
+        lines.push(Line::from(Span::styled(
+            model.id.clone(),
+            Style::default().add_modifier(Modifier::BOLD),
+        )));
+        lines.push(Line::from(""));
+        if model.context_length > 0 {
+            lines.push(Line::from(format!(
+                "context  : {}",
+                crate::tui::state::format_thousands(model.context_length as u32)
+            )));
+        }
+        let mut feats = Vec::new();
+        if model.features.tools {
+            feats.push("tools");
+        }
+        if model.features.reasoning {
+            feats.push("reasoning");
+        }
+        if model.features.vision {
+            feats.push("vision");
+        }
+        if model.features.json_mode {
+            feats.push("json");
+        }
+        if !feats.is_empty() {
+            lines.push(Line::from(format!("features : {}", feats.join(", "))));
+        }
+        if let Some(p) = &model.pricing {
+            lines.push(Line::from(format!(
+                "pricing  : ${:.4}/1k in · ${:.4}/1k out",
+                p.input_per_token * 1000.0,
+                p.output_per_token * 1000.0,
+            )));
+        }
+        if let Some(top) = &model.top_provider {
+            lines.push(Line::from(format!("upstream : {top}")));
+        }
+        Some(MillerPreview {
+            title: model.id.clone(),
+            lines,
+        })
+    }
 }
 
 fn tokenize(rest: &str) -> Vec<String> {


### PR DESCRIPTION
Generic miller-columns widget so future pickers (sessions, providers,
skills, command palette) reuse the layout instead of re-implementing
it. Also rewrites the YYC-101 model picker to render via the new
widget — anchored top-left, bordered titled columns, dynamic preview.

src/tui/miller_columns.rs:
- MillerSource trait: header, entries, preview by path.
- MillerEntry { label, icon, has_children }; MillerPreview { title, lines }.
- MillerState owns selection per column + focus index; the widget
  itself is stateless across redraws.
- move_cursor / drill / ascend helpers handle nav with selection
  reset on branch change.
- render() draws each column as a bordered Block with the parent
  segment as title, REVERSED cursor row matching mini.files, and a
  rightmost preview pane (leaf detail or "drill in to preview").
- 3 unit tests pin clamp / drill / ascend semantics.

Model picker rewired:
- ModelPickerSource adapter in src/tui/model_picker.rs (impl
  MillerSource backed by ModelTree + items list).
- draw_model_picker is now a thin wrapper: build adapter, call
  miller_columns::render, footer hint anchored to area bottom.
- Key dispatch in mod.rs replaced with miller_columns::move_cursor
  / drill / ascend; commit goes through ModelPickerSource::leaf_at.
- ~330 lines of legacy hand-rolled column / details / picker_*
  helpers removed.

245 lib tests pass.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>