### PR TITLE
YYC-102: provider column in unified /model picker

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -20,6 +20,47 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
+/// Heuristic for "local" provider endpoints (loopback, link-local, mDNS
+/// `.local`, RFC1918 private IPv4). Used to skip the API key requirement
+/// when switching to or starting up against a self-hosted endpoint that
+/// typically doesn't need auth.
+fn is_local_base_url(base_url: &str) -> bool {
+    let lower = base_url.to_ascii_lowercase();
+    let host_port = lower
+        .split_once("://")
+        .map(|(_, rest)| rest)
+        .unwrap_or(&lower);
+    let host = host_port
+        .split(|c: char| c == '/' || c == '?')
+        .next()
+        .unwrap_or("");
+    let host = host
+        .strip_prefix('[')
+        .and_then(|h| h.split_once(']').map(|(host, _)| host))
+        .unwrap_or_else(|| host.split(':').next().unwrap_or(""));
+    if host == "localhost" || host.ends_with(".local") {
+        return true;
+    }
+    if host == "127.0.0.1" || host == "0.0.0.0" || host == "::1" {
+        return true;
+    }
+    let parts: Vec<&str> = host.split('.').collect();
+    if parts.len() == 4 {
+        let a = parts[0].parse::<u8>().ok();
+        let b = parts[1].parse::<u8>().ok();
+        if let (Some(a), Some(b)) = (a, b) {
+            if a == 127 || a == 10 || (a == 192 && b == 168) || (a == 172 && (16..=31).contains(&b))
+            {
+                return true;
+            }
+            if a == 169 && b == 254 {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 /// The core agent — orchestrates the LLM, tools, hooks, and state.
 ///
 /// One Agent per session. Hold it across turns: the hook registry's stateful
@@ -103,11 +144,21 @@ impl Agent {
         mut hooks: HookRegistry,
         pause_tx: Option<PauseSender>,
     ) -> Result<Self> {
-        let api_key = config.api_key().ok_or_else(|| {
-            anyhow::anyhow!(
-                "No API key configured. Set VULCAN_API_KEY or add api_key to ~/.vulcan/config.toml"
-            )
-        })?;
+        // Local / self-hosted endpoints don't require auth; allow empty
+        // string in that case (matches `switch_provider` semantics).
+        let api_key = match config.api_key() {
+            Some(k) => k,
+            None if config.provider.disable_catalog
+                || is_local_base_url(&config.provider.base_url) =>
+            {
+                String::new()
+            }
+            None => {
+                anyhow::bail!(
+                    "No API key configured. Set VULCAN_API_KEY or add api_key to ~/.vulcan/config.toml"
+                );
+            }
+        };
 
         // ── Catalog: validate the configured model and (optionally) override
         // max_context with whatever the catalog says it actually is. Non-fatal:
@@ -347,12 +398,23 @@ impl Agent {
                 .ok_or_else(|| anyhow::anyhow!("Provider profile '{name}' not found in config"))?,
             None => config.provider.clone(),
         };
-        let api_key = config.api_key_for(&next_config).ok_or_else(|| {
-            anyhow::anyhow!(
-                "No API key for provider '{}' (set VULCAN_API_KEY or supply api_key in config)",
-                profile.unwrap_or("[provider]"),
-            )
-        })?;
+        // Local / self-hosted endpoints (Ollama, llama.cpp, vLLM unauth)
+        // typically don't need an API key; skip the requirement when the
+        // base URL looks local or the user explicitly disabled catalog
+        // fetching. Falls back to empty string so the OpenAI-compat path
+        // sends `Authorization: Bearer ` and the server ignores it.
+        let api_key = match config.api_key_for(&next_config) {
+            Some(k) => k,
+            None if next_config.disable_catalog || is_local_base_url(&next_config.base_url) => {
+                String::new()
+            }
+            None => {
+                anyhow::bail!(
+                    "No API key for provider '{}' (set VULCAN_API_KEY or supply api_key in config)",
+                    profile.unwrap_or("[provider]"),
+                );
+            }
+        };
 
         let selection = Self::resolve_model_selection(&next_config, &api_key).await?;
         let provider: Box<dyn LLMProvider> = Box::new(

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -797,23 +797,24 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                         Some(KeyEv::Press(event)) => {
                             if let Event::Key(key) = event {
                                 if key.kind == KeyEventKind::Press {
-                                    let mut commit_id: Option<String> = None;
+                                    let mut commit: Option<(Option<String>, String)> = None;
                                     let mut close = false;
-                                    let provider_label = {
-                                        let a = agent.lock().await;
-                                        a.active_profile()
-                                            .map(str::to_string)
-                                            .unwrap_or_else(|| "default".into())
-                                    };
                                     let mut state = miller_columns::MillerState {
                                         path: app.model_picker_path.clone(),
                                         focus: app.model_picker_focus,
                                     };
-                                    let source = model_picker::ModelPickerSource::new(
-                                        &app.model_picker_tree,
-                                        &app.model_picker_items,
-                                        format!("~ {provider_label}"),
-                                    );
+                                    let source = model_picker::UnifiedPickerSource {
+                                        provider_labels: &app.picker_provider_labels,
+                                        provider_keys: &app.picker_provider_keys,
+                                        items_by_key: &app.picker_items_by_key,
+                                        trees_by_key: &app.picker_trees_by_key,
+                                    };
+                                    let resolve_leaf = |path: &[usize]| -> Option<(Option<String>, String)> {
+                                        source.leaf_at(path).map(|(k, id)| {
+                                            let key = if k == "default" { None } else { Some(k) };
+                                            (key, id)
+                                        })
+                                    };
                                     match key.code {
                                         KeyCode::Up | KeyCode::Char('k') => {
                                             miller_columns::move_cursor(&mut state, &source, -1);
@@ -828,49 +829,42 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                         }
                                         KeyCode::Right | KeyCode::Char('l') => {
                                             if !miller_columns::drill(&mut state, &source) {
-                                                // Leaf — commit.
-                                                commit_id = source.leaf_at(&state.path)
-                                                    .and_then(|i| app.model_picker_items.get(i))
-                                                    .map(|m| m.id.clone());
+                                                commit = resolve_leaf(&state.path);
                                             }
                                         }
                                         KeyCode::Char('L') => {
-                                            // mini.files L: drill, and if the
-                                            // child is a leaf, commit.
-                                            if !miller_columns::drill(&mut state, &source) {
-                                                commit_id = source.leaf_at(&state.path)
-                                                    .and_then(|i| app.model_picker_items.get(i))
-                                                    .map(|m| m.id.clone());
-                                            } else {
-                                                commit_id = source.leaf_at(&state.path)
-                                                    .and_then(|i| app.model_picker_items.get(i))
-                                                    .map(|m| m.id.clone());
-                                            }
+                                            miller_columns::drill(&mut state, &source);
+                                            commit = resolve_leaf(&state.path);
                                         }
                                         KeyCode::Char('H') => {
-                                            // mini.files H: ascend AND trim
-                                            // rightward — already implicit in
-                                            // ascend() since deeper path is
-                                            // dropped.
                                             if !miller_columns::ascend(&mut state) {
                                                 close = true;
                                             }
                                         }
                                         KeyCode::Enter => {
-                                            commit_id = source
-                                                .leaf_at(&state.path)
-                                                .and_then(|i| app.model_picker_items.get(i))
-                                                .map(|m| m.id.clone());
+                                            commit = resolve_leaf(&state.path);
                                         }
                                         KeyCode::Esc | KeyCode::Char('q') => close = true,
                                         _ => {}
                                     }
                                     app.model_picker_path = state.path;
                                     app.model_picker_focus = state.focus;
-                                    if let Some(id) = commit_id {
+                                    if let Some((profile, id)) = commit {
                                         let result = {
                                             let mut a = agent.lock().await;
-                                            a.switch_model(&id).await
+                                            // Switch provider first when the
+                                            // picked profile differs from the
+                                            // active one.
+                                            let active = a.active_profile().map(str::to_string);
+                                            if active != profile {
+                                                if let Err(e) = a.switch_provider(profile.as_deref(), config).await {
+                                                    Err(e)
+                                                } else {
+                                                    a.switch_model(&id).await
+                                                }
+                                            } else {
+                                                a.switch_model(&id).await
+                                            }
                                         };
                                         match result {
                                             Ok(selection) => {
@@ -879,10 +873,14 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                                 app.token_max =
                                                     selection.max_context as u32;
                                                 app.pricing = selection.pricing;
+                                                app.provider_label = profile.clone();
+                                                let label = profile
+                                                    .as_deref()
+                                                    .unwrap_or("default");
                                                 app.messages.push(ChatMessage {
                                                     role: ChatRole::System,
                                                     content: format!(
-                                                        "Model switched to {} · context {}",
+                                                        "Switched to {label} · {} · context {}",
                                                         app.model_label,
                                                         crate::tui::state::format_thousands(
                                                             app.token_max
@@ -1596,31 +1594,15 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                                                         ..Default::default()
                                                                     });
                                                                 }
-                                                                Ok(models) => {
-                                                                    let provider_label = {
-                                                                        let a = agent.lock().await;
-                                                                        a.active_profile()
-                                                                            .map(str::to_string)
-                                                                            .unwrap_or_else(|| "default".into())
-                                                                    };
-                                                                    let tree =
-                                                                        crate::tui::model_picker::build_model_tree(
-                                                                            &provider_label,
-                                                                            &models,
-                                                                        );
-                                                                    app.model_picker_path =
-                                                                        initial_path_for_active_model(
-                                                                            &tree,
-                                                                            &active,
-                                                                            &models,
-                                                                        );
-                                                                    app.model_picker_focus = app
-                                                                        .model_picker_path
-                                                                        .len()
-                                                                        .saturating_sub(1);
-                                                                    app.model_picker_tree = tree;
-                                                                    app.model_picker_items = models;
-                                                                    app.show_model_picker = true;
+                                                                Ok(active_models) => {
+                                                                    open_unified_picker(
+                                                                        &mut app,
+                                                                        config,
+                                                                        &agent,
+                                                                        &active,
+                                                                        active_models,
+                                                                    )
+                                                                    .await;
                                                                 }
                                                                 Err(e) => {
                                                                     app.messages.push(ChatMessage {
@@ -2125,15 +2107,13 @@ fn draw_session_picker(f: &mut ratatui::Frame, area: Rect, app: &AppState) {
 fn draw_model_picker(f: &mut ratatui::Frame, area: Rect, app: &AppState) {
     // YYC-102: render via the universal miller_columns widget. The
     // overlay anchors top-left and grows rightward as the user drills.
-    let provider_label = app
-        .provider_label
-        .clone()
-        .unwrap_or_else(|| "default".into());
-    let source = model_picker::ModelPickerSource::new(
-        &app.model_picker_tree,
-        &app.model_picker_items,
-        format!("~ {provider_label}"),
-    );
+    // Column 0 = configured providers; columns 1+ = lab/series/version.
+    let source = model_picker::UnifiedPickerSource {
+        provider_labels: &app.picker_provider_labels,
+        provider_keys: &app.picker_provider_keys,
+        items_by_key: &app.picker_items_by_key,
+        trees_by_key: &app.picker_trees_by_key,
+    };
     let state = miller_columns::MillerState {
         path: app.model_picker_path.clone(),
         focus: app.model_picker_focus,
@@ -2158,6 +2138,133 @@ fn draw_model_picker(f: &mut ratatui::Frame, area: Rect, app: &AppState) {
         Paragraph::new(Line::from(Span::styled(hint, app.theme.muted))),
         footer,
     );
+}
+
+async fn open_unified_picker(
+    app: &mut AppState,
+    config: &Config,
+    agent: &Arc<Mutex<Agent>>,
+    active_model_id: &str,
+    active_provider_models: Vec<crate::provider::catalog::ModelInfo>,
+) {
+    use std::collections::HashMap;
+
+    // Build the column-0 list: [default + named profiles, sorted].
+    let mut labels: Vec<String> = Vec::new();
+    let mut keys: Vec<Option<String>> = Vec::new();
+    labels.push("default".to_string());
+    keys.push(None);
+    let mut named: Vec<&String> = config.providers.keys().collect();
+    named.sort();
+    for n in named {
+        labels.push(n.clone());
+        keys.push(Some(n.clone()));
+    }
+
+    // Determine active provider key.
+    let active_profile = {
+        let a = agent.lock().await;
+        a.active_profile().map(str::to_string)
+    };
+    let active_key: String = active_profile.clone().unwrap_or_else(|| "default".into());
+
+    // Seed the catalog cache with the already-loaded active provider.
+    let mut items_by_key: HashMap<String, Vec<crate::provider::catalog::ModelInfo>> =
+        HashMap::new();
+    items_by_key.insert(active_key.clone(), active_provider_models);
+
+    // Fetch catalogs for the other providers in parallel. Disable_catalog
+    // entries (e.g. Ollama) are skipped — they get an empty tree and a
+    // "type the model id with /model <id>" hint via the empty list.
+    let mut handles: Vec<(String, tokio::task::JoinHandle<_>)> = Vec::new();
+    for (key_opt, _label) in keys.iter().zip(labels.iter()) {
+        let cache_key = key_opt.clone().unwrap_or_else(|| "default".into());
+        if items_by_key.contains_key(&cache_key) {
+            continue;
+        }
+        let provider_cfg = match key_opt {
+            Some(name) => config.providers.get(name).cloned(),
+            None => Some(config.provider.clone()),
+        };
+        let Some(provider_cfg) = provider_cfg else {
+            continue;
+        };
+        if provider_cfg.disable_catalog {
+            items_by_key.insert(cache_key, Vec::new());
+            continue;
+        }
+        let api_key = config.api_key_for(&provider_cfg).unwrap_or_default();
+        let handle = tokio::spawn(async move {
+            use std::time::Duration;
+            let client = match reqwest::Client::builder()
+                .timeout(Duration::from_secs(5))
+                .build()
+            {
+                Ok(c) => c,
+                Err(_) => return Vec::new(),
+            };
+            let cat = crate::provider::catalog::for_base_url(
+                client,
+                &provider_cfg.base_url,
+                &api_key,
+                Duration::from_secs(0),
+            );
+            cat.list_models().await.unwrap_or_default()
+        });
+        handles.push((cache_key, handle));
+    }
+    for (cache_key, handle) in handles {
+        match handle.await {
+            Ok(models) => {
+                items_by_key.insert(cache_key, models);
+            }
+            Err(_) => {
+                items_by_key.insert(cache_key, Vec::new());
+            }
+        }
+    }
+
+    // Build trees for every provider.
+    let mut trees_by_key: HashMap<String, crate::tui::model_picker::ModelTree> = HashMap::new();
+    for (key_opt, label) in keys.iter().zip(labels.iter()) {
+        let cache_key = key_opt.clone().unwrap_or_else(|| "default".into());
+        let models = items_by_key
+            .get(&cache_key)
+            .cloned()
+            .unwrap_or_default();
+        let tree =
+            crate::tui::model_picker::build_model_tree(label, &models);
+        trees_by_key.insert(cache_key, tree);
+    }
+
+    // Initial path: active provider in column 0, then drill into the
+    // active model if we can match it.
+    let active_idx = keys
+        .iter()
+        .position(|k| match (k, &active_profile) {
+            (None, None) => true,
+            (Some(a), Some(b)) => a == b,
+            _ => false,
+        })
+        .unwrap_or(0);
+
+    let active_provider_tree = trees_by_key.get(&active_key).cloned().unwrap_or_default();
+    let active_provider_items = items_by_key.get(&active_key).cloned().unwrap_or_default();
+    let inner_path = initial_path_for_active_model(
+        &active_provider_tree,
+        active_model_id,
+        &active_provider_items,
+    );
+    let mut path = vec![active_idx];
+    path.extend(inner_path);
+
+    app.picker_provider_labels = labels;
+    app.picker_provider_keys = keys;
+    app.picker_items_by_key = items_by_key;
+    app.picker_trees_by_key = trees_by_key;
+    app.model_picker_focus = path.len().saturating_sub(1);
+    app.model_picker_path = path;
+    app.show_model_picker = true;
 }
 
 fn initial_path_for_active_model(

--- a/src/tui/model_picker.rs
+++ b/src/tui/model_picker.rs
@@ -193,6 +193,196 @@ fn build_series_node(series: &str, leaves: &[(usize, Vec<String>)]) -> TreeNode 
     node
 }
 
+/// `MillerSource` adapter for the unified picker (YYC-102 follow-up).
+/// Column 0 = configured providers; columns 1+ = the highlighted
+/// provider's lab/series/version tree. Catalogs are passed in keyed by
+/// stable cache keys (`"default"` for the legacy `[provider]` block,
+/// the profile name for `[providers.<name>]` blocks).
+pub struct UnifiedPickerSource<'a> {
+    /// Display labels for column 0, parallel to `provider_keys`.
+    pub provider_labels: &'a [String],
+    /// Cache keys per column-0 row. `None` ↔ legacy `[provider]`.
+    pub provider_keys: &'a [Option<String>],
+    /// Per-provider catalog (already fetched).
+    pub items_by_key: &'a std::collections::HashMap<String, Vec<ModelInfo>>,
+    /// Per-provider model tree built from the catalog.
+    pub trees_by_key: &'a std::collections::HashMap<String, ModelTree>,
+}
+
+impl<'a> UnifiedPickerSource<'a> {
+    pub fn key_for(&self, provider_idx: usize) -> &str {
+        match self.provider_keys.get(provider_idx) {
+            Some(Some(name)) => name.as_str(),
+            _ => "default",
+        }
+    }
+
+    fn tree_for(&self, provider_idx: usize) -> Option<&'a ModelTree> {
+        self.trees_by_key.get(self.key_for(provider_idx))
+    }
+
+    fn items_for(&self, provider_idx: usize) -> Option<&'a [ModelInfo]> {
+        self.items_by_key
+            .get(self.key_for(provider_idx))
+            .map(|v| v.as_slice())
+    }
+
+    fn nodes_at(&self, path: &[usize]) -> Option<&'a [TreeNode]> {
+        let provider_idx = *path.first()?;
+        let tree = self.tree_for(provider_idx)?;
+        let inner = &path[1..];
+        Some(tree.column_at(inner.len(), inner))
+    }
+
+    pub fn leaf_at(&self, path: &[usize]) -> Option<(String, String)> {
+        let provider_idx = *path.first()?;
+        let tree = self.tree_for(provider_idx)?;
+        let items = self.items_for(provider_idx)?;
+        let inner = &path[1..];
+        let mut current: &[TreeNode] = &tree.labs;
+        let mut leaf: Option<usize> = None;
+        for &idx in inner {
+            let node = current.get(idx)?;
+            if node.children.is_empty() {
+                leaf = node.model_index;
+                break;
+            }
+            leaf = node.model_index;
+            current = &node.children;
+        }
+        let id = items.get(leaf?)?.id.clone();
+        let provider_key = match self.provider_keys.get(provider_idx)? {
+            Some(name) => name.clone(),
+            None => "default".to_string(),
+        };
+        Some((provider_key, id))
+    }
+}
+
+impl<'a> MillerSource for UnifiedPickerSource<'a> {
+    fn header(&self, path: &[usize]) -> String {
+        if path.is_empty() {
+            return "~ providers".to_string();
+        }
+        let provider_idx = path[0];
+        let label = self
+            .provider_labels
+            .get(provider_idx)
+            .cloned()
+            .unwrap_or_else(|| "?".into());
+        if path.len() == 1 {
+            return label;
+        }
+        let Some(tree) = self.tree_for(provider_idx) else {
+            return label;
+        };
+        let inner = &path[1..];
+        let mut current: &[TreeNode] = &tree.labs;
+        let mut last = label;
+        for &idx in inner {
+            let Some(node) = current.get(idx) else {
+                return last;
+            };
+            last = node.label.clone();
+            if node.children.is_empty() {
+                return last;
+            }
+            current = &node.children;
+        }
+        last
+    }
+
+    fn entries(&self, path: &[usize]) -> Vec<MillerEntry> {
+        if path.is_empty() {
+            return self
+                .provider_labels
+                .iter()
+                .enumerate()
+                .map(|(i, label)| MillerEntry {
+                    label: label.clone(),
+                    icon: "▸".into(),
+                    has_children: self.tree_for(i).map(|t| !t.labs.is_empty()).unwrap_or(false),
+                })
+                .collect();
+        }
+        let Some(nodes) = self.nodes_at(path) else {
+            return Vec::new();
+        };
+        nodes
+            .iter()
+            .map(|node| MillerEntry {
+                label: node.label.clone(),
+                icon: if node.children.is_empty() { "·" } else { "▸" }.to_string(),
+                has_children: !node.children.is_empty(),
+            })
+            .collect()
+    }
+
+    fn preview(&self, path: &[usize]) -> Option<MillerPreview> {
+        if path.len() < 2 {
+            return None;
+        }
+        let provider_idx = *path.first()?;
+        let items = self.items_for(provider_idx)?;
+        let tree = self.tree_for(provider_idx)?;
+        let inner = &path[1..];
+        let mut current: &[TreeNode] = &tree.labs;
+        let mut leaf: Option<usize> = None;
+        for &idx in inner {
+            let node = current.get(idx)?;
+            if node.children.is_empty() {
+                leaf = node.model_index;
+                break;
+            }
+            leaf = node.model_index;
+            current = &node.children;
+        }
+        let model = items.get(leaf?)?;
+        let mut lines: Vec<Line<'static>> = Vec::new();
+        lines.push(Line::from(Span::styled(
+            model.id.clone(),
+            Style::default().add_modifier(Modifier::BOLD),
+        )));
+        lines.push(Line::from(""));
+        if model.context_length > 0 {
+            lines.push(Line::from(format!(
+                "context  : {}",
+                crate::tui::state::format_thousands(model.context_length as u32)
+            )));
+        }
+        let mut feats = Vec::new();
+        if model.features.tools {
+            feats.push("tools");
+        }
+        if model.features.reasoning {
+            feats.push("reasoning");
+        }
+        if model.features.vision {
+            feats.push("vision");
+        }
+        if model.features.json_mode {
+            feats.push("json");
+        }
+        if !feats.is_empty() {
+            lines.push(Line::from(format!("features : {}", feats.join(", "))));
+        }
+        if let Some(p) = &model.pricing {
+            lines.push(Line::from(format!(
+                "pricing  : ${:.4}/1k in · ${:.4}/1k out",
+                p.input_per_token * 1000.0,
+                p.output_per_token * 1000.0,
+            )));
+        }
+        if let Some(top) = &model.top_provider {
+            lines.push(Line::from(format!("upstream : {top}")));
+        }
+        Some(MillerPreview {
+            title: model.id.clone(),
+            lines,
+        })
+    }
+}
+
 /// `MillerSource` adapter that drives the universal miller-columns
 /// widget from a `ModelTree` + the source catalog (YYC-102).
 pub struct ModelPickerSource<'a> {

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -540,15 +540,20 @@ pub struct AppState {
     /// Index into `sessions` for the highlighted row in the picker.
     pub session_picker_selection: usize,
 
-    /// Model picker overlay (YYC-97 → YYC-101 hierarchical). Opened by
-    /// `/model` with no args; items are populated from the active
-    /// provider's catalog at open time. Tree columns drill
-    /// lab → series → version. `Enter` triggers `Agent::switch_model`.
+    /// Unified model picker overlay (YYC-97 → YYC-101 → YYC-102). Opened
+    /// by `/model` with no args. Column 0 lists configured providers;
+    /// columns 1+ drill the highlighted provider's catalog
+    /// lab → series → version. `Enter` switches both provider and model.
     pub show_model_picker: bool,
-    /// Source catalog for the picker; rebuilt each open.
-    pub model_picker_items: Vec<crate::provider::catalog::ModelInfo>,
-    /// Hierarchical tree built from `model_picker_items`.
-    pub model_picker_tree: super::model_picker::ModelTree,
+    /// Display labels for column 0, parallel to `picker_provider_keys`.
+    pub picker_provider_labels: Vec<String>,
+    /// Cache keys per column-0 row. `None` = legacy `[provider]` block.
+    pub picker_provider_keys: Vec<Option<String>>,
+    /// Catalog cache keyed by provider key (`"default"` for legacy).
+    pub picker_items_by_key:
+        std::collections::HashMap<String, Vec<crate::provider::catalog::ModelInfo>>,
+    /// Tree cache keyed by provider key.
+    pub picker_trees_by_key: std::collections::HashMap<String, super::model_picker::ModelTree>,
     /// Selection index per drilled column.
     pub model_picker_path: Vec<usize>,
     /// Which column currently has focus (0 = column 0, etc.).
@@ -670,8 +675,10 @@ impl AppState {
             session_picker_selection: 0,
 
             show_model_picker: false,
-            model_picker_items: Vec::new(),
-            model_picker_tree: super::model_picker::ModelTree::default(),
+            picker_provider_labels: Vec::new(),
+            picker_provider_keys: Vec::new(),
+            picker_items_by_key: std::collections::HashMap::new(),
+            picker_trees_by_key: std::collections::HashMap::new(),
             model_picker_path: Vec::new(),
             model_picker_focus: 0,
 


### PR DESCRIPTION
Column 0 of the unified picker now lists configured providers
(default + named profiles from providers.toml) instead of a single
provider's labs. Drilling l→ shows that provider's lab → series →
version → details. Enter swaps both provider and model in one shot.

UnifiedPickerSource (src/tui/model_picker.rs):
- Backed by per-provider catalogs and trees, keyed by stable cache
  keys ("default" for the legacy [provider] block).
- header() walks: providers root → provider name → lab → series → ...
- entries() at depth 0 lists providers; deeper drills the per-provider
  ModelTree.
- preview() at depth ≥ 2 renders model details (id, ctx, features,
  pricing, upstream).
- leaf_at(path) returns (provider_key, model_id) so commit can
  switch_provider then switch_model atomically.

Open path (src/tui/mod.rs::open_unified_picker):
- Builds [default + sorted named] for column 0.
- Seeds the catalog cache with the active provider's already-loaded
  models.
- Fetches every other provider's catalog in parallel via tokio::spawn
  with a 5s timeout. Failed/empty catalogs render as empty tree.
  disable_catalog providers are skipped (empty tree, hint to use
  /model <id> typed form).
- Builds a tree per provider.
- Initial path: active provider in column 0, drilled to the active
  model's lab/series/version when a match exists in the catalog.

Key dispatch: provider swap + model swap is unified through Enter / l
on a leaf — Agent::switch_provider runs first iff the picked profile
differs from the active one; then Agent::switch_model. System
message reports both: "Switched to <profile> · <model> · context X".

AppState fields:
- show_model_picker / model_picker_path / model_picker_focus stay
  (path is now [provider_idx, lab_idx, series_idx, ...]).
- New: picker_provider_labels, picker_provider_keys,
  picker_items_by_key, picker_trees_by_key.
- Old model_picker_tree / model_picker_items removed.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>