### PR TITLE
YYC-103: extract inline <think> tags as reasoning content

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -761,15 +761,31 @@ impl Agent {
     }
 
     /// Run a prompt with streaming — sends text tokens through `ui_tx` as they
-    /// arrive. Honors all hook events.
+    /// arrive. Honors all hook events. Internal cancel token is fresh per
+    /// turn; callers that need to fire the cancel without holding the
+    /// `Agent` mutex should use `run_prompt_stream_with_cancel` instead.
     pub async fn run_prompt_stream(
         &mut self,
         input: &str,
         ui_tx: mpsc::UnboundedSender<StreamEvent>,
     ) -> Result<String> {
-        // Fresh per-turn cancel token (see run_prompt).
-        self.turn_cancel = CancellationToken::new();
-        let cancel = self.turn_cancel.clone();
+        let cancel = CancellationToken::new();
+        self.run_prompt_stream_with_cancel(input, ui_tx, cancel).await
+    }
+
+    /// Streaming variant that accepts an external cancel token. The TUI uses
+    /// this so the Ctrl+C handler can fire the token directly without
+    /// blocking on the agent mutex held by the in-flight prompt task.
+    pub async fn run_prompt_stream_with_cancel(
+        &mut self,
+        input: &str,
+        ui_tx: mpsc::UnboundedSender<StreamEvent>,
+        cancel: CancellationToken,
+    ) -> Result<String> {
+        // Mirror the external token onto `self.turn_cancel` so internal
+        // tool dispatch / hook plumbing that still references `self.turn_cancel`
+        // sees the cancellation. The external token is the source of truth.
+        self.turn_cancel = cancel.clone();
 
         let system = self.prompt_builder.build_system_prompt(&self.tools);
         let tool_defs = self.tools.definitions();

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -1,5 +1,6 @@
 pub mod catalog;
 pub mod openai;
+pub mod think_sanitizer;
 
 #[cfg(any(test, feature = "bench-soak"))]
 pub mod mock;

--- a/src/provider/openai.rs
+++ b/src/provider/openai.rs
@@ -653,7 +653,10 @@ impl LLMProvider for OpenAIProvider {
                 }
                 let mut combined_reasoning = native_reasoning_delta;
                 combined_reasoning.push_str(&sanitized.reasoning);
-                if !combined_reasoning.is_empty() {
+                // YYC-103: empty `<think></think>` blocks stream `\n` or
+                // whitespace; suppress those so a stub THINKING header
+                // doesn't get inserted between text segments.
+                if !combined_reasoning.trim().is_empty() {
                     let _ = tx.send(StreamEvent::Reasoning(combined_reasoning));
                 }
             }
@@ -664,7 +667,7 @@ impl LLMProvider for OpenAIProvider {
             content.push_str(&leftover.text);
             let _ = tx.send(StreamEvent::Text(leftover.text));
         }
-        if !leftover.reasoning.is_empty() {
+        if !leftover.reasoning.trim().is_empty() {
             reasoning.push_str(&leftover.reasoning);
             let _ = tx.send(StreamEvent::Reasoning(leftover.reasoning));
         }

--- a/src/provider/openai.rs
+++ b/src/provider/openai.rs
@@ -533,6 +533,19 @@ impl LLMProvider for OpenAIProvider {
             );
         }
 
+        // YYC-103: extract any inline `<think>…</think>` blocks from the
+        // accumulated content and route them to the reasoning trace.
+        let mut sanitizer = crate::provider::think_sanitizer::ThinkSanitizer::new();
+        let sanitized = sanitizer.feed(&content);
+        let tail = sanitizer.flush();
+        content = format!("{}{}", sanitized.text, tail.text);
+        if !sanitized.reasoning.is_empty() {
+            reasoning.push_str(&sanitized.reasoning);
+        }
+        if !tail.reasoning.is_empty() {
+            reasoning.push_str(&tail.reasoning);
+        }
+
         let inferred_tool_calls = if tool_calls.is_empty() {
             infer_content_tool_calls(&content, tools)
         } else {
@@ -582,6 +595,9 @@ impl LLMProvider for OpenAIProvider {
         let mut usage: Option<Usage> = None;
         let mut finish_reason: Option<String> = None;
         let mut raw_stream = self.debug_mode.logs_wire().then(String::new);
+        // YYC-103: split inline `<think>` blocks out of the visible content
+        // stream as they arrive.
+        let mut think = crate::provider::think_sanitizer::ThinkSanitizer::new();
 
         // Read the HTTP response as a byte stream — chunks arrive as the LLM generates
         let mut stream = response.bytes_stream();
@@ -620,16 +636,37 @@ impl LLMProvider for OpenAIProvider {
                     &mut finish_reason,
                 );
 
-                // Send any new content/reasoning deltas through the channel.
-                if content.len() > prev_content_len {
-                    let delta = &content[prev_content_len..];
-                    let _ = tx.send(StreamEvent::Text(delta.to_string()));
+                // YYC-103: run the just-appended content delta through
+                // the think-tag sanitizer so `<think>…</think>` blocks
+                // route to the reasoning channel instead of leaking
+                // into chat. Native reasoning_content (DeepSeek /
+                // OpenRouter) still flows through unchanged.
+                let raw_content_delta = content[prev_content_len..].to_string();
+                content.truncate(prev_content_len);
+                let sanitized = think.feed(&raw_content_delta);
+                content.push_str(&sanitized.text);
+                let native_reasoning_delta = reasoning[prev_reasoning_len..].to_string();
+                reasoning.push_str(&sanitized.reasoning);
+
+                if !sanitized.text.is_empty() {
+                    let _ = tx.send(StreamEvent::Text(sanitized.text));
                 }
-                if reasoning.len() > prev_reasoning_len {
-                    let delta = &reasoning[prev_reasoning_len..];
-                    let _ = tx.send(StreamEvent::Reasoning(delta.to_string()));
+                let mut combined_reasoning = native_reasoning_delta;
+                combined_reasoning.push_str(&sanitized.reasoning);
+                if !combined_reasoning.is_empty() {
+                    let _ = tx.send(StreamEvent::Reasoning(combined_reasoning));
                 }
             }
+        }
+        // Drain any pending partial-tag buffer left at stream close.
+        let leftover = think.flush();
+        if !leftover.text.is_empty() {
+            content.push_str(&leftover.text);
+            let _ = tx.send(StreamEvent::Text(leftover.text));
+        }
+        if !leftover.reasoning.is_empty() {
+            reasoning.push_str(&leftover.reasoning);
+            let _ = tx.send(StreamEvent::Reasoning(leftover.reasoning));
         }
 
         if let Some(raw) = raw_stream.as_ref() {

--- a/src/provider/think_sanitizer.rs
+++ b/src/provider/think_sanitizer.rs
@@ -1,0 +1,260 @@
+//! `<think>…</think>` extractor for streaming providers (YYC-103).
+//!
+//! Local / open-weight models (llama.cpp, Qwen reasoning variants,
+//! DeepSeek-R1 distills) emit chain-of-thought as inline `<think>` tags
+//! in the regular content stream rather than the structured
+//! `reasoning_content` field. This sanitizer is a small state machine
+//! that splits each text chunk into visible content + reasoning trace
+//! across chunk boundaries (no tag is required to land in a single
+//! delta).
+//!
+//! Tag matching is case-insensitive on the tag name; attributes are
+//! tolerated (`<think id="…">`). The sanitizer never swallows real
+//! text — anything that looks like a partial tag but doesn't resolve
+//! is flushed as plain content on the next chunk that disambiguates it.
+
+#[derive(Debug, Default)]
+pub struct ThinkSanitizer {
+    in_think: bool,
+    /// Buffered tail that begins with `<` and might still resolve to a
+    /// `<think...>` or `</think...>` tag. Stays empty in the steady
+    /// state.
+    pending: String,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct SanitizeOut {
+    pub text: String,
+    pub reasoning: String,
+}
+
+const OPEN_TAG: &str = "<think";
+const CLOSE_TAG: &str = "</think";
+
+impl ThinkSanitizer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Feed one streamed chunk. Returns the visible text + reasoning
+    /// fragments to emit. Pending partial tags are buffered until a
+    /// future chunk resolves them.
+    pub fn feed(&mut self, chunk: &str) -> SanitizeOut {
+        let mut input = std::mem::take(&mut self.pending);
+        input.push_str(chunk);
+        let mut out = SanitizeOut::default();
+        let mut cursor = 0usize;
+        while cursor < input.len() {
+            let rest = &input[cursor..];
+            if self.in_think {
+                // Look for the closing tag.
+                match find_tag_ci(rest, CLOSE_TAG) {
+                    TagMatch::Full { start, end } => {
+                        out.reasoning.push_str(&rest[..start]);
+                        cursor += end;
+                        self.in_think = false;
+                    }
+                    TagMatch::Partial { start } => {
+                        out.reasoning.push_str(&rest[..start]);
+                        self.pending.push_str(&rest[start..]);
+                        return out;
+                    }
+                    TagMatch::None => {
+                        out.reasoning.push_str(rest);
+                        return out;
+                    }
+                }
+            } else {
+                match find_tag_ci(rest, OPEN_TAG) {
+                    TagMatch::Full { start, end } => {
+                        out.text.push_str(&rest[..start]);
+                        cursor += end;
+                        self.in_think = true;
+                    }
+                    TagMatch::Partial { start } => {
+                        out.text.push_str(&rest[..start]);
+                        self.pending.push_str(&rest[start..]);
+                        return out;
+                    }
+                    TagMatch::None => {
+                        out.text.push_str(rest);
+                        return out;
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    /// Flush any pending buffer. Called once after the upstream stream
+    /// closes so partial tags that never resolved are still emitted.
+    pub fn flush(&mut self) -> SanitizeOut {
+        let pending = std::mem::take(&mut self.pending);
+        let mut out = SanitizeOut::default();
+        if pending.is_empty() {
+            return out;
+        }
+        if self.in_think {
+            out.reasoning.push_str(&pending);
+        } else {
+            out.text.push_str(&pending);
+        }
+        out
+    }
+}
+
+#[derive(Debug)]
+enum TagMatch {
+    /// Full tag consumed. `start` = byte offset of `<`. `end` = byte
+    /// offset just past `>`.
+    Full { start: usize, end: usize },
+    /// A `<` was found but the rest of the buffer is too short to
+    /// disambiguate. `start` = byte offset of the `<`.
+    Partial { start: usize },
+    None,
+}
+
+fn find_tag_ci(haystack: &str, prefix: &str) -> TagMatch {
+    let prefix_lower = prefix.to_ascii_lowercase();
+    let prefix_bytes = prefix_lower.as_bytes();
+    let bytes = haystack.as_bytes();
+    let mut i = 0usize;
+    while i < bytes.len() {
+        if bytes[i] != b'<' {
+            i += 1;
+            continue;
+        }
+        let avail = bytes.len() - i;
+        // Compare character-by-character against prefix (case-insensitive
+        // for ASCII letters).
+        let mut matched = 0usize;
+        while matched < prefix_bytes.len() && matched < avail {
+            let a = bytes[i + matched].to_ascii_lowercase();
+            let b = prefix_bytes[matched];
+            if a != b {
+                break;
+            }
+            matched += 1;
+        }
+        if matched < prefix_bytes.len() {
+            if matched == avail && matched > 0 {
+                // Buffer ended mid-prefix — the next chunk could still
+                // complete the tag.
+                return TagMatch::Partial { start: i };
+            }
+            i += 1;
+            continue;
+        }
+        // Prefix matched. We now need to find the closing `>` for the
+        // open tag (allowing whitespace/attributes).
+        let after = i + matched;
+        let mut j = after;
+        while j < bytes.len() && bytes[j] != b'>' {
+            j += 1;
+        }
+        if j == bytes.len() {
+            // Tag opened but no closing `>` yet — buffer for the next
+            // chunk.
+            return TagMatch::Partial { start: i };
+        }
+        // Validate the char immediately after the prefix is either
+        // `>` or whitespace (rejects `<thinker>` etc.).
+        let after_byte = bytes[after];
+        let prefix_terminates = after_byte == b'>'
+            || after_byte == b' '
+            || after_byte == b'\t'
+            || after_byte == b'\n'
+            || after_byte == b'/';
+        if !prefix_terminates {
+            i += 1;
+            continue;
+        }
+        return TagMatch::Full {
+            start: i,
+            end: j + 1,
+        };
+    }
+    TagMatch::None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn whole_block_in_one_chunk_routes_to_reasoning() {
+        let mut s = ThinkSanitizer::new();
+        let out = s.feed("Hello <think>secret thoughts</think> world");
+        assert_eq!(out.text, "Hello  world");
+        assert_eq!(out.reasoning, "secret thoughts");
+    }
+
+    #[test]
+    fn block_split_across_two_chunks() {
+        let mut s = ThinkSanitizer::new();
+        let a = s.feed("Hello <think>part1");
+        assert_eq!(a.text, "Hello ");
+        assert_eq!(a.reasoning, "part1");
+        let b = s.feed(" part2</think> world");
+        assert_eq!(b.reasoning, " part2");
+        assert_eq!(b.text, " world");
+    }
+
+    #[test]
+    fn opening_tag_split_across_chunks() {
+        let mut s = ThinkSanitizer::new();
+        let a = s.feed("Hello <thi");
+        assert_eq!(a.text, "Hello ");
+        assert!(a.reasoning.is_empty());
+        let b = s.feed("nk>secret</think>!");
+        assert_eq!(b.text, "!");
+        assert_eq!(b.reasoning, "secret");
+    }
+
+    #[test]
+    fn case_insensitive_tag_match() {
+        let mut s = ThinkSanitizer::new();
+        let out = s.feed("Pre <Think>x</THINK> post");
+        assert_eq!(out.text, "Pre  post");
+        assert_eq!(out.reasoning, "x");
+    }
+
+    #[test]
+    fn partial_open_with_attribute_then_close() {
+        let mut s = ThinkSanitizer::new();
+        let out = s.feed("Pre <think id=\"a\">trace</think> post");
+        assert_eq!(out.text, "Pre  post");
+        assert_eq!(out.reasoning, "trace");
+    }
+
+    #[test]
+    fn lone_lt_passes_through() {
+        let mut s = ThinkSanitizer::new();
+        let out = s.feed("a < b");
+        assert_eq!(out.text, "a < b");
+    }
+
+    #[test]
+    fn fake_tag_passes_through() {
+        let mut s = ThinkSanitizer::new();
+        // <thinker> is not a think tag.
+        let out = s.feed("ok <thinker> wat");
+        assert_eq!(out.text, "ok <thinker> wat");
+    }
+
+    #[test]
+    fn multiple_blocks_per_turn() {
+        let mut s = ThinkSanitizer::new();
+        let out = s.feed("a<think>1</think>b<think>2</think>c");
+        assert_eq!(out.text, "abc");
+        assert_eq!(out.reasoning, "12");
+    }
+
+    #[test]
+    fn flush_drains_pending_as_plain_text() {
+        let mut s = ThinkSanitizer::new();
+        let _ = s.feed("foo <thi");
+        let out = s.flush();
+        assert_eq!(out.text, "<thi");
+    }
+}

--- a/src/tui/chat_render.rs
+++ b/src/tui/chat_render.rs
@@ -198,7 +198,7 @@ impl ChatRenderStore {
                     }
                     MessageSegment::Text(text) if !text.is_empty() => {
                         text_emitted = true;
-                        push_markdown_body(&mut lines, text, accent, theme);
+                        push_markdown_body(&mut lines, text, accent, theme, options.width);
                     }
                     MessageSegment::Text(_) => {}
                 }
@@ -229,7 +229,7 @@ impl ChatRenderStore {
                     options.muted_style,
                 ));
             } else {
-                push_markdown_body(&mut lines, &message.content, accent, theme);
+                push_markdown_body(&mut lines, &message.content, accent, theme, options.width);
             }
         }
 
@@ -264,12 +264,60 @@ fn push_markdown_body(
     text: &str,
     accent: ratatui::style::Color,
     theme: &Theme,
+    width: u16,
 ) {
+    // YYC-104: pre-wrap each rendered markdown line so the `▎` accent
+    // bar stays on every visual row. Letting Paragraph::wrap handle it
+    // breaks the bar after the first row.
+    let inner_width = width.saturating_sub(2).max(1) as usize;
     for line in render_markdown(text, theme) {
-        let mut spans = vec![Span::styled("▎ ", Style::default().fg(accent))];
-        spans.extend(line.spans.into_iter());
-        lines.push(Line::from(spans));
+        for row in wrap_spans(line.spans, inner_width) {
+            let mut spans = vec![Span::styled("▎ ", Style::default().fg(accent))];
+            spans.extend(row.into_iter());
+            lines.push(Line::from(spans));
+        }
     }
+}
+
+/// Soft-wrap a sequence of spans into rows that each fit `width`
+/// columns. Splits inside spans when a span itself is wider than the
+/// remaining space; preserves per-span styles.
+fn wrap_spans(spans: Vec<Span<'static>>, width: usize) -> Vec<Vec<Span<'static>>> {
+    if width == 0 {
+        return vec![spans];
+    }
+    let mut rows: Vec<Vec<Span<'static>>> = vec![Vec::new()];
+    let mut col = 0usize;
+    for span in spans {
+        let style = span.style;
+        let chars: Vec<char> = span.content.chars().collect();
+        let mut idx = 0usize;
+        while idx < chars.len() {
+            let remaining = width.saturating_sub(col);
+            if remaining == 0 {
+                rows.push(Vec::new());
+                col = 0;
+                continue;
+            }
+            let take = chars.len() - idx;
+            let take = take.min(remaining);
+            let chunk: String = chars[idx..idx + take].iter().collect();
+            rows.last_mut().unwrap().push(Span::styled(chunk, style));
+            col += take;
+            idx += take;
+            if col >= width {
+                rows.push(Vec::new());
+                col = 0;
+            }
+        }
+    }
+    if rows.last().is_some_and(|r| r.is_empty()) {
+        rows.pop();
+    }
+    if rows.is_empty() {
+        rows.push(Vec::new());
+    }
+    rows
 }
 
 fn agent_placeholder(has_reasoning: bool, muted: Style) -> Line<'static> {

--- a/src/tui/chat_render.rs
+++ b/src/tui/chat_render.rs
@@ -170,7 +170,7 @@ impl ChatRenderStore {
                 let segment_lines_before = lines.len();
                 match segment {
                     MessageSegment::Reasoning(reasoning)
-                        if options.show_reasoning && !reasoning.is_empty() =>
+                        if options.show_reasoning && !reasoning.trim().is_empty() =>
                     {
                         lines.extend(reasoning_lines(reasoning, false, theme));
                     }

--- a/src/tui/chat_render.rs
+++ b/src/tui/chat_render.rs
@@ -269,8 +269,14 @@ fn push_markdown_body(
     // YYC-104: pre-wrap each rendered markdown line so the `▎` accent
     // bar stays on every visual row. Letting Paragraph::wrap handle it
     // breaks the bar after the first row.
+    // Trim trailing whitespace/newlines so models that emit `\n\n`
+    // suffixes don't leave empty `▎` rails after the body.
+    let trimmed = text.trim_end_matches(|c: char| c == '\n' || c == '\r' || c == ' ' || c == '\t');
+    if trimmed.is_empty() {
+        return;
+    }
     let inner_width = width.saturating_sub(2).max(1) as usize;
-    for line in render_markdown(text, theme) {
+    for line in render_markdown(trimmed, theme) {
         for row in wrap_spans(line.spans, inner_width) {
             let mut spans = vec![Span::styled("▎ ", Style::default().fg(accent))];
             spans.extend(row.into_iter());

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -364,7 +364,15 @@ async fn handle_stream_event(
                     // ordered renderer) and the legacy `content` field
                     // (kept so other code that peeks at .content keeps working).
                     last.append_text(&chunk);
-                    last.content.push_str(&chunk);
+                    // Strip leading whitespace so models that emit `\n\n`
+                    // preambles don't render gaps before the visible body
+                    // when the renderer falls back to `content`.
+                    if last.content.is_empty() {
+                        let trimmed = chunk.trim_start_matches(|c: char| c == '\n' || c == '\r' || c == ' ' || c == '\t');
+                        last.content.push_str(trimmed);
+                    } else {
+                        last.content.push_str(&chunk);
+                    }
                 }
             }
         }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -325,11 +325,17 @@ fn submit_prompt(
     app.at_bottom = true;
     app.note_prompt_submitted(&msg);
 
+    // YYC-105: hold a cancel token outside the agent mutex so Ctrl+C
+    // can fire it without waiting for the prompt task to release the
+    // lock. The agent mirrors the same token internally for tools /
+    // hooks that still consult `self.turn_cancel`.
+    let cancel = tokio_util::sync::CancellationToken::new();
+    app.current_turn_cancel = Some(cancel.clone());
     let tx = stream_tx.clone();
     let a = agent.clone();
     tokio::spawn(async move {
         let mut a = a.lock().await;
-        let _ = a.run_prompt_stream(&msg, tx).await;
+        let _ = a.run_prompt_stream_with_cancel(&msg, tx, cancel).await;
     });
 }
 
@@ -377,6 +383,7 @@ async fn handle_stream_event(
         }
         StreamEvent::Done(resp) => {
             app.thinking = false;
+            app.current_turn_cancel = None;
             if let Some(usage) = resp.usage {
                 // YYC-60: track lifetime totals for cost (YYC-67) and the
                 // latest prompt size for the in-status capacity bar.
@@ -403,6 +410,7 @@ async fn handle_stream_event(
                 }
             }
             app.thinking = false;
+            app.current_turn_cancel = None;
             // YYC-67: record provider-level error for telemetry.
             app.provider_errors_total = app.provider_errors_total.saturating_add(1);
             app.note_error(&e);
@@ -1296,12 +1304,13 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                             if pending_quit {
                                                 exit = true;
                                             } else if app.thinking {
-                                                // Turn in flight: single Ctrl+C cancels it.
-                                                // Double Ctrl+C still exits (pending_quit path).
-                                                let a = agent.clone();
-                                                tokio::spawn(async move {
-                                                    a.lock().await.cancel_current_turn();
-                                                });
+                                                // YYC-105: fire the externally-held token directly
+                                                // rather than queueing a lock acquisition that
+                                                // would block on the in-flight prompt task. The
+                                                // agent mirror updates next iteration.
+                                                if let Some(c) = app.current_turn_cancel.as_ref() {
+                                                    c.cancel();
+                                                }
                                                 app.messages.push(ChatMessage {
                                                     role: ChatRole::System,
                                                     content: "Cancelling current turn… (Ctrl+C again to quit)".into(),
@@ -1756,7 +1765,10 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                             }
                         }
                     }
-                    None => app.thinking = false,
+                    None => {
+                        app.thinking = false;
+                        app.current_turn_cancel = None;
+                    }
                 }
             }
         }

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -232,7 +232,15 @@ impl ChatMessage {
     /// trailing segment if it's also reasoning. New tool calls or text break
     /// the run, so subsequent reasoning starts a fresh segment — that's the
     /// whole point of YYC-71.
+    ///
+    /// Whitespace-only chunks are dropped so empty `<think></think>` blocks
+    /// from local providers (YYC-103) don't create empty reasoning segments
+    /// that the renderer would later show as a stub THINKING header
+    /// between adjacent text deltas.
     pub fn append_reasoning(&mut self, chunk: &str) {
+        if chunk.trim().is_empty() {
+            return;
+        }
         match self.segments.last_mut() {
             Some(MessageSegment::Reasoning(r)) => r.push_str(chunk),
             _ => self

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -219,13 +219,26 @@ impl ChatMessage {
     }
 
     /// Append a text chunk to the segment timeline, coalescing with the
-    /// trailing segment if it's also text.
+    /// trailing segment if it's also text. Leading whitespace on a fresh
+    /// text segment (start of message, or after a tool/reasoning break)
+    /// is stripped so models that emit `\n\n` preambles don't render
+    /// gaps before the visible body.
     pub fn append_text(&mut self, chunk: &str) {
         match self.segments.last_mut() {
-            Some(MessageSegment::Text(t)) => t.push_str(chunk),
-            _ => self.segments.push(MessageSegment::Text(chunk.to_string())),
+            Some(MessageSegment::Text(t)) => {
+                t.push_str(chunk);
+                self.bump_render_version();
+            }
+            _ => {
+                let trimmed = chunk.trim_start_matches(|c: char| c == '\n' || c == '\r');
+                if trimmed.is_empty() {
+                    return;
+                }
+                self.segments
+                    .push(MessageSegment::Text(trimmed.to_string()));
+                self.bump_render_version();
+            }
         }
-        self.bump_render_version();
     }
 
     /// Append a reasoning chunk to the segment timeline, coalescing with the

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -524,6 +524,11 @@ pub struct AppState {
 
     cursor: Cell<(u16, u16)>,
     pub model_label: String,
+    /// Cancel token for the in-flight agent turn (YYC-105). Held outside
+    /// the agent mutex so the Ctrl+C handler can fire it without
+    /// blocking on the lock that the prompt task is holding for the
+    /// duration of the stream. `None` when no turn is in flight.
+    pub current_turn_cancel: Option<tokio_util::sync::CancellationToken>,
     /// Active named provider profile, if any (YYC-96). `None` means the
     /// session is running on the legacy unnamed `[provider]` block —
     /// `model_status()` omits the prefix in that case.
@@ -673,6 +678,7 @@ impl AppState {
             cursor: Cell::new((0, 0)),
             model_label,
             provider_label: None,
+            current_turn_cancel: None,
             prompt_tokens_total: 0,
             completion_tokens_total: 0,
             prompt_tokens_last: 0,

--- a/src/tui/views.rs
+++ b/src/tui/views.rs
@@ -235,7 +235,14 @@ fn push_visible_fixed_lines(
 fn single_stack(f: &mut TuiFrame, area: Rect, app: &AppState) {
     let layout = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Min(5), Constraint::Length(3)])
+        .constraints([
+            Constraint::Min(5),
+            Constraint::Length(super::widgets::prompt_row_height(
+                &app.input,
+                area.width,
+                app.mode_label(),
+            )),
+        ])
         .split(area);
 
     let inner = frame(
@@ -281,7 +288,14 @@ fn split_sessions(f: &mut TuiFrame, area: Rect, app: &AppState) {
     let outer = frame(f, area, app.view.title(), Some("5 sess · 2 live"), None, &app.theme);
     let v = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Min(5), Constraint::Length(3)])
+        .constraints([
+            Constraint::Min(5),
+            Constraint::Length(super::widgets::prompt_row_height(
+                &app.input,
+                area.width,
+                app.mode_label(),
+            )),
+        ])
         .split(outer);
 
     let h = Layout::default()
@@ -449,7 +463,14 @@ fn tiled_mesh(f: &mut TuiFrame, area: Rect, app: &AppState) {
     let outer = frame(f, area, app.view.title(), Some(&status), None, &app.theme);
     let v = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Min(5), Constraint::Length(3)])
+        .constraints([
+            Constraint::Min(5),
+            Constraint::Length(super::widgets::prompt_row_height(
+                &app.input,
+                area.width,
+                app.mode_label(),
+            )),
+        ])
         .split(outer);
 
     let rows = Layout::default()
@@ -541,7 +562,14 @@ fn tree_of_thought(f: &mut TuiFrame, area: Rect, app: &AppState) {
     let outer = frame(f, area, app.view.title(), Some(&summary), None, &app.theme);
     let v = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Min(5), Constraint::Length(3)])
+        .constraints([
+            Constraint::Min(5),
+            Constraint::Length(super::widgets::prompt_row_height(
+                &app.input,
+                area.width,
+                app.mode_label(),
+            )),
+        ])
         .split(outer);
     let h = Layout::default()
         .direction(Direction::Horizontal)
@@ -656,7 +684,11 @@ fn trading_floor(f: &mut TuiFrame, area: Rect, app: &AppState) {
         .constraints([
             Constraint::Min(8),    // grid
             Constraint::Length(1), // ticker
-            Constraint::Length(3), // prompt row
+            Constraint::Length(super::widgets::prompt_row_height(
+                &app.input,
+                area.width,
+                app.mode_label(),
+            )), // prompt row (YYC-104: wraps with input)
         ])
         .split(outer);
 

--- a/src/tui/widgets.rs
+++ b/src/tui/widgets.rs
@@ -259,6 +259,18 @@ pub fn render_message_body(
 /// the caret (RED) stay structural — they're chrome, not chat content.
 /// Capacity-warning fg colors (yellow/red) stay on the design's warn
 /// palette so the urgency cue is identical across themes.
+/// Compute total prompt-row height for a given input width + mode label.
+/// Caller layouts use this to reserve enough vertical space for wrap.
+/// Returns at least 3 (1 divider + 1 input + 1 hints).
+pub fn prompt_row_height(input: &str, width: u16, mode: &str) -> u16 {
+    let prefix = mode.chars().count() as u16 + 2 + 3 + 1; // [MODE] + space + ❯ + cursor
+    let avail = width.saturating_sub(prefix).max(1) as usize;
+    let chars = input.chars().count();
+    let input_lines = ((chars + 1).max(1) + avail - 1) / avail; // +1 for cursor block
+    let input_lines = input_lines.max(1) as u16;
+    1 + input_lines + 1
+}
+
 pub fn prompt_row(
     f: &mut TuiFrame,
     area: Rect,
@@ -276,11 +288,14 @@ pub fn prompt_row(
         return (area.x, area.y);
     }
     let body_style = Style::default().fg(theme.body_fg);
+    // YYC-104: input row height grows with wrap so long prompts stay
+    // visible instead of scrolling off the right edge.
+    let input_height = area.height.saturating_sub(2).max(1);
     let layout = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Length(1),
-            Constraint::Length(1),
+            Constraint::Length(input_height),
             Constraint::Length(1),
         ])
         .split(area);
@@ -308,11 +323,21 @@ pub fn prompt_row(
         }),
     );
     let line = Line::from(vec![mode_pill, caret, input_span, cursor_block]);
-    f.render_widget(Paragraph::new(line), layout[1]);
+    f.render_widget(
+        Paragraph::new(line).wrap(Wrap { trim: false }),
+        layout[1],
+    );
 
-    let mode_width = mode.chars().count() as u16 + 2;
-    let cursor_x = layout[1].x + mode_width + 3 + input.chars().count() as u16;
-    let cursor_y = layout[1].y;
+    // Compute cursor (x, y) accounting for wrap. The prefix is
+    // [MODE] + " ❯ " before the input.
+    let prefix_chars = mode.chars().count() as u16 + 2 + 3;
+    let cell_width = layout[1].width.max(1);
+    let typed = input.chars().count() as u16;
+    let total_offset = prefix_chars + typed;
+    let cursor_y_offset = total_offset / cell_width;
+    let cursor_x_offset = total_offset % cell_width;
+    let cursor_x = layout[1].x + cursor_x_offset;
+    let cursor_y = layout[1].y + cursor_y_offset;
 
     let muted_style = theme.muted;
     let mut hint_spans: Vec<Span<'static>> = Vec::new();


### PR DESCRIPTION
Local / open-weight models (llama.cpp, Qwen reasoning variants,
DeepSeek-R1 distills) emit chain-of-thought as inline `<think>…</think>`
blocks in the regular content stream rather than the structured
reasoning_content field DeepSeek/OpenRouter use. Vulcan was passing
the tags through verbatim so the chat surface rendered raw markers
and the Ctrl-R reasoning toggle never saw the trace.

Sanitizer (src/provider/think_sanitizer.rs):
- Stateful machine: in_think flag + pending byte buffer for partial
  tags split across SSE chunks.
- Case-insensitive tag matching, attribute-tolerant
  (`<think id="x">` works), tag-name-strict (`<thinker>` is plain text).
- feed(chunk) returns the text + reasoning fragments to emit.
- flush() drains any unresolved partial tag at stream close so we
  never swallow real text.
- 9 unit tests cover single-chunk, two-chunk split (mid-content and
  mid-tag), case variations, attributes, lone `<`, fake-tag
  passthrough, multiple blocks per turn, flush.

Provider integration (src/provider/openai.rs):
- chat_stream: post-process each parse_line content delta through
  the sanitizer; reasoning fragments flow into the existing
  reasoning_content channel alongside any native delta. Stream-close
  flush drains pending partial tags.
- chat (buffered): sanitize the assembled content once at the end
  before tool-call inference and ChatResponse build.

Existing reasoning_content / OpenRouter `reasoning` paths untouched —
sanitizer is additive for providers that don't ship a structured
reasoning field.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>