### PR TITLE
YYC-107: context-aware tool registration + descriptions (initial)

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -106,6 +106,9 @@ pub struct Agent {
     last_saved_count: usize,
     /// Max agent loop iterations per prompt. 0 = unlimited (default).
     max_iterations: u32,
+    /// Workspace context probed at session start (YYC-107). Used to
+    /// filter the tool registry and feed dynamic tool descriptions.
+    tool_context: crate::tools::ToolContext,
 }
 
 #[derive(Debug, Clone)]
@@ -183,9 +186,12 @@ impl Agent {
         );
 
         let diff_sink = crate::tools::new_diff_sink();
-        let lsp_manager = Arc::new(crate::code::lsp::LspManager::new(
-            std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
-        ));
+        let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+        let lsp_manager = Arc::new(crate::code::lsp::LspManager::new(cwd.clone()));
+        // YYC-107: probe the workspace once so tool registration can
+        // drop irrelevant tools (cargo_check off-Rust, etc.) and the
+        // remaining tools can render runtime-aware descriptions.
+        let tool_context = crate::tools::ToolContext::probe(cwd);
         let mut tools = ToolRegistry::new_with_diff_and_lsp(
             Some(diff_sink.clone()),
             Some(lsp_manager.clone()),
@@ -288,6 +294,9 @@ impl Agent {
             )));
         }
 
+        // YYC-107: drop tools that aren't relevant to this workspace.
+        tools.filter_for_context(&tool_context);
+
         Ok(Self {
             provider,
             tools,
@@ -306,6 +315,7 @@ impl Agent {
             active_profile: None,
             lsp_manager,
             last_saved_count: 0,
+            tool_context,
             max_iterations: config.provider.max_iterations,
         })
     }
@@ -593,6 +603,9 @@ impl Agent {
             )),
             last_saved_count: 0,
             max_iterations: 0,
+            tool_context: crate::tools::ToolContext::probe(
+                std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
+            ),
         }
     }
 
@@ -640,8 +653,12 @@ impl Agent {
         self.turn_cancel = CancellationToken::new();
         let cancel = self.turn_cancel.clone();
 
-        let system = self.prompt_builder.build_system_prompt(&self.tools);
-        let tool_defs = self.tools.definitions();
+        let system = self
+            .prompt_builder
+            .build_system_prompt_with_context(&self.tools, Some(&self.tool_context));
+        let tool_defs = self
+            .tools
+            .definitions_with_context(Some(&self.tool_context));
         let mut messages = vec![Message::System { content: system }];
 
         // Load history for *this* agent's session — set by `resume_session` or
@@ -798,8 +815,12 @@ impl Agent {
         // sees the cancellation. The external token is the source of truth.
         self.turn_cancel = cancel.clone();
 
-        let system = self.prompt_builder.build_system_prompt(&self.tools);
-        let tool_defs = self.tools.definitions();
+        let system = self
+            .prompt_builder
+            .build_system_prompt_with_context(&self.tools, Some(&self.tool_context));
+        let tool_defs = self
+            .tools
+            .definitions_with_context(Some(&self.tool_context));
         let mut messages = vec![Message::System { content: system }];
 
         if let Some(history) = self.memory.load_history(&self.session_id)? {

--- a/src/prompt_builder.rs
+++ b/src/prompt_builder.rs
@@ -1,26 +1,58 @@
-use crate::tools::ToolRegistry;
+use crate::tools::{ToolContext, ToolRegistry};
 
 /// Builds the system prompt injected into every conversation.
 pub struct PromptBuilder;
 
 impl PromptBuilder {
     pub fn build_system_prompt(&self, tools: &ToolRegistry) -> String {
-        let cwd = std::env::current_dir()
-            .ok()
-            .map(|p| p.display().to_string())
+        self.build_system_prompt_with_context(tools, None)
+    }
+
+    pub fn build_system_prompt_with_context(
+        &self,
+        tools: &ToolRegistry,
+        ctx: Option<&ToolContext>,
+    ) -> String {
+        let cwd = ctx
+            .map(|c| c.cwd.display().to_string())
+            .or_else(|| std::env::current_dir().ok().map(|p| p.display().to_string()))
             .unwrap_or_else(|| "(unknown)".into());
-        let env_section = format!(
-            "## Environment\n\
-             - working directory: `{cwd}`\n\
-             - bash and other shell commands run in this directory unless `workdir` is supplied.\n"
+        let mut env_lines = vec![format!("- working directory: `{cwd}`")];
+        if let Some(c) = ctx {
+            if let Some(manifest) = &c.cargo_manifest {
+                let pkg = c
+                    .cargo_package_name
+                    .clone()
+                    .unwrap_or_else(|| "(unnamed)".into());
+                env_lines.push(format!(
+                    "- rust workspace: package `{pkg}` at `{}`",
+                    manifest.display()
+                ));
+                if !c.cargo_bin_targets.is_empty() {
+                    env_lines.push(format!(
+                        "- bin targets: {}",
+                        c.cargo_bin_targets.join(", ")
+                    ));
+                }
+            } else {
+                env_lines
+                    .push("- no Cargo.toml within depth=4 — `cargo_check` is not registered".into());
+            }
+            if c.git_present {
+                env_lines.push("- git: working tree present".into());
+            }
+        }
+        env_lines.push(
+            "- bash and other shell commands run in the working directory unless `workdir` is supplied.".into(),
         );
+        let env_section = format!("## Environment\n{}\n", env_lines.join("\n"));
 
         let tool_section = format!(
             "## Available Tools\n\
              You have access to the following tools. When you need to perform an action, \
              call the appropriate tool directly through the tool-calling interface:\n\n{}\n",
             tools
-                .definitions()
+                .definitions_with_context(ctx)
                 .iter()
                 .map(|t| format!("- `{}`: {}", t.function.name, t.function.description))
                 .collect::<Vec<_>>()

--- a/src/tools/cargo.rs
+++ b/src/tools/cargo.rs
@@ -7,7 +7,7 @@
 //! auto-diagnostics hook for a "did my edit compile?" Rust path that
 //! doesn't depend on tooling state.
 
-use crate::tools::{Tool, ToolResult};
+use crate::tools::{Tool, ToolContext, ToolResult};
 use anyhow::Result;
 use async_trait::async_trait;
 use serde_json::{Value, json};
@@ -42,6 +42,33 @@ impl Tool for CargoCheckTool {
             }
         })
     }
+    fn is_relevant(&self, ctx: &ToolContext) -> bool {
+        // YYC-107: only register cargo_check when there's a Cargo.toml
+        // within the probe depth. Saves the agent from the confusing
+        // "could not find Cargo.toml" error path on non-Rust workspaces.
+        ctx.cargo_manifest.is_some()
+    }
+
+    fn dynamic_description(&self, ctx: &ToolContext) -> Option<String> {
+        let manifest = ctx.cargo_manifest.as_ref()?;
+        let mut out = String::from(
+            "Run `cargo check --message-format=json` and return parsed compiler diagnostics. \
+             Use this instead of `cargo check` via bash — structured errors with paths, lines, \
+             rendered messages.",
+        );
+        if let Some(name) = &ctx.cargo_package_name {
+            out.push_str(&format!(" Workspace package: `{name}`."));
+        }
+        if !ctx.cargo_bin_targets.is_empty() {
+            out.push_str(&format!(
+                " Binary targets: {}.",
+                ctx.cargo_bin_targets.join(", ")
+            ));
+        }
+        out.push_str(&format!(" Manifest: `{}`.", manifest.display()));
+        Some(out)
+    }
+
     async fn call(&self, params: Value, cancel: CancellationToken) -> Result<ToolResult> {
         let package = params.get("package").and_then(|v| v.as_str());
         let all_targets = params

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -74,6 +74,127 @@ pub trait Tool: Send + Sync {
     /// (or rely on `kill_on_drop` for child processes) and return
     /// `ToolResult::err("Cancelled")` on cancel.
     async fn call(&self, params: Value, cancel: CancellationToken) -> Result<ToolResult>;
+
+    /// YYC-107: per-session availability check. Default = always
+    /// register. Tools that only make sense in certain workspaces
+    /// (cargo_check needs Cargo.toml, etc.) override this.
+    fn is_relevant(&self, _ctx: &ToolContext) -> bool {
+        true
+    }
+
+    /// YYC-107: optional runtime-aware description. Returns
+    /// `Some(string)` to override the static description with
+    /// workspace-derived context (e.g. discovered bin targets).
+    fn dynamic_description(&self, _ctx: &ToolContext) -> Option<String> {
+        None
+    }
+}
+
+/// Workspace context surfaced to tools at session start (YYC-107).
+/// Built once by `Agent::with_hooks_and_pause` and passed into
+/// `is_relevant` / `dynamic_description` so tools can reflect what's
+/// actually in the cwd.
+#[derive(Debug, Clone)]
+pub struct ToolContext {
+    pub cwd: std::path::PathBuf,
+    /// First Cargo.toml found within `MAX_CONTEXT_DEPTH` of cwd.
+    pub cargo_manifest: Option<std::path::PathBuf>,
+    /// Parsed package name from the discovered Cargo.toml, when readable.
+    pub cargo_package_name: Option<String>,
+    /// Parsed `[[bin]]` target names from the discovered Cargo.toml.
+    pub cargo_bin_targets: Vec<String>,
+    /// True when the cwd is inside a git working tree.
+    pub git_present: bool,
+}
+
+const MAX_CONTEXT_DEPTH: usize = 4;
+
+impl ToolContext {
+    /// Build the context by probing the filesystem rooted at `cwd`.
+    pub fn probe(cwd: std::path::PathBuf) -> Self {
+        let cargo_manifest = find_cargo_manifest(&cwd, MAX_CONTEXT_DEPTH);
+        let (cargo_package_name, cargo_bin_targets) = match &cargo_manifest {
+            Some(path) => parse_cargo_manifest(path),
+            None => (None, Vec::new()),
+        };
+        let git_present = is_git_workspace(&cwd);
+        Self {
+            cwd,
+            cargo_manifest,
+            cargo_package_name,
+            cargo_bin_targets,
+            git_present,
+        }
+    }
+}
+
+fn find_cargo_manifest(start: &std::path::Path, max_depth: usize) -> Option<std::path::PathBuf> {
+    fn walk(dir: &std::path::Path, depth_left: usize) -> Option<std::path::PathBuf> {
+        let candidate = dir.join("Cargo.toml");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        if depth_left == 0 {
+            return None;
+        }
+        let entries = std::fs::read_dir(dir).ok()?;
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            // Skip hidden and target/ to keep the probe fast.
+            let name = path
+                .file_name()
+                .and_then(|s| s.to_str())
+                .unwrap_or_default();
+            if name.starts_with('.') || name == "target" || name == "node_modules" {
+                continue;
+            }
+            if let Some(found) = walk(&path, depth_left - 1) {
+                return Some(found);
+            }
+        }
+        None
+    }
+    walk(start, max_depth)
+}
+
+fn parse_cargo_manifest(path: &std::path::Path) -> (Option<String>, Vec<String>) {
+    let raw = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(_) => return (None, Vec::new()),
+    };
+    let parsed: toml::Value = match toml::from_str(&raw) {
+        Ok(v) => v,
+        Err(_) => return (None, Vec::new()),
+    };
+    let pkg_name = parsed
+        .get("package")
+        .and_then(|p| p.get("name"))
+        .and_then(|n| n.as_str())
+        .map(|s| s.to_string());
+    let bins: Vec<String> = parsed
+        .get("bin")
+        .and_then(|b| b.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|b| b.get("name").and_then(|n| n.as_str()).map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+    (pkg_name, bins)
+}
+
+fn is_git_workspace(start: &std::path::Path) -> bool {
+    let mut cur = Some(start);
+    while let Some(p) = cur {
+        if p.join(".git").exists() {
+            return true;
+        }
+        cur = p.parent();
+    }
+    false
 }
 
 pub mod ask_user;
@@ -213,17 +334,48 @@ impl ToolRegistry {
         self.tools.insert(tool.name().to_string(), tool);
     }
 
-    /// Get all tool definitions for the LLM
+    /// YYC-107: drop tools whose `is_relevant(ctx)` returns false.
+    /// Called once at session start by `Agent::with_hooks_and_pause`
+    /// after the registry is fully populated.
+    pub fn filter_for_context(&mut self, ctx: &ToolContext) {
+        let drop_keys: Vec<String> = self
+            .tools
+            .iter()
+            .filter_map(|(name, tool)| {
+                if tool.is_relevant(ctx) {
+                    None
+                } else {
+                    Some(name.clone())
+                }
+            })
+            .collect();
+        for k in drop_keys {
+            self.tools.remove(&k);
+        }
+    }
+
+    /// Get all tool definitions for the LLM. Tools that override
+    /// `dynamic_description` get their runtime description; the rest
+    /// fall back to the static one.
     pub fn definitions(&self) -> Vec<ToolDefinition> {
+        self.definitions_with_context(None)
+    }
+
+    pub fn definitions_with_context(&self, ctx: Option<&ToolContext>) -> Vec<ToolDefinition> {
         self.tools
             .values()
-            .map(|t| ToolDefinition {
-                tool_type: "function".into(),
-                function: crate::provider::ToolFunction {
-                    name: t.name().to_string(),
-                    description: t.description().to_string(),
-                    parameters: t.schema(),
-                },
+            .map(|t| {
+                let description = ctx
+                    .and_then(|c| t.dynamic_description(c))
+                    .unwrap_or_else(|| t.description().to_string());
+                ToolDefinition {
+                    tool_type: "function".into(),
+                    function: crate::provider::ToolFunction {
+                        name: t.name().to_string(),
+                        description,
+                        parameters: t.schema(),
+                    },
+                }
             })
             .collect()
     }
@@ -316,7 +468,94 @@ fn validate_tool_params(
 mod tests {
     use super::*;
     use serde_json::json;
+    use tempfile::tempdir;
     use tokio_util::sync::CancellationToken;
+
+    #[test]
+    fn tool_context_finds_cargo_manifest_at_root_and_nested() {
+        let dir = tempdir().unwrap();
+        // Empty dir → no manifest.
+        let ctx = ToolContext::probe(dir.path().to_path_buf());
+        assert!(ctx.cargo_manifest.is_none());
+
+        // Cargo.toml at root.
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"demo\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        let ctx = ToolContext::probe(dir.path().to_path_buf());
+        assert!(ctx.cargo_manifest.is_some());
+        assert_eq!(ctx.cargo_package_name.as_deref(), Some("demo"));
+
+        // Nested Cargo.toml is found within depth.
+        let nested_dir = tempdir().unwrap();
+        let sub = nested_dir.path().join("crate").join("nested");
+        std::fs::create_dir_all(&sub).unwrap();
+        std::fs::write(
+            sub.join("Cargo.toml"),
+            "[package]\nname = \"deep\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        let ctx = ToolContext::probe(nested_dir.path().to_path_buf());
+        assert_eq!(ctx.cargo_package_name.as_deref(), Some("deep"));
+    }
+
+    #[test]
+    fn tool_context_parses_bin_targets() {
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            r#"
+[package]
+name = "demo"
+version = "0.1.0"
+
+[[bin]]
+name = "alpha"
+path = "src/alpha.rs"
+
+[[bin]]
+name = "beta"
+path = "src/beta.rs"
+"#,
+        )
+        .unwrap();
+        let ctx = ToolContext::probe(dir.path().to_path_buf());
+        let mut bins = ctx.cargo_bin_targets.clone();
+        bins.sort();
+        assert_eq!(bins, vec!["alpha".to_string(), "beta".to_string()]);
+    }
+
+    #[test]
+    fn cargo_check_is_filtered_when_no_manifest() {
+        // Probe an empty dir → no manifest → CargoCheckTool::is_relevant false.
+        let dir = tempdir().unwrap();
+        let ctx = ToolContext::probe(dir.path().to_path_buf());
+        assert!(!cargo::CargoCheckTool.is_relevant(&ctx));
+    }
+
+    #[test]
+    fn cargo_check_dynamic_description_lists_targets() {
+        let dir = tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            r#"
+[package]
+name = "demo"
+version = "0.1.0"
+
+[[bin]]
+name = "primary"
+path = "src/primary.rs"
+"#,
+        )
+        .unwrap();
+        let ctx = ToolContext::probe(dir.path().to_path_buf());
+        let dyn_desc = cargo::CargoCheckTool.dynamic_description(&ctx).unwrap();
+        assert!(dyn_desc.contains("`demo`"));
+        assert!(dyn_desc.contains("primary"));
+    }
 
     #[tokio::test]
     async fn missing_required_field_yields_clear_error() {

--- a/src/tui/chat_render.rs
+++ b/src/tui/chat_render.rs
@@ -172,7 +172,7 @@ impl ChatRenderStore {
                     MessageSegment::Reasoning(reasoning)
                         if options.show_reasoning && !reasoning.trim().is_empty() =>
                     {
-                        lines.extend(reasoning_lines(reasoning, false, theme));
+                        lines.extend(reasoning_lines(reasoning, false, theme, options.width));
                     }
                     MessageSegment::Reasoning(_) => {}
                     MessageSegment::ToolCall {
@@ -221,7 +221,7 @@ impl ChatRenderStore {
             }
         } else {
             if options.show_reasoning && is_agent && !message.reasoning.is_empty() {
-                lines.extend(reasoning_lines(&message.reasoning, false, theme));
+                lines.extend(reasoning_lines(&message.reasoning, false, theme, options.width));
             }
             if is_agent && message.content.is_empty() {
                 lines.push(agent_placeholder(

--- a/src/tui/views.rs
+++ b/src/tui/views.rs
@@ -517,7 +517,7 @@ fn tiled_mesh(f: &mut TuiFrame, area: Rect, app: &AppState) {
         if i == 0 && app.show_reasoning {
             lines.push(Line::from(""));
             if let Some(reasoning) = app.latest_reasoning() {
-                for l in super::widgets::reasoning_lines(reasoning, false, &app.theme) {
+                for l in super::widgets::reasoning_lines(reasoning, false, &app.theme, area.width) {
                     lines.push(l);
                 }
             } else {
@@ -630,7 +630,7 @@ fn tree_of_thought(f: &mut TuiFrame, area: Rect, app: &AppState) {
     if app.show_reasoning {
         if let Some(reasoning) = app.latest_reasoning() {
             lines.push(Line::from(""));
-            for l in super::widgets::reasoning_lines(reasoning, false, &app.theme) {
+            for l in super::widgets::reasoning_lines(reasoning, false, &app.theme, area.width) {
                 lines.push(l);
             }
         }

--- a/src/tui/widgets.rs
+++ b/src/tui/widgets.rs
@@ -164,7 +164,12 @@ pub enum ToolStatus {
 /// role. The visible reasoning rows sit on the structural FAINT
 /// backdrop (a Bauhaus tint that's always lighter than PAPER) — the
 /// inset-card affordance is design-locked, not themed.
-pub fn reasoning_lines(text: &str, hidden: bool, theme: &Theme) -> Vec<Line<'static>> {
+pub fn reasoning_lines(
+    text: &str,
+    hidden: bool,
+    theme: &Theme,
+    width: u16,
+) -> Vec<Line<'static>> {
     if hidden {
         return vec![Line::from(Span::styled(
             "░░░ reasoning trace hidden · Ctrl-R to show ░░░",
@@ -175,11 +180,28 @@ pub fn reasoning_lines(text: &str, hidden: bool, theme: &Theme) -> Vec<Line<'sta
         " ▒ THINKING",
         theme.muted.add_modifier(Modifier::BOLD),
     ))];
+    // YYC-104 follow-up: pre-wrap each source line so the `▒` rail
+    // repeats on every visual row instead of breaking after the first
+    // when Paragraph::wrap takes over.
+    let prefix = " ▒ ";
+    let inner_width = width.saturating_sub(prefix.chars().count() as u16).max(1) as usize;
+    let body_style = theme.muted.add_modifier(Modifier::ITALIC);
     for raw in text.lines() {
-        lines.push(Line::from(Span::styled(
-            format!(" ▒ {}", raw),
-            theme.muted.add_modifier(Modifier::ITALIC),
-        )));
+        let chars: Vec<char> = raw.chars().collect();
+        if chars.is_empty() {
+            lines.push(Line::from(Span::styled(prefix.to_string(), body_style)));
+            continue;
+        }
+        let mut idx = 0usize;
+        while idx < chars.len() {
+            let end = (idx + inner_width).min(chars.len());
+            let chunk: String = chars[idx..end].iter().collect();
+            lines.push(Line::from(Span::styled(
+                format!("{prefix}{chunk}"),
+                body_style,
+            )));
+            idx = end;
+        }
     }
     lines
 }


### PR DESCRIPTION
Tools surfaced to the model now reflect the cwd. Two `Tool` trait
hooks land:

- `is_relevant(&ToolContext) -> bool` filters tools that don't apply
  to the current workspace.
- `dynamic_description(&ToolContext) -> Option<String>` rewrites the
  tool's description with runtime context.

`ToolContext` is probed once at agent startup
(`Agent::with_hooks_and_pause`):

- Walks cwd up to depth 4 looking for Cargo.toml (skipping
  `target/`, hidden dirs, `node_modules/`).
- Parses the discovered manifest for package name + `[[bin]]`
  targets.
- Detects whether the cwd sits inside a git working tree.

`ToolRegistry::filter_for_context` drops irrelevant tools after
registration. `ToolRegistry::definitions_with_context` substitutes the
dynamic description when a tool provides one.

PromptBuilder gains `build_system_prompt_with_context`. The
`## Environment` block now lists package + bin targets when present,
or "no Cargo.toml — cargo_check is not registered" otherwise. Agent
calls the context-aware variant on every iteration.

CargoCheckTool wires both:

- `is_relevant` returns true only when a Cargo.toml is found in the
  probe.
- `dynamic_description` lists package name and `[[bin]]` target
  names plus the manifest path.

Tests: 4 new — context probe at root, nested manifest find, bin
targets parsed, CargoCheckTool filter + description path.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>