### PR TITLE
chore(ci): swap test job to nextest + add llvm-cov coverage job

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,19 @@
+# nextest config — see https://nexte.st/docs/configuration/
+[profile.default]
+# Show test output for failed tests inline; quiet for passing.
+failure-output = "immediate-final"
+success-output = "never"
+status-level = "fail"
+final-status-level = "flaky"
+# Per-test timeout; gateway tests use sqlite + tokio so 60s is generous.
+slow-timeout = { period = "30s", terminate-after = 4 }
+
+[profile.ci]
+# CI runs get retries for flake tolerance + JUnit output for downstream tools.
+retries = 2
+failure-output = "immediate-final"
+success-output = "never"
+fail-fast = false
+
+[profile.ci.junit]
+path = "junit.xml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,42 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@nextest
       - name: Build
         run: cargo build --all-targets --features "${{ matrix.features }}"
-      - name: Test
-        run: cargo test --all-targets --features "${{ matrix.features }}"
+      - name: Test (nextest)
+        run: cargo nextest run --profile ci --all-targets --features "${{ matrix.features }}"
+      - name: Doc tests
+        run: cargo test --doc --features "${{ matrix.features }}"
+      - name: Upload junit
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: junit-${{ matrix.features || 'default' }}
+          path: target/nextest/ci/junit.xml
+          if-no-files-found: ignore
+
+  coverage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: taiki-e/install-action@nextest
+      - name: Generate coverage (lcov)
+        run: cargo llvm-cov nextest --all-features --workspace --lcov --output-path lcov.info
+      - name: Coverage summary
+        run: cargo llvm-cov report --all-features --workspace --summary-only
+      - name: Upload lcov
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lcov
+          path: lcov.info
+          retention-days: 14
 
   feature-powerset:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Add `.config/nextest.toml` with default + ci profiles. CI profile
  enables retries, JUnit output for downstream tools, and
  immediate-final failure output.
- Replace `cargo test` with `cargo nextest run --profile ci` in the
  feature matrix so failures surface faster and JUnit lands in
  artifacts. Doc tests still run via `cargo test --doc` since nextest
  doesn't execute them.
- Add `coverage` job using `cargo-llvm-cov nextest`. Uploads
  `lcov.info` as an artifact for later codecov/coveralls wiring.

Both nextest and llvm-cov use prebuilt binaries via
`taiki-e/install-action` so the job stays under cache-cold targets.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>