### PR TITLE
test: insta snapshot guards for prompt builder + chat render

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2498,6 +2498,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.47.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+dependencies = [
+ "console",
+ "once_cell",
+ "similar",
+ "tempfile",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4162,6 +4174,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5049,6 +5067,7 @@ dependencies = [
  "hmac",
  "http",
  "ignore",
+ "insta",
  "lsp-types",
  "portable-pty",
  "r2d2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,6 +171,9 @@ tempfile = "3.27.0"
 divan = "0.1"
 hdrhistogram = "7"
 tokio = { version = "1", features = ["full", "test-util"] }
+# Snapshot testing for prompt builder + TUI render output (YYC follow-up).
+# Pinned to crates.io latest stable; default features sufficient.
+insta = "1.47.2"
 
 [[bench]]
 name = "tui_render"

--- a/src/prompt_builder.rs
+++ b/src/prompt_builder.rs
@@ -115,6 +115,36 @@ mod tests {
         );
     }
 
+    /// Snapshot guard for the system prompt produced against the *default*
+    /// tool registry. Catches accidental wording drift in the
+    /// guidelines/preferences/format sections without rewriting the
+    /// existing per-keyword assertions. Tool list is normalized so adding
+    /// a new tool doesn't churn this snapshot.
+    #[test]
+    fn system_prompt_snapshot_default_registry() {
+        let prompt = PromptBuilder.build_system_prompt(&ToolRegistry::new());
+        let normalized = normalize_tool_list(&prompt);
+        insta::assert_snapshot!("system_prompt_default_registry", normalized);
+    }
+
+    fn normalize_tool_list(prompt: &str) -> String {
+        // Replace the `## Available Tools` body up to the next `##` with a
+        // single placeholder so prompt copy changes are caught here, but
+        // tool churn lives in dedicated assertions above.
+        let marker = "## Available Tools";
+        let Some(start) = prompt.find(marker) else {
+            return prompt.to_string();
+        };
+        let tail = &prompt[start + marker.len()..];
+        let end_rel = tail.find("\n##").unwrap_or(tail.len());
+        let mut out = String::with_capacity(prompt.len());
+        out.push_str(&prompt[..start]);
+        out.push_str(marker);
+        out.push_str("\n<tool list normalized>\n");
+        out.push_str(&tail[end_rel..]);
+        out
+    }
+
     /// YYC-86: the prompt must steer the model toward native tools and
     /// position bash as a last resort. Without this section, even with
     /// the YYC-85 description nudges the agent still falls back to

--- a/src/snapshots/vulcan__prompt_builder__tests__system_prompt_default_registry.snap
+++ b/src/snapshots/vulcan__prompt_builder__tests__system_prompt_default_registry.snap
@@ -1,0 +1,30 @@
+---
+source: src/prompt_builder.rs
+expression: normalized
+---
+You are Vulcan, a Rust AI agent. You help with coding, research, file management, and automation.
+
+## Guidelines
+- Be concise and precise
+- When working on multi-step tasks, use tools iteratively — one tool call at a time
+- Read files before editing them
+- After 5+ tool calls on a complex task, suggest saving a skill
+
+## Tool preferences
+Prefer native tools over `bash`. Bash is the last resort — use it only for pipes, ad-hoc sysadmin, or commands no native tool covers.
+
+| Task | Use | Not |
+|---|---|---|
+| Search file contents | `search_files` | `bash rg` / `grep -r` |
+| Structural code query | `code_query` (tree-sitter) | `bash grep` |
+| Read a file | `read_file` | `bash cat` / `head` / `tail` |
+| List a directory | `list_files` | `bash ls` / `tree` / `find` |
+| Check Rust compiles | `cargo_check` | `bash cargo check` |
+| Git status / diff / log / commit / push | `git_*` | `bash git ...` |
+| Goto-def, refs, hover | `goto_definition` / `find_references` / `hover` | (no bash equiv) |
+
+## Available Tools
+<tool list normalized>
+
+## Response Format
+Respond naturally. If the user's request doesn't need tools, just answer directly. When tools are needed, call the tool directly instead of printing a JSON blob or a literal `tool_calls` block in assistant text. Tool call arguments must be valid JSON matching the tool schema.

--- a/src/tui/chat_render.rs
+++ b/src/tui/chat_render.rs
@@ -698,4 +698,49 @@ mod tests {
         assert!(tool < text);
         assert!(rendered.iter().any(|line| line.contains("OK")));
     }
+
+    /// Snapshot-locks the visible rendering of a small fixed transcript.
+    /// Catches accidental changes to spacing, prefixes, tool-card layout,
+    /// and reasoning placement that the per-assertion tests above wouldn't
+    /// notice. Width pinned to 60, theme system, dense=true so the snapshot
+    /// is reproducible across machines.
+    #[test]
+    fn snapshot_small_transcript_render() {
+        let mut store = ChatRenderStore::default();
+
+        let messages = vec![
+            ChatMessage::new(ChatRole::User, "what's in src/main.rs?"),
+            {
+                let mut m = ChatMessage::new(ChatRole::Agent, "");
+                m.append_reasoning("inspecting file");
+                m.push_tool_start_with("read_file", Some("src/main.rs".to_string()));
+                m.finish_tool_with(
+                    "read_file",
+                    true,
+                    Some("fn main() {}".to_string()),
+                    Some("1 line".to_string()),
+                    0,
+                    Some(12),
+                );
+                m.append_text("The file is a one-line `main`.");
+                m
+            },
+        ];
+
+        let options = ChatRenderOptions {
+            show_reasoning: true,
+            dense: true,
+            width: 60,
+            muted_style: Style::default(),
+        };
+        let window = store.visible_lines_at(&messages, options, &Theme::system(), 0, 200);
+        let body: String = window
+            .lines
+            .iter()
+            .map(line_text)
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        insta::assert_snapshot!("chat_render_small_transcript", body);
+    }
 }

--- a/src/tui/snapshots/vulcan__tui__chat_render__tests__chat_render_small_transcript.snap
+++ b/src/tui/snapshots/vulcan__tui__chat_render__tests__chat_render_small_transcript.snap
@@ -1,0 +1,17 @@
+---
+source: src/tui/chat_render.rs
+expression: body
+---
+▆ YOU
+▎ what's in src/main.rs?
+▆ AGENT
+ ▒ THINKING
+ ▒ inspecting file
+
+┌──────────────────────────────────────────────────────────┐
+│ × read_file   src/main.rs                      ✓ OK 12ms │
+│  1 line                                                  │
+│  fn main() {}                                            │
+└──────────────────────────────────────────────────────────┘
+
+▎ The file is a one-line main.


### PR DESCRIPTION
Add insta as a dev-dependency and lock two surfaces with snapshot
tests so accidental wording/layout drift is caught immediately:

- `src/prompt_builder.rs`: snapshot the full system prompt against an
  empty `ToolRegistry`. Tool list is normalized so adding a tool
  doesn't churn the snapshot — the per-keyword assertions above still
  guard the tools list independently.
- `src/tui/chat_render.rs`: snapshot the rendered text lines from a
  small fixed transcript (user message + agent reply with reasoning,
  tool card, and follow-up text). Width 60, system theme, dense=true
  for reproducibility.

Snapshot files live next to the source under `src/snapshots/` and
`src/tui/snapshots/` per insta defaults. Update via
`INSTA_UPDATE=always cargo test` or `cargo insta accept`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>