### PR TITLE
chore: cargo-machete CI gate + drop unused tower-http dep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,3 +120,10 @@ jobs:
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           command: check
+
+  machete:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bnjbvr/cargo-machete@main

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4704,7 +4704,6 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -5088,7 +5087,6 @@ dependencies = [
  "toml",
  "toml_edit",
  "tower",
- "tower-http",
  "tracing",
  "tracing-subscriber",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ bench-soak = ["dep:dhat", "dep:hdrhistogram"]
 gateway = [
     "dep:axum",
     "dep:tower",
-    "dep:tower-http",
     "dep:subtle",
     "dep:hmac",
     "dep:sha2",
@@ -108,7 +107,6 @@ ignore = "0.4.25"
 # Gateway daemon HTTP stack. Optional — only linked under `gateway`.
 axum = { version = "0.8.9", optional = true }
 tower = { version = "0.5.3", features = ["util"], optional = true }
-tower-http = { version = "0.6.8", features = ["trace", "cors"], optional = true }
 subtle = { version = "2.6.1", optional = true }
 # Webhook HMAC verification (Task 16). hmac 0.12 + sha2 0.10 share `digest 0.10`,
 # already in Cargo.lock transitively — picking the matching majors avoids


### PR DESCRIPTION
`cargo machete` flagged `tower-http` as unused: it was wired into the
gateway feature but never imported anywhere in `src/`. Drop both the
dep and its entry in the `gateway` feature list. Verified
`cargo build --features gateway` and `cargo test --features gateway`
still pass.

Adds a `machete` job to CI using `bnjbvr/cargo-machete@main` so future
unused deps get caught at PR time. No project-side config needed —
machete picks up `Cargo.toml` automatically.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>