### PR TITLE
YYC-113: pool gateway DB connections via r2d2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,6 +371,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,6 +542,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1121,6 +1141,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -3320,6 +3341,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "r2d2"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
+dependencies = [
+ "log",
+ "parking_lot",
+ "scheduled-thread-pool",
+]
+
+[[package]]
+name = "r2d2_sqlite"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5576df16239e4e422c4835c8ed00be806d4491855c7847dba60b7aa8408b469b"
+dependencies = [
+ "r2d2",
+ "rusqlite",
+ "uuid",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3338,6 +3381,17 @@ checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3377,6 +3431,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "ratatui"
@@ -3803,6 +3863,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scheduled-thread-pool"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
+dependencies = [
+ "parking_lot",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3989,7 +4058,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4010,7 +4079,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -4930,6 +4999,7 @@ dependencies = [
  "atomic",
  "getrandom 0.4.2",
  "js-sys",
+ "rand 0.10.1",
  "wasm-bindgen",
 ]
 
@@ -4981,6 +5051,8 @@ dependencies = [
  "ignore",
  "lsp-types",
  "portable-pty",
+ "r2d2",
+ "r2d2_sqlite",
  "ratatui",
  "reqwest 0.13.2",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ gateway = [
     "dep:hmac",
     "dep:sha2",
     "dep:serenity",
+    "dep:r2d2",
+    "dep:r2d2_sqlite",
 ]
 
 [dependencies]
@@ -114,6 +116,11 @@ subtle = { version = "2.6.1", optional = true }
 hmac = { version = "0.12.1", optional = true }
 sha2 = { version = "0.10.9", optional = true }
 serenity = { version = "0.12", default-features = false, features = ["client", "gateway", "http", "model", "rustls_backend"], optional = true }
+# Connection pool for the gateway daemon's SQLite store (YYC-113). Replaces
+# the global Arc<Mutex<Connection>> that serialized every concurrent agent
+# lane through one lock. Versions verified at crates.io latest stable.
+r2d2 = { version = "0.8.10", optional = true }
+r2d2_sqlite = { version = "0.33.0", optional = true }
 
 # `http` types are shared between axum and the `Platform` trait method
 # `verify_webhook`. Promoted to a direct, NON-feature-gated dep so the trait

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -11,8 +11,8 @@ use crate::gateway::outbound::OutboundDispatcher;
 use crate::gateway::queue::{InboundQueue, InboundRow, OutboundQueue};
 use crate::gateway::registry::PlatformRegistry;
 use crate::gateway::server::{AppState, build_router};
+use crate::memory::DbPool;
 use anyhow::{Context, Result};
-use rusqlite::Connection;
 use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
 
@@ -44,7 +44,7 @@ where
         .clone()
         .ok_or_else(|| anyhow::anyhow!("missing [gateway] config; set api_token before running"))?;
 
-    let db = crate::memory::open_gateway_connection()?;
+    let db = crate::memory::open_gateway_pool()?;
     let mut registry = PlatformRegistry::new();
     registry.register("loopback", Arc::new(LoopbackPlatform::default()));
     if gateway.discord.enabled {
@@ -66,16 +66,16 @@ async fn run_on_listener_with_parts<S>(
     gateway: crate::config::GatewayConfig,
     listener: TcpListener,
     shutdown: S,
-    db: Arc<std::sync::Mutex<Connection>>,
+    db: DbPool,
     registry: Arc<PlatformRegistry>,
     agent_map: Arc<AgentMap>,
 ) -> Result<()>
 where
     S: Future<Output = ()> + Send + 'static,
 {
-    let inbound = Arc::new(InboundQueue::new(Arc::clone(&db)));
+    let inbound = Arc::new(InboundQueue::new(db.clone()));
     let outbound = Arc::new(OutboundQueue::new(
-        Arc::clone(&db),
+        db.clone(),
         gateway.outbound_max_attempts,
     ));
 
@@ -217,8 +217,6 @@ mod tests {
     use crate::skills::SkillRegistry;
     use crate::tools::ToolRegistry;
     use async_trait::async_trait;
-    use rusqlite::Connection;
-    use std::sync::Mutex as StdMutex;
     use tokio::sync::oneshot;
     use tokio_util::sync::CancellationToken;
 
@@ -237,10 +235,8 @@ mod tests {
         config
     }
 
-    fn fresh_db() -> Arc<StdMutex<Connection>> {
-        let conn = Connection::open_in_memory().expect("open mem db");
-        crate::memory::initialize_test_conn(&conn).expect("schema");
-        Arc::new(StdMutex::new(conn))
+    fn fresh_db() -> DbPool {
+        crate::memory::in_memory_gateway_pool().expect("in-memory pool")
     }
 
     fn empty_skills() -> Arc<SkillRegistry> {
@@ -414,7 +410,7 @@ mod tests {
         let config = config_with_gateway();
         let gateway = config.gateway.clone().expect("gateway config");
         let db = fresh_db();
-        let inbound = InboundQueue::new(Arc::clone(&db));
+        let inbound = InboundQueue::new(db.clone());
         inbound
             .enqueue(crate::platform::InboundMessage {
                 platform: "loopback".into(),

--- a/src/gateway/outbound.rs
+++ b/src/gateway/outbound.rs
@@ -107,20 +107,16 @@ async fn drain_due(queue: &OutboundQueue, registry: &PlatformRegistry) -> anyhow
 mod tests {
     use super::*;
     use std::sync::Arc;
-    use std::sync::Mutex as StdMutex;
     use std::time::Duration;
-
-    use rusqlite::Connection;
 
     use crate::gateway::loopback::LoopbackPlatform;
     use crate::gateway::queue::OutboundQueue;
     use crate::gateway::registry::PlatformRegistry;
+    use crate::memory::DbPool;
     use crate::platform::OutboundMessage;
 
-    fn fresh_db() -> Arc<StdMutex<Connection>> {
-        let c = Connection::open_in_memory().expect("open mem db");
-        crate::memory::initialize_test_conn(&c).expect("schema");
-        Arc::new(StdMutex::new(c))
+    fn fresh_db() -> DbPool {
+        crate::memory::in_memory_gateway_pool().expect("in-memory pool")
     }
 
     fn out_msg(text: &str) -> OutboundMessage {
@@ -161,7 +157,7 @@ mod tests {
     #[tokio::test]
     async fn failed_send_retries_after_backoff() {
         let db = fresh_db();
-        let q = Arc::new(OutboundQueue::new(Arc::clone(&db), 5));
+        let q = Arc::new(OutboundQueue::new(db.clone(), 5));
         let lp = Arc::new(LoopbackPlatform::failing_first(2));
         let mut reg = PlatformRegistry::new();
         reg.register("loopback", lp.clone());
@@ -180,7 +176,7 @@ mod tests {
         let mut ok = false;
         for _ in 0..40 {
             {
-                let conn = db.lock().expect("lock");
+                let conn = db.get().expect("checkout");
                 let now = chrono::Utc::now().timestamp();
                 let _ = conn.execute(
                     "UPDATE outbound_queue SET next_attempt_at = ?1 WHERE id = ?2 AND state = 'pending'",

--- a/src/gateway/queue.rs
+++ b/src/gateway/queue.rs
@@ -1,12 +1,11 @@
-use std::sync::{Arc, Mutex};
-
 use anyhow::{Result, anyhow};
-use rusqlite::{Connection, params};
+use rusqlite::params;
 
+use crate::memory::DbPool;
 use crate::platform::{InboundMessage, OutboundMessage};
 
 pub struct InboundQueue {
-    conn: Arc<Mutex<Connection>>,
+    conn: DbPool,
 }
 
 #[derive(Debug, Clone)]
@@ -21,12 +20,15 @@ pub struct InboundRow {
 }
 
 impl InboundQueue {
-    pub fn new(conn: Arc<Mutex<Connection>>) -> Self {
+    pub fn new(conn: DbPool) -> Self {
         Self { conn }
     }
 
     pub async fn enqueue(&self, msg: InboundMessage) -> Result<i64> {
-        let conn = self.conn.lock().map_err(|_| anyhow!("queue DB poisoned"))?;
+        let conn = self
+            .conn
+            .get()
+            .map_err(|e| anyhow!("queue DB pool checkout: {e}"))?;
         let now = chrono::Utc::now().timestamp();
         conn.execute(
             "INSERT INTO inbound_queue (platform, chat_id, user_id, text, received_at, state) \
@@ -37,7 +39,10 @@ impl InboundQueue {
     }
 
     pub async fn claim_next(&self) -> Result<Option<InboundRow>> {
-        let conn = self.conn.lock().map_err(|_| anyhow!("queue DB poisoned"))?;
+        let conn = self
+            .conn
+            .get()
+            .map_err(|e| anyhow!("queue DB pool checkout: {e}"))?;
         // RETURNING (SQLite >= 3.35) makes the claim a single atomic statement.
         let mut stmt = conn.prepare(
             "UPDATE inbound_queue \
@@ -63,13 +68,19 @@ impl InboundQueue {
     }
 
     pub async fn mark_done(&self, id: i64) -> Result<()> {
-        let conn = self.conn.lock().map_err(|_| anyhow!("queue DB poisoned"))?;
+        let conn = self
+            .conn
+            .get()
+            .map_err(|e| anyhow!("queue DB pool checkout: {e}"))?;
         conn.execute("DELETE FROM inbound_queue WHERE id = ?1", params![id])?;
         Ok(())
     }
 
     pub async fn complete_with_outbound(&self, id: i64, msg: OutboundMessage) -> Result<i64> {
-        let mut conn = self.conn.lock().map_err(|_| anyhow!("queue DB poisoned"))?;
+        let mut conn = self
+            .conn
+            .get()
+            .map_err(|e| anyhow!("queue DB pool checkout: {e}"))?;
         let tx = conn.transaction()?;
         let now = chrono::Utc::now().timestamp();
         let attachments_json = serde_json::to_string(&msg.attachments)?;
@@ -86,7 +97,10 @@ impl InboundQueue {
     }
 
     pub async fn mark_failed(&self, id: i64, error: &str) -> Result<()> {
-        let conn = self.conn.lock().map_err(|_| anyhow!("queue DB poisoned"))?;
+        let conn = self
+            .conn
+            .get()
+            .map_err(|e| anyhow!("queue DB pool checkout: {e}"))?;
         // inbound_queue has no last_error column; narrate via tracing instead.
         tracing::warn!(target: "gateway::queue", id, error, "inbound message marked failed");
         conn.execute(
@@ -97,7 +111,10 @@ impl InboundQueue {
     }
 
     pub async fn recover_processing(&self) -> Result<usize> {
-        let conn = self.conn.lock().map_err(|_| anyhow!("queue DB poisoned"))?;
+        let conn = self
+            .conn
+            .get()
+            .map_err(|e| anyhow!("queue DB pool checkout: {e}"))?;
         let n = conn.execute(
             "UPDATE inbound_queue SET state='pending' WHERE state='processing'",
             [],
@@ -107,7 +124,7 @@ impl InboundQueue {
 }
 
 pub struct OutboundQueue {
-    conn: Arc<Mutex<Connection>>,
+    conn: DbPool,
     max_attempts: u32,
 }
 
@@ -133,12 +150,15 @@ fn outbound_backoff_secs(attempts: i64) -> i64 {
 }
 
 impl OutboundQueue {
-    pub fn new(conn: Arc<Mutex<Connection>>, max_attempts: u32) -> Self {
+    pub fn new(conn: DbPool, max_attempts: u32) -> Self {
         Self { conn, max_attempts }
     }
 
     pub async fn enqueue(&self, msg: OutboundMessage) -> Result<i64> {
-        let conn = self.conn.lock().map_err(|_| anyhow!("queue DB poisoned"))?;
+        let conn = self
+            .conn
+            .get()
+            .map_err(|e| anyhow!("queue DB pool checkout: {e}"))?;
         let now = chrono::Utc::now().timestamp();
         let attachments_json = serde_json::to_string(&msg.attachments)?;
         conn.execute(
@@ -151,7 +171,10 @@ impl OutboundQueue {
     }
 
     pub async fn claim_due(&self, now: i64) -> Result<Option<OutboundRow>> {
-        let conn = self.conn.lock().map_err(|_| anyhow!("queue DB poisoned"))?;
+        let conn = self
+            .conn
+            .get()
+            .map_err(|e| anyhow!("queue DB pool checkout: {e}"))?;
         let mut stmt = conn.prepare(
             "UPDATE outbound_queue \
              SET state='sending', attempts = attempts + 1 \
@@ -183,7 +206,10 @@ impl OutboundQueue {
     }
 
     pub async fn mark_done(&self, id: i64) -> Result<()> {
-        let conn = self.conn.lock().map_err(|_| anyhow!("queue DB poisoned"))?;
+        let conn = self
+            .conn
+            .get()
+            .map_err(|e| anyhow!("queue DB pool checkout: {e}"))?;
         conn.execute("DELETE FROM outbound_queue WHERE id = ?1", params![id])?;
         Ok(())
     }
@@ -198,7 +224,10 @@ impl OutboundQueue {
         };
         let next_at = now + outbound_backoff_secs(row.attempts);
         {
-            let conn = self.conn.lock().map_err(|_| anyhow!("queue DB poisoned"))?;
+            let conn = self
+                .conn
+                .get()
+                .map_err(|e| anyhow!("queue DB pool checkout: {e}"))?;
             conn.execute(
                 "UPDATE outbound_queue \
                  SET state = ?1, next_attempt_at = ?2, last_error = ?3 \
@@ -211,7 +240,10 @@ impl OutboundQueue {
     }
 
     pub async fn recover_sending(&self) -> Result<usize> {
-        let conn = self.conn.lock().map_err(|_| anyhow!("queue DB poisoned"))?;
+        let conn = self
+            .conn
+            .get()
+            .map_err(|e| anyhow!("queue DB pool checkout: {e}"))?;
         let n = conn.execute(
             "UPDATE outbound_queue SET state='pending' WHERE state='sending'",
             [],
@@ -220,7 +252,10 @@ impl OutboundQueue {
     }
 
     pub async fn peek(&self, id: i64) -> Result<OutboundRow> {
-        let conn = self.conn.lock().map_err(|_| anyhow!("queue DB poisoned"))?;
+        let conn = self
+            .conn
+            .get()
+            .map_err(|e| anyhow!("queue DB pool checkout: {e}"))?;
         let mut stmt = conn.prepare(
             "SELECT id, platform, chat_id, text, attachments_json, enqueued_at, \
                     next_attempt_at, attempts, state, last_error \
@@ -252,10 +287,8 @@ impl OutboundQueue {
 mod tests {
     use super::*;
 
-    fn test_conn() -> Arc<Mutex<Connection>> {
-        let conn = Connection::open_in_memory().expect("open mem db");
-        crate::memory::initialize_test_conn(&conn).expect("schema");
-        Arc::new(Mutex::new(conn))
+    fn test_conn() -> DbPool {
+        crate::memory::in_memory_gateway_pool().expect("in-memory pool")
     }
 
     fn sample_msg() -> InboundMessage {
@@ -326,7 +359,7 @@ mod tests {
     #[tokio::test]
     async fn outbound_mark_done_deletes() {
         let conn = test_conn();
-        let q = OutboundQueue::new(Arc::clone(&conn), 5);
+        let q = OutboundQueue::new(conn.clone(), 5);
         let id = q.enqueue(sample_out_msg()).await.unwrap();
         let _ = q.claim_due(chrono::Utc::now().timestamp()).await.unwrap();
         q.mark_done(id).await.unwrap();
@@ -336,7 +369,7 @@ mod tests {
     #[tokio::test]
     async fn outbound_recover_sending_resets_to_pending() {
         let conn = test_conn();
-        let q = OutboundQueue::new(Arc::clone(&conn), 5);
+        let q = OutboundQueue::new(conn.clone(), 5);
         q.enqueue(sample_out_msg()).await.unwrap();
         let _ = q.claim_due(chrono::Utc::now().timestamp()).await.unwrap();
         drop(q);
@@ -365,7 +398,7 @@ mod tests {
     #[tokio::test]
     async fn outbound_claim_due_skips_future_rows() {
         let conn = test_conn();
-        let q = OutboundQueue::new(Arc::clone(&conn), 5);
+        let q = OutboundQueue::new(conn.clone(), 5);
         let id = q.enqueue(sample_out_msg()).await.unwrap();
         let _ = q.claim_due(chrono::Utc::now().timestamp()).await.unwrap();
         q.mark_failed(id, "nope").await.unwrap();
@@ -410,11 +443,11 @@ mod tests {
     #[tokio::test]
     async fn mark_done_deletes_row() {
         let conn = test_conn();
-        let q = InboundQueue::new(Arc::clone(&conn));
+        let q = InboundQueue::new(conn.clone());
         let id = q.enqueue(sample_msg()).await.unwrap();
         let _ = q.claim_next().await.unwrap();
         q.mark_done(id).await.unwrap();
-        let conn = conn.lock().expect("lock test conn");
+        let conn = conn.get().expect("get test conn");
         let exists: i64 = conn
             .query_row(
                 "SELECT count(*) FROM inbound_queue WHERE id = ?1",
@@ -437,7 +470,7 @@ mod tests {
     #[tokio::test]
     async fn recover_processing_resets_to_pending() {
         let conn = test_conn();
-        let q = InboundQueue::new(Arc::clone(&conn));
+        let q = InboundQueue::new(conn.clone());
         q.enqueue(sample_msg()).await.unwrap();
         let _ = q.claim_next().await.unwrap();
         drop(q);
@@ -450,8 +483,8 @@ mod tests {
     #[tokio::test]
     async fn complete_with_outbound_enqueues_reply_and_deletes_inbound_atomically() {
         let conn = test_conn();
-        let inbound = InboundQueue::new(Arc::clone(&conn));
-        let outbound = OutboundQueue::new(Arc::clone(&conn), 5);
+        let inbound = InboundQueue::new(conn.clone());
+        let outbound = OutboundQueue::new(conn.clone(), 5);
         let id = inbound.enqueue(sample_msg()).await.unwrap();
         let row = inbound.claim_next().await.unwrap().expect("row");
         assert_eq!(row.id, id);

--- a/src/gateway/routes/inbound.rs
+++ b/src/gateway/routes/inbound.rs
@@ -49,24 +49,21 @@ pub async fn handle(
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
-    use std::sync::Mutex as StdMutex;
 
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
-    use rusqlite::Connection;
     use tower::ServiceExt;
 
     use crate::gateway::loopback::LoopbackPlatform;
     use crate::gateway::registry::PlatformRegistry;
     use crate::gateway::server::{AppState, build_router};
+    use crate::memory::DbPool;
 
-    fn fresh_db() -> Arc<StdMutex<Connection>> {
-        let c = Connection::open_in_memory().expect("open mem db");
-        crate::memory::initialize_test_conn(&c).expect("schema");
-        Arc::new(StdMutex::new(c))
+    fn fresh_db() -> DbPool {
+        crate::memory::in_memory_gateway_pool().expect("in-memory pool")
     }
 
-    fn app_state_with(registry: PlatformRegistry, db: Arc<StdMutex<Connection>>) -> AppState {
+    fn app_state_with(registry: PlatformRegistry, db: DbPool) -> AppState {
         // Build an AppState pointing at the given db + registry. Use
         // Config::default() and an AgentMap::new — neither is exercised
         // by /v1/inbound (it just enqueues), so that's fine.
@@ -75,9 +72,9 @@ mod tests {
             crate::gateway::agent_map::AgentMap::new(config, std::time::Duration::from_secs(60));
         AppState {
             api_token: Arc::new("secret".into()),
-            inbound: Arc::new(crate::gateway::queue::InboundQueue::new(Arc::clone(&db))),
+            inbound: Arc::new(crate::gateway::queue::InboundQueue::new(db.clone())),
             outbound: Arc::new(crate::gateway::queue::OutboundQueue::new(
-                Arc::clone(&db),
+                db.clone(),
                 5,
             )),
             registry: Arc::new(registry),
@@ -104,7 +101,7 @@ mod tests {
     #[tokio::test]
     async fn post_inbound_enqueues_and_returns_id() {
         let db = fresh_db();
-        let state = app_state_with(registry_with_loopback(), Arc::clone(&db));
+        let state = app_state_with(registry_with_loopback(), db.clone());
         let inbound_q = Arc::clone(&state.inbound);
         let app = build_router(state);
 
@@ -177,23 +174,22 @@ mod tests {
 
     #[tokio::test]
     async fn post_inbound_db_error_returns_503() {
-        // Force the inbound enqueue to fail. Approach: open a FRESH in-memory
-        // connection that has NOT had the schema applied, so the INSERT into
-        // `inbound_queue` errors with "no such table".
-        let unschemed = Arc::new(StdMutex::new(
-            Connection::open_in_memory().expect("open mem db"),
-        ));
+        // Force the inbound enqueue to fail. Approach: build a pool against a
+        // FRESH in-memory connection that has NOT had the schema applied, so
+        // the INSERT into `inbound_queue` errors with "no such table".
+        let unschemed: DbPool = r2d2::Pool::builder()
+            .max_size(1)
+            .build(r2d2_sqlite::SqliteConnectionManager::memory())
+            .expect("unschemed in-memory pool");
         // Build the state pointing at the unschemed db.
         let config = Arc::new(crate::config::Config::default());
         let agent_map =
             crate::gateway::agent_map::AgentMap::new(config, std::time::Duration::from_secs(60));
         let state = AppState {
             api_token: Arc::new("secret".into()),
-            inbound: Arc::new(crate::gateway::queue::InboundQueue::new(Arc::clone(
-                &unschemed,
-            ))),
+            inbound: Arc::new(crate::gateway::queue::InboundQueue::new(unschemed.clone())),
             outbound: Arc::new(crate::gateway::queue::OutboundQueue::new(
-                Arc::clone(&unschemed),
+                unschemed.clone(),
                 5,
             )),
             registry: Arc::new(registry_with_loopback()),

--- a/src/gateway/routes/lanes.rs
+++ b/src/gateway/routes/lanes.rs
@@ -17,14 +17,12 @@ pub async fn handle(State(state): State<AppState>) -> Json<serde_json::Value> {
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
-    use std::sync::Mutex as StdMutex;
     use std::time::{Duration, Instant};
 
     use anyhow::Result;
     use async_trait::async_trait;
     use axum::body::{Body, to_bytes};
     use axum::http::{Request, StatusCode};
-    use rusqlite::Connection;
     use tokio_util::sync::CancellationToken;
     use tower::ServiceExt;
 
@@ -36,15 +34,14 @@ mod tests {
     use crate::gateway::server::{AppState, build_router};
     use crate::hooks::HookRegistry;
     use crate::hooks::audit::AuditHook;
+    use crate::memory::DbPool;
     use crate::provider::mock::MockProvider;
     use crate::provider::{ChatResponse, LLMProvider, Message, StreamEvent, ToolDefinition};
     use crate::skills::SkillRegistry;
     use crate::tools::ToolRegistry;
 
-    fn fresh_db() -> Arc<StdMutex<Connection>> {
-        let c = Connection::open_in_memory().expect("open mem db");
-        crate::memory::initialize_test_conn(&c).expect("schema");
-        Arc::new(StdMutex::new(c))
+    fn fresh_db() -> DbPool {
+        crate::memory::in_memory_gateway_pool().expect("in-memory pool")
     }
 
     fn empty_skills() -> Arc<SkillRegistry> {
@@ -95,16 +92,13 @@ mod tests {
         )))
     }
 
-    fn build_app_state(db: Arc<StdMutex<Connection>>) -> AppState {
+    fn build_app_state(db: DbPool) -> AppState {
         let config = Arc::new(Config::default());
         let agent_map = AgentMap::new(config, Duration::from_secs(60));
         AppState {
             api_token: Arc::new("secret".into()),
-            inbound: Arc::new(crate::gateway::queue::InboundQueue::new(Arc::clone(&db))),
-            outbound: Arc::new(crate::gateway::queue::OutboundQueue::new(
-                Arc::clone(&db),
-                5,
-            )),
+            inbound: Arc::new(crate::gateway::queue::InboundQueue::new(db.clone())),
+            outbound: Arc::new(crate::gateway::queue::OutboundQueue::new(db.clone(), 5)),
             registry: Arc::new(PlatformRegistry::new()),
             agent_map: Arc::new(agent_map),
         }
@@ -113,7 +107,7 @@ mod tests {
     #[tokio::test]
     async fn get_lanes_lists_active_lanes() {
         let db = fresh_db();
-        let state = build_app_state(Arc::clone(&db));
+        let state = build_app_state(db.clone());
 
         let now = Instant::now();
         let lane_a = LaneKey {

--- a/src/gateway/routes/webhook.rs
+++ b/src/gateway/routes/webhook.rs
@@ -46,21 +46,18 @@ pub async fn handle(
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
-    use std::sync::Mutex as StdMutex;
 
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
-    use rusqlite::Connection;
     use tower::ServiceExt;
 
     use crate::gateway::loopback::LoopbackPlatform;
     use crate::gateway::registry::PlatformRegistry;
     use crate::gateway::server::{AppState, build_router};
+    use crate::memory::DbPool;
 
-    fn fresh_db() -> Arc<StdMutex<Connection>> {
-        let c = Connection::open_in_memory().expect("open mem db");
-        crate::memory::initialize_test_conn(&c).expect("schema");
-        Arc::new(StdMutex::new(c))
+    fn fresh_db() -> DbPool {
+        crate::memory::in_memory_gateway_pool().expect("in-memory pool")
     }
 
     fn sign_loopback(secret: &str, body: &[u8]) -> String {
@@ -72,17 +69,14 @@ mod tests {
         bytes.iter().map(|b| format!("{b:02x}")).collect()
     }
 
-    fn app_state_with(registry: PlatformRegistry, db: Arc<StdMutex<Connection>>) -> AppState {
+    fn app_state_with(registry: PlatformRegistry, db: DbPool) -> AppState {
         let config = Arc::new(crate::config::Config::default());
         let agent_map =
             crate::gateway::agent_map::AgentMap::new(config, std::time::Duration::from_secs(60));
         AppState {
             api_token: Arc::new("secret".into()),
-            inbound: Arc::new(crate::gateway::queue::InboundQueue::new(Arc::clone(&db))),
-            outbound: Arc::new(crate::gateway::queue::OutboundQueue::new(
-                Arc::clone(&db),
-                5,
-            )),
+            inbound: Arc::new(crate::gateway::queue::InboundQueue::new(db.clone())),
+            outbound: Arc::new(crate::gateway::queue::OutboundQueue::new(db.clone(), 5)),
             registry: Arc::new(registry),
             agent_map: Arc::new(agent_map),
         }
@@ -94,7 +88,7 @@ mod tests {
         let mut reg = PlatformRegistry::new();
         let lp = Arc::new(LoopbackPlatform::with_webhook_secret("hush"));
         reg.register("loopback", lp.clone());
-        let state = app_state_with(reg, Arc::clone(&db));
+        let state = app_state_with(reg, db.clone());
         let inbound_q = Arc::clone(&state.inbound);
         let app = build_router(state);
 

--- a/src/gateway/server.rs
+++ b/src/gateway/server.rs
@@ -96,21 +96,18 @@ async fn bearer_auth(
 mod tests {
     use super::*;
     use std::sync::Arc;
-    use std::sync::Mutex as StdMutex;
     use std::time::Duration;
 
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
-    use rusqlite::Connection;
     use tower::ServiceExt;
 
     use crate::config::Config;
     use crate::gateway::agent_map::AgentMap;
+    use crate::memory::DbPool;
 
-    fn fresh_db() -> Arc<StdMutex<Connection>> {
-        let c = Connection::open_in_memory().expect("open mem db");
-        crate::memory::initialize_test_conn(&c).expect("schema");
-        Arc::new(StdMutex::new(c))
+    fn fresh_db() -> DbPool {
+        crate::memory::in_memory_gateway_pool().expect("in-memory pool")
     }
 
     fn test_app_state(token: &str) -> AppState {
@@ -119,11 +116,8 @@ mod tests {
         let db = fresh_db();
         AppState {
             api_token: Arc::new(token.into()),
-            inbound: Arc::new(crate::gateway::queue::InboundQueue::new(Arc::clone(&db))),
-            outbound: Arc::new(crate::gateway::queue::OutboundQueue::new(
-                Arc::clone(&db),
-                5,
-            )),
+            inbound: Arc::new(crate::gateway::queue::InboundQueue::new(db.clone())),
+            outbound: Arc::new(crate::gateway::queue::OutboundQueue::new(db.clone(), 5)),
             registry: Arc::new(crate::gateway::registry::PlatformRegistry::new()),
             agent_map: Arc::new(agent_map),
         }

--- a/src/gateway/worker.rs
+++ b/src/gateway/worker.rs
@@ -84,12 +84,10 @@ pub async fn process_one(
 mod tests {
     use super::*;
     use std::sync::Arc;
-    use std::sync::Mutex as StdMutex;
     use std::time::Duration;
 
     use anyhow::Result;
     use async_trait::async_trait;
-    use rusqlite::Connection;
     use tokio_util::sync::CancellationToken;
 
     use crate::agent::Agent;
@@ -97,16 +95,15 @@ mod tests {
     use crate::gateway::agent_map::{AgentBuilder, AgentMap};
     use crate::gateway::queue::{InboundQueue, OutboundQueue};
     use crate::hooks::HookRegistry;
+    use crate::memory::DbPool;
     use crate::platform::InboundMessage;
     use crate::provider::mock::MockProvider;
     use crate::provider::{ChatResponse, LLMProvider, Message, StreamEvent, ToolDefinition};
     use crate::skills::SkillRegistry;
     use crate::tools::ToolRegistry;
 
-    fn fresh_db() -> Arc<StdMutex<Connection>> {
-        let c = Connection::open_in_memory().expect("open mem db");
-        crate::memory::initialize_test_conn(&c).expect("schema");
-        Arc::new(StdMutex::new(c))
+    fn fresh_db() -> DbPool {
+        crate::memory::in_memory_gateway_pool().expect("in-memory pool")
     }
 
     fn empty_skills() -> Arc<SkillRegistry> {
@@ -208,8 +205,8 @@ mod tests {
     #[tokio::test]
     async fn worker_runs_agent_and_enqueues_reply() {
         let db = fresh_db();
-        let inbound = InboundQueue::new(Arc::clone(&db));
-        let outbound = OutboundQueue::new(Arc::clone(&db), 5);
+        let inbound = InboundQueue::new(db.clone());
+        let outbound = OutboundQueue::new(db.clone(), 5);
         let agent_map = agent_map_with_canned_reply("hi back");
 
         let id = inbound
@@ -241,8 +238,8 @@ mod tests {
     #[tokio::test]
     async fn worker_panic_marks_inbound_failed() {
         let db = fresh_db();
-        let inbound = InboundQueue::new(Arc::clone(&db));
-        let outbound = OutboundQueue::new(Arc::clone(&db), 5);
+        let inbound = InboundQueue::new(db.clone());
+        let outbound = OutboundQueue::new(db.clone(), 5);
         let agent_map = agent_map_with_panicking_provider();
 
         inbound

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -35,9 +35,9 @@ mod schema;
 mod tests;
 
 #[cfg(feature = "gateway")]
-pub(crate) use schema::open_gateway_connection;
+pub(crate) use schema::{DbPool, open_gateway_pool};
 #[cfg(all(test, feature = "gateway"))]
-pub(crate) use schema::initialize_test_conn;
+pub(crate) use schema::in_memory_gateway_pool;
 
 use codec::{decode_message, encode_message};
 use schema::{initialize_conn, upsert_session_metadata, upsert_session_provider_profile};

--- a/src/memory/schema.rs
+++ b/src/memory/schema.rs
@@ -5,12 +5,17 @@
 //! (YYC-111).
 
 #[cfg(feature = "gateway")]
-use std::sync::{Arc, Mutex};
-
-#[cfg(feature = "gateway")]
 use anyhow::Context;
 use anyhow::Result;
 use rusqlite::{Connection, params};
+
+/// Connection pool used by the gateway daemon (YYC-113). Replaces the
+/// previous `Arc<Mutex<Connection>>` that serialized every gateway worker
+/// through one lock. r2d2 hands each caller its own pooled connection;
+/// SQLite handles concurrent readers + a single writer cleanly with WAL
+/// mode (already set in `SCHEMA`).
+#[cfg(feature = "gateway")]
+pub type DbPool = r2d2::Pool<r2d2_sqlite::SqliteConnectionManager>;
 
 pub(in crate::memory) const SCHEMA: &str = r#"
 PRAGMA foreign_keys = ON;
@@ -98,20 +103,34 @@ pub(in crate::memory) fn initialize_conn(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
-#[cfg(all(test, feature = "gateway"))]
-pub(crate) fn initialize_test_conn(conn: &Connection) -> Result<()> {
-    initialize_conn(conn)
-}
-
 #[cfg(feature = "gateway")]
-pub(crate) fn open_gateway_connection() -> Result<Arc<Mutex<Connection>>> {
+pub(crate) fn open_gateway_pool() -> Result<DbPool> {
     let dir = crate::config::vulcan_home();
     std::fs::create_dir_all(&dir).ok();
     let path = dir.join("sessions.db");
-    let conn = Connection::open(&path)
-        .with_context(|| format!("Failed to open session DB at {}", path.display()))?;
+    let manager = r2d2_sqlite::SqliteConnectionManager::file(&path);
+    let pool = r2d2::Pool::builder()
+        .build(manager)
+        .with_context(|| format!("Failed to build gateway DB pool at {}", path.display()))?;
+    let conn = pool.get().context("Failed to check out a connection for schema init")?;
     initialize_conn(&conn).context("Failed to initialize session DB schema")?;
-    Ok(Arc::new(Mutex::new(conn)))
+    Ok(pool)
+}
+
+/// Build an in-memory pool for tests. Single connection so all checkouts
+/// share state (a fresh `:memory:` per checkout would lose every prior
+/// write). Consumers that need a multi-connection pool should use
+/// `open_gateway_pool` against a temp file.
+#[cfg(all(test, feature = "gateway"))]
+pub(crate) fn in_memory_gateway_pool() -> Result<DbPool> {
+    let manager = r2d2_sqlite::SqliteConnectionManager::memory();
+    let pool = r2d2::Pool::builder()
+        .max_size(1)
+        .build(manager)
+        .context("build in-memory gateway DB pool")?;
+    let conn = pool.get().context("get conn from in-memory gateway pool")?;
+    initialize_conn(&conn).context("initialize in-memory gateway DB schema")?;
+    Ok(pool)
 }
 
 pub(in crate::memory) fn upsert_session_metadata(


### PR DESCRIPTION
gateway/mod.rs held db: Arc<std::sync::Mutex<Connection>>. Every
concurrent agent lane serialized through that single lock — a
bottleneck under any meaningful gateway load.

Introduce DbPool = r2d2::Pool<r2d2_sqlite::SqliteConnectionManager> in
crate::memory and have open_gateway_pool() return it. Each gateway
queue/route/worker call now does pool.get() instead of mutex.lock(),
so concurrent lanes claim their own connection (SQLite WAL mode,
already set in SCHEMA, handles concurrent readers + a single writer).

Tests use crate::memory::in_memory_gateway_pool() — a single-connection
pool over :memory: so multiple checkouts share state. The unschemed-DB
test in routes/inbound.rs builds its own pool against a raw
SqliteConnectionManager::memory() to keep its "no such table" repro.

r2d2 + r2d2_sqlite are gated behind the gateway feature so non-gateway
builds don't pull them in. Versions verified against crates.io latest
(r2d2 0.8.10, r2d2_sqlite 0.33.0; rusqlite 0.39 compatibility).

cargo test --features gateway --lib -- --test-threads=1 passes
(252 tests, including 54 gateway-feature tests).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>