### PR TITLE
YYC-119: re-target builder onto main (Graphite cleanup)

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -123,23 +123,45 @@ struct StreamTurn {
     tool_defs: Vec<ToolDefinition>,
 }
 
+pub struct AgentBuilder<'a> {
+    config: &'a Config,
+    hooks: HookRegistry,
+    pause_tx: Option<PauseSender>,
+    max_iterations: Option<u32>,
+}
+
+impl<'a> AgentBuilder<'a> {
+    pub fn with_hooks(mut self, hooks: HookRegistry) -> Self {
+        self.hooks = hooks;
+        self
+    }
+
+    pub fn with_pause_channel(mut self, pause_tx: PauseSender) -> Self {
+        self.pause_tx = Some(pause_tx);
+        self
+    }
+
+    pub fn with_max_iterations(mut self, max_iterations: u32) -> Self {
+        self.max_iterations = Some(max_iterations);
+        self
+    }
+
+    pub async fn build(self) -> Result<Agent> {
+        Agent::build_from_parts(self.config, self.hooks, self.pause_tx, self.max_iterations).await
+    }
+}
+
 impl Agent {
-    /// Construct an Agent with no caller-supplied hooks. Built-in hooks (skills
-    /// injection, etc.) are still registered.
-    pub async fn new(config: &Config) -> Result<Self> {
-        Self::with_hooks_and_pause(config, HookRegistry::new(), None).await
+    pub fn builder(config: &Config) -> AgentBuilder<'_> {
+        AgentBuilder {
+            config,
+            hooks: HookRegistry::new(),
+            pause_tx: None,
+            max_iterations: None,
+        }
     }
 
-    /// Construct with caller-supplied hooks and no interactive pause channel.
-    /// The TUI uses `with_hooks_and_pause` to wire one up.
-    pub async fn with_hooks(config: &Config, hooks: HookRegistry) -> Result<Self> {
-        Self::with_hooks_and_pause(config, hooks, None).await
-    }
-
-    /// Construct an Agent with a caller-supplied hook registry and an optional
-    /// pause emitter. Built-ins (skills, safety) are registered into the
-    /// registry; if a pause emitter is provided, `SafetyHook` is wired up to
-    /// route blocks through it as `AgentPause::SafetyApproval`.
+    /// Build an Agent from a fully configured `AgentBuilder`.
     ///
     /// Async because it fetches the provider's model catalog at startup
     /// (YYC-64). Catalog-fetch failures are non-fatal — logged and continued
@@ -147,10 +169,11 @@ impl Agent {
     ///
     /// Returns `Err` for fatal init failures (missing API key, provider build
     /// failure, or model not found in catalog).
-    pub async fn with_hooks_and_pause(
+    async fn build_from_parts(
         config: &Config,
         mut hooks: HookRegistry,
         pause_tx: Option<PauseSender>,
+        max_iterations: Option<u32>,
     ) -> Result<Self> {
         // Local / self-hosted endpoints don't require auth; allow empty
         // string in that case (matches `switch_provider` semantics).
@@ -321,7 +344,7 @@ impl Agent {
             lsp_manager,
             last_saved_count: 0,
             tool_context,
-            max_iterations: config.provider.max_iterations,
+            max_iterations: max_iterations.unwrap_or(config.provider.max_iterations),
         })
     }
 
@@ -616,8 +639,8 @@ impl Agent {
     }
 
     /// Fires `session_start` on all hook handlers. Call once after construction
-    /// (Agent::new doesn't call it itself because hooks aren't always async-
-    /// available at construction time).
+    /// (`AgentBuilder::build` doesn't call it itself because hooks aren't
+    /// always async-available at construction time).
     pub async fn start_session(&self) {
         if let Err(e) = self
             .memory
@@ -1638,6 +1661,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn builder_accepts_hooks_pause_channel_and_max_iterations() {
+        let mut config = Config::default();
+        config.provider.base_url = "http://127.0.0.1:11434/v1".into();
+        config.provider.disable_catalog = true;
+        config.provider.max_iterations = 12;
+        let (pause_tx, _pause_rx) = crate::pause::channel(1);
+
+        let agent = Agent::builder(&config)
+            .with_hooks(HookRegistry::new())
+            .with_pause_channel(pause_tx)
+            .with_max_iterations(3)
+            .build()
+            .await
+            .unwrap();
+
+        assert_eq!(agent.max_iterations, 3);
+        assert!(
+            agent
+                .tools
+                .definitions()
+                .iter()
+                .any(|tool| tool.function.name == "ask_user")
+        );
+    }
+
+    #[tokio::test]
     async fn single_turn_text_response() {
         let (mut agent, mock) = agent_with_mock();
         mock.enqueue_text("Hello there");
@@ -1872,7 +1921,7 @@ mod tests {
             ..Default::default()
         };
 
-        let mut agent = Agent::new(&config).await.unwrap();
+        let mut agent = Agent::builder(&config).build().await.unwrap();
         let session_id = agent.session_id().to_string();
 
         assert_eq!(agent.active_model(), "model-a");

--- a/src/gateway/agent_map.rs
+++ b/src/gateway/agent_map.rs
@@ -33,7 +33,7 @@ use std::future::Future;
 use std::pin::Pin;
 
 /// Test-only agent factory. `get_or_spawn` calls this in lieu of
-/// `Agent::with_hooks_and_pause` so tests can swap in a `MockProvider`-backed
+/// `AgentBuilder::build` so tests can swap in a `MockProvider`-backed
 /// Agent without an API key. Boxed-future return so the closure type can be
 /// erased behind `dyn Fn`.
 #[cfg(test)]
@@ -79,7 +79,7 @@ impl AgentMap {
     }
 
     /// Test-only constructor that uses `builder` to materialize Agents instead
-    /// of going through `Agent::with_hooks_and_pause`. Lets tests inject a
+    /// of going through `AgentBuilder::build`. Lets tests inject a
     /// MockProvider-backed Agent without needing an API key.
     #[cfg(test)]
     pub(crate) fn with_builder(
@@ -118,7 +118,7 @@ impl AgentMap {
         // cold spawn on one lane doesn't block first-touches on every other
         // lane. Acquire the write lock only briefly to insert.
         //
-        // ApprovalHook is registered inside `with_hooks_and_pause`; with
+        // ApprovalHook is registered inside `AgentBuilder::build`; with
         // `None` here it uses the explicit auto-deny constructor so gateway
         // agents never block waiting for a TUI approval consumer.
         let mut hook_reg = HookRegistry::new();
@@ -131,12 +131,18 @@ impl AgentMap {
                 if let Some(builder) = self.builder.as_ref() {
                     builder(hook_reg).await?
                 } else {
-                    Agent::with_hooks_and_pause(&self.config, hook_reg, None).await?
+                    Agent::builder(&self.config)
+                        .with_hooks(hook_reg)
+                        .build()
+                        .await?
                 }
             }
             #[cfg(not(test))]
             {
-                Agent::with_hooks_and_pause(&self.config, hook_reg, None).await?
+                Agent::builder(&self.config)
+                    .with_hooks(hook_reg)
+                    .build()
+                    .await?
             }
         };
         let agent = Arc::new(Mutex::new(agent));
@@ -389,7 +395,7 @@ mod tests {
     }
 
     /// Builder that returns a fresh `Agent::for_test` per lane, each backed by
-    /// its own `MockProvider`. Bypasses `Agent::with_hooks_and_pause` so the
+    /// its own `MockProvider`. Bypasses `AgentBuilder::build` so the
     /// tests don't need a real API key.
     fn mock_agent_builder() -> AgentBuilder {
         Arc::new(|hooks: HookRegistry| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ async fn main() -> anyhow::Result<()> {
         }
         Some(Command::Prompt { text }) => {
             init_cli_logging();
-            let mut agent = vulcan::agent::Agent::new(&config).await?;
+            let mut agent = vulcan::agent::Agent::builder(&config).build().await?;
             if cli.r#continue {
                 agent.continue_last_session()?;
             }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -135,7 +135,7 @@ pub struct SessionSummary {
 impl SessionStore {
     /// Open (or create) the session store at `~/.vulcan/sessions.db`. Panics
     /// on fatal DB initialization errors — matches the existing pattern in
-    /// `Agent::new` (api key, provider).
+    /// `AgentBuilder::build` (api key, provider).
     pub fn new() -> Self {
         let dir = crate::config::vulcan_home();
         std::fs::create_dir_all(&dir).ok();

--- a/src/tools/git.rs
+++ b/src/tools/git.rs
@@ -341,6 +341,9 @@ mod tests {
     use super::*;
     use serde_json::json;
     use tempfile::tempdir;
+    use tokio::sync::Mutex;
+
+    static CWD_LOCK: Mutex<()> = Mutex::const_new(());
 
     /// Run `args` in `cwd`. Wraps tokio's Command directly so the test
     /// doesn't need to hop through the public Tool trait.
@@ -366,6 +369,7 @@ mod tests {
         let cwd = dir.path();
         git(cwd, &["init", "-q"]).await;
         std::fs::write(cwd.join("a.txt"), "hello\n").unwrap();
+        let _cwd = CWD_LOCK.lock().await;
         // The tool reads from the process cwd, so chdir for this test.
         let prev = std::env::current_dir().unwrap();
         std::env::set_current_dir(cwd).unwrap();
@@ -385,6 +389,7 @@ mod tests {
     #[tokio::test]
     async fn git_status_outside_repo_returns_clean_error() {
         let dir = tempdir().unwrap();
+        let _cwd = CWD_LOCK.lock().await;
         let prev = std::env::current_dir().unwrap();
         std::env::set_current_dir(dir.path()).unwrap();
         let result = GitStatusTool

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -91,7 +91,7 @@ pub trait Tool: Send + Sync {
 }
 
 /// Workspace context surfaced to tools at session start (YYC-107).
-/// Built once by `Agent::with_hooks_and_pause` and passed into
+/// Built once by `AgentBuilder::build` and passed into
 /// `is_relevant` / `dynamic_description` so tools can reflect what's
 /// actually in the cwd.
 #[derive(Debug, Clone)]
@@ -339,7 +339,7 @@ impl ToolRegistry {
     }
 
     /// YYC-107: drop tools whose `is_relevant(ctx)` returns false.
-    /// Called once at session start by `Agent::with_hooks_and_pause`
+    /// Called once at session start by `AgentBuilder::build`
     /// after the registry is fully populated.
     pub fn filter_for_context(&mut self, ctx: &ToolContext) {
         let drop_keys: Vec<String> = self

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -502,7 +502,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
     let (stream_tx, mut stream_rx) = mpsc::unbounded_channel::<StreamEvent>();
 
     // ── Hook registry: audit-log + (room for safety-gate, etc.). Built-in
-    // hooks (skills) are registered by Agent::with_hooks itself.
+    // hooks (skills) are registered by AgentBuilder.
     let mut hook_reg = HookRegistry::new();
     let (audit_hook, audit_buf) = AuditHook::new(200);
     hook_reg.register(audit_hook);
@@ -516,7 +516,11 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
     // ── Long-lived agent: one per TUI session, shared across prompts so
     // hook handlers' state (audit log, rate limits, etc.) survives turns.
     let agent = Arc::new(Mutex::new(
-        Agent::with_hooks_and_pause(config, hook_reg, Some(pause_tx_for_agent)).await?,
+        Agent::builder(config)
+            .with_hooks(hook_reg)
+            .with_pause_channel(pause_tx_for_agent)
+            .build()
+            .await?,
     ));
 
     // ── Apply resume target if any. Errors here are non-fatal — we report


### PR DESCRIPTION
## Summary

PR #174 (YYC-119) merged into Graphite intermediate \`graphite-base/174\` rather than \`main\`. Cherry-picks d3e194e onto current main so the builder pattern actually lands on trunk.

This unblocks 11 stacked PRs (yyc-109 through yyc-108) that depend on Agent::builder being on main.

## Test plan

- [x] cargo build --all-features --all-targets
- [x] cargo test --all-features --lib (283 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)