### PR TITLE
YYC-124: enable bracketed paste so multiline pastes don't submit per line

### DIFF
--- a/src/tui/init.rs
+++ b/src/tui/init.rs
@@ -12,7 +12,15 @@ use ratatui::backend::CrosstermBackend;
 pub(super) fn init_terminal() -> Result<Terminal<CrosstermBackend<std::io::Stdout>>> {
     ratatui::crossterm::terminal::enable_raw_mode()?;
     let mut stdout = std::io::stdout();
-    ratatui::crossterm::execute!(stdout, ratatui::crossterm::terminal::EnterAlternateScreen)?;
+    ratatui::crossterm::execute!(
+        stdout,
+        ratatui::crossterm::terminal::EnterAlternateScreen,
+        // YYC-124: ask the terminal to wrap pastes in CSI 200~/201~ so
+        // crossterm hands them to us as one Event::Paste(String) instead
+        // of N KeyCode::Char events. Without this, multiline pastes
+        // submit a prompt per line.
+        ratatui::crossterm::event::EnableBracketedPaste,
+    )?;
     let backend = CrosstermBackend::new(stdout);
     let terminal = Terminal::new(backend)?;
     Ok(terminal)
@@ -23,6 +31,9 @@ pub(super) fn restore_terminal() -> Result<()> {
     ratatui::crossterm::terminal::disable_raw_mode()?;
     ratatui::crossterm::execute!(
         std::io::stdout(),
+        // Disable before leaving the alt screen so the user's primary
+        // terminal isn't left in bracketed-paste mode if Vulcan exits.
+        ratatui::crossterm::event::DisableBracketedPaste,
         ratatui::crossterm::terminal::LeaveAlternateScreen,
     )?;
     Ok(())

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -779,6 +779,21 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
             ev = key_rx.recv() => {
                 match ev {
                     Some(KeyEv::Press(event)) => {
+                        // YYC-124: bracketed-paste payload — terminals that
+                        // support CSI 200~/201~ deliver the whole pasted
+                        // buffer as one Event::Paste(String) instead of N
+                        // separate KeyCode::Char events. Append the chunk
+                        // to the input buffer in one shot; embedded
+                        // newlines stay literal so multiline pastes don't
+                        // submit a prompt per line. Skipped while a pause
+                        // overlay is active so the paste can't smuggle
+                        // text into the resume keystroke handler.
+                        if let Event::Paste(text) = &event {
+                            if app.pending_pause.is_none() {
+                                app.input.push_str(text);
+                            }
+                            continue;
+                        }
                         if let Event::Key(key) = event
                             && key.kind == KeyEventKind::Press {
                                 // ── If a pause is active, intercept the keys that


### PR DESCRIPTION
Pasting a multiline buffer into the TUI used to deliver each character
as a separate KeyCode::Char event. Newlines hit the Enter handler one
by one — every line submitted as its own prompt and the rest of the
paste landed in a fresh, empty input.

Enable bracketed paste mode in init_terminal so terminals that
support CSI 200~/201~ wrap the whole pasted buffer and crossterm
hands it to us as a single Event::Paste(String). The TUI loop now
appends the entire chunk to app.input in one shot — embedded
newlines stay literal so the user can edit/submit when they're ready.

Skipped while a pause overlay is active so a paste can't smuggle
text into the resume keystroke handler. Also disable the mode in
restore_terminal so an exit doesn't leave the user's primary
terminal in bracketed-paste state.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>