### PR TITLE
YYC-123: mouse wheel scroll + faster keyboard scroll

### DIFF
--- a/src/tui/init.rs
+++ b/src/tui/init.rs
@@ -20,6 +20,12 @@ pub(super) fn init_terminal() -> Result<Terminal<CrosstermBackend<std::io::Stdou
         // of N KeyCode::Char events. Without this, multiline pastes
         // submit a prompt per line.
         ratatui::crossterm::event::EnableBracketedPaste,
+        // YYC-123: capture mouse events so the scroll wheel can drive
+        // the chat viewport directly. Without this, the terminal sends
+        // scroll-wheel motions as escape sequences that don't reach
+        // crossterm cleanly — users have to rely on Up/Down, which
+        // only steps one line per render frame.
+        ratatui::crossterm::event::EnableMouseCapture,
     )?;
     let backend = CrosstermBackend::new(stdout);
     let terminal = Terminal::new(backend)?;
@@ -32,7 +38,9 @@ pub(super) fn restore_terminal() -> Result<()> {
     ratatui::crossterm::execute!(
         std::io::stdout(),
         // Disable before leaving the alt screen so the user's primary
-        // terminal isn't left in bracketed-paste mode if Vulcan exits.
+        // terminal isn't left in bracketed-paste / mouse-capture state
+        // if Vulcan exits.
+        ratatui::crossterm::event::DisableMouseCapture,
         ratatui::crossterm::event::DisableBracketedPaste,
         ratatui::crossterm::terminal::LeaveAlternateScreen,
     )?;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -794,6 +794,28 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                             }
                             continue;
                         }
+                        // YYC-123: mouse wheel drives the chat viewport
+                        // directly. Three lines per notch matches a
+                        // typical terminal scroll feel; PageUp/PageDown
+                        // remain available for bigger jumps.
+                        if let Event::Mouse(m) = &event {
+                            use ratatui::crossterm::event::MouseEventKind;
+                            const SCROLL_LINES: u16 = 3;
+                            match m.kind {
+                                MouseEventKind::ScrollUp => {
+                                    app.scroll = app.scroll.saturating_sub(SCROLL_LINES);
+                                    app.at_bottom = false;
+                                }
+                                MouseEventKind::ScrollDown => {
+                                    let max = app.chat_max_scroll.get();
+                                    app.scroll =
+                                        app.scroll.saturating_add(SCROLL_LINES).min(max);
+                                    app.at_bottom = app.scroll >= max;
+                                }
+                                _ => {}
+                            }
+                            continue;
+                        }
                         if let Event::Key(key) = event
                             && key.kind == KeyEventKind::Press {
                                 // ── If a pause is active, intercept the keys that
@@ -1311,7 +1333,11 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                                 continue;
                                             }
                                         }
-                                        app.scroll = app.scroll.saturating_sub(1);
+                                        // YYC-123: 3 lines per arrow keypress so
+                                        // holding Up/Down feels closer to a
+                                        // mouse-wheel scroll instead of crawling
+                                        // one line at a time per render frame.
+                                        app.scroll = app.scroll.saturating_sub(3);
                                         app.at_bottom = false;
                                     }
                                     KeyCode::Down => {
@@ -1325,7 +1351,7 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                             }
                                         }
                                         let max = app.chat_max_scroll.get();
-                                        app.scroll = app.scroll.saturating_add(1).min(max);
+                                        app.scroll = app.scroll.saturating_add(3).min(max);
                                         app.at_bottom = app.scroll >= max;
                                     }
                                     KeyCode::PageUp => {


### PR DESCRIPTION
Scroll felt queued because the only scroll surface was Up/Down keys
stepping one line per render frame. Holding the key crawled at ~60
lines/sec with no way to flick down a long history.

Two fixes:

* Enable mouse capture in init_terminal so the terminal forwards
  scroll-wheel motions to crossterm. Wire ScrollUp/ScrollDown to
  the chat viewport at 3 lines per notch — matches typical terminal
  scroll feel and gives the user a direct-control surface.
* Bump keyboard Up/Down step from 1 line to 3, matching wheel
  velocity. PageUp/PageDown stay at 10 for bigger jumps.

Disable mouse capture in restore_terminal so an exit doesn't leave
the user's primary terminal forwarding mouse events.

Also accept prompt-builder snapshot drift (YYC-107 `## Environment`
block) — same fix as YYC-37 PR.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>