### PR TITLE
YYC-125: steer-by-default, /queue for explicit deferred FIFO

### DIFF
--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -152,9 +152,17 @@ pub(super) async fn handle_stream_event(
             }
             app.note_done();
             refresh_sessions(agent, app).await;
-            // YYC-61: drain one queued prompt per turn end. Subsequent queued
-            // prompts ride the next Done event in the same way.
-            if let Some(next) = app.queue.pop_front() {
+            // YYC-125: drain ALL queued steers at turn end as a single
+            // batched prompt. Multiple mid-turn submissions land as one
+            // combined user message rather than dripping one prompt per
+            // turn. /queue deferrals (deferred_queue) drain strictly
+            // after the steer batch — and only one per Done — so user
+            // intent is preserved.
+            if !app.queue.is_empty() {
+                let parts: Vec<String> = app.queue.drain(..).collect();
+                let batched = parts.join("\n\n");
+                submit_prompt(app, agent, stream_tx, batched);
+            } else if let Some(next) = app.deferred_queue.pop_front() {
                 submit_prompt(app, agent, stream_tx, next);
             }
         }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1017,14 +1017,25 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                             });
                                             continue;
                                         }
-                                        // YYC-61: plain text during busy → queue.
+                                        // YYC-61 → YYC-125: plain text during busy queues
+                                        // as a "steer" — drained as a single batched
+                                        // prompt at the next turn-end Done. Use /queue
+                                        // for explicit FIFO post-turn scheduling.
                                         if !app.input.is_empty()
                                             && app.thinking
                                             && !is_slash
                                         {
                                             let msg = app.input.trim().to_string();
                                             if !msg.is_empty() {
-                                                app.queue.push_back(msg);
+                                                app.queue.push_back(msg.clone());
+                                                app.messages.push(ChatMessage {
+                                                    role: ChatRole::System,
+                                                    content: format!(
+                                                        "Steered (#{} pending): {msg}",
+                                                        app.queue.len()
+                                                    ),
+                                                    ..Default::default()
+                                                });
                                             }
                                             app.input.clear();
                                             app.slash_menu_selection = 0;
@@ -1119,6 +1130,36 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
                                                         events::refresh_sessions(&agent, &mut app).await;
                                                         app.show_session_picker = true;
                                                         app.session_picker_selection = 0;
+                                                        continue;
+                                                    }
+                                                    s if s.starts_with("queue ") => {
+                                                        // YYC-125: defer until after the steer batch.
+                                                        let body = s[6..].trim();
+                                                        if body.is_empty() {
+                                                            app.messages.push(ChatMessage {
+                                                                role: ChatRole::System,
+                                                                content: "Usage: /queue <msg> — schedules a prompt to run after the next turn ends and any pending steers flush.".into(),
+                                                                ..Default::default()
+                                                            });
+                                                            continue;
+                                                        }
+                                                        app.deferred_queue.push_back(body.to_string());
+                                                        app.messages.push(ChatMessage {
+                                                            role: ChatRole::System,
+                                                            content: format!(
+                                                                "Queued (#{}, deferred): {body}",
+                                                                app.deferred_queue.len()
+                                                            ),
+                                                            ..Default::default()
+                                                        });
+                                                        continue;
+                                                    }
+                                                    "queue" => {
+                                                        app.messages.push(ChatMessage {
+                                                            role: ChatRole::System,
+                                                            content: "Usage: /queue <msg> — schedules a prompt to run after the next turn ends and any pending steers flush.".into(),
+                                                            ..Default::default()
+                                                        });
                                                         continue;
                                                     }
                                                     s if s.starts_with("search ") => {

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -143,9 +143,15 @@ pub struct AppState {
     /// Diff render style (YYC-77). Toggled via `/diff-style`.
     pub diff_style: DiffStyle,
     /// Pending prompts submitted while the agent was busy (YYC-61).
-    /// Drained one-at-a-time from the front when each turn completes.
+    /// Per YYC-125, plain-text submissions during an agent turn act as
+    /// "steers": they queue here and the entire batch fires as one
+    /// combined user message at the next turn-end Done event.
     /// In-memory only — never persisted to sessions.db.
     pub queue: VecDeque<String>,
+    /// Explicit `/queue <msg>` deferrals (YYC-125). Strict FIFO post-
+    /// turn drain — one message per Done event, after the steer batch
+    /// has flushed.
+    pub deferred_queue: VecDeque<String>,
     pub show_reasoning: bool,
     pub session_label: String,
 
@@ -317,6 +323,7 @@ impl AppState {
             prompt_mode: PromptMode::Insert,
             diff_style: DiffStyle::default(),
             queue: VecDeque::new(),
+            deferred_queue: VecDeque::new(),
             show_reasoning: true,
             session_label: "new session".into(),
 


### PR DESCRIPTION
Reworked the busy-prompt path so plain text typed during an agent
turn behaves as a "steer": it queues into app.queue and the *entire*
batch fires as one combined user message at the next turn-end Done.
Multiple steers are joined with a blank-line separator so the model
sees them as one coherent follow-up rather than dripping a fresh
turn per submission.

Add `/queue <msg>` slash command for explicit deferred FIFO. Each
/queue entry lands in a separate `app.deferred_queue`; the Done
handler drains the steer batch first, then pops at most one
deferred prompt. Empty `/queue` (no body) emits a usage hint.
mid_turn_safe = true since it only mutates AppState.

Steer feedback: pushing a steer surfaces a `Steered (#N pending)`
system message so the user can see what's queued without scrolling.
The deferred path uses `Queued (#N, deferred)` so the two surfaces
read distinctly.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>