### PR TITLE
YYC-128: real LLM context compaction with sliding window

### DIFF
--- a/src/agent/run.rs
+++ b/src/agent/run.rs
@@ -135,20 +135,8 @@ impl Agent {
             tracing::debug!("Agent iteration {iteration}");
 
             if self.context.should_compact(&messages) {
-                let summary = self.context.compact(&messages)?;
-                messages = vec![
-                    Message::System {
-                        content: format!("Previous conversation context:\n{summary}"),
-                    },
-                    Message::User {
-                        content: input.to_string(),
-                    },
-                ];
-                // YYC-138: replace the persisted snapshot atomically so
-                // the next save_messages doesn't slice the wrong tail and
-                // leave orphan Tool rows pointing at a tool_calls
-                // Assistant turn that's no longer in history.
-                self.replace_history(&messages)?;
+                self.compact_buffered_messages_if_possible(&mut messages, cancel.clone())
+                    .await;
             }
 
             if cancel.is_cancelled() {
@@ -501,52 +489,93 @@ impl Agent {
     pub(in crate::agent) async fn compact_stream_messages_if_needed(
         &mut self,
         messages: &mut Vec<Message>,
-        input: &str,
+        _input: &str,
         ui_tx: &mpsc::UnboundedSender<StreamEvent>,
         iteration: usize,
     ) {
-        // YYC-105: same compaction discipline as run_prompt — when the
-        // accumulated history would push the next request past the
-        // configured trigger ratio, summarize older turns and replace
-        // them with a single system primer. Without this, small-context
-        // models (llama-cpp Q2_0 quants, etc.) silently truncate the
-        // request and behave as if the session has no history.
+        // YYC-105 + YYC-128: when the accumulated history would push the next
+        // request past the configured trigger ratio, ask the provider to
+        // summarize the older turns and splice the summary in place of them.
+        // Without this, small-context models (llama-cpp Q2_0 quants, etc.)
+        // silently truncate the request and behave as if the session has no
+        // history.
         if !self.context.should_compact(messages) {
             return;
         }
 
-        match self.context.compact(messages) {
-            Ok(summary) => {
-                let kept_count = messages.len();
-                *messages = vec![
-                    Message::System {
-                        content: format!("Previous conversation context:\n{summary}"),
-                    },
-                    Message::User {
-                        content: input.to_string(),
-                    },
-                ];
-                // YYC-138: align the persisted snapshot with the in-memory
-                // reset so the next append doesn't orphan Tool rows from
-                // the pre-compaction history.
-                if let Err(e) = self.replace_history(messages) {
-                    tracing::warn!(
-                        "agent iteration {iteration}: failed to replace persisted history after compaction: {e}"
-                    );
-                }
-                let _ = ui_tx.send(StreamEvent::Text(format!(
-                    "_(compacted {kept_count} earlier turns into a summary to fit context)_\n"
-                )));
-                tracing::info!(
-                    "agent iteration {iteration}: compacted {kept_count} prior messages"
-                );
-            }
-            Err(e) => {
-                tracing::warn!(
-                    "agent iteration {iteration}: compaction failed: {e} (continuing with full history)"
-                );
-            }
+        let pre_count = messages.len();
+        let cancel = self.turn_cancel.clone();
+        let compacted = self
+            .compact_buffered_messages_if_possible(messages, cancel)
+            .await;
+        if compacted {
+            let kept_count = pre_count.saturating_sub(messages.len()).max(1);
+            let _ = ui_tx.send(StreamEvent::Text(format!(
+                "_(compacted {kept_count} earlier turns into a summary to fit context)_\n"
+            )));
+            tracing::info!("agent iteration {iteration}: compacted {kept_count} prior messages");
+        } else {
+            tracing::warn!(
+                "agent iteration {iteration}: compaction skipped (no safe split or summarizer call failed)"
+            );
         }
+    }
+
+    /// Summarize an older slice of `messages` via a provider call and splice
+    /// the summary in place of the slice. Preserves the leading System
+    /// prompt and the trailing window past the safe split index.
+    ///
+    /// Returns `true` when the buffer was actually rewritten — caller can use
+    /// that to surface a UX note. Returns `false` when:
+    /// - no User-message boundary exists in the trailing window, or
+    /// - the summarizer call returns an empty body / errors.
+    ///
+    /// Failures are logged at warn level and the buffer is left untouched
+    /// so the agent can continue with the full history (the next provider
+    /// call may simply fail with a context-overflow error, which is still
+    /// strictly better than silently losing the entire session — YYC-128).
+    pub(in crate::agent) async fn compact_buffered_messages_if_possible(
+        &mut self,
+        messages: &mut Vec<Message>,
+        cancel: CancellationToken,
+    ) -> bool {
+        use crate::context::ContextManager;
+
+        let split = match self.context.safe_split_index(messages) {
+            Some(i) if i > 1 => i, // need at least one message to summarize
+            _ => return false,
+        };
+
+        let request = ContextManager::summarization_request(&messages[1..split]);
+        let response = match self.provider.chat(&request, &[], cancel).await {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!("compaction summarizer call failed: {e}");
+                return false;
+            }
+        };
+        let summary = response.content.unwrap_or_default();
+        if summary.trim().is_empty() {
+            tracing::warn!("compaction summarizer returned empty body");
+            return false;
+        }
+
+        let mut new_messages = Vec::with_capacity(messages.len() - split + 2);
+        new_messages.push(messages[0].clone());
+        new_messages.push(Message::System {
+            content: format!("Summary of earlier conversation:\n{summary}"),
+        });
+        new_messages.extend(messages[split..].iter().cloned());
+        *messages = new_messages;
+
+        self.context.install_summary(summary);
+        // YYC-138: persist the rewritten snapshot atomically so the next
+        // save_messages append doesn't orphan Tool rows from the dropped
+        // pre-summary slice.
+        if let Err(e) = self.replace_history(messages) {
+            tracing::warn!("failed to replace persisted history after compaction: {e}");
+        }
+        true
     }
 
     pub(in crate::agent) async fn collect_stream_response(

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -292,41 +292,94 @@ async fn prepare_stream_turn_builds_prompt_and_persists_user_message() {
 }
 
 #[tokio::test]
-async fn compact_stream_messages_if_needed_replaces_history_and_emits_note() {
-    let (mut agent, _mock) = agent_with_mock();
+async fn compact_stream_messages_if_needed_replaces_history_with_summary_and_keeps_recent_window() {
+    // YYC-128: real compaction calls the provider to summarize the older
+    // slice, splices the summary in place of it, and preserves the recent
+    // window verbatim — including the new user prompt.
+    let (mut agent, mock) = agent_with_mock();
     agent.context = ContextManager::new(10);
+    // Summarizer call returns this body — the new System message should
+    // contain it and not the legacy "Previous conversation context:" stub.
+    mock.enqueue_text("- user wanted X done\n- file /tmp/foo.txt was created");
+
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
-    let mut messages = vec![
-        Message::System {
-            content: "system".into(),
-        },
-        Message::User {
-            content: "old prompt".into(),
-        },
-        Message::Assistant {
-            content: Some("old answer".into()),
+    let mut messages = vec![Message::System {
+        content: "system".into(),
+    }];
+    // Build 8 (User, Assistant) turns so the keep_recent=6 window leaves
+    // older content to summarize.
+    for i in 0..8 {
+        messages.push(Message::User {
+            content: format!("turn {i} user"),
+        });
+        messages.push(Message::Assistant {
+            content: Some(format!("turn {i} answer")),
             tool_calls: None,
             reasoning_content: None,
-        },
-    ];
+        });
+    }
+    messages.push(Message::User {
+        content: "new prompt".into(),
+    });
+    let pre_len = messages.len();
 
     agent
         .compact_stream_messages_if_needed(&mut messages, "new prompt", &tx, 0)
         .await;
 
-    assert_eq!(messages.len(), 2);
+    // History was actually rewritten.
+    assert!(messages.len() < pre_len);
+    // First message stays the original System prompt.
+    assert!(matches!(&messages[0], Message::System { content } if content == "system"));
+    // Second message is the inserted summary System block.
+    match &messages[1] {
+        Message::System { content } => {
+            assert!(content.starts_with("Summary of earlier conversation:"));
+            assert!(content.contains("/tmp/foo.txt"));
+        }
+        other => panic!("expected summary System, got {other:?}"),
+    }
+    // Recent window preserved verbatim — the new user prompt is still last.
     assert!(matches!(
-        &messages[0],
-        Message::System { content } if content.starts_with("Previous conversation context:")
+        messages.last(),
+        Some(Message::User { content }) if content == "new prompt"
     ));
-    assert!(matches!(
-        &messages[1],
-        Message::User { content } if content == "new prompt"
-    ));
+    // UX note emitted to the stream.
     assert!(matches!(
         rx.try_recv(),
         Ok(StreamEvent::Text(note)) if note.contains("compacted")
     ));
+}
+
+#[tokio::test]
+async fn compact_skips_when_no_user_boundary_in_recent_window() {
+    // No User in the trailing window (mid tool-loop): compaction must be a
+    // no-op so we don't break the tool_calls/Tool wire invariant.
+    let (mut agent, _mock) = agent_with_mock();
+    agent.context = ContextManager::new(10);
+    let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+    let original = vec![
+        Message::System {
+            content: "system".into(),
+        },
+        Message::Assistant {
+            content: Some("a".repeat(200)),
+            tool_calls: None,
+            reasoning_content: None,
+        },
+        Message::Assistant {
+            content: Some("b".repeat(200)),
+            tool_calls: None,
+            reasoning_content: None,
+        },
+    ];
+    let mut messages = original.clone();
+
+    agent
+        .compact_stream_messages_if_needed(&mut messages, "x", &tx, 0)
+        .await;
+
+    assert_eq!(messages.len(), original.len());
 }
 
 #[tokio::test]

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,15 +1,38 @@
 use crate::provider::Message;
-use anyhow::Result;
 
-/// Manages token budget and context compression
+/// System prompt for the summarizer LLM call. Drives a tight, factual
+/// summary that preserves anything the agent will need to keep working
+/// after the older turns are dropped (YYC-128).
+const SUMMARIZATION_SYSTEM_PROMPT: &str = "\
+You are a context summarizer for a coding agent. The conversation that follows is being \
+truncated to fit a smaller context window. Produce a tight, factual summary that preserves \
+everything the agent will need to keep working:
+
+- File paths mentioned and what was read, written, or modified
+- Decisions made and constraints set by the user (preferences, do/don't lists)
+- Errors encountered, their root causes, and the fix that was applied
+- Tool outputs that informed a decision (compile errors, test failures, search hits)
+- Open questions or in-flight work that wasn't completed
+- The user's current goal
+
+Write in dense bullet-point form. Drop pleasantries, repeated context, verbose tool dumps, \
+and chit-chat. Aim for under 1500 words. Do not add commentary about being a summarizer.";
+
+/// Manages token budget and decides when context needs to be compacted.
+///
+/// Compaction itself runs in the agent (it needs the provider to call the
+/// LLM); this struct just tracks usage, decides when to trigger, and finds
+/// a safe split point in the message history.
 pub struct ContextManager {
     max_context: usize,
     current_tokens: usize,
-    /// Rolling summary of old conversation for compaction
     summary: Option<String>,
-    /// Token budget remaining for current context
     reserved_tokens: usize,
     trigger_ratio: f64,
+    /// Minimum number of trailing messages to keep verbatim across a
+    /// compaction. The actual kept window may be longer if the safe
+    /// split has to walk past tool sequences (YYC-128).
+    keep_recent: usize,
 }
 
 impl ContextManager {
@@ -20,18 +43,21 @@ impl ContextManager {
             summary: None,
             reserved_tokens: 50_000,
             trigger_ratio: 0.85,
+            keep_recent: 6,
         }
     }
 
-    /// Record token usage from an LLM response
+    /// Record token usage from an LLM response.
+    ///
+    /// Provider usage already covers the prompt sent on this request, so
+    /// replace the previous estimate instead of adding to it. Otherwise
+    /// a freshly installed compaction summary gets counted again on the
+    /// next response.
     pub fn record_usage(&mut self, prompt_tokens: usize, completion_tokens: usize) {
-        // Provider usage already includes the prompt sent on this request.
-        // Replace the previous estimate instead of adding to it, or a compacted
-        // summary gets counted again on the next response.
         self.current_tokens = prompt_tokens.saturating_add(completion_tokens);
     }
 
-    /// Check if context should be compacted based on token usage
+    /// Should the next turn be preceded by a compaction pass?
     pub fn should_compact(&self, messages: &[Message]) -> bool {
         if self.summary.is_none() && messages.len() > 50 {
             return true;
@@ -42,56 +68,50 @@ impl ContextManager {
             || estimated_tokens + self.reserved_tokens >= self.max_context
     }
 
-    /// Compact the context — creates a summary of all but the last few messages
-    pub fn compact(&mut self, messages: &[Message]) -> Result<String> {
-        // In a real implementation, this would call the LLM to summarize the conversation.
-        // For now, we create a simple structural summary.
-        let user_msgs: Vec<_> = messages
-            .iter()
-            .filter_map(|m| match m {
-                Message::User { content } => Some(content.clone()),
-                _ => None,
-            })
-            .collect();
-
-        let tool_counts = messages
-            .iter()
-            .filter_map(|m| match m {
-                Message::Tool { content, .. } => Some(content),
-                _ => None,
-            })
-            .count();
-
-        let assistant_msgs = messages
-            .iter()
-            .filter_map(|m| match m {
-                Message::Assistant { content, .. } => content.clone(),
-                _ => None,
-            })
-            .collect::<Vec<_>>();
-
-        let summary = format!(
-            "[Previous conversation]\n\
-             - User messages: {}\n\
-             - Assistant responses: {}\n\
-             - Tool calls made: {}\n\
-             - Topics discussed: {}\n\
-             Compaction triggered at ~{}% context usage.\n\
-             See session history for full details.",
-            user_msgs.len(),
-            assistant_msgs.len(),
-            tool_counts,
-            user_msgs.last().unwrap_or(&"—".to_string()),
-            (self.current_tokens as f64 / self.max_context as f64 * 100.0) as u64,
-        );
-
-        self.summary = Some(summary.clone());
-        self.current_tokens = self.estimate_tokens_str(&summary);
-
-        Ok(summary)
+    /// Find the index where the kept-recent window starts.
+    ///
+    /// The returned index `i` is positioned at a `User` message, so the
+    /// pre-summary slice `messages[..i]` ends cleanly and the post-summary
+    /// slice `messages[i..]` cannot orphan a `Tool` message (every Tool in
+    /// it follows its calling Assistant within the same slice).
+    ///
+    /// Returns `None` when no User boundary exists in the trailing window
+    /// — the caller should skip compaction in that case rather than risk
+    /// breaking the wire-protocol invariant.
+    pub fn safe_split_index(&self, messages: &[Message]) -> Option<usize> {
+        let target = messages.len().saturating_sub(self.keep_recent).max(1);
+        (target..messages.len()).find(|&i| matches!(messages[i], Message::User { .. }))
     }
 
-    /// Rough token estimation for messages
+    /// Build the request that asks the provider to summarize an older
+    /// slice of the conversation. The agent runs this request through its
+    /// own provider so ContextManager stays free of the `LLMProvider`
+    /// trait (and therefore async).
+    pub fn summarization_request(messages_to_summarize: &[Message]) -> Vec<Message> {
+        let history_text = format_history(messages_to_summarize);
+        vec![
+            Message::System {
+                content: SUMMARIZATION_SYSTEM_PROMPT.to_string(),
+            },
+            Message::User {
+                content: history_text,
+            },
+        ]
+    }
+
+    /// Install a freshly produced summary. Resets the running token
+    /// estimate to just the summary length so `record_usage` on the
+    /// next response replaces (rather than stacks on top of) it.
+    pub fn install_summary(&mut self, summary: String) {
+        self.current_tokens = self.estimate_tokens_str(&summary);
+        self.summary = Some(summary);
+    }
+
+    /// Best-effort prior summary, mainly for diagnostics.
+    pub fn summary(&self) -> Option<&str> {
+        self.summary.as_deref()
+    }
+
     fn estimate_tokens(&self, messages: &[Message]) -> usize {
         let text: String = messages
             .iter()
@@ -108,9 +128,56 @@ impl ContextManager {
     }
 
     fn estimate_tokens_str(&self, text: &str) -> usize {
-        // Rough estimate: ~4 characters per token for English text
+        // Rough estimate: ~4 characters per token for English text.
         text.len() / 4 + 1
     }
+}
+
+/// Render messages as a transcript the summarizer LLM can read.
+fn format_history(messages: &[Message]) -> String {
+    let mut out = String::new();
+    for msg in messages {
+        match msg {
+            Message::System { content } => {
+                out.push_str("[SYSTEM]\n");
+                out.push_str(content);
+            }
+            Message::User { content } => {
+                out.push_str("[USER]\n");
+                out.push_str(content);
+            }
+            Message::Assistant {
+                content,
+                tool_calls,
+                ..
+            } => {
+                out.push_str("[ASSISTANT]\n");
+                if let Some(c) = content {
+                    out.push_str(c);
+                }
+                if let Some(calls) = tool_calls
+                    && !calls.is_empty()
+                {
+                    out.push_str("\n[tool_calls]\n");
+                    for tc in calls {
+                        out.push_str(&format!(
+                            "- {}({}) [id={}]\n",
+                            tc.function.name, tc.function.arguments, tc.id,
+                        ));
+                    }
+                }
+            }
+            Message::Tool {
+                tool_call_id,
+                content,
+            } => {
+                out.push_str(&format!("[TOOL id={tool_call_id}]\n"));
+                out.push_str(content);
+            }
+        }
+        out.push_str("\n\n");
+    }
+    out
 }
 
 #[cfg(test)]
@@ -124,6 +191,7 @@ mod tests {
             summary: None,
             reserved_tokens: 0,
             trigger_ratio: 0.85,
+            keep_recent: 6,
         }
     }
 
@@ -136,6 +204,14 @@ mod tests {
     fn user(content: impl Into<String>) -> Message {
         Message::User {
             content: content.into(),
+        }
+    }
+
+    fn asst(content: impl Into<String>) -> Message {
+        Message::Assistant {
+            content: Some(content.into()),
+            tool_calls: None,
+            reasoning_content: None,
         }
     }
 
@@ -162,36 +238,6 @@ mod tests {
     }
 
     #[test]
-    fn compact_summary_preserves_latest_user_input() {
-        let mut ctx = manager(100);
-        let messages = vec![
-            user("first topic"),
-            Message::Assistant {
-                content: Some("assistant answer".into()),
-                tool_calls: None,
-                reasoning_content: None,
-            },
-            user("latest user request"),
-        ];
-
-        let summary = ctx.compact(&messages).unwrap();
-
-        assert!(summary.contains("latest user request"));
-    }
-
-    #[test]
-    fn record_usage_after_compaction_does_not_double_count_summary_tokens() {
-        let mut ctx = manager(1000);
-        let summary = ctx.compact(&[user("latest user request")]).unwrap();
-        let summary_tokens = ctx.estimate_tokens_str(&summary);
-        assert_eq!(ctx.current_tokens, summary_tokens);
-
-        ctx.record_usage(10, 5);
-
-        assert_eq!(ctx.current_tokens, 15);
-    }
-
-    #[test]
     fn long_history_heuristic_fires_only_once_per_session() {
         let mut ctx = manager(1_000_000);
         let messages = (0..51)
@@ -199,8 +245,87 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert!(ctx.should_compact(&messages));
-        ctx.compact(&messages).unwrap();
+        ctx.install_summary("stub".into());
 
         assert!(!ctx.should_compact(&messages));
+    }
+
+    #[test]
+    fn install_summary_resets_token_count_to_summary_size() {
+        let mut ctx = manager(1000);
+        ctx.install_summary("a short summary".into());
+        let summary_tokens = ctx.estimate_tokens_str("a short summary");
+        assert_eq!(ctx.current_tokens, summary_tokens);
+
+        ctx.record_usage(10, 5);
+        // record_usage replaces, doesn't add.
+        assert_eq!(ctx.current_tokens, 15);
+    }
+
+    #[test]
+    fn safe_split_lands_on_user_message_in_recent_window() {
+        let ctx = manager(1_000_000);
+        // 0:Sys 1:U 2:A 3:U 4:A 5:U 6:A 7:U 8:A — keep_recent=6 → target=3.
+        let messages = vec![
+            Message::System {
+                content: "sys".into(),
+            },
+            user("u1"),
+            asst("a1"),
+            user("u2"),
+            asst("a2"),
+            user("u3"),
+            asst("a3"),
+            user("u4"),
+            asst("a4"),
+        ];
+
+        let split = ctx.safe_split_index(&messages).expect("user in tail");
+        assert_eq!(split, 3); // first User at or after target=3
+        assert!(matches!(messages[split], Message::User { .. }));
+    }
+
+    #[test]
+    fn safe_split_returns_none_when_tail_has_no_user_boundary() {
+        let ctx = manager(1_000_000);
+        // System + a long Assistant-only / Tool tail (e.g. mid tool-loop).
+        let messages = vec![
+            Message::System {
+                content: "sys".into(),
+            },
+            asst("a1"),
+            asst("a2"),
+            asst("a3"),
+            asst("a4"),
+            asst("a5"),
+            asst("a6"),
+            asst("a7"),
+        ];
+        assert!(ctx.safe_split_index(&messages).is_none());
+    }
+
+    #[test]
+    fn summarization_request_includes_system_and_renders_history() {
+        let messages = vec![
+            user("touch /tmp/foo.txt"),
+            asst("done; created /tmp/foo.txt"),
+        ];
+        let req = ContextManager::summarization_request(&messages);
+        assert_eq!(req.len(), 2);
+        match (&req[0], &req[1]) {
+            (
+                Message::System { content: sys },
+                Message::User {
+                    content: rendered, ..
+                },
+            ) => {
+                assert!(sys.contains("summarizer"));
+                assert!(rendered.contains("[USER]"));
+                assert!(rendered.contains("touch /tmp/foo.txt"));
+                assert!(rendered.contains("[ASSISTANT]"));
+                assert!(rendered.contains("/tmp/foo.txt"));
+            }
+            _ => panic!("expected System+User pair, got {req:?}"),
+        }
     }
 }


### PR DESCRIPTION
Problem: ContextManager::compact() built a 5-line structural stub
(message counts + the latest user message) and replaced the entire
prior history with it. Long sessions that hit the 85% trigger
silently dropped every file path, decision, error, and tool output.

Fix: replace the stub with a provider-driven summary call.

ContextManager now exposes:
- safe_split_index(messages): walk from len-keep_recent forward to
  the first User message; returns None if the trailing window has
  no User boundary so we never break the tool_calls/Tool wire
  invariant by cutting mid tool-loop.
- summarization_request(slice): build the [System(prompt), User(transcript)]
  request the agent feeds into the provider. Stays infra-free —
  ContextManager doesn't depend on the LLMProvider trait.
- install_summary(s): replaces the previous stub-write path,
  resets current_tokens to summary length so record_usage on the
  next response replaces (not stacks) the count.

Agent::compact_buffered_messages_if_possible(messages, cancel) is
the new orchestrator. On compact:

  [Sys, ...old, ...recent_window]
    → [Sys, Sys(summary), ...recent_window]

Recent window is preserved verbatim (default keep_recent=6) so the
agent keeps full fidelity on the active task. The leading System
prompt is preserved.

Failure modes are explicit:
- no User boundary in the tail → no-op, agent continues with full
  history (next provider call may overflow, but that's strictly
  better than silently losing the session).
- summarizer call errors / returns empty body → no-op, warn log.

Both run_prompt and the streaming path now route through the same
helper. The streaming path still emits the "_compacted N earlier
turns_" UX note.

Tests: ContextManager unit tests (split/install/request shape) +
two agent-level integration tests (real summary spliced in;
no-User-boundary skip).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>