### PR TITLE
YYC-126: parking_lot::Mutex for async-fn-body lock sites

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5068,6 +5068,7 @@ dependencies = [
  "ignore",
  "insta",
  "lsp-types",
+ "parking_lot",
  "portable-pty",
  "r2d2",
  "r2d2_sqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,11 @@ gateway = [
 # Async runtime
 tokio = { version = "1", features = ["full"] }
 
+# Synchronization primitives for short critical sections inside async code
+# (YYC-126). parking_lot::Mutex avoids std::sync::Mutex's panic-on-poisoning
+# while staying drop-in for guards that don't need to cross .await.
+parking_lot = "0.12"
+
 # HTTP / LLM API
 reqwest = { version = "0.13", features = ["json", "stream"] }
 

--- a/src/hooks/approval.rs
+++ b/src/hooks/approval.rs
@@ -18,9 +18,9 @@ use crate::config::{ApprovalConfig, ApprovalMode};
 use crate::hooks::{HookHandler, HookOutcome};
 use crate::pause::{AgentPause, AgentResume, OptionKind, PauseKind, PauseOption, PauseSender};
 use anyhow::Result;
+use parking_lot::Mutex;
 use serde_json::Value;
 use std::collections::HashSet;
-use std::sync::Mutex;
 use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
 
@@ -69,9 +69,7 @@ impl HookHandler for ApprovalHook {
         if matches!(mode, ApprovalMode::Always) {
             return Ok(HookOutcome::Continue);
         }
-        if matches!(mode, ApprovalMode::Session)
-            && self.session_allow.lock().unwrap().contains(tool)
-        {
+        if matches!(mode, ApprovalMode::Session) && self.session_allow.lock().contains(tool) {
             return Ok(HookOutcome::Continue);
         }
 
@@ -156,7 +154,7 @@ impl HookHandler for ApprovalHook {
         match resume {
             Ok(AgentResume::Allow) => Ok(HookOutcome::Continue),
             Ok(AgentResume::AllowAndRemember) => {
-                self.session_allow.lock().unwrap().insert(tool.to_string());
+                self.session_allow.lock().insert(tool.to_string());
                 Ok(HookOutcome::Continue)
             }
             Ok(AgentResume::Deny) => Ok(HookOutcome::Block {

--- a/src/hooks/audit.rs
+++ b/src/hooks/audit.rs
@@ -10,7 +10,9 @@
 //! needle.
 
 use std::collections::{BTreeMap, VecDeque};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+
+use parking_lot::Mutex;
 
 use anyhow::Result;
 use chrono::{DateTime, Utc};
@@ -114,32 +116,27 @@ impl AuditHook {
     /// Snapshot the current bash-redirect counts. Useful in tests; the
     /// TUI consumes the live handle directly.
     pub fn bash_counts_snapshot(&self) -> BashRedirectCounts {
-        self.bash_counts
-            .lock()
-            .map(|c| c.clone())
-            .unwrap_or_default()
+        self.bash_counts.lock().clone()
     }
 
     fn push(&self, entry: AuditEntry) {
-        if let Ok(mut buf) = self.buf.lock() {
-            if buf.len() >= self.capacity {
-                buf.pop_front();
-            }
-            buf.push_back(entry);
+        let mut buf = self.buf.lock();
+        if buf.len() >= self.capacity {
+            buf.pop_front();
         }
+        buf.push_back(entry);
     }
 
     fn record_bash(&self, command: &str) {
         let category = match_native_category(command);
-        if let Ok(mut counts) = self.bash_counts.lock() {
-            counts.total = counts.total.saturating_add(1);
-            match category {
-                Some(cat) => {
-                    *counts.by_category.entry(cat.to_string()).or_insert(0) += 1;
-                }
-                None => {
-                    counts.legitimate = counts.legitimate.saturating_add(1);
-                }
+        let mut counts = self.bash_counts.lock();
+        counts.total = counts.total.saturating_add(1);
+        match category {
+            Some(cat) => {
+                *counts.by_category.entry(cat.to_string()).or_insert(0) += 1;
+            }
+            None => {
+                counts.legitimate = counts.legitimate.saturating_add(1);
             }
         }
     }
@@ -240,7 +237,7 @@ mod tests {
         // Unrelated command — also legitimate.
         run_bash(&hook, "npm install").await;
 
-        let snap = counts.lock().unwrap().clone();
+        let snap = counts.lock().clone();
         assert_eq!(snap.total, 6);
         assert_eq!(snap.redirected(), 4);
         assert_eq!(snap.legitimate, 2);
@@ -259,7 +256,7 @@ mod tests {
                 CancellationToken::new(),
             )
             .await;
-        let snap = counts.lock().unwrap().clone();
+        let snap = counts.lock().clone();
         assert_eq!(snap, BashRedirectCounts::default());
     }
 

--- a/src/hooks/diagnostics.rs
+++ b/src/hooks/diagnostics.rs
@@ -65,7 +65,7 @@ impl HookHandler for DiagnosticsHook {
             return Ok(HookOutcome::Continue);
         }
 
-        let edit = match self.diff_sink.lock().unwrap().clone() {
+        let edit = match self.diff_sink.lock().clone() {
             Some(d) => d,
             None => return Ok(HookOutcome::Continue),
         };

--- a/src/hooks/safety.rs
+++ b/src/hooks/safety.rs
@@ -9,7 +9,8 @@
 //! customization will land when there's demand. See Linear YYC-26.
 
 use std::collections::HashSet;
-use std::sync::Mutex;
+
+use parking_lot::Mutex;
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -50,16 +51,11 @@ impl SafetyHook {
     /// the *exact same* command in this session will bypass the safety check.
     /// Public so the TUI can pre-seed approvals if it ever wants to.
     pub fn approve(&self, command: &str) {
-        if let Ok(mut set) = self.approved.lock() {
-            set.insert(command.to_string());
-        }
+        self.approved.lock().insert(command.to_string());
     }
 
     fn is_approved(&self, command: &str) -> bool {
-        self.approved
-            .lock()
-            .map(|s| s.contains(command))
-            .unwrap_or(false)
+        self.approved.lock().contains(command)
     }
 }
 

--- a/src/tools/file.rs
+++ b/src/tools/file.rs
@@ -257,7 +257,7 @@ impl Tool for WriteFile {
                 after: crate::tools::snippet(content, 6, 800),
                 at: chrono::Local::now(),
             };
-            *sink.lock().unwrap() = Some(diff);
+            *sink.lock() = Some(diff);
         }
 
         // YYC-bonus: surface a real diff in the card preview without
@@ -441,7 +441,7 @@ impl Tool for PatchFile {
                 after: crate::tools::snippet(new, 6, 800),
                 at: chrono::Local::now(),
             };
-            *sink.lock().unwrap() = Some(diff);
+            *sink.lock() = Some(diff);
         }
 
         // YYC-bonus: render a Claude Code-style diff in the card.
@@ -578,7 +578,7 @@ mod tests {
         .await
         .unwrap();
 
-        let diff = sink.lock().unwrap().clone().expect("diff captured");
+        let diff = sink.lock().clone().expect("diff captured");
         assert_eq!(diff.tool, "write_file");
         assert_eq!(diff.path, path_str);
         assert_eq!(diff.before, "old contents");
@@ -631,7 +631,7 @@ mod tests {
         .await
         .unwrap();
 
-        let diff = sink.lock().unwrap().clone().expect("diff captured");
+        let diff = sink.lock().clone().expect("diff captured");
         assert_eq!(diff.tool, "edit_file");
         assert_eq!(diff.before, "1");
         assert_eq!(diff.after, "42");

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -232,10 +232,10 @@ pub struct EditDiff {
 /// Shared latest-edit slot. `None` until the first successful edit;
 /// overwritten on every subsequent edit. The TUI clones the Arc and
 /// peeks the inner Option each render.
-pub type EditDiffSink = Arc<std::sync::Mutex<Option<EditDiff>>>;
+pub type EditDiffSink = Arc<parking_lot::Mutex<Option<EditDiff>>>;
 
 pub fn new_diff_sink() -> EditDiffSink {
-    Arc::new(std::sync::Mutex::new(None))
+    Arc::new(parking_lot::Mutex::new(None))
 }
 
 /// Trim a string to a max number of lines + chars so the TUI doesn't

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -392,30 +392,30 @@ impl AppState {
     /// trading-floor tool-log pane. Returns demo data if no audit buffer is
     /// attached or it's still empty.
     pub fn tool_log_view(&self, max: usize) -> Vec<ToolLogRow> {
-        if let Some(buf) = &self.audit_log
-            && let Ok(buf) = buf.lock()
-            && !buf.is_empty()
-        {
-            return buf
-                .iter()
-                .rev()
-                .take(max)
-                .map(|e| {
-                    let kind_marker = match e.kind {
-                        AuditKind::Started => "●",
-                        AuditKind::Ok => "✓",
-                        AuditKind::Err => "✗",
-                    };
-                    ToolLogRow {
-                        time: e.time.with_timezone(&Local).format("%H:%M:%S").to_string(),
-                        actor: short_tool(&e.tool),
-                        msg: format!("{} {}", kind_marker, e.detail),
-                    }
-                })
-                .collect::<Vec<_>>()
-                .into_iter()
-                .rev()
-                .collect();
+        if let Some(buf) = &self.audit_log {
+            let buf = buf.lock();
+            if !buf.is_empty() {
+                return buf
+                    .iter()
+                    .rev()
+                    .take(max)
+                    .map(|e| {
+                        let kind_marker = match e.kind {
+                            AuditKind::Started => "●",
+                            AuditKind::Ok => "✓",
+                            AuditKind::Err => "✗",
+                        };
+                        ToolLogRow {
+                            time: e.time.with_timezone(&Local).format("%H:%M:%S").to_string(),
+                            actor: short_tool(&e.tool),
+                            msg: format!("{} {}", kind_marker, e.detail),
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .into_iter()
+                    .rev()
+                    .collect();
+            }
         }
         demo_tool_log()
     }
@@ -503,7 +503,7 @@ impl AppState {
     /// value so the renderer doesn't hold the mutex across draws.
     pub fn latest_diff(&self) -> Option<crate::tools::EditDiff> {
         let sink = self.diff_sink.as_ref()?;
-        sink.lock().ok()?.clone()
+        sink.lock().clone()
     }
 
     /// Cumulative token count (input + output across all turns). Used by


### PR DESCRIPTION
Problem: SafetyHook, ApprovalHook, AuditHook, and DiagnosticsHook
(via EditDiffSink) all called std::sync::Mutex::lock() inside
async fn bodies. Holding a std mutex inside async code blocks a
tokio worker until the guard drops; .unwrap() on a poisoned guard
panics every subsequent caller.

The critical sections are short and never cross an .await, so
parking_lot::Mutex (drop-in API, no poisoning, no async overhead)
is the right tool — tokio::sync::Mutex would be overkill.

Fix:
- Add parking_lot 0.12 as a direct dep.
- Switch SafetyHook.approved, ApprovalHook.session_allow,
  AuditBuffer, BashCountsHandle, and EditDiffSink to
  parking_lot::Mutex.
- Drop .unwrap() / if-let-Ok / .map().unwrap_or() patterns at all
  call sites — parking_lot::lock() returns the guard directly.

Out of scope (kept on std::sync::Mutex):
- src/memory/mod.rs — every fn is sync, no async fn body to
  violate.
- src/tools/shell.rs — PtySession + registry locks live in sync
  helper fns called from async, never literally inside an async
  fn body. The guard never crosses .await.

Acceptance: no std::sync::Mutex::lock() inside async fn bodies in
src/hooks/, src/tools/shell.rs, src/memory/mod.rs. All 314 lib
tests pass.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>