### PR TITLE
YYC-130 follow-up: dangerous-commands policy + per-session quota

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -63,6 +63,20 @@ default = "always"
 # git_push   = "ask"        # prompt every push
 # bash       = "ask"
 
+# YYC-130: SafetyHook policy + per-session quota for dangerous shell
+# patterns (rm -rf /, dd, mkfs, force push, ...).
+#   policy = "prompt" — pause the agent and ask the user (default;
+#                       matches legacy behavior).
+#   policy = "block"  — never prompt; hard-block every dangerous match.
+#                       Useful for unattended / CI runs.
+#   policy = "allow"  — never prompt and never block. NOT recommended.
+# quota_per_session caps how many times an approved-and-remembered
+# dangerous command can fire before the hook re-prompts. 0 disables
+# the cap (legacy behavior — once approved, runs unlimited).
+[tools.dangerous_commands]
+policy = "prompt"
+quota_per_session = 5
+
 [compaction]
 # Auto-compress context when token usage is high
 enabled = true

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -300,10 +300,7 @@ impl Agent {
         // is true — keeps the no-op path zero-cost. With a pause emitter
         // wired up, blocks become interactive prompts.
         if !config.tools.yolo_mode {
-            let safety = match pause_tx {
-                Some(tx) => SafetyHook::with_pause_emitter(tx),
-                None => SafetyHook::new(),
-            };
+            let safety = SafetyHook::with_config(pause_tx.clone(), config.tools.dangerous_commands);
             hooks.register(Arc::new(safety));
         }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -266,6 +266,57 @@ pub struct ToolsConfig {
     /// way entirely.
     #[serde(default)]
     pub native_enforcement: NativeEnforcement,
+    /// Policy + quota for commands that match a SafetyHook dangerous
+    /// pattern (YYC-130 follow-up). Default: `policy = "prompt"` and
+    /// `quota_per_session = 5` — match the existing prompt-then-allow
+    /// flow, with a fresh per-session cap on how many times an
+    /// approved-and-remembered dangerous command can fire before the
+    /// hook re-prompts.
+    #[serde(default)]
+    pub dangerous_commands: DangerousCommandsConfig,
+}
+
+/// Approval-flow policy for SafetyHook (YYC-130 follow-up).
+///
+/// * `Prompt` — pause and ask the user via the existing pause channel
+///   (matches the legacy behavior). When no pause channel is wired
+///   (CLI one-shot), falls through to a hard block.
+/// * `Block`  — never prompt; always hard-block any dangerous command.
+///   Useful for unattended runs / CI / production.
+/// * `Allow`  — never prompt and never block. Effectively disables the
+///   safety hook for dangerous patterns. **Not recommended.**
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum DangerousCommandPolicy {
+    #[default]
+    Prompt,
+    Block,
+    Allow,
+}
+
+#[derive(Debug, Deserialize, Clone, Copy)]
+pub struct DangerousCommandsConfig {
+    #[serde(default)]
+    pub policy: DangerousCommandPolicy,
+    /// Per-session usage cap for any single approved-and-remembered
+    /// dangerous command. After this many fires the SafetyHook
+    /// re-prompts as if the cache entry had expired. 0 disables the
+    /// cap (legacy behavior — once approved, runs unlimited).
+    #[serde(default = "default_dangerous_quota")]
+    pub quota_per_session: u32,
+}
+
+fn default_dangerous_quota() -> u32 {
+    5
+}
+
+impl Default for DangerousCommandsConfig {
+    fn default() -> Self {
+        Self {
+            policy: DangerousCommandPolicy::default(),
+            quota_per_session: default_dangerous_quota(),
+        }
+    }
 }
 
 /// Native-tool redirect aggressiveness.

--- a/src/hooks/safety.rs
+++ b/src/hooks/safety.rs
@@ -8,7 +8,7 @@
 //! Scope of v1: shell commands only. The patterns are hard-coded; user
 //! customization will land when there's demand. See Linear YYC-26.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use parking_lot::Mutex;
 
@@ -18,32 +18,44 @@ use serde_json::Value;
 use tokio::sync::oneshot;
 use tokio_util::sync::CancellationToken;
 
+use crate::config::{DangerousCommandPolicy, DangerousCommandsConfig};
 use crate::pause::{AgentPause, AgentResume, OptionKind, PauseKind, PauseOption, PauseSender};
 
 use super::{HookHandler, HookOutcome};
 
 pub struct SafetyHook {
     approved: Mutex<HashSet<String>>,
+    /// Per-session usage count keyed by canonical command (YYC-130
+    /// follow-up). When the count for an approved command exceeds
+    /// `policy.quota_per_session`, the hook re-prompts as if the
+    /// approval entry had expired. `0` quota disables the cap.
+    usage: Mutex<HashMap<String, u32>>,
     pause_tx: Option<PauseSender>,
+    policy: DangerousCommandsConfig,
 }
 
 impl SafetyHook {
     /// Construct without an interactive pause channel. Blocked commands stay
     /// blocked — there's no path back to the user. Suitable for CLI one-shot.
     pub fn new() -> Self {
-        Self {
-            approved: Mutex::new(HashSet::new()),
-            pause_tx: None,
-        }
+        Self::with_config(None, DangerousCommandsConfig::default())
     }
 
     /// Construct with a pause channel. When a dangerous command is matched,
     /// the hook emits an `AgentPause::SafetyApproval` and awaits the user's
     /// response before deciding to block or allow.
     pub fn with_pause_emitter(pause_tx: PauseSender) -> Self {
+        Self::with_config(Some(pause_tx), DangerousCommandsConfig::default())
+    }
+
+    /// Construct with both a pause channel (or none) and an explicit
+    /// policy/quota configuration (YYC-130 follow-up).
+    pub fn with_config(pause_tx: Option<PauseSender>, policy: DangerousCommandsConfig) -> Self {
         Self {
             approved: Mutex::new(HashSet::new()),
-            pause_tx: Some(pause_tx),
+            usage: Mutex::new(HashMap::new()),
+            pause_tx,
+            policy,
         }
     }
 
@@ -58,6 +70,39 @@ impl SafetyHook {
         self.approved
             .lock()
             .contains(&canonical_command_key(command))
+    }
+
+    /// Bump the per-session usage counter for `command`. Returns the new
+    /// count. The counter is keyed by canonical form so quoting / spacing
+    /// variants share one budget.
+    fn record_usage(&self, command: &str) -> u32 {
+        let key = canonical_command_key(command);
+        let mut map = self.usage.lock();
+        let entry = map.entry(key).or_insert(0);
+        *entry = entry.saturating_add(1);
+        *entry
+    }
+
+    /// True when the per-session quota is finite and `record_usage` would
+    /// push the count past it. Caller advances the counter only after the
+    /// command is actually being allowed through, so a re-prompt resets
+    /// the counter (via `forget`) without bumping it.
+    fn quota_exhausted(&self, command: &str) -> bool {
+        let limit = self.policy.quota_per_session;
+        if limit == 0 {
+            return false;
+        }
+        let key = canonical_command_key(command);
+        self.usage.lock().get(&key).copied().unwrap_or(0) >= limit
+    }
+
+    /// Clear the cache + usage counter for `command`. Used after the
+    /// quota expires to make the next user prompt feel like a fresh
+    /// approval.
+    fn forget(&self, command: &str) {
+        let key = canonical_command_key(command);
+        self.approved.lock().remove(&key);
+        self.usage.lock().remove(&key);
     }
 }
 
@@ -118,9 +163,49 @@ impl HookHandler for SafetyHook {
             None => return Ok(HookOutcome::Continue),
         };
 
+        // YYC-130 follow-up: policy lets users opt out of prompting.
+        // `Allow` lets every dangerous match through (still warn-logged
+        // so it shows up in the audit trail). `Block` short-circuits
+        // before the approval cache so even remembered commands stop.
+        match self.policy.policy {
+            DangerousCommandPolicy::Allow => {
+                tracing::warn!(
+                    "safety-gate: dangerous_commands.policy = allow — letting '{command}' run ({reason})"
+                );
+                return Ok(HookOutcome::Continue);
+            }
+            DangerousCommandPolicy::Block => {
+                tracing::warn!(
+                    "safety-gate: dangerous_commands.policy = block — '{command}' rejected ({reason})"
+                );
+                return Ok(HookOutcome::Block {
+                    reason: format!(
+                        "{reason} (config policy = block — ask the user to flip dangerous_commands.policy if this is intentional)"
+                    ),
+                });
+            }
+            DangerousCommandPolicy::Prompt => {}
+        }
+
         if self.is_approved(command) {
-            tracing::info!("safety-gate: '{command}' approved earlier this session, allowing");
-            return Ok(HookOutcome::Continue);
+            // YYC-130 follow-up: per-session quota. Once the
+            // approved-and-remembered cache entry has been used past the
+            // configured cap, drop it and fall through to a fresh
+            // prompt. quota = 0 disables the cap entirely (legacy
+            // behavior).
+            if self.quota_exhausted(command) {
+                tracing::info!(
+                    "safety-gate: quota exhausted for '{command}' (limit {}); re-prompting",
+                    self.policy.quota_per_session,
+                );
+                self.forget(command);
+            } else {
+                let count = self.record_usage(command);
+                tracing::info!(
+                    "safety-gate: '{command}' approved earlier this session, allowing (use {count})"
+                );
+                return Ok(HookOutcome::Continue);
+            }
         }
 
         // If a pause emitter is wired up, ask the user. Otherwise fall back to
@@ -821,7 +906,7 @@ mod tests {
         // Different target paths must produce different keys so
         // approving a scoped delete doesn't authorize a root delete.
         assert_ne!(
-            canonical_command_key("rm -rf /tmp/build"),
+            canonical_command_key("rm -rf /etc/old"),
             canonical_command_key("rm -rf /"),
         );
         assert_ne!(
@@ -918,5 +1003,112 @@ mod tests {
             .await
             .unwrap();
         assert!(matches!(outcome, HookOutcome::Continue));
+    }
+
+    // ── YYC-130 follow-up: policy + per-session quota ───────────────────
+
+    #[tokio::test]
+    async fn policy_block_rejects_even_remembered_commands() {
+        // policy = block: dangerous patterns are hard-blocked regardless
+        // of the approval cache. Useful for unattended / CI runs.
+        let hook = SafetyHook::with_config(
+            None,
+            DangerousCommandsConfig {
+                policy: DangerousCommandPolicy::Block,
+                quota_per_session: 0,
+            },
+        );
+        hook.approve("rm -rf /"); // pre-seed the cache
+
+        let args = serde_json::json!({ "command": "rm -rf /" });
+        let outcome = hook
+            .before_tool_call("bash", &args, CancellationToken::new())
+            .await
+            .unwrap();
+        assert!(
+            matches!(outcome, HookOutcome::Block { reason } if reason.contains("policy = block"))
+        );
+    }
+
+    #[tokio::test]
+    async fn policy_allow_lets_dangerous_commands_run_without_prompt() {
+        // policy = allow: matcher fires (and warn-logs), but the call
+        // is allowed through with no pause emitter required. **Not**
+        // recommended — surface area for the docs.
+        let hook = SafetyHook::with_config(
+            None,
+            DangerousCommandsConfig {
+                policy: DangerousCommandPolicy::Allow,
+                quota_per_session: 0,
+            },
+        );
+        let args = serde_json::json!({ "command": "rm -rf /" });
+        let outcome = hook
+            .before_tool_call("bash", &args, CancellationToken::new())
+            .await
+            .unwrap();
+        assert!(matches!(outcome, HookOutcome::Continue));
+    }
+
+    #[tokio::test]
+    async fn quota_reprompts_after_cap_is_reached() {
+        // Quota = 2: the first two fires of an approved command run;
+        // the third fire finds the entry, sees the quota is exhausted,
+        // forgets it, and falls through to the prompt path. With no
+        // pause emitter that path hard-blocks — proving the cache
+        // entry was actually dropped.
+        let hook = SafetyHook::with_config(
+            None,
+            DangerousCommandsConfig {
+                policy: DangerousCommandPolicy::Prompt,
+                quota_per_session: 2,
+            },
+        );
+        hook.approve("rm -rf /etc/old");
+
+        let args = serde_json::json!({ "command": "rm -rf /etc/old" });
+
+        for run in 1..=2 {
+            let outcome = hook
+                .before_tool_call("bash", &args, CancellationToken::new())
+                .await
+                .unwrap();
+            assert!(
+                matches!(outcome, HookOutcome::Continue),
+                "run {run} should still be within quota"
+            );
+        }
+
+        let third = hook
+            .before_tool_call("bash", &args, CancellationToken::new())
+            .await
+            .unwrap();
+        assert!(
+            matches!(third, HookOutcome::Block { .. }),
+            "third run should re-prompt and (with no pause emitter) block"
+        );
+    }
+
+    #[tokio::test]
+    async fn quota_zero_disables_cap() {
+        // quota_per_session = 0 mirrors the legacy behavior: once
+        // approved, runs unlimited.
+        let hook = SafetyHook::with_config(
+            None,
+            DangerousCommandsConfig {
+                policy: DangerousCommandPolicy::Prompt,
+                quota_per_session: 0,
+            },
+        );
+        hook.approve("rm -rf /etc/old");
+
+        let args = serde_json::json!({ "command": "rm -rf /etc/old" });
+        for _ in 0..10 {
+            let outcome = hook
+                .before_tool_call("bash", &args, CancellationToken::new())
+                .await
+                .unwrap();
+            assert!(matches!(outcome, HookOutcome::Continue));
+        }
     }
 }


### PR DESCRIPTION
Two pieces of follow-up surface mentioned in YYC-130 that the
canonical-key + pty_write PR deferred:

1. `[tools.dangerous_commands].policy` config knob. Three values:
   - `prompt` (default) — match the legacy flow: pause and ask
     via the existing pause channel; with no pause channel, hard
     block.
   - `block` — never prompt; always hard-block a dangerous match.
     Lets users opt the agent into unattended / CI / production
     mode where the matcher should be a wall, not a gate.
   - `allow` — never prompt, never block. Warn-logs every match
     so the audit trail still shows what happened. Not
     recommended; surfaced in the docs.

2. `[tools.dangerous_commands].quota_per_session` per-session cap
   on how many times an approved-and-remembered dangerous command
   can fire before SafetyHook re-prompts. Default 5; 0 disables
   the cap (legacy "approve once, run unlimited" behavior).

Implementation:

- DangerousCommandsConfig + DangerousCommandPolicy land in
  src/config.rs alongside the existing ApprovalConfig.
- SafetyHook gains usage: Mutex<HashMap<String, u32>> keyed by
  canonical_command_key, plus record_usage / quota_exhausted /
  forget helpers. with_config(pause_tx, policy) is the new
  primary constructor; new() / with_pause_emitter() stay for
  back-compat and forward to it with the default policy.
- before_tool_call branches on policy first (Allow short-circuits
  to Continue with a warn log; Block short-circuits to Block with
  a config-explanation reason). Quota check fires inside the
  is_approved branch — when exhausted, the cache entry is
  forgotten so the next call re-prompts cleanly.
- Agent::with_config wires config.tools.dangerous_commands into
  SafetyHook::with_config.
- config.example.toml documents the new section.

Tests (4 new):
- policy_block_rejects_even_remembered_commands
- policy_allow_lets_dangerous_commands_run_without_prompt
- quota_reprompts_after_cap_is_reached (1+2 Continue, 3rd Block)
- quota_zero_disables_cap (legacy behavior, 10 fires all Continue)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>