### PR TITLE
YYC-135: redact secrets from provider wire-debug logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5073,6 +5073,7 @@ dependencies = [
  "r2d2",
  "r2d2_sqlite",
  "ratatui",
+ "regex",
  "reqwest 0.13.2",
  "rusqlite",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,9 @@ tokio = { version = "1", features = ["full"] }
 # while staying drop-in for guards that don't need to cross .await.
 parking_lot = "0.12"
 
+# Pattern-based secret redaction in provider wire-debug logs (YYC-135).
+regex = "1"
+
 # HTTP / LLM API
 reqwest = { version = "0.13", features = ["json", "stream"] }
 

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -1,6 +1,7 @@
 pub mod catalog;
 pub mod factory;
 pub mod openai;
+pub mod redact;
 pub mod think_sanitizer;
 
 pub mod mock;

--- a/src/provider/openai.rs
+++ b/src/provider/openai.rs
@@ -1,4 +1,5 @@
 use crate::config::ProviderDebugMode;
+use crate::provider::redact::{redact_response_text, redact_value};
 use crate::provider::{
     ChatResponse, LLMProvider, Message, ProviderError, StreamEvent, ToolCall, ToolDefinition, Usage,
 };
@@ -83,11 +84,18 @@ impl OpenAIProvider {
         let url = format!("{}/chat/completions", self.base_url);
         let body = self.build_request(messages, tools);
         if self.debug_mode.logs_wire() {
+            // YYC-135: redact recognizable secret shapes (Bearer tokens,
+            // sk-* keys, GitHub PATs, AWS access key IDs) and truncate
+            // long string leaves before they hit the log file. Without
+            // this the wire-debug log becomes a covert exfiltration
+            // vector — exactly the file users tend to share for
+            // support.
+            let redacted = redact_value(&body);
             tracing::info!(
                 provider = "openai-compat",
                 model = %self.model,
                 url = %url,
-                request_body = %body,
+                request_body = %redacted,
                 "provider wire request"
             );
         }
@@ -336,19 +344,26 @@ fn summarize_wire_response(raw: &str) -> WireResponseSummary {
 fn log_wire_response(model: &str, raw: &str) {
     let summary = summarize_wire_response(raw);
     if let Some(body) = summary.raw_body {
+        // YYC-135: same redaction discipline as the request log — secret
+        // material can show up in a non-streaming response body when an
+        // upstream echoes the request, and assistant text could include
+        // tool output that read a config file.
+        let redacted = redact_response_text(&body);
         tracing::info!(
             provider = "openai-compat",
             model = %model,
-            response_body = %body,
+            response_body = %redacted,
             "provider wire response"
         );
     } else {
+        let preview = summary.non_sse_preview.as_deref().unwrap_or("");
+        let redacted_preview = redact_response_text(preview);
         tracing::info!(
             provider = "openai-compat",
             model = %model,
             sse_data_lines = summary.sse_data_lines,
             has_done_marker = summary.has_done_marker,
-            non_sse_preview = summary.non_sse_preview.as_deref().unwrap_or(""),
+            non_sse_preview = %redacted_preview,
             "provider wire response (stream summary; completion chunks suppressed)"
         );
     }
@@ -1311,6 +1326,41 @@ data: [DONE]
         assert!((8000..10000).contains(&d4), "got {d4}");
         assert!((16000..20000).contains(&d5), "got {d5}");
         assert!((16000..20000).contains(&d6), "got {d6} (should be capped)");
+    }
+
+    #[test]
+    fn wire_request_redaction_strips_bearer_and_sk_keys_from_logged_body() {
+        // YYC-135 acceptance pin: a request body that carries a Bearer
+        // token or sk-* key (e.g. via tool-output content) must be
+        // logged with the secret redacted. Reproduces the do_request
+        // log path: build_request would produce a JSON body, and
+        // redact_value is what runs before tracing::info!.
+        use crate::provider::redact::redact_value;
+        let body = serde_json::json!({
+            "model": "claude-haiku-4.5",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "the auth header was Bearer sk-test-aaaaaaaaaaaaaaaa",
+                },
+                {
+                    "role": "assistant",
+                    "content": "ok, calling the API with sk-test-bbbbbbbbbbbbbbbb",
+                },
+            ],
+        });
+        let redacted = redact_value(&body);
+        let serialized = redacted.to_string();
+        assert!(
+            !serialized.contains("sk-test-aaaaaaaaaaaaaaaa"),
+            "Bearer sk- key leaked: {serialized}",
+        );
+        assert!(
+            !serialized.contains("sk-test-bbbbbbbbbbbbbbbb"),
+            "bare sk- key leaked: {serialized}",
+        );
+        assert!(serialized.contains("Bearer [REDACTED]"));
+        assert!(serialized.contains("sk-[REDACTED]"));
     }
 
     #[test]

--- a/src/provider/redact.rs
+++ b/src/provider/redact.rs
@@ -1,0 +1,223 @@
+//! Wire-debug log redaction (YYC-135).
+//!
+//! `do_request` and `log_wire_response` log raw request/response bodies at
+//! `info!` when `debug = "wire"`. Those bodies routinely include:
+//!
+//! - Conversation history (often confidential)
+//! - Tool outputs that read config files (`api_key` material)
+//! - File contents the agent was asked to inspect
+//! - The `Bearer <token>` header (only in `Authorization`, but error paths
+//!   echo the request shape)
+//!
+//! Without redaction, `debug = "wire"` silently turns the local log file
+//! into a secret-exfiltration vector — exactly the file a user is most
+//! likely to copy into a support ticket.
+//!
+//! This module exposes:
+//! - `redact_string`: strip recognizable secret shapes and truncate long
+//!   strings (preserving the head so the log is still useful).
+//! - `redact_value`: deep walk a `serde_json::Value`, applying
+//!   `redact_string` to every string leaf.
+//! - `redact_response_text`: same but for free-form raw response bodies
+//!   (which may be SSE text rather than JSON).
+
+use std::sync::OnceLock;
+
+use regex::Regex;
+use serde_json::Value;
+
+/// Strings longer than this are truncated to head + elision marker. The
+/// log still surfaces the first chunk (enough to debug shape / leading
+/// fields) without dumping kilobytes of file content per request.
+pub(crate) const MAX_STRING_LEN: usize = 500;
+
+/// Compiled secret-shape patterns. Lazy-initialized once per process.
+fn secret_patterns() -> &'static [(Regex, &'static str)] {
+    static PATTERNS: OnceLock<Vec<(Regex, &'static str)>> = OnceLock::new();
+    PATTERNS.get_or_init(|| {
+        vec![
+            // `Bearer <token>` — preserve the label, redact the token.
+            // Captures group 1 = the prefix so callers can splice it back.
+            (
+                Regex::new(r"(?i)(Bearer\s+)[A-Za-z0-9_\-\.=/+]{8,}").expect("Bearer regex"),
+                "$1[REDACTED]",
+            ),
+            // OpenAI / Anthropic / OpenRouter family.
+            (
+                Regex::new(r"sk-ant-[A-Za-z0-9_\-]{16,}").expect("anthropic key regex"),
+                "sk-ant-[REDACTED]",
+            ),
+            (
+                Regex::new(r"sk-or-[A-Za-z0-9_\-]{16,}").expect("openrouter key regex"),
+                "sk-or-[REDACTED]",
+            ),
+            (
+                Regex::new(r"sk-[A-Za-z0-9_\-]{16,}").expect("sk- key regex"),
+                "sk-[REDACTED]",
+            ),
+            // GitHub personal access tokens / fine-grained tokens.
+            (
+                Regex::new(r"ghp_[A-Za-z0-9]{20,}").expect("github pat regex"),
+                "ghp_[REDACTED]",
+            ),
+            (
+                Regex::new(r"github_pat_[A-Za-z0-9_]{20,}").expect("github fine-grained regex"),
+                "github_pat_[REDACTED]",
+            ),
+            // AWS access key ID shape.
+            (
+                Regex::new(r"AKIA[0-9A-Z]{16}").expect("aws key id regex"),
+                "AKIA[REDACTED]",
+            ),
+        ]
+    })
+}
+
+/// Strip recognizable secret shapes from `s`, then truncate if longer than
+/// `MAX_STRING_LEN` chars. Designed to be safe to call on any string that
+/// might land in a debug log.
+pub fn redact_string(s: &str) -> String {
+    let mut out = s.to_string();
+    for (re, replacement) in secret_patterns() {
+        let replaced = re.replace_all(&out, *replacement);
+        out = replaced.into_owned();
+    }
+    if out.chars().count() > MAX_STRING_LEN {
+        let elided = out.chars().count() - MAX_STRING_LEN;
+        let head: String = out.chars().take(MAX_STRING_LEN).collect();
+        out = format!("{head}… [{elided} chars elided]");
+    }
+    out
+}
+
+/// Deep-walk a JSON value and apply `redact_string` to every string leaf.
+/// Object keys are kept as-is (they're schema, not secret data).
+pub fn redact_value(value: &Value) -> Value {
+    match value {
+        Value::String(s) => Value::String(redact_string(s)),
+        Value::Array(arr) => Value::Array(arr.iter().map(redact_value).collect()),
+        Value::Object(map) => {
+            let mut out = serde_json::Map::with_capacity(map.len());
+            for (k, v) in map {
+                out.insert(k.clone(), redact_value(v));
+            }
+            Value::Object(out)
+        }
+        _ => value.clone(),
+    }
+}
+
+/// Redact a free-form (non-JSON) response body. SSE streams are line-based
+/// text — apply `redact_string` then re-truncate the whole blob so a
+/// chunked response can't expand past the cap.
+pub fn redact_response_text(text: &str) -> String {
+    redact_string(text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn redact_string_strips_bearer_token() {
+        let raw = "Authorization: Bearer sk-test-1234567890abcdef";
+        let red = redact_string(raw);
+        assert!(!red.contains("sk-test-1234567890abcdef"));
+        assert!(red.contains("Bearer [REDACTED]"));
+    }
+
+    #[test]
+    fn redact_string_strips_bare_sk_key() {
+        let raw = "config api_key = \"sk-1234567890abcdef0123\"";
+        let red = redact_string(raw);
+        assert!(!red.contains("sk-1234567890abcdef0123"));
+        assert!(red.contains("sk-[REDACTED]"));
+    }
+
+    #[test]
+    fn redact_string_strips_anthropic_key() {
+        let raw = "key=sk-ant-api03-AAAAAAAAAAAAAAAAA";
+        let red = redact_string(raw);
+        assert!(!red.contains("sk-ant-api03-AAAAAAAAAAAAAAAAA"));
+        assert!(red.contains("sk-ant-[REDACTED]"));
+    }
+
+    #[test]
+    fn redact_string_strips_openrouter_key() {
+        let raw = "OPENROUTER_API_KEY=sk-or-v1-abcdefghijklmnopqrstuvwx";
+        let red = redact_string(raw);
+        assert!(!red.contains("sk-or-v1-abcdefghijklmnopqrstuvwx"));
+        assert!(red.contains("sk-or-[REDACTED]"));
+    }
+
+    #[test]
+    fn redact_string_strips_github_token() {
+        let raw = "ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ012345";
+        let red = redact_string(raw);
+        assert!(!red.contains("aBcDeFgHiJkLmNoPqRsTuVwXyZ012345"));
+        assert!(red.contains("ghp_[REDACTED]"));
+    }
+
+    #[test]
+    fn redact_string_strips_aws_access_key_id() {
+        let raw = "AKIAIOSFODNN7EXAMPLE";
+        let red = redact_string(raw);
+        assert!(red.contains("AKIA[REDACTED]"));
+    }
+
+    #[test]
+    fn redact_string_truncates_long_payload() {
+        let raw = "a".repeat(MAX_STRING_LEN + 200);
+        let red = redact_string(&raw);
+        assert!(red.contains("[200 chars elided]"));
+        assert!(red.chars().count() < MAX_STRING_LEN + 100);
+    }
+
+    #[test]
+    fn redact_string_short_passthrough_unchanged() {
+        let raw = "the quick brown fox";
+        assert_eq!(redact_string(raw), raw);
+    }
+
+    #[test]
+    fn redact_value_walks_nested_objects_and_arrays() {
+        let v = json!({
+            "model": "claude-haiku-4.5",
+            "messages": [
+                {"role": "system", "content": "You are an assistant."},
+                {"role": "user", "content": "use Bearer sk-test-aaaaaaaaaaaaaaaaaaaa"},
+            ],
+            "tools": [{"name": "bash", "args": {"command": "echo sk-1234567890abcdef0123"}}],
+        });
+
+        let red = redact_value(&v);
+        let serialized = red.to_string();
+        assert!(!serialized.contains("sk-test-aaaaaaaaaaaaaaaaaaaa"));
+        assert!(!serialized.contains("sk-1234567890abcdef0123"));
+        assert!(serialized.contains("Bearer [REDACTED]"));
+        assert!(serialized.contains("sk-[REDACTED]"));
+        // Schema keys are preserved verbatim — they're not secret data.
+        assert!(serialized.contains("messages"));
+        assert!(serialized.contains("tools"));
+        // Non-secret content survives.
+        assert!(serialized.contains("You are an assistant."));
+    }
+
+    #[test]
+    fn redact_value_truncates_long_string_leaves() {
+        let big = "x".repeat(MAX_STRING_LEN + 50);
+        let v = json!({"messages": [{"role": "user", "content": big}]});
+        let red = redact_value(&v);
+        let s = red.to_string();
+        assert!(s.contains("[50 chars elided]"));
+    }
+
+    #[test]
+    fn redact_response_text_handles_sse_with_embedded_keys() {
+        let raw = "data: {\"id\":\"x\",\"choices\":[{\"delta\":{\"content\":\"see Bearer sk-leak-123456789012345678\"}}]}\n";
+        let red = redact_response_text(raw);
+        assert!(!red.contains("sk-leak-123456789012345678"));
+        assert!(red.contains("Bearer [REDACTED]"));
+    }
+}


### PR DESCRIPTION
Problem: do_request and log_wire_response logged the full request /
response body at info! when debug = "wire". Bodies routinely include:

- Conversation history (often confidential)
- Tool outputs that read config files (api_key material)
- File contents the agent was asked to inspect

Without redaction the wire-debug log file becomes a covert
exfiltration vector — exactly the file users tend to share for
support.

Fix: introduce src/provider/redact.rs with two entry points used
by both log paths in src/provider/openai.rs:

- redact_value(&Value): deep-walks JSON, applies redact_string to
  every string leaf, preserves object keys (schema isn't secret).
- redact_response_text(&str): same but for free-form non-JSON
  response bodies (SSE text, etc.).

redact_string strips recognizable secret shapes via compiled
regexes (cached in OnceLock, no per-call setup):
- Bearer <token>      → Bearer [REDACTED]
- sk-ant-...          → sk-ant-[REDACTED]
- sk-or-...           → sk-or-[REDACTED]
- sk-...              → sk-[REDACTED]
- ghp_..., github_pat_... → ghp_/github_pat_[REDACTED]
- AKIA[A-Z0-9]{16}    → AKIA[REDACTED]

Strings longer than MAX_STRING_LEN (500 chars) get truncated to
head + "[N chars elided]" so a single multi-MB tool result can't
balloon the log.

regex 1.x added as a direct dep (already in lockfile transitively
via gateway / other deps).

Tests (12 new):
- redact_string covers each pattern shape (Bearer, sk-*, sk-ant-*,
  sk-or-*, github PAT, AWS access key id) — every test asserts the
  raw secret is gone AND the redacted marker is present.
- redact_string truncates payloads longer than MAX_STRING_LEN.
- Short / non-secret strings pass through unchanged.
- redact_value walks nested objects and arrays; schema keys
  preserved.
- redact_value truncates long string leaves.
- redact_response_text handles SSE-shaped text with embedded keys.
- Acceptance pin: wire_request_redaction_strips_bearer_and_sk_keys_from_logged_body
  reproduces the do_request log shape and verifies neither sk-test-*
  variant leaks.

Out of scope (future): a config knob to opt back in to raw mode
("debug = wire-raw") for users actively debugging upstream wire
formats. Today's default is the safer redacted form for everyone.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>