### PR TITLE
YYC-133: evict gateway lane Agent on panic to prevent stuck future

### DIFF
--- a/src/gateway/agent_map.rs
+++ b/src/gateway/agent_map.rs
@@ -210,6 +210,18 @@ impl AgentMap {
         Arc::clone(&self.inner)
     }
 
+    /// Force-remove the entry for `lane` so the next `get_or_spawn` builds
+    /// a fresh Agent. Used by the worker when a panic during run_prompt
+    /// leaves the Agent in an unknown state — its hooks, message buffer,
+    /// and tool registry can all be mid-mutation, so the safe move is to
+    /// drop the whole instance and start over (YYC-133).
+    ///
+    /// No-op when the lane has no entry. Returns whether an entry was
+    /// removed so the caller can log appropriately.
+    pub async fn evict(&self, lane: &LaneKey) -> bool {
+        self.inner.write().await.remove(lane).is_some()
+    }
+
     /// Spawn a background task that periodically evicts lanes idle longer
     /// than `self.idle_ttl`. The returned `EvictorHandle` aborts the loop on
     /// drop, so callers don't need to remember to call `.abort()` on shutdown.

--- a/src/gateway/worker.rs
+++ b/src/gateway/worker.rs
@@ -39,14 +39,16 @@ pub async fn process_one(
     // may be inconsistent, but the next get_or_spawn after eviction will
     // build a fresh one. This is the same trade-off catch_unwind always
     // makes; the alternative (poisoning the lane forever) is worse.
-    let result: anyhow::Result<String> = AssertUnwindSafe(async {
+    let unwind = AssertUnwindSafe(async {
         let agent = agent_map.get_or_spawn(&lane).await?;
         let mut agent = agent.lock().await;
         agent.run_prompt(&row.text).await
     })
     .catch_unwind()
-    .await
-    .unwrap_or_else(|payload| {
+    .await;
+
+    let panicked = unwind.is_err();
+    let result: anyhow::Result<String> = unwind.unwrap_or_else(|payload| {
         let msg = payload
             .downcast_ref::<&'static str>()
             .map(|s| (*s).to_string())
@@ -56,6 +58,21 @@ pub async fn process_one(
             "agent panicked while running prompt: {msg}"
         ))
     });
+
+    // YYC-133: if the future panicked, the Agent's internal state is
+    // suspect — message buffer mid-write, tool registry mid-mutation,
+    // hooks holding partial state. Force-evict the lane entry so the
+    // *next* inbound row builds a fresh Agent rather than locking
+    // against a deadlocked / corrupted one.
+    if panicked {
+        let removed = agent_map.evict(&lane).await;
+        tracing::warn!(
+            lane = %row.platform,
+            chat_id = %row.chat_id,
+            removed,
+            "evicted lane agent after panic; next request will build fresh state",
+        );
+    }
 
     match result {
         Ok(reply) => {
@@ -269,6 +286,98 @@ mod tests {
                 .await
                 .unwrap()
                 .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn worker_panic_evicts_lane_so_next_request_builds_fresh_agent() {
+        // YYC-133 acceptance pin: a panic during run_prompt should
+        // remove the lane's cached Agent. The next inbound row for the
+        // same lane gets a freshly built Agent and runs cleanly.
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let db = fresh_db();
+        let inbound = InboundQueue::new(db.clone());
+        let outbound = OutboundQueue::new(db.clone(), 5);
+
+        // Builder counts how many Agents it constructs. First call →
+        // panicking provider; second call → canned-reply provider.
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_for_builder = Arc::clone(&calls);
+        let builder: AgentBuilder = Arc::new(move |hooks: HookRegistry| {
+            let n = calls_for_builder.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async move {
+                if n == 0 {
+                    Ok(Agent::for_test(
+                        Box::new(PanickingProvider),
+                        ToolRegistry::new(),
+                        hooks,
+                        empty_skills(),
+                    ))
+                } else {
+                    let mock = Arc::new(MockProvider::new(128_000));
+                    mock.enqueue_text("recovered");
+                    Ok(Agent::for_test(
+                        Box::new(ProviderHandle(mock)),
+                        ToolRegistry::new(),
+                        hooks,
+                        empty_skills(),
+                    ))
+                }
+            })
+        });
+        let agent_map = AgentMap::with_builder(test_config(), Duration::from_secs(60), builder);
+
+        // First row: panics. process_one should propagate the panic AND
+        // evict the lane.
+        inbound
+            .enqueue(InboundMessage {
+                platform: "loopback".into(),
+                chat_id: "c".into(),
+                user_id: "u".into(),
+                text: "boom".into(),
+            })
+            .await
+            .unwrap();
+        let row = inbound.claim_next().await.unwrap().expect("row");
+        let res = process_one(row, &agent_map, &inbound, &outbound).await;
+        assert!(res.is_err());
+
+        // Lane should now be empty in the AgentMap (evicted).
+        let lane = LaneKey {
+            platform: "loopback".into(),
+            chat_id: "c".into(),
+        };
+        assert!(
+            !agent_map.inner().read().await.contains_key(&lane),
+            "lane should have been evicted after panic"
+        );
+
+        // Second row: builder fires a second time, returns a clean
+        // Agent, and the worker drives it to a Continue + reply.
+        inbound
+            .enqueue(InboundMessage {
+                platform: "loopback".into(),
+                chat_id: "c".into(),
+                user_id: "u".into(),
+                text: "again".into(),
+            })
+            .await
+            .unwrap();
+        let row = inbound.claim_next().await.unwrap().expect("row");
+        process_one(row, &agent_map, &inbound, &outbound)
+            .await
+            .unwrap();
+
+        let reply = outbound
+            .claim_due(chrono::Utc::now().timestamp())
+            .await
+            .unwrap()
+            .expect("outbound row from recovered agent");
+        assert_eq!(reply.text, "recovered");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            2,
+            "builder should have run twice — once for the panicking agent, once for the rebuild"
         );
     }
 }


### PR DESCRIPTION
Problem: gateway/worker.rs::process_one wrapped Agent::run_prompt
in AssertUnwindSafe + catch_unwind. If the future panicked while
holding the per-lane Mutex<Agent> guard, two things were wrong:

1. The panicked Agent's internal state (message buffer, hook
   registry, tool registry) was potentially mid-mutation. Even if
   the guard's Drop ran during unwinding, the *Agent* itself was
   left in an inconsistent state.
2. The cached lane entry kept pointing at this poisoned Agent.
   Every subsequent inbound row for that lane locked against the
   same suspect instance.

Result: one panic could wedge a lane indefinitely until eviction
TTL kicked in (default 30 minutes).

Fix:

- AgentMap::evict(&LaneKey): force-remove the entry under a write
  lock; returns whether anything was actually removed so the
  caller can log appropriately.
- process_one separates the catch_unwind branch from the result
  branch. On panic: log warn and call agent_map.evict(&lane)
  before bubbling the error. The next get_or_spawn for that lane
  builds a fresh Agent.

Tests (1 new):
- worker_panic_evicts_lane_so_next_request_builds_fresh_agent
  (acceptance pin): builder counter wraps two providers — first
  call returns a PanickingProvider, second returns a normal
  MockProvider with a canned reply. After the first inbound row
  panics, asserts the lane is removed from the AgentMap. Second
  inbound row triggers the builder a second time, the recovered
  Agent runs cleanly, and the canned reply lands in the outbound
  queue. Final assertion: builder ran exactly twice.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>