### PR TITLE
YYC-131: per-call edit_diff on ToolResult eliminates TOCTOU race

### DIFF
--- a/src/hooks/diagnostics.rs
+++ b/src/hooks/diagnostics.rs
@@ -65,12 +65,26 @@ impl HookHandler for DiagnosticsHook {
             return Ok(HookOutcome::Continue);
         }
 
-        let edit = match self.diff_sink.lock().clone() {
-            Some(d) => d,
-            None => return Ok(HookOutcome::Continue),
+        // YYC-131: prefer the per-call diff carried on this ToolResult
+        // over the global sink. The sink is single-slot and last-write
+        // wins under concurrent dispatch, so two near-simultaneous
+        // edits could leave one DiagnosticsHook reading the *other*
+        // call's diff. The per-call field cannot race because it
+        // travels with the result.
+        let edit = if let Some(d) = result.edit_diff.clone() {
+            d
+        } else {
+            // Fall back to the global sink for results that don't carry
+            // a per-call diff (older paths or tools we haven't migrated).
+            // Validate against the matching tool name so a stale entry
+            // can't trigger diagnostics for an unrelated call.
+            match self.diff_sink.lock().clone() {
+                Some(d) if d.tool == tool => d,
+                _ => return Ok(HookOutcome::Continue),
+            }
         };
-        // Defense against stale sink contents — only act if the latest
-        // sink entry was produced by the tool we just observed.
+        // Defense against stale sink contents on the fallback path —
+        // only act if the diff is for the tool we just observed.
         if edit.tool != tool {
             return Ok(HookOutcome::Continue);
         }

--- a/src/tools/file.rs
+++ b/src/tools/file.rs
@@ -249,15 +249,21 @@ impl Tool for WriteFile {
         tokio::fs::write(path, content).await?;
         let bytes = content.len();
 
+        // YYC-66 / YYC-131: build the diff record once, then attach it
+        // to BOTH the global sink (TUI's last-write panel) and this
+        // call's ToolResult (per-call AfterToolCall hook input).
+        // Without the per-call attachment, concurrent dispatch could
+        // overwrite the sink before DiagnosticsHook sees the matching
+        // entry.
+        let diff = crate::tools::EditDiff {
+            path: path.to_string(),
+            tool: "write_file".into(),
+            before: crate::tools::snippet(&before, 6, 800),
+            after: crate::tools::snippet(content, 6, 800),
+            at: chrono::Local::now(),
+        };
         if let Some(sink) = &self.diff_sink {
-            let diff = crate::tools::EditDiff {
-                path: path.to_string(),
-                tool: "write_file".into(),
-                before: crate::tools::snippet(&before, 6, 800),
-                after: crate::tools::snippet(content, 6, 800),
-                at: chrono::Local::now(),
-            };
-            *sink.lock() = Some(diff);
+            *sink.lock() = Some(diff.clone());
         }
 
         // YYC-bonus: surface a real diff in the card preview without
@@ -268,7 +274,9 @@ impl Tool for WriteFile {
             format!("MODIFIED · {path}")
         };
         let display = diff_preview(&before, content, &label);
-        Ok(ToolResult::ok(format!("Wrote {bytes} bytes to {path}")).with_display_preview(display))
+        Ok(ToolResult::ok(format!("Wrote {bytes} bytes to {path}"))
+            .with_display_preview(display)
+            .with_edit_diff(diff))
     }
 }
 
@@ -431,17 +439,20 @@ impl Tool for PatchFile {
         tokio::fs::write(path, &new_content).await?;
         let replaces = accepted_offsets.len();
 
-        // YYC-66: capture the before/after snippets so the TUI diff pane
-        // shows actual edited text rather than demo data.
+        // YYC-66 / YYC-131: build the diff once, attach to both the
+        // global sink (TUI's last-write panel) and this call's
+        // ToolResult (per-call AfterToolCall hook input). Per-call
+        // attachment is what lets DiagnosticsHook react to the right
+        // file under concurrent dispatch.
+        let diff = crate::tools::EditDiff {
+            path: path.to_string(),
+            tool: "edit_file".into(),
+            before: crate::tools::snippet(old, 6, 800),
+            after: crate::tools::snippet(new, 6, 800),
+            at: chrono::Local::now(),
+        };
         if let Some(sink) = &self.diff_sink {
-            let diff = crate::tools::EditDiff {
-                path: path.to_string(),
-                tool: "edit_file".into(),
-                before: crate::tools::snippet(old, 6, 800),
-                after: crate::tools::snippet(new, 6, 800),
-                at: chrono::Local::now(),
-            };
-            *sink.lock() = Some(diff);
+            *sink.lock() = Some(diff.clone());
         }
 
         // YYC-bonus: render a Claude Code-style diff in the card.
@@ -451,7 +462,9 @@ impl Tool for PatchFile {
         } else {
             format!("Applied {replaces} of {total} hunk(s) in {path} (others rejected).")
         };
-        Ok(ToolResult::ok(msg).with_display_preview(display))
+        Ok(ToolResult::ok(msg)
+            .with_display_preview(display)
+            .with_edit_diff(diff))
     }
 }
 
@@ -635,6 +648,108 @@ mod tests {
         assert_eq!(diff.tool, "edit_file");
         assert_eq!(diff.before, "1");
         assert_eq!(diff.after, "42");
+    }
+
+    // ── YYC-131: per-call edit_diff travels with ToolResult ─────────────
+
+    #[tokio::test]
+    async fn write_file_attaches_per_call_edit_diff_to_tool_result() {
+        // Per-call diff lives on ToolResult so AfterToolCall hooks can
+        // see *this* call's edit even when the global sink races under
+        // concurrent dispatch (YYC-131).
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("a.txt");
+        let path_str = path.to_string_lossy().to_string();
+
+        let sink = crate::tools::new_diff_sink();
+        let tool = WriteFile::new(Some(sink.clone()));
+        let result = tool
+            .call(
+                json!({"path": path_str.clone(), "content": "hello"}),
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        let diff = result.edit_diff.expect("ToolResult.edit_diff populated");
+        assert_eq!(diff.tool, "write_file");
+        assert_eq!(diff.path, path_str);
+        assert_eq!(diff.after, "hello");
+    }
+
+    #[tokio::test]
+    async fn patch_file_attaches_per_call_edit_diff_to_tool_result() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("a.rs");
+        let path_str = path.to_string_lossy().to_string();
+        std::fs::write(&path, "fn foo() { 1 }\n").unwrap();
+
+        let sink = crate::tools::new_diff_sink();
+        let tool = PatchFile::new(Some(sink.clone()));
+        let result = tool
+            .call(
+                json!({"path": path_str.clone(), "old_string": "1", "new_string": "42"}),
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        let diff = result.edit_diff.expect("ToolResult.edit_diff populated");
+        assert_eq!(diff.tool, "edit_file");
+        assert_eq!(diff.path, path_str);
+        assert_eq!(diff.before, "1");
+        assert_eq!(diff.after, "42");
+    }
+
+    #[tokio::test]
+    async fn concurrent_writes_to_different_paths_each_carry_their_own_diff() {
+        // YYC-131 acceptance pin: concurrent dispatch where two
+        // write_file calls hit the global sink near-simultaneously
+        // would have produced one ToolResult with the *other* file's
+        // diff under the old single-slot scheme. With per-call
+        // attachment, each ToolResult carries its own diff regardless
+        // of sink ordering.
+        let dir = tempdir().unwrap();
+        let path_a = dir.path().join("a.txt").to_string_lossy().to_string();
+        let path_b = dir.path().join("b.txt").to_string_lossy().to_string();
+
+        let sink = crate::tools::new_diff_sink();
+        let tool = std::sync::Arc::new(WriteFile::new(Some(sink.clone())));
+
+        let ta = {
+            let tool = tool.clone();
+            let path = path_a.clone();
+            tokio::spawn(async move {
+                tool.call(
+                    json!({"path": path, "content": "AAA"}),
+                    CancellationToken::new(),
+                )
+                .await
+            })
+        };
+        let tb = {
+            let tool = tool.clone();
+            let path = path_b.clone();
+            tokio::spawn(async move {
+                tool.call(
+                    json!({"path": path, "content": "BBB"}),
+                    CancellationToken::new(),
+                )
+                .await
+            })
+        };
+        let (ra, rb) = tokio::join!(ta, tb);
+        let ra = ra.unwrap().unwrap();
+        let rb = rb.unwrap().unwrap();
+
+        // Each ToolResult carries the diff for its own path — never
+        // the other's.
+        let da = ra.edit_diff.expect("call A should carry its own edit_diff");
+        let db = rb.edit_diff.expect("call B should carry its own edit_diff");
+        assert_eq!(da.path, path_a, "call A diff path mismatch");
+        assert_eq!(db.path, path_b, "call B diff path mismatch");
+        assert_eq!(da.after, "AAA");
+        assert_eq!(db.after, "BBB");
     }
 
     #[test]

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -25,6 +25,12 @@ pub struct ToolResult {
     /// (`Replaced 1 occurrence(s) in foo.rs`). Plain-output tools
     /// leave this `None` and the renderer falls back to `output`.
     pub display_preview: Option<String>,
+    /// Per-call diff record from a file-editing tool (YYC-131). Travels
+    /// with the result through the dispatch pipeline so AfterToolCall
+    /// hooks (e.g. DiagnosticsHook) can see *this* call's diff rather
+    /// than racing on a global last-write slot under concurrent
+    /// dispatch.
+    pub edit_diff: Option<EditDiff>,
 }
 
 impl ToolResult {
@@ -34,6 +40,7 @@ impl ToolResult {
             media: Vec::new(),
             is_error: false,
             display_preview: None,
+            edit_diff: None,
         }
     }
 
@@ -43,11 +50,20 @@ impl ToolResult {
             media: Vec::new(),
             is_error: true,
             display_preview: None,
+            edit_diff: None,
         }
     }
 
     pub fn with_display_preview(mut self, preview: impl Into<String>) -> Self {
         self.display_preview = Some(preview.into());
+        self
+    }
+
+    /// Attach the per-call edit diff so AfterToolCall hooks can react
+    /// to *this* call without racing on the global EditDiffSink slot
+    /// (YYC-131).
+    pub fn with_edit_diff(mut self, diff: EditDiff) -> Self {
+        self.edit_diff = Some(diff);
         self
     }
 }

--- a/src/tools/shell.rs
+++ b/src/tools/shell.rs
@@ -910,6 +910,7 @@ fn format_command_result(exit_code: i32, success: bool, stdout: &str, stderr: &s
         media: Vec::new(),
         is_error: !success,
         display_preview: None,
+        edit_diff: None,
     }
 }
 


### PR DESCRIPTION
Problem: EditDiffSink was Arc<parking_lot::Mutex<Option<EditDiff>>>
— a single-slot last-write-wins record. WriteFile and PatchFile
populated it after a successful write; DiagnosticsHook read it
during AfterToolCall to learn which file was edited.

When the agent dispatched concurrent tool calls
(futures_util::future::join_all in agent/run.rs), two near-
simultaneous edits to different paths would race the slot:

1. Call A writes diff_A to the sink.
2. Call B writes diff_B to the sink (overwrites diff_A).
3. AfterToolCall fires for call A → reads diff_B → runs
   diagnostics on the wrong file (or, if the tool name didn't
   match, silently skips).

Fix: attach the diff record to ToolResult itself so it travels
with the result through dispatch:

- ToolResult gains `pub edit_diff: Option<EditDiff>` plus a
  `with_edit_diff(diff)` builder.
- WriteFile / PatchFile build the diff once, then attach it to
  BOTH the global sink (for the TUI's last-write panel — the
  TUI specifically wants last-write-wins) AND the ToolResult
  returned from the call.
- DiagnosticsHook prefers `result.edit_diff` and only falls back
  to the sink (with the tool-name guard) when the per-call field
  is absent. Per-call data cannot race because it's bound to the
  result object that's about to be passed to *this* hook
  invocation.

Sites updated:
- src/tools/mod.rs: ToolResult gains the field + builder.
- src/tools/file.rs: WriteFile + PatchFile attach via
  with_edit_diff in addition to writing the global sink.
- src/tools/shell.rs: format_command_result struct literal gains
  the explicit None init for the new field.
- src/hooks/diagnostics.rs: prefer per-call diff; sink fallback
  validated by tool-name match.

Tests (3 new):
- write_file_attaches_per_call_edit_diff_to_tool_result
- patch_file_attaches_per_call_edit_diff_to_tool_result
- concurrent_writes_to_different_paths_each_carry_their_own_diff
  (acceptance pin): two parallel WriteFile calls under
  tokio::join! to different paths; each ToolResult carries its
  own diff regardless of which one wrote the sink last.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>