### PR TITLE
YYC-20: skill auto-creation from experience (LLM-driven drafts)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -91,6 +91,12 @@ max_hits = 5
 min_score = 0.0
 max_chars_per_hit = 400
 
+# YYC-20: after a 5+ iteration turn, ask the active provider to summarize
+# what was learned and write a draft skill to <skills_dir>/_pending/.
+# The user reviews + moves into <skills_dir>/ to activate. Off by
+# default — opting in burns extra tokens at the end of long turns.
+auto_create_skills = false
+
 [compaction]
 # Auto-compress context when token usage is high
 enabled = true

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -23,6 +23,7 @@ mod dispatch;
 mod provider;
 mod run;
 mod session;
+mod skills;
 
 #[cfg(test)]
 mod tests;
@@ -113,6 +114,11 @@ pub struct Agent {
     /// Workspace context probed at session start (YYC-107). Used to
     /// filter the tool registry and feed dynamic tool descriptions.
     pub(in crate::agent) tool_context: crate::tools::ToolContext,
+    /// YYC-20: when true, after a 5+ iteration turn the agent asks
+    /// the active provider to summarize the turn as a draft skill
+    /// and writes it under `<skills_dir>/_pending/`. Off by default
+    /// (`config.auto_create_skills`).
+    pub(in crate::agent) auto_create_skills: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -355,6 +361,7 @@ impl Agent {
             last_saved_count: 0,
             tool_context,
             max_iterations: max_iterations.unwrap_or(config.provider.max_iterations),
+            auto_create_skills: config.auto_create_skills,
         })
     }
 
@@ -424,6 +431,7 @@ impl Agent {
             tool_context: crate::tools::ToolContext::probe(
                 std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),
             ),
+            auto_create_skills: false,
         }
     }
 

--- a/src/agent/run.rs
+++ b/src/agent/run.rs
@@ -225,7 +225,7 @@ impl Agent {
                 self.save_messages(&messages)?;
                 self.turns = self.turns.saturating_add(1);
                 if iteration >= 5 {
-                    self.skills.try_auto_create(input, &text)?;
+                    let _ = self.auto_create_skill_from_turn(input, &text).await;
                 }
                 return Ok(text);
             }
@@ -383,7 +383,9 @@ impl Agent {
                 self.save_messages(&messages)?;
                 self.turns = self.turns.saturating_add(1);
                 if iteration >= 5 {
-                    self.skills.try_auto_create(input, &full_response)?;
+                    let _ = self
+                        .auto_create_skill_from_turn(input, &full_response)
+                        .await;
                 }
 
                 // YYC-104: empty terminal turn — surface a structured hint

--- a/src/agent/skills.rs
+++ b/src/agent/skills.rs
@@ -1,0 +1,225 @@
+//! Auto-skill creation (YYC-20).
+//!
+//! After a turn that took 5+ iterations, optionally ask the active
+//! provider to summarize what was learned as a reusable skill
+//! (name + description + triggers + content). Writes the draft to
+//! `<skills_dir>/_pending/<name>.md` for manual review — never
+//! installs to the active skills directory directly so the user
+//! always sees a draft before it loads.
+//!
+//! Gated by `config.auto_create_skills`. Off by default — opting in
+//! burns an extra LLM round-trip at the end of long turns.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use serde::Deserialize;
+
+use crate::provider::Message;
+
+use super::Agent;
+
+const GENERATION_SYSTEM_PROMPT: &str = "\
+You are a skill summarizer. The user just completed a multi-step task with an AI agent. \
+Distill what was learned into a reusable skill the agent can load on future tasks.
+
+Output JSON ONLY (no commentary, no code fences) matching this schema:
+{
+  \"name\": \"kebab-case-name\",
+  \"description\": \"one line summary\",
+  \"triggers\": [\"keyword\"],
+  \"content\": \"markdown body with the actual instructions\"
+}
+
+Constraints:
+- name: 3-40 chars, lowercase a-z 0-9 and dashes only.
+- description: 10-200 chars.
+- triggers: 1-5 short keywords or phrases.
+- content: markdown bullets / headings; concrete, actionable, under 1000 words.";
+
+#[derive(Debug, Deserialize)]
+struct DraftSkill {
+    /// Raw name from the LLM. Sanitized via `sanitize_skill_name`
+    /// before it's used as a filename / frontmatter slug, so the raw
+    /// field is intentionally not read directly elsewhere.
+    #[allow(dead_code)]
+    name: String,
+    description: String,
+    #[serde(default)]
+    triggers: Vec<String>,
+    content: String,
+}
+
+impl Agent {
+    /// Generate a draft skill from the just-completed turn and write
+    /// it to the pending directory. Returns the path on success.
+    /// Never errors on LLM / parse failure — logs and returns
+    /// `Ok(None)` so the agent loop is unaffected (YYC-20).
+    pub(in crate::agent) async fn auto_create_skill_from_turn(
+        &self,
+        input: &str,
+        response: &str,
+    ) -> Result<Option<PathBuf>> {
+        if !self.auto_create_skills {
+            return Ok(None);
+        }
+
+        let user_prompt = format!(
+            "User input:\n{}\n\nFinal agent response:\n{}\n\nGenerate the skill JSON now.",
+            input, response,
+        );
+        let messages = vec![
+            Message::System {
+                content: GENERATION_SYSTEM_PROMPT.to_string(),
+            },
+            Message::User {
+                content: user_prompt,
+            },
+        ];
+
+        let cancel = self.turn_cancel.clone();
+        let resp = match self.provider.chat(&messages, &[], cancel).await {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!("auto-skill: provider call failed: {e}");
+                return Ok(None);
+            }
+        };
+
+        let body = resp.content.unwrap_or_default();
+        let body = strip_json_fence(body.trim());
+        let draft: DraftSkill = match serde_json::from_str(body) {
+            Ok(d) => d,
+            Err(e) => {
+                tracing::warn!(
+                    "auto-skill: JSON parse failed ({e}). Body head: {:.100}",
+                    body
+                );
+                return Ok(None);
+            }
+        };
+
+        let safe_name = sanitize_skill_name(&draft.name);
+        if safe_name.is_empty() {
+            tracing::warn!("auto-skill: name sanitized to empty, skipping");
+            return Ok(None);
+        }
+
+        let pending_dir = self.skills.skills_dir().join("_pending");
+        std::fs::create_dir_all(&pending_dir)?;
+        let path = pending_dir.join(format!("{safe_name}.md"));
+        if path.exists() {
+            tracing::info!("auto-skill: draft for '{safe_name}' already pending review, skipping",);
+            return Ok(None);
+        }
+
+        let body = render_skill_markdown(&draft, &safe_name);
+        std::fs::write(&path, body)?;
+        tracing::info!("auto-skill: wrote draft to {}", path.display());
+        Ok(Some(path))
+    }
+}
+
+fn strip_json_fence(content: &str) -> &str {
+    if let Some(rest) = content.strip_prefix("```json") {
+        return rest.strip_suffix("```").unwrap_or(rest).trim();
+    }
+    if let Some(rest) = content.strip_prefix("```") {
+        return rest.strip_suffix("```").unwrap_or(rest).trim();
+    }
+    content
+}
+
+/// Lowercase + restrict to `[a-z0-9-]`, drop runs of dashes, cap length.
+/// Empty if nothing usable remains.
+fn sanitize_skill_name(raw: &str) -> String {
+    let mut out = String::new();
+    let mut last_dash = false;
+    for c in raw.trim().chars() {
+        let lower = c.to_ascii_lowercase();
+        if lower.is_ascii_alphanumeric() {
+            out.push(lower);
+            last_dash = false;
+        } else if (c == '-' || c == '_' || c.is_whitespace()) && !last_dash && !out.is_empty() {
+            out.push('-');
+            last_dash = true;
+        }
+    }
+    while out.ends_with('-') {
+        out.pop();
+    }
+    out.chars().take(40).collect()
+}
+
+fn render_skill_markdown(draft: &DraftSkill, sanitized_name: &str) -> String {
+    let triggers: Vec<String> = draft
+        .triggers
+        .iter()
+        .filter(|t| !t.trim().is_empty())
+        .take(8)
+        .map(|t| format!("\"{}\"", t.replace('"', "\\\"")))
+        .collect();
+    let triggers_line = if triggers.is_empty() {
+        "[]".to_string()
+    } else {
+        format!("[{}]", triggers.join(", "))
+    };
+    format!(
+        "---\nname: {sanitized_name}\ndescription: {description}\ntriggers: {triggers}\nauto_generated: true\n---\n\n{content}\n",
+        description = draft.description.replace('\n', " "),
+        triggers = triggers_line,
+        content = draft.content,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_skill_name_strips_punctuation_and_lowercases() {
+        assert_eq!(
+            sanitize_skill_name("Fix Bash Force Push"),
+            "fix-bash-force-push"
+        );
+        assert_eq!(sanitize_skill_name("config_migration"), "config-migration");
+        assert_eq!(sanitize_skill_name("...UPPER!CASE-name?"), "uppercase-name",);
+    }
+
+    #[test]
+    fn sanitize_skill_name_caps_length() {
+        let raw = "a".repeat(80);
+        let out = sanitize_skill_name(&raw);
+        assert!(out.len() <= 40);
+    }
+
+    #[test]
+    fn sanitize_skill_name_returns_empty_on_garbage() {
+        assert_eq!(sanitize_skill_name("?? ! / .,"), "");
+    }
+
+    #[test]
+    fn strip_json_fence_handles_json_marker_and_bare_fence() {
+        assert_eq!(strip_json_fence("```json\n{\"x\":1}\n```"), "{\"x\":1}",);
+        assert_eq!(strip_json_fence("```\n{\"x\":1}\n```"), "{\"x\":1}");
+        assert_eq!(strip_json_fence("{\"x\":1}"), "{\"x\":1}");
+    }
+
+    #[test]
+    fn render_skill_markdown_emits_frontmatter_and_body() {
+        let draft = DraftSkill {
+            name: "ignored-here".into(),
+            description: "Fix force-push safety".into(),
+            triggers: vec!["force push".into(), "git push -f".into()],
+            content: "## How\n- Use --force-with-lease".into(),
+        };
+        let out = render_skill_markdown(&draft, "fix-force-push");
+        assert!(out.starts_with("---"));
+        assert!(out.contains("name: fix-force-push"));
+        assert!(out.contains("description: Fix force-push safety"));
+        assert!(out.contains("\"force push\""));
+        assert!(out.contains("\"git push -f\""));
+        assert!(out.contains("auto_generated: true"));
+        assert!(out.contains("Use --force-with-lease"));
+    }
+}

--- a/src/agent/skills.rs
+++ b/src/agent/skills.rs
@@ -145,10 +145,13 @@ fn sanitize_skill_name(raw: &str) -> String {
             last_dash = true;
         }
     }
-    while out.ends_with('-') {
-        out.pop();
+
+    let mut result: String = out.chars().take(40).collect();
+    while result.ends_with('-') {
+        result.pop();
     }
-    out.chars().take(40).collect()
+    result
+
 }
 
 fn render_skill_markdown(draft: &DraftSkill, sanitized_name: &str) -> String {

--- a/src/config.rs
+++ b/src/config.rs
@@ -91,6 +91,14 @@ pub struct Config {
     #[serde(default = "default_skills_dir")]
     pub skills_dir: PathBuf,
 
+    /// YYC-20: when true, after 5+ iterations the agent asks the
+    /// active provider to summarize the turn as a draft skill and
+    /// writes it to `<skills_dir>/_pending/<name>.md` for manual
+    /// review. Off by default — opting in burns extra tokens at the
+    /// end of long turns.
+    #[serde(default)]
+    pub auto_create_skills: bool,
+
     #[serde(default)]
     pub compaction: CompactionConfig,
 
@@ -510,6 +518,7 @@ impl Default for Config {
             providers: HashMap::new(),
             tools: ToolsConfig::default(),
             skills_dir: default_skills_dir(),
+            auto_create_skills: false,
             compaction: CompactionConfig::default(),
             embeddings: EmbeddingsConfig::default(),
             tui: TuiConfig::default(),

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -156,19 +156,15 @@ impl SkillRegistry {
         self.skills.is_empty()
     }
 
+    /// Where this registry reads skill files from. Used by YYC-20's
+    /// auto-creation path to write drafts under
+    /// `<skills_dir>/_pending/<name>.md`.
+    pub fn skills_dir(&self) -> &PathBuf {
+        &self.skills_dir
+    }
+
     /// List all loaded skills
     pub fn list(&self) -> &[Skill] {
         &self.skills
-    }
-
-    /// Try to auto-create a skill from a complex interaction
-    pub fn try_auto_create(&self, input: &str, response: &str) -> Result<Option<String>> {
-        // This is a stub — in the real implementation, this would use the LLM
-        // to analyze the interaction and suggest a skill to save.
-        // For now, we log the opportunity.
-        tracing::info!(
-            "Auto-skill opportunity detected:\n  Input: {input:.80}\n  Response: {response:.80}"
-        );
-        Ok(None)
     }
 }


### PR DESCRIPTION
Replaces the old `SkillRegistry::try_auto_create` stub (which only
logged) with a real LLM-driven skill drafter wired into the Agent
loop. Off by default (opt-in via `config.auto_create_skills`)
because each fire burns an extra provider round-trip at the end
of a long turn.

Behavior when enabled:

1. Agent loop reaches iteration ≥ 5 and produces a final response.
2. `Agent::auto_create_skill_from_turn(input, response)` runs:
   - Builds a System+User pair asking the provider to emit a JSON
     skill (`name`, `description`, `triggers`, `content`).
   - Strips ```json fences if the model emitted them.
   - Parses via serde. Bad JSON → log warn, return Ok(None).
   - Sanitizes name to `[a-z0-9-]` lowercase, caps 40 chars,
     collapses dash runs.
   - Writes `<skills_dir>/_pending/<sanitized_name>.md` with
     frontmatter (`auto_generated: true`).
   - Skips if the pending file already exists (idempotent).
3. The loop ignores any error so a flaky generation never blocks
   the user-visible response.

Drafts land in `_pending/` so the user reviews + moves the file
into the active skills directory before it loads on a future
session — never installs to live skills automatically.

Files:
- src/config.rs: `Config.auto_create_skills: bool` (default false).
- src/skills/mod.rs: `skills_dir()` accessor; old stub removed.
- src/agent/skills.rs (NEW): `auto_create_skill_from_turn`,
  `sanitize_skill_name`, `strip_json_fence`,
  `render_skill_markdown`, plus DraftSkill JSON shape.
- src/agent/mod.rs: `mod skills;` + `auto_create_skills` field on
  Agent struct (wired from config; for_test sets false).
- src/agent/run.rs: both `try_auto_create` call sites swapped to
  `auto_create_skill_from_turn(...).await`. Errors absorbed via
  `let _ =` so generation never breaks the turn.
- config.example.toml: documented opt-in.

Tests (4 new, in src/agent/skills.rs):
- sanitize_skill_name lowercases + dashes punctuation, caps length,
  empty on garbage.
- strip_json_fence handles ```json marker, bare ```, and bare JSON.
- render_skill_markdown emits frontmatter with sanitized name +
  triggers + auto_generated marker + body.

Out of scope (deferred):
- Manual review prompt via PauseChannel — current flow is "draft
  to disk, user reviews next time." Pause-based interactive review
  needs the agent to know the user is at a TUI; CLI / gateway
  paths can't hold a turn open for an answer. Future iteration.
- `vulcan skills list` CLI command — drafts live under
  `_pending/`; `ls ~/.vulcan/skills/_pending` works for v1.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>