### PR TITLE
YYC-140: dedup base_url trim into provider::normalize_base_url

### DIFF
--- a/src/code/embed.rs
+++ b/src/code/embed.rs
@@ -100,7 +100,7 @@ impl EmbeddingIndex {
         } else {
             &self.cfg.base_url
         };
-        format!("{}/embeddings", base.trim_end_matches('/'))
+        format!("{}/embeddings", crate::provider::normalize_base_url(base))
     }
 
     fn api_key(&self) -> Option<&str> {

--- a/src/provider/catalog.rs
+++ b/src/provider/catalog.rs
@@ -70,7 +70,7 @@ impl OpenRouterCatalog {
     pub fn new(client: Client, base_url: &str, api_key: &str, cache_ttl: Duration) -> Self {
         Self {
             client,
-            base_url: base_url.trim_end_matches('/').to_string(),
+            base_url: super::normalize_base_url(base_url),
             api_key: api_key.to_string(),
             cache_ttl,
         }
@@ -197,7 +197,7 @@ impl OpenAICatalog {
     pub fn new(client: Client, base_url: &str, api_key: &str, cache_ttl: Duration) -> Self {
         Self {
             client,
-            base_url: base_url.trim_end_matches('/').to_string(),
+            base_url: super::normalize_base_url(base_url),
             api_key: api_key.to_string(),
             cache_ttl,
         }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -432,3 +432,11 @@ pub struct Usage {
     pub completion_tokens: usize,
     pub total_tokens: usize,
 }
+
+/// Strip a single trailing `/` so callers can interpolate `{base}/path`
+/// without doubling slashes. Idempotent: safe to call on already-clean URLs.
+/// One canonical helper instead of three open-coded `.trim_end_matches('/')`
+/// sites that drift apart over time.
+pub fn normalize_base_url(url: &str) -> String {
+    url.trim_end_matches('/').to_string()
+}

--- a/src/provider/openai.rs
+++ b/src/provider/openai.rs
@@ -43,7 +43,7 @@ impl OpenAIProvider {
 
         Ok(Self {
             client,
-            base_url: base_url.trim_end_matches('/').to_string(),
+            base_url: crate::provider::normalize_base_url(base_url),
             api_key: api_key.to_string(),
             model: model.to_string(),
             max_context,


### PR DESCRIPTION
## Summary

Four open-coded `.trim_end_matches('/')` sites against base URLs collapse into one canonical helper, `provider::normalize_base_url`.

Sites touched:
- `src/provider/openai.rs:46` (`OpenAiProvider::new`)
- `src/provider/catalog.rs:73` (`OpenRouterCatalog::new`)
- `src/provider/catalog.rs:200` (`OpenAICatalog::new`)
- `src/code/embed.rs:103` (`EmbedClient::endpoint`)

Future tweaks (multi-slash, scheme validation, etc.) land in one place rather than drifting across four.

Closes YYC-140.

## Test plan

- [x] `cargo test --lib` — 298 pass locally
- [ ] CI: build, nextest, doc-tests, clippy, deny, machete, feature-powerset