### PR TITLE
YYC-142: configurable max_output_tokens (drop hardcoded 8096)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -30,6 +30,11 @@ catalog_cache_ttl_hours = 24
 # When the agent hits this limit without a text-only response, the turn
 # ends with a "reached maximum iteration limit" message.
 # max_iterations = 0
+# Cap on output tokens (`max_tokens`) for a single response. Provider
+# default if unset (currently 8096). Lower this for small-context models
+# where the default would crowd out the prompt; raise it for long-form
+# output models that accept >8k.
+# max_output_tokens = 8096
 
 # Optional named provider profiles. The active TUI `/model` command uses
 # `[provider]` today; named profiles bind base URL, auth, and default model

--- a/src/config.rs
+++ b/src/config.rs
@@ -355,6 +355,12 @@ pub struct ProviderConfig {
     /// turn ends with a "reached maximum iteration limit" message.
     #[serde(default)]
     pub max_iterations: u32,
+    /// Cap on `max_tokens` (max output tokens) the provider will produce
+    /// for a single response. Provider default if `None` (currently 8096).
+    /// Lower this for small-context models where the default would crowd
+    /// out room for the prompt; raise it for models with long-form output.
+    #[serde(default)]
+    pub max_output_tokens: Option<usize>,
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]
@@ -497,6 +503,7 @@ impl Default for ProviderConfig {
             disable_catalog: false,
             debug: ProviderDebugMode::Off,
             max_iterations: 0,
+            max_output_tokens: None,
         }
     }
 }

--- a/src/provider/factory.rs
+++ b/src/provider/factory.rs
@@ -47,6 +47,7 @@ impl ProviderFactory for DefaultProviderFactory {
                     &cfg.model,
                     max_context,
                     cfg.max_retries,
+                    cfg.max_output_tokens,
                     json_mode,
                     cfg.debug,
                 )

--- a/src/provider/openai.rs
+++ b/src/provider/openai.rs
@@ -10,6 +10,11 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
+/// Default cap on output tokens when the user hasn't configured one.
+/// Anthropic Sonnet/Haiku, GPT-4o, OpenRouter all accept up to 8192;
+/// 8096 leaves a small margin and matches the historical hardcode.
+pub(crate) const DEFAULT_MAX_OUTPUT_TOKENS: usize = 8096;
+
 /// OpenAI-compatible provider (works with OpenRouter, Anthropic, Ollama, etc.)
 pub struct OpenAIProvider {
     client: Client,
@@ -18,6 +23,7 @@ pub struct OpenAIProvider {
     model: String,
     max_context: usize,
     max_retries: u32,
+    max_output_tokens: usize,
     /// Capability metadata from the provider catalog. This tells us the model
     /// can support structured outputs if some future caller explicitly asks
     /// for them, but normal chat/tool turns do not auto-enable
@@ -27,12 +33,14 @@ pub struct OpenAIProvider {
 }
 
 impl OpenAIProvider {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         base_url: &str,
         api_key: &str,
         model: &str,
         max_context: usize,
         max_retries: u32,
+        max_output_tokens: Option<usize>,
         supports_json_mode: bool,
         debug_mode: ProviderDebugMode,
     ) -> Result<Self> {
@@ -48,6 +56,7 @@ impl OpenAIProvider {
             model: model.to_string(),
             max_context,
             max_retries,
+            max_output_tokens: max_output_tokens.unwrap_or(DEFAULT_MAX_OUTPUT_TOKENS),
             _supports_json_mode: supports_json_mode,
             debug_mode,
         })
@@ -58,7 +67,7 @@ impl OpenAIProvider {
             "model": self.model,
             "messages": messages,
             "stream": true,
-            "max_tokens": 8096,
+            "max_tokens": self.max_output_tokens,
         });
 
         if !tools.is_empty() {
@@ -1052,6 +1061,7 @@ mod tests {
             "test-model",
             128_000,
             0,
+            None,
             supports_json_mode,
             ProviderDebugMode::Off,
         )


### PR DESCRIPTION
## Summary

`OpenAIProvider::build_request` was sending a hardcoded `"max_tokens": 8096` for every request. Two failure modes:

- **Small-context models** (DeepSeek 8K, older Llama, Ollama defaults) see `max_tokens=8096` against an 8K window — provider rejects or leaves zero room for the prompt.
- **Long-form output models** (Gemini 2.5, Claude extended-output that accept ≥16K output) get artificially capped at 8096 with no override.

Fix: add `max_output_tokens: Option<usize>` to `ProviderConfig`. Plumbed through `DefaultProviderFactory::build` → `OpenAIProvider::new` → `build_request`. `None` preserves historical 8096 via `DEFAULT_MAX_OUTPUT_TOKENS` constant in `provider/openai.rs`. `config.example.toml` documents the new field.

```toml
[provider]
max_output_tokens = 4096   # opt-in; 8096 if unset
```

Closes YYC-142.

## Test plan

- [x] `cargo test --lib` — 298 pass locally
- [ ] CI: build, nextest, doc-tests, clippy, deny, machete, feature-powerset