### PR TITLE
YYC-18 PR-1: add SentMessage, PlatformCapabilities, attachment types

### DIFF
--- a/src/gateway/discord.rs
+++ b/src/gateway/discord.rs
@@ -85,17 +85,25 @@ impl Platform for DiscordPlatform {
         Ok(())
     }
 
-    async fn send(&self, msg: &OutboundMessage) -> Result<()> {
+    async fn send(&self, msg: &OutboundMessage) -> Result<crate::platform::SentMessage> {
         let channel_id = ChannelId::new(Self::channel_id_from_chat(&msg.chat_id)?);
-        channel_id
+        let sent = channel_id
             .say(&self.http, &msg.text)
             .await
             .context("discord send failed")?;
-        Ok(())
+        Ok(crate::platform::SentMessage {
+            message_id: sent.id.get().to_string(),
+        })
     }
 
     async fn recv(&self) -> Result<InboundMessage> {
         anyhow::bail!("discord receives messages through the Serenity gateway task")
+    }
+
+    fn capabilities(&self) -> crate::platform::PlatformCapabilities {
+        // PR-1 declares only what's wired today (text-only send). PR-4
+        // flips edit + media + threads to true alongside their wire impls.
+        crate::platform::PlatformCapabilities::default()
     }
 }
 
@@ -190,5 +198,18 @@ mod tests {
     fn channel_id_from_chat_rejects_non_numeric_chat_id() {
         let err = DiscordPlatform::channel_id_from_chat("not-a-channel").expect_err("invalid id");
         assert!(err.to_string().contains("invalid Discord channel id"));
+    }
+
+    #[test]
+    fn discord_capabilities_declare_no_features_for_now() {
+        // PR-1 declares Discord's current shipping surface (no edit, no
+        // typed media). PR-4 flips these to true alongside the matching
+        // wire impls.
+        let p = DiscordPlatform::new("Bot abc.def.ghi").expect("ctor");
+        let caps = p.capabilities();
+        assert!(!caps.supports_edit);
+        assert!(!caps.supports_media_send);
+        assert!(!caps.supports_media_recv);
+        assert!(!caps.supports_threads);
     }
 }

--- a/src/gateway/loopback.rs
+++ b/src/gateway/loopback.rs
@@ -63,7 +63,7 @@ impl Platform for LoopbackPlatform {
         Ok(())
     }
 
-    async fn send(&self, msg: &OutboundMessage) -> Result<()> {
+    async fn send(&self, msg: &OutboundMessage) -> Result<crate::platform::SentMessage> {
         // Atomic compare-and-decrement: if there are failures left, decrement
         // and error; else record and return Ok.
         loop {
@@ -80,7 +80,13 @@ impl Platform for LoopbackPlatform {
             }
         }
         self.recorded.lock().await.push(msg.clone());
-        Ok(())
+        Ok(crate::platform::SentMessage {
+            message_id: uuid::Uuid::new_v4().to_string(),
+        })
+    }
+
+    fn capabilities(&self) -> crate::platform::PlatformCapabilities {
+        crate::platform::PlatformCapabilities::default()
     }
 
     async fn recv(&self) -> Result<InboundMessage> {
@@ -177,5 +183,28 @@ mod tests {
         assert!(lp.send(&m).await.is_ok());
         assert!(lp.send(&m).await.is_ok());
         assert_eq!(lp.recorded().await.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn loopback_send_returns_unique_message_ids() {
+        let lp = LoopbackPlatform::new();
+        let m = OutboundMessage {
+            platform: "loopback".into(),
+            chat_id: "c".into(),
+            text: "x".into(),
+            attachments: vec![],
+        };
+        let s1 = lp.send(&m).await.unwrap();
+        let s2 = lp.send(&m).await.unwrap();
+        assert_ne!(s1.message_id, s2.message_id);
+        assert!(!s1.message_id.is_empty());
+    }
+
+    #[test]
+    fn loopback_capabilities_declare_no_features_for_now() {
+        let lp = LoopbackPlatform::new();
+        let caps = lp.capabilities();
+        assert!(!caps.supports_edit);
+        assert!(!caps.supports_media_send);
     }
 }

--- a/src/gateway/loopback.rs
+++ b/src/gateway/loopback.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
 use tokio::sync::Mutex;
+use uuid::Uuid;
 
 use crate::platform::{InboundMessage, OutboundMessage, Platform};
 
@@ -81,7 +82,7 @@ impl Platform for LoopbackPlatform {
         }
         self.recorded.lock().await.push(msg.clone());
         Ok(crate::platform::SentMessage {
-            message_id: uuid::Uuid::new_v4().to_string(),
+            message_id: Uuid::new_v4().to_string(),
         })
     }
 

--- a/src/gateway/outbound.rs
+++ b/src/gateway/outbound.rs
@@ -97,7 +97,9 @@ async fn drain_due(queue: &OutboundQueue, registry: &PlatformRegistry) -> anyhow
             attachments: row.attachments,
         };
         match registry.send(&msg).await {
-            Ok(()) => queue.mark_done(id).await?,
+            Ok(_sent) => queue.mark_done(id).await?,
+            // PR-2 will capture `_sent.message_id` into RenderRegistry so
+            // edit-in-place can target it. For PR-1 the id is logged-only.
             Err(e) => queue.mark_failed(id, &e.to_string()).await?,
         }
     }

--- a/src/gateway/registry.rs
+++ b/src/gateway/registry.rs
@@ -32,7 +32,7 @@ impl PlatformRegistry {
         self.inner.get(name).cloned()
     }
 
-    pub async fn send(&self, msg: &OutboundMessage) -> Result<()> {
+    pub async fn send(&self, msg: &OutboundMessage) -> Result<crate::platform::SentMessage> {
         let plat = self
             .get(&msg.platform)
             .ok_or_else(|| anyhow!("unknown platform: {}", msg.platform))?;
@@ -80,6 +80,21 @@ mod tests {
     async fn registry_get_returns_none_for_missing() {
         let reg = PlatformRegistry::new();
         assert!(reg.get("nope").is_none());
+    }
+
+    #[tokio::test]
+    async fn registry_send_returns_sent_message_id() {
+        let lp = Arc::new(LoopbackPlatform::default());
+        let mut reg = PlatformRegistry::new();
+        reg.register("loopback", lp.clone());
+        let sent = reg
+            .send(&out_msg("loopback", "c", "hello"))
+            .await
+            .expect("send ok");
+        assert!(!sent.message_id.is_empty(), "message id should be set");
+        let recorded = lp.recorded().await;
+        assert_eq!(recorded.len(), 1);
+        assert_eq!(recorded[0].text, "hello");
     }
 
     #[tokio::test]

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -78,9 +78,12 @@ pub struct Attachment {
 
 /// An attachment to send. `OutboundMessage` will gain a `Vec<Self>`
 /// in PR-2 once StreamRenderer wires media into the outbound pipeline.
+/// `path` is the local file to upload — `PathBuf` matches what
+/// `Platform::download_attachment` returns so a roundtrip
+/// (receive → re-send) is friction-free.
 #[derive(Debug, Clone)]
 pub struct OutboundAttachment {
-    pub path: String,
+    pub path: std::path::PathBuf,
     pub kind: AttachmentKind,
     pub caption: Option<String>,
 }
@@ -170,11 +173,11 @@ mod tests {
     #[test]
     fn outbound_attachment_carries_path_and_kind() {
         let a = OutboundAttachment {
-            path: "/tmp/x.png".into(),
+            path: std::path::PathBuf::from("/tmp/x.png"),
             kind: AttachmentKind::Image,
             caption: None,
         };
-        assert_eq!(a.path, "/tmp/x.png");
+        assert_eq!(a.path, std::path::PathBuf::from("/tmp/x.png"));
     }
 
     struct StubPlatform;

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -90,17 +90,34 @@ pub struct OutboundAttachment {
 pub trait Platform: Send + Sync {
     fn name(&self) -> &str;
     async fn start(&self) -> Result<()>;
-    async fn send(&self, msg: &OutboundMessage) -> Result<()>;
+
+    /// Deliver `msg`. Returns the platform's id for the sent message
+    /// so the caller can target it later via `edit` (PR-2 wires this
+    /// through the StreamRenderer).
+    async fn send(&self, msg: &OutboundMessage) -> Result<SentMessage>;
+
     async fn recv(&self) -> Result<InboundMessage>;
 
-    /// Verify a platform-specific webhook request and return the parsed
-    /// `InboundMessage`. The default impl errors so platforms that don't
-    /// accept webhooks (loopback in production, future poll-only platforms)
-    /// don't have to implement it. Webhook handlers (`POST /webhook/:platform`)
-    /// pass the raw request headers + body so each platform can apply its own
-    /// HMAC scheme + payload schema. Uses `http::HeaderMap` (not
-    /// `axum::http::HeaderMap`) so this trait stays free of an axum dep —
-    /// `http` is a small standalone crate axum re-exports anyway.
+    /// Edit the text of an already-sent message. Default impl bails so
+    /// platforms that don't support edits can ignore this method.
+    /// Capability-discoverable via `capabilities().supports_edit`.
+    async fn edit(&self, _chat_id: &str, _message_id: &str, _text: &str) -> Result<()> {
+        anyhow::bail!("platform does not support edit")
+    }
+
+    /// Download a received attachment to a local path. Default impl
+    /// bails so platforms that don't host attachments (loopback today)
+    /// can ignore this method.
+    async fn download_attachment(&self, _att: &Attachment) -> Result<std::path::PathBuf> {
+        anyhow::bail!("platform does not support attachment download")
+    }
+
+    /// Declarative feature snapshot. Default = nothing supported.
+    /// Concrete platforms override.
+    fn capabilities(&self) -> PlatformCapabilities {
+        PlatformCapabilities::default()
+    }
+
     async fn verify_webhook(
         &self,
         _headers: &http::HeaderMap,
@@ -158,5 +175,59 @@ mod tests {
             caption: None,
         };
         assert_eq!(a.path, "/tmp/x.png");
+    }
+
+    struct StubPlatform;
+
+    #[async_trait::async_trait]
+    impl Platform for StubPlatform {
+        fn name(&self) -> &str {
+            "stub"
+        }
+        async fn start(&self) -> Result<()> {
+            Ok(())
+        }
+        async fn send(&self, _msg: &OutboundMessage) -> Result<SentMessage> {
+            Ok(SentMessage {
+                message_id: "stub-1".into(),
+            })
+        }
+        async fn recv(&self) -> Result<InboundMessage> {
+            anyhow::bail!("stub has no inbound")
+        }
+    }
+
+    #[tokio::test]
+    async fn default_edit_impl_returns_unsupported_error() {
+        let p = StubPlatform;
+        let err = p
+            .edit("c", "m", "x")
+            .await
+            .expect_err("default should bail");
+        assert!(err.to_string().contains("not support"));
+    }
+
+    #[tokio::test]
+    async fn default_download_attachment_returns_unsupported_error() {
+        let p = StubPlatform;
+        let att = Attachment {
+            url: None,
+            local_path: None,
+            mime: None,
+            kind: AttachmentKind::Other,
+            original_name: None,
+        };
+        let err = p
+            .download_attachment(&att)
+            .await
+            .expect_err("default should bail");
+        assert!(err.to_string().contains("not support"));
+    }
+
+    #[test]
+    fn default_capabilities_is_zero_features() {
+        let p = StubPlatform;
+        let caps = p.capabilities();
+        assert_eq!(caps, PlatformCapabilities::default());
     }
 }

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -23,6 +23,68 @@ pub struct OutboundMessage {
     pub attachments: Vec<String>,
 }
 
+/// Result of a successful `Platform::send`. Carries the platform's
+/// message id so the caller can later target it for edit-in-place
+/// streaming (YYC-18 PR-2 wires this into the StreamRenderer).
+#[derive(Debug, Clone)]
+pub struct SentMessage {
+    pub message_id: String,
+}
+
+/// What a platform supports. Drives renderer behavior — the
+/// StreamRenderer (PR-2) reads `supports_edit` to decide whether to
+/// stream via edits or append fresh messages, and `edit_min_interval_ms`
+/// to throttle edit calls under platform rate limits.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PlatformCapabilities {
+    pub supports_edit: bool,
+    pub supports_media_send: bool,
+    pub supports_media_recv: bool,
+    pub supports_threads: bool,
+    /// Minimum interval between consecutive `edit` calls for the same
+    /// message, in milliseconds. 0 means edits are not supported (or
+    /// the platform doesn't impose a floor — but in practice the value
+    /// is set when `supports_edit = true`).
+    pub edit_min_interval_ms: u64,
+}
+
+/// Type of a media attachment. Drives the platform-side decoder
+/// (Telegram has separate `send_photo` / `send_document` / `send_voice`
+/// endpoints; Discord uploads any file the same way but the kind still
+/// drives rendering hints).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum AttachmentKind {
+    Image,
+    Document,
+    Audio,
+    Video,
+    Voice,
+    Sticker,
+    #[default]
+    Other,
+}
+
+/// An attachment received from a platform. `local_path` is populated
+/// after `Platform::download_attachment` materializes the bytes.
+/// Receivers store these on `InboundMessage.attachments` (PR-2).
+#[derive(Debug, Clone)]
+pub struct Attachment {
+    pub url: Option<String>,
+    pub local_path: Option<String>,
+    pub mime: Option<String>,
+    pub kind: AttachmentKind,
+    pub original_name: Option<String>,
+}
+
+/// An attachment to send. `OutboundMessage` will gain a `Vec<Self>`
+/// in PR-2 once StreamRenderer wires media into the outbound pipeline.
+#[derive(Debug, Clone)]
+pub struct OutboundAttachment {
+    pub path: String,
+    pub kind: AttachmentKind,
+    pub caption: Option<String>,
+}
+
 /// A platform that can send and receive messages
 #[async_trait::async_trait]
 pub trait Platform: Send + Sync {
@@ -45,5 +107,56 @@ pub trait Platform: Send + Sync {
         _body: &[u8],
     ) -> Result<InboundMessage> {
         anyhow::bail!("platform does not accept webhooks")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sent_message_carries_string_id() {
+        let s = SentMessage {
+            message_id: "abc123".into(),
+        };
+        assert_eq!(s.message_id, "abc123");
+    }
+
+    #[test]
+    fn platform_capabilities_default_is_zero_features() {
+        let caps = PlatformCapabilities::default();
+        assert!(!caps.supports_edit);
+        assert!(!caps.supports_media_send);
+        assert!(!caps.supports_media_recv);
+        assert!(!caps.supports_threads);
+        assert_eq!(caps.edit_min_interval_ms, 0);
+    }
+
+    #[test]
+    fn attachment_kind_default_is_other() {
+        assert_eq!(AttachmentKind::default(), AttachmentKind::Other);
+    }
+
+    #[test]
+    fn attachment_carries_optional_fields() {
+        let a = Attachment {
+            url: Some("https://x".into()),
+            local_path: None,
+            mime: Some("image/png".into()),
+            kind: AttachmentKind::Image,
+            original_name: Some("x.png".into()),
+        };
+        assert_eq!(a.kind, AttachmentKind::Image);
+        assert!(a.local_path.is_none());
+    }
+
+    #[test]
+    fn outbound_attachment_carries_path_and_kind() {
+        let a = OutboundAttachment {
+            path: "/tmp/x.png".into(),
+            kind: AttachmentKind::Image,
+            caption: None,
+        };
+        assert_eq!(a.path, "/tmp/x.png");
     }
 }


### PR DESCRIPTION
YYC-18 PR-1: add SentMessage, PlatformCapabilities, attachment types

Net-new types only — no existing surface touched yet. PR-2/3/4 wire
these into the StreamRenderer + Telegram + Discord parity work.

* SentMessage  — carries the platform's id back so the next chunk
                 can target it for edit-in-place.
* PlatformCapabilities — declarative feature flags + edit throttle
                         floor.
* Attachment / OutboundAttachment / AttachmentKind — typed media
                 plumbing, unused this PR.

cargo test --lib platform::tests passes (5 new tests).

YYC-18 PR-1: extend Platform trait with edit/download/capabilities

* `send` now returns `SentMessage` so the caller can target the
  produced message for later edits.
* `edit(chat_id, message_id, text)` — default bails. Platforms that
  support it (Telegram, Discord) will override in PR-3/4.
* `download_attachment(&Attachment)` — default bails. Same story.
* `capabilities() -> PlatformCapabilities` — default = zero features.

Existing trait callers (PlatformRegistry, OutboundDispatcher,
LoopbackPlatform, DiscordPlatform) will fail to compile until
Tasks 3-5 update them. That's intentional — keeps each commit
small and easy to read.

YYC-18 PR-1: thread SentMessage return through registry + platforms

* PlatformRegistry::send returns Result<SentMessage>.
* OutboundDispatcher::drain_due ignores the id for now (PR-2 wires
  it into RenderRegistry for edit-in-place).
* LoopbackPlatform::send synthesizes a UUID v4 — fixtures need
  unique ids per send to test the renderer's edit-target capture.
* DiscordPlatform::send returns Message::id stringified.
* Both impls override capabilities() with the default (zero features)
  so the trait method's "PR-4 flips these on" semantics is explicit.

cargo test --lib green: 16 platform/loopback/discord/registry tests
including 5 new ones from PR-1.