### PR TITLE
YYC-18 PR-2a: extend InboundMessage + OutboundMessage with new fields

### DIFF
--- a/src/gateway/discord.rs
+++ b/src/gateway/discord.rs
@@ -45,6 +45,9 @@ impl DiscordPlatform {
             chat_id: channel_id.to_string(),
             user_id: user_id.to_string(),
             text: text.to_string(),
+            message_id: None,
+            reply_to: None,
+            attachments: vec![],
         })
     }
 

--- a/src/gateway/loopback.rs
+++ b/src/gateway/loopback.rs
@@ -141,6 +141,9 @@ impl Platform for LoopbackPlatform {
             chat_id: parsed["chat_id"].as_str().unwrap_or_default().to_string(),
             user_id: parsed["user_id"].as_str().unwrap_or_default().to_string(),
             text: parsed["text"].as_str().unwrap_or_default().to_string(),
+            message_id: None,
+            reply_to: None,
+            attachments: vec![],
         })
     }
 }
@@ -157,6 +160,8 @@ mod tests {
             chat_id: "c".into(),
             text: "one".into(),
             attachments: vec![],
+            reply_to: None,
+            edit_target: None,
         };
         let m2 = OutboundMessage {
             text: "two".into(),
@@ -178,6 +183,8 @@ mod tests {
             chat_id: "c".into(),
             text: "x".into(),
             attachments: vec![],
+            reply_to: None,
+            edit_target: None,
         };
         assert!(lp.send(&m).await.is_err());
         assert!(lp.send(&m).await.is_err());
@@ -194,6 +201,8 @@ mod tests {
             chat_id: "c".into(),
             text: "x".into(),
             attachments: vec![],
+            reply_to: None,
+            edit_target: None,
         };
         let s1 = lp.send(&m).await.unwrap();
         let s2 = lp.send(&m).await.unwrap();

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -417,6 +417,9 @@ mod tests {
                 chat_id: "c".into(),
                 user_id: "u".into(),
                 text: "recover me".into(),
+                message_id: None,
+                reply_to: None,
+                attachments: vec![],
             })
             .await
             .unwrap();

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -92,8 +92,13 @@ where
     }
 
     let evictor = agent_map.spawn_evictor();
-    let outbound_dispatcher =
-        OutboundDispatcher::new(Arc::clone(&outbound), Arc::clone(&registry)).spawn();
+    let render_registry = Arc::new(crate::gateway::render_registry::RenderRegistry::new());
+    let outbound_dispatcher = OutboundDispatcher::new(
+        Arc::clone(&outbound),
+        Arc::clone(&registry),
+        Arc::clone(&render_registry),
+    )
+    .spawn();
     let discord_dispatcher = if gateway.discord.enabled {
         Some(DiscordPlatform::spawn_gateway_client(
             gateway.discord.bot_token.clone(),

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -26,6 +26,7 @@ pub mod registry;
 pub mod render_registry;
 pub mod routes;
 pub mod server;
+pub mod stream_render;
 pub mod worker;
 
 pub async fn run(config: &Config, bind_override: Option<String>) -> Result<()> {

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -23,6 +23,7 @@ pub mod loopback;
 pub mod outbound;
 pub mod queue;
 pub mod registry;
+pub mod render_registry;
 pub mod routes;
 pub mod server;
 pub mod worker;

--- a/src/gateway/outbound.rs
+++ b/src/gateway/outbound.rs
@@ -119,6 +119,11 @@ async fn drain_due(
         };
         let result = if let Some(anchor) = edit_target {
             // Route to edit; ignore SentMessage shape (edit returns ()).
+            // PR-2b TODO: on persistent edit failure (anchor stale,
+            // message deleted, message-too-old), forget the registry
+            // anchor and fall back to a fresh send rather than retry
+            // the same edit forever. Today, mark_failed reschedules
+            // and the next attempt re-edits the same anchor.
             let plat = registry
                 .get(&msg.platform)
                 .ok_or_else(|| anyhow::anyhow!("unknown platform: {}", msg.platform))?;
@@ -140,6 +145,16 @@ async fn drain_due(
                         chat_id: msg.chat_id.clone(),
                         turn_id: msg.chat_id.clone(),
                     };
+                    // PR-2b TODO: anchor write happens before mark_done.
+                    // If the subsequent mark_done fails (DB pool / disk),
+                    // recover_sending will re-deliver the row → second
+                    // Platform::send → second visible message, but the
+                    // registry still holds the *first* anchor. The next
+                    // edit then targets a message whose body diverges
+                    // from what the registry expects. Move the
+                    // set_anchor call into a transaction with mark_done
+                    // (or capture-after-mark-done) when worker streaming
+                    // lands.
                     render_registry.set_anchor(key, sent.message_id);
                     Ok(())
                 }

--- a/src/gateway/outbound.rs
+++ b/src/gateway/outbound.rs
@@ -14,19 +14,26 @@ use tokio::task::JoinHandle;
 
 use crate::gateway::queue::OutboundQueue;
 use crate::gateway::registry::PlatformRegistry;
+use crate::gateway::render_registry::{RenderKey, RenderRegistry};
 use crate::platform::OutboundMessage;
 
 pub struct OutboundDispatcher {
     queue: Arc<OutboundQueue>,
     registry: Arc<PlatformRegistry>,
+    render_registry: Arc<RenderRegistry>,
     poll_interval: Duration,
 }
 
 impl OutboundDispatcher {
-    pub fn new(queue: Arc<OutboundQueue>, registry: Arc<PlatformRegistry>) -> Self {
+    pub fn new(
+        queue: Arc<OutboundQueue>,
+        registry: Arc<PlatformRegistry>,
+        render_registry: Arc<RenderRegistry>,
+    ) -> Self {
         Self {
             queue,
             registry,
+            render_registry,
             poll_interval: Duration::from_millis(250),
         }
     }
@@ -42,9 +49,15 @@ impl OutboundDispatcher {
         let Self {
             queue,
             registry,
+            render_registry,
             poll_interval,
         } = self;
-        let handle = tokio::spawn(dispatch_loop(queue, registry, poll_interval));
+        let handle = tokio::spawn(dispatch_loop(
+            queue,
+            registry,
+            render_registry,
+            poll_interval,
+        ));
         OutboundDispatcherHandle { handle }
     }
 }
@@ -68,6 +81,7 @@ impl Drop for OutboundDispatcherHandle {
 async fn dispatch_loop(
     queue: Arc<OutboundQueue>,
     registry: Arc<PlatformRegistry>,
+    render_registry: Arc<RenderRegistry>,
     poll_interval: Duration,
 ) {
     let mut ticker = tokio::time::interval(poll_interval);
@@ -77,19 +91,24 @@ async fn dispatch_loop(
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     loop {
         ticker.tick().await;
-        if let Err(e) = drain_due(&queue, &registry).await {
+        if let Err(e) = drain_due(&queue, &registry, &render_registry).await {
             tracing::error!(target: "gateway::outbound", error = %e, "drain_due errored");
         }
     }
 }
 
-async fn drain_due(queue: &OutboundQueue, registry: &PlatformRegistry) -> anyhow::Result<()> {
+async fn drain_due(
+    queue: &OutboundQueue,
+    registry: &PlatformRegistry,
+    render_registry: &RenderRegistry,
+) -> anyhow::Result<()> {
     loop {
         let now = chrono::Utc::now().timestamp();
         let Some(row) = queue.claim_due(now).await? else {
             return Ok(());
         };
         let id = row.id;
+        let edit_target = row.edit_target.clone();
         let msg = OutboundMessage {
             platform: row.platform,
             chat_id: row.chat_id,
@@ -98,10 +117,37 @@ async fn drain_due(queue: &OutboundQueue, registry: &PlatformRegistry) -> anyhow
             reply_to: row.reply_to,
             edit_target: row.edit_target,
         };
-        match registry.send(&msg).await {
-            Ok(_sent) => queue.mark_done(id).await?,
-            // PR-2 will capture `_sent.message_id` into RenderRegistry so
-            // edit-in-place can target it. For PR-1 the id is logged-only.
+        let result = if let Some(anchor) = edit_target {
+            // Route to edit; ignore SentMessage shape (edit returns ()).
+            let plat = registry
+                .get(&msg.platform)
+                .ok_or_else(|| anyhow::anyhow!("unknown platform: {}", msg.platform))?;
+            plat.edit(&msg.chat_id, &anchor, &msg.text).await
+        } else {
+            // First send: capture the SentMessage id into RenderRegistry
+            // under the lane key so the next chunk can target it.
+            let plat = registry
+                .get(&msg.platform)
+                .ok_or_else(|| anyhow::anyhow!("unknown platform: {}", msg.platform))?;
+            match plat.send(&msg).await {
+                Ok(sent) => {
+                    // Build the RenderKey from (platform, chat_id, turn_id).
+                    // Turn id isn't stored on the row in PR-2a — use chat_id
+                    // as a stand-in. PR-2b adds a turn_id column when it
+                    // wires the worker streaming path.
+                    let key = RenderKey {
+                        platform: msg.platform.clone(),
+                        chat_id: msg.chat_id.clone(),
+                        turn_id: msg.chat_id.clone(),
+                    };
+                    render_registry.set_anchor(key, sent.message_id);
+                    Ok(())
+                }
+                Err(e) => Err(e),
+            }
+        };
+        match result {
+            Ok(()) => queue.mark_done(id).await?,
             Err(e) => queue.mark_failed(id, &e.to_string()).await?,
         }
     }
@@ -141,7 +187,8 @@ mod tests {
         let mut reg = PlatformRegistry::new();
         reg.register("loopback", lp.clone());
         let reg = Arc::new(reg);
-        let dispatcher = OutboundDispatcher::new(q.clone(), reg)
+        let render_reg = Arc::new(RenderRegistry::new());
+        let dispatcher = OutboundDispatcher::new(q.clone(), reg, render_reg)
             .with_poll_interval(Duration::from_millis(20))
             .spawn();
 
@@ -160,6 +207,98 @@ mod tests {
         drop(dispatcher);
     }
 
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct EditTrackingPlatform {
+        send_calls: Arc<AtomicUsize>,
+        edit_calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::platform::Platform for EditTrackingPlatform {
+        fn name(&self) -> &str {
+            "edit-tracker"
+        }
+        async fn start(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn send(
+            &self,
+            _msg: &OutboundMessage,
+        ) -> anyhow::Result<crate::platform::SentMessage> {
+            self.send_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(crate::platform::SentMessage {
+                message_id: "tracked-1".into(),
+            })
+        }
+        async fn edit(&self, _c: &str, _m: &str, _t: &str) -> anyhow::Result<()> {
+            self.edit_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+        async fn recv(&self) -> anyhow::Result<crate::platform::InboundMessage> {
+            anyhow::bail!("no recv")
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatcher_routes_to_edit_when_edit_target_set() {
+        let queue = Arc::new(OutboundQueue::new(fresh_db(), 5));
+        let render_reg = Arc::new(RenderRegistry::new());
+        let send_calls = Arc::new(AtomicUsize::new(0));
+        let edit_calls = Arc::new(AtomicUsize::new(0));
+        let plat = Arc::new(EditTrackingPlatform {
+            send_calls: send_calls.clone(),
+            edit_calls: edit_calls.clone(),
+        });
+        let mut reg = PlatformRegistry::new();
+        reg.register("edit-tracker", plat);
+        let registry = Arc::new(reg);
+
+        queue
+            .enqueue(OutboundMessage {
+                platform: "edit-tracker".into(),
+                chat_id: "c".into(),
+                text: "edit me".into(),
+                attachments: vec![],
+                reply_to: None,
+                edit_target: Some("anchor-1".into()),
+            })
+            .await
+            .unwrap();
+        drain_due(&queue, &registry, &render_reg).await.unwrap();
+        assert_eq!(send_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(edit_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn dispatcher_captures_send_anchor_into_render_registry() {
+        let queue = Arc::new(OutboundQueue::new(fresh_db(), 5));
+        let render_reg = Arc::new(RenderRegistry::new());
+        let plat = Arc::new(LoopbackPlatform::default());
+        let mut reg = PlatformRegistry::new();
+        reg.register("loopback", plat);
+        let registry = Arc::new(reg);
+
+        queue
+            .enqueue(OutboundMessage {
+                platform: "loopback".into(),
+                chat_id: "c".into(),
+                text: "first".into(),
+                attachments: vec![],
+                reply_to: None,
+                edit_target: None,
+            })
+            .await
+            .unwrap();
+        drain_due(&queue, &registry, &render_reg).await.unwrap();
+        let anchor = render_reg.anchor(&RenderKey {
+            platform: "loopback".into(),
+            chat_id: "c".into(),
+            turn_id: "c".into(),
+        });
+        assert!(anchor.is_some(), "first send should populate the registry");
+    }
+
     #[tokio::test]
     async fn failed_send_retries_after_backoff() {
         let db = fresh_db();
@@ -171,7 +310,8 @@ mod tests {
 
         let id = q.enqueue(out_msg("payload")).await.unwrap();
 
-        let dispatcher = OutboundDispatcher::new(q.clone(), reg)
+        let render_reg = Arc::new(RenderRegistry::new());
+        let dispatcher = OutboundDispatcher::new(q.clone(), reg, render_reg)
             .with_poll_interval(Duration::from_millis(20))
             .spawn();
 

--- a/src/gateway/outbound.rs
+++ b/src/gateway/outbound.rs
@@ -95,6 +95,8 @@ async fn drain_due(queue: &OutboundQueue, registry: &PlatformRegistry) -> anyhow
             chat_id: row.chat_id,
             text: row.text,
             attachments: row.attachments,
+            reply_to: None,
+            edit_target: None,
         };
         match registry.send(&msg).await {
             Ok(_sent) => queue.mark_done(id).await?,
@@ -127,6 +129,8 @@ mod tests {
             chat_id: "c".into(),
             text: text.into(),
             attachments: vec![],
+            reply_to: None,
+            edit_target: None,
         }
     }
 

--- a/src/gateway/outbound.rs
+++ b/src/gateway/outbound.rs
@@ -95,8 +95,8 @@ async fn drain_due(queue: &OutboundQueue, registry: &PlatformRegistry) -> anyhow
             chat_id: row.chat_id,
             text: row.text,
             attachments: row.attachments,
-            reply_to: None,
-            edit_target: None,
+            reply_to: row.reply_to,
+            edit_target: row.edit_target,
         };
         match registry.send(&msg).await {
             Ok(_sent) => queue.mark_done(id).await?,

--- a/src/gateway/queue.rs
+++ b/src/gateway/queue.rs
@@ -455,6 +455,9 @@ mod tests {
             chat_id: "c1".into(),
             user_id: "u1".into(),
             text: "hi".into(),
+            message_id: None,
+            reply_to: None,
+            attachments: vec![],
         }
     }
 
@@ -464,6 +467,8 @@ mod tests {
             chat_id: "c1".into(),
             text: "hello".into(),
             attachments: vec![],
+            reply_to: None,
+            edit_target: None,
         }
     }
 
@@ -739,6 +744,8 @@ mod tests {
                     chat_id: "c1".into(),
                     text: "reply".into(),
                     attachments: vec![],
+                    reply_to: None,
+                    edit_target: None,
                 },
             )
             .await

--- a/src/gateway/queue.rs
+++ b/src/gateway/queue.rs
@@ -362,7 +362,7 @@ impl OutboundQueue {
              SET state='sending', attempts = attempts + 1 \
              WHERE id = (SELECT id FROM outbound_queue \
                          WHERE state='pending' AND next_attempt_at <= ?1 \
-                         ORDER BY next_attempt_at ASC LIMIT 1) \
+                         ORDER BY next_attempt_at ASC, id ASC LIMIT 1) \
              RETURNING id, platform, chat_id, text, attachments_json, enqueued_at, \
                        next_attempt_at, attempts, state, last_error, edit_target, reply_to",
         )?;

--- a/src/gateway/queue.rs
+++ b/src/gateway/queue.rs
@@ -2,7 +2,7 @@ use anyhow::{Result, anyhow};
 use rusqlite::params;
 
 use crate::memory::DbPool;
-use crate::platform::{InboundMessage, OutboundMessage};
+use crate::platform::{InboundMessage, OutboundAttachment, OutboundMessage};
 
 /// Default per-row attempt cap before mark_failed routes a row to the
 /// dead-letter queue (YYC-137). Operators can override via
@@ -151,9 +151,18 @@ impl InboundQueue {
         let attachments_json = serde_json::to_string(&msg.attachments)?;
         tx.execute(
             "INSERT INTO outbound_queue \
-             (platform, chat_id, text, attachments_json, enqueued_at, next_attempt_at, state) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?5, 'pending')",
-            params![msg.platform, msg.chat_id, msg.text, attachments_json, now],
+             (platform, chat_id, text, attachments_json, enqueued_at, next_attempt_at, state, \
+              edit_target, reply_to) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?5, 'pending', ?6, ?7)",
+            params![
+                msg.platform,
+                msg.chat_id,
+                msg.text,
+                attachments_json,
+                now,
+                msg.edit_target,
+                msg.reply_to,
+            ],
         )?;
         let outbound_id = tx.last_insert_rowid();
         tx.execute("DELETE FROM inbound_queue WHERE id = ?1", params![id])?;
@@ -292,12 +301,18 @@ pub struct OutboundRow {
     pub platform: String,
     pub chat_id: String,
     pub text: String,
-    pub attachments: Vec<String>,
+    pub attachments: Vec<OutboundAttachment>,
     pub enqueued_at: i64,
     pub next_attempt_at: i64,
     pub attempts: i64,
     pub state: String,
     pub last_error: Option<String>,
+    /// YYC-18 PR-2a: anchor for edit-in-place streaming. When `Some`,
+    /// the OutboundDispatcher routes to `Platform::edit` instead of
+    /// `Platform::send`.
+    pub edit_target: Option<String>,
+    /// Reply / thread target on the platform side.
+    pub reply_to: Option<String>,
 }
 
 // Retry waits indexed by failures-so-far: 1st → 5s, 2nd → 30s, ... clamps at 7200s.
@@ -321,9 +336,18 @@ impl OutboundQueue {
         let attachments_json = serde_json::to_string(&msg.attachments)?;
         conn.execute(
             "INSERT INTO outbound_queue \
-             (platform, chat_id, text, attachments_json, enqueued_at, next_attempt_at, state) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?5, 'pending')",
-            params![msg.platform, msg.chat_id, msg.text, attachments_json, now],
+             (platform, chat_id, text, attachments_json, enqueued_at, next_attempt_at, state, \
+              edit_target, reply_to) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?5, 'pending', ?6, ?7)",
+            params![
+                msg.platform,
+                msg.chat_id,
+                msg.text,
+                attachments_json,
+                now,
+                msg.edit_target,
+                msg.reply_to,
+            ],
         )?;
         Ok(conn.last_insert_rowid())
     }
@@ -340,12 +364,12 @@ impl OutboundQueue {
                          WHERE state='pending' AND next_attempt_at <= ?1 \
                          ORDER BY next_attempt_at ASC LIMIT 1) \
              RETURNING id, platform, chat_id, text, attachments_json, enqueued_at, \
-                       next_attempt_at, attempts, state, last_error",
+                       next_attempt_at, attempts, state, last_error, edit_target, reply_to",
         )?;
         let mut rows = stmt.query(params![now])?;
         if let Some(row) = rows.next()? {
             let attachments_json: String = row.get(4)?;
-            let attachments: Vec<String> = serde_json::from_str(&attachments_json)?;
+            let attachments: Vec<OutboundAttachment> = serde_json::from_str(&attachments_json)?;
             Ok(Some(OutboundRow {
                 id: row.get(0)?,
                 platform: row.get(1)?,
@@ -357,6 +381,8 @@ impl OutboundQueue {
                 attempts: row.get(7)?,
                 state: row.get(8)?,
                 last_error: row.get(9)?,
+                edit_target: row.get(10)?,
+                reply_to: row.get(11)?,
             }))
         } else {
             Ok(None)
@@ -416,13 +442,13 @@ impl OutboundQueue {
             .map_err(|e| anyhow!("queue DB pool checkout: {e}"))?;
         let mut stmt = conn.prepare(
             "SELECT id, platform, chat_id, text, attachments_json, enqueued_at, \
-                    next_attempt_at, attempts, state, last_error \
+                    next_attempt_at, attempts, state, last_error, edit_target, reply_to \
              FROM outbound_queue WHERE id = ?1",
         )?;
         let mut rows = stmt.query(params![id])?;
         if let Some(row) = rows.next()? {
             let attachments_json: String = row.get(4)?;
-            let attachments: Vec<String> = serde_json::from_str(&attachments_json)?;
+            let attachments: Vec<OutboundAttachment> = serde_json::from_str(&attachments_json)?;
             Ok(OutboundRow {
                 id: row.get(0)?,
                 platform: row.get(1)?,
@@ -434,6 +460,8 @@ impl OutboundQueue {
                 attempts: row.get(7)?,
                 state: row.get(8)?,
                 last_error: row.get(9)?,
+                edit_target: row.get(10)?,
+                reply_to: row.get(11)?,
             })
         } else {
             Err(anyhow!("row not found"))
@@ -470,6 +498,54 @@ mod tests {
             reply_to: None,
             edit_target: None,
         }
+    }
+
+    #[tokio::test]
+    async fn outbound_queue_round_trips_edit_target_and_reply_to() {
+        let q = OutboundQueue::new(test_conn(), 5);
+        let msg = OutboundMessage {
+            platform: "loopback".into(),
+            chat_id: "c".into(),
+            text: "edit me".into(),
+            attachments: vec![],
+            reply_to: Some("parent-msg-1".into()),
+            edit_target: Some("anchor-msg-7".into()),
+        };
+        q.enqueue(msg).await.unwrap();
+        let row = q
+            .claim_due(chrono::Utc::now().timestamp())
+            .await
+            .unwrap()
+            .expect("row");
+        assert_eq!(row.edit_target, Some("anchor-msg-7".into()));
+        assert_eq!(row.reply_to, Some("parent-msg-1".into()));
+    }
+
+    #[tokio::test]
+    async fn outbound_queue_round_trips_typed_attachments() {
+        use crate::platform::{AttachmentKind, OutboundAttachment};
+        let q = OutboundQueue::new(test_conn(), 5);
+        let msg = OutboundMessage {
+            platform: "loopback".into(),
+            chat_id: "c".into(),
+            text: "hi".into(),
+            attachments: vec![OutboundAttachment {
+                path: std::path::PathBuf::from("/tmp/x.png"),
+                kind: AttachmentKind::Image,
+                caption: Some("cap".into()),
+            }],
+            reply_to: None,
+            edit_target: None,
+        };
+        q.enqueue(msg).await.unwrap();
+        let row = q
+            .claim_due(chrono::Utc::now().timestamp())
+            .await
+            .unwrap()
+            .expect("row");
+        assert_eq!(row.attachments.len(), 1);
+        assert_eq!(row.attachments[0].kind, AttachmentKind::Image);
+        assert_eq!(row.attachments[0].caption.as_deref(), Some("cap"));
     }
 
     #[tokio::test]

--- a/src/gateway/registry.rs
+++ b/src/gateway/registry.rs
@@ -52,6 +52,8 @@ mod tests {
             chat_id: chat.into(),
             text: text.into(),
             attachments: vec![],
+            reply_to: None,
+            edit_target: None,
         }
     }
 

--- a/src/gateway/render_registry.rs
+++ b/src/gateway/render_registry.rs
@@ -17,6 +17,10 @@ use parking_lot::RwLock;
 pub struct RenderKey {
     pub platform: String,
     pub chat_id: String,
+    /// PR-2a stand-in: callers populate this with `chat_id` because the
+    /// worker hasn't yet been switched to streaming and there's no real
+    /// per-turn id surfaced to the dispatcher. PR-2b adds a real
+    /// `turn_id` column on `outbound_queue` and threads it through.
     pub turn_id: String,
 }
 

--- a/src/gateway/render_registry.rs
+++ b/src/gateway/render_registry.rs
@@ -1,0 +1,109 @@
+//! In-memory map from (platform, chat_id, turn_id) → platform message id.
+//!
+//! StreamRenderer (PR-2a) writes the first chunk's anchor into this
+//! registry once OutboundDispatcher captures it; subsequent chunks
+//! read the anchor and emit OutboundMessages with `edit_target`
+//! populated so the dispatcher routes to `Platform::edit`.
+//!
+//! Lifetime: entries live until the turn ends + a 5-minute grace
+//! period. PR-2b (worker streaming switch) wires the explicit purge.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct RenderKey {
+    pub platform: String,
+    pub chat_id: String,
+    pub turn_id: String,
+}
+
+#[derive(Default)]
+pub struct RenderRegistry {
+    inner: Arc<RwLock<HashMap<RenderKey, String>>>,
+}
+
+impl RenderRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn anchor(&self, key: &RenderKey) -> Option<String> {
+        self.inner.read().get(key).cloned()
+    }
+
+    pub fn set_anchor(&self, key: RenderKey, message_id: String) {
+        self.inner.write().insert(key, message_id);
+    }
+
+    pub fn forget(&self, key: &RenderKey) {
+        self.inner.write().remove(key);
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.read().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(platform: &str, chat: &str, turn: &str) -> RenderKey {
+        RenderKey {
+            platform: platform.into(),
+            chat_id: chat.into(),
+            turn_id: turn.into(),
+        }
+    }
+
+    #[test]
+    fn anchor_returns_none_for_unknown_key() {
+        let r = RenderRegistry::new();
+        assert!(r.anchor(&key("loopback", "c", "t1")).is_none());
+    }
+
+    #[test]
+    fn set_anchor_then_anchor_returns_the_id() {
+        let r = RenderRegistry::new();
+        r.set_anchor(key("loopback", "c", "t1"), "msg-7".into());
+        assert_eq!(
+            r.anchor(&key("loopback", "c", "t1")).as_deref(),
+            Some("msg-7")
+        );
+    }
+
+    #[test]
+    fn set_anchor_overwrites_existing_id() {
+        let r = RenderRegistry::new();
+        let k = key("loopback", "c", "t1");
+        r.set_anchor(k.clone(), "msg-7".into());
+        r.set_anchor(k.clone(), "msg-8".into());
+        assert_eq!(r.anchor(&k).as_deref(), Some("msg-8"));
+    }
+
+    #[test]
+    fn forget_removes_key() {
+        let r = RenderRegistry::new();
+        let k = key("loopback", "c", "t1");
+        r.set_anchor(k.clone(), "msg-7".into());
+        r.forget(&k);
+        assert!(r.anchor(&k).is_none());
+    }
+
+    #[test]
+    fn keys_with_different_turn_ids_are_distinct() {
+        let r = RenderRegistry::new();
+        r.set_anchor(key("loopback", "c", "t1"), "a".into());
+        r.set_anchor(key("loopback", "c", "t2"), "b".into());
+        assert_eq!(r.anchor(&key("loopback", "c", "t1")).as_deref(), Some("a"));
+        assert_eq!(r.anchor(&key("loopback", "c", "t2")).as_deref(), Some("b"));
+        assert_eq!(r.len(), 2);
+    }
+}

--- a/src/gateway/routes/inbound.rs
+++ b/src/gateway/routes/inbound.rs
@@ -33,6 +33,9 @@ pub async fn handle(
         chat_id: body.chat_id,
         user_id: body.user_id,
         text: body.text,
+        message_id: None,
+        reply_to: None,
+        attachments: vec![],
     };
     match state.inbound.enqueue(msg).await {
         Ok(id) => Ok((StatusCode::ACCEPTED, Json(serde_json::json!({"id": id})))),

--- a/src/gateway/stream_render.rs
+++ b/src/gateway/stream_render.rs
@@ -1,0 +1,195 @@
+//! StreamRenderer — turns a stream of `StreamEvent`s into OutboundMessages.
+//!
+//! First chunk: emits an `OutboundMessage` with `edit_target = None`.
+//! When the OutboundDispatcher delivers it, it captures the returned
+//! `SentMessage::message_id` into RenderRegistry under
+//! (platform, chat_id, turn_id). Subsequent chunks read that anchor
+//! and emit `OutboundMessage { edit_target: Some(anchor), .. }` so
+//! the dispatcher routes to `Platform::edit`.
+//!
+//! Throttle: emits at most one OutboundMessage per
+//! `edit_min_interval_ms` (from the platform's capabilities). Tool
+//! call boundaries (`StreamEvent::ToolCallStart` / `ToolCallEnd`)
+//! and `StreamEvent::Done` / `Error` flush immediately.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use crate::gateway::queue::OutboundQueue;
+use crate::gateway::render_registry::{RenderKey, RenderRegistry};
+use crate::platform::OutboundMessage;
+use crate::provider::StreamEvent;
+
+pub struct StreamRenderer {
+    key: RenderKey,
+    interval: Duration,
+    buffer: String,
+    last_emit: Instant,
+    outbound: Arc<OutboundQueue>,
+    registry: Arc<RenderRegistry>,
+    /// First-emit guard. We always send (no edit) on the first chunk;
+    /// subsequent chunks attempt edit_target.
+    sent_first: bool,
+}
+
+impl StreamRenderer {
+    pub fn new(
+        key: RenderKey,
+        edit_min_interval_ms: u64,
+        outbound: Arc<OutboundQueue>,
+        registry: Arc<RenderRegistry>,
+    ) -> Self {
+        Self {
+            key,
+            interval: Duration::from_millis(edit_min_interval_ms),
+            buffer: String::new(),
+            last_emit: Instant::now() - Duration::from_secs(3600),
+            outbound,
+            registry,
+            sent_first: false,
+        }
+    }
+
+    pub async fn handle(&mut self, ev: StreamEvent) -> anyhow::Result<()> {
+        match ev {
+            StreamEvent::Text(chunk) | StreamEvent::Reasoning(chunk) => {
+                self.buffer.push_str(&chunk);
+                if self.last_emit.elapsed() >= self.interval {
+                    self.flush(false).await?;
+                }
+            }
+            StreamEvent::ToolCallStart { .. } | StreamEvent::ToolCallEnd { .. } => {
+                self.flush(false).await?;
+            }
+            StreamEvent::Done(_) | StreamEvent::Error(_) => {
+                self.flush(true).await?;
+                // Forget the anchor — turn is over.
+                self.registry.forget(&self.key);
+            }
+        }
+        Ok(())
+    }
+
+    async fn flush(&mut self, _final: bool) -> anyhow::Result<()> {
+        if self.buffer.is_empty() {
+            return Ok(());
+        }
+        let edit_target = if self.sent_first {
+            self.registry.anchor(&self.key)
+        } else {
+            None
+        };
+        let msg = OutboundMessage {
+            platform: self.key.platform.clone(),
+            chat_id: self.key.chat_id.clone(),
+            text: self.buffer.clone(),
+            attachments: Vec::new(),
+            reply_to: None,
+            edit_target,
+        };
+        self.outbound.enqueue(msg).await?;
+        self.last_emit = Instant::now();
+        self.sent_first = true;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory::in_memory_gateway_pool;
+
+    fn key() -> RenderKey {
+        RenderKey {
+            platform: "loopback".into(),
+            chat_id: "c".into(),
+            turn_id: "t1".into(),
+        }
+    }
+
+    fn fresh_outbound() -> Arc<OutboundQueue> {
+        Arc::new(OutboundQueue::new(in_memory_gateway_pool().unwrap(), 5))
+    }
+
+    #[tokio::test]
+    async fn first_text_chunk_enqueues_send_with_no_edit_target() {
+        let outbound = fresh_outbound();
+        let registry = Arc::new(RenderRegistry::new());
+        let mut r = StreamRenderer::new(key(), 0, outbound.clone(), registry);
+        r.handle(StreamEvent::Text("hello".into())).await.unwrap();
+        let row = outbound
+            .claim_due(chrono::Utc::now().timestamp())
+            .await
+            .unwrap()
+            .expect("row");
+        assert_eq!(row.text, "hello");
+        assert!(row.edit_target.is_none());
+    }
+
+    #[tokio::test]
+    async fn subsequent_chunk_uses_anchor_from_registry() {
+        let outbound = fresh_outbound();
+        let registry = Arc::new(RenderRegistry::new());
+        let mut r = StreamRenderer::new(key(), 0, outbound.clone(), registry.clone());
+        r.handle(StreamEvent::Text("first ".into())).await.unwrap();
+        // Simulate dispatcher capturing the anchor.
+        registry.set_anchor(key(), "msg-7".into());
+        r.handle(StreamEvent::Text("second".into())).await.unwrap();
+        let _row1 = outbound
+            .claim_due(chrono::Utc::now().timestamp())
+            .await
+            .unwrap()
+            .unwrap();
+        let row2 = outbound
+            .claim_due(chrono::Utc::now().timestamp())
+            .await
+            .unwrap()
+            .expect("second row");
+        assert_eq!(row2.text, "first second");
+        assert_eq!(row2.edit_target.as_deref(), Some("msg-7"));
+    }
+
+    #[tokio::test]
+    async fn done_flushes_and_forgets_anchor() {
+        let outbound = fresh_outbound();
+        let registry = Arc::new(RenderRegistry::new());
+        let mut r = StreamRenderer::new(key(), 0, outbound.clone(), registry.clone());
+        r.handle(StreamEvent::Text("partial".into())).await.unwrap();
+        registry.set_anchor(key(), "msg-1".into());
+        r.handle(StreamEvent::Done(crate::provider::ChatResponse {
+            content: None,
+            tool_calls: None,
+            usage: None,
+            finish_reason: None,
+            reasoning_content: None,
+        }))
+        .await
+        .unwrap();
+        assert!(
+            registry.anchor(&key()).is_none(),
+            "Done should forget the anchor"
+        );
+    }
+
+    #[tokio::test]
+    async fn throttle_holds_chunks_within_interval() {
+        let outbound = fresh_outbound();
+        let registry = Arc::new(RenderRegistry::new());
+        // 1 second floor — first chunk emits, second chunk shouldn't.
+        let mut r = StreamRenderer::new(key(), 1000, outbound.clone(), registry);
+        r.handle(StreamEvent::Text("a".into())).await.unwrap();
+        r.handle(StreamEvent::Text("b".into())).await.unwrap();
+        // Only one row should be claimable — the second chunk was buffered.
+        let row1 = outbound
+            .claim_due(chrono::Utc::now().timestamp())
+            .await
+            .unwrap()
+            .expect("row1");
+        assert_eq!(row1.text, "a");
+        let row2 = outbound
+            .claim_due(chrono::Utc::now().timestamp())
+            .await
+            .unwrap();
+        assert!(row2.is_none(), "second chunk should be held by throttle");
+    }
+}

--- a/src/gateway/stream_render.rs
+++ b/src/gateway/stream_render.rs
@@ -27,9 +27,21 @@ pub struct StreamRenderer {
     last_emit: Instant,
     outbound: Arc<OutboundQueue>,
     registry: Arc<RenderRegistry>,
-    /// First-emit guard. We always send (no edit) on the first chunk;
-    /// subsequent chunks attempt edit_target.
-    sent_first: bool,
+    /// "Have we enqueued at least one outbound row for this turn?"
+    /// First chunk: false → emit with `edit_target = None`. Subsequent
+    /// chunks: true → read RenderRegistry for the anchor.
+    ///
+    /// Race window — PR-2b TODO: between `enqueued_first = true` (here)
+    /// and the dispatcher writing the anchor (after Platform::send
+    /// returns), a second chunk that fires inside the throttle interval
+    /// reads `None` and emits another no-anchor send, producing a
+    /// duplicate first message on the user's screen. The 1s Telegram
+    /// edit-floor + the dispatcher's 250ms poll make this a narrow
+    /// window in practice; PR-2b should tighten it by either
+    ///   (a) blocking subsequent enqueues until the anchor lands, or
+    ///   (b) capturing the anchor synchronously inside the renderer
+    ///       (skip the dispatcher round-trip for first send).
+    enqueued_first: bool,
 }
 
 impl StreamRenderer {
@@ -46,7 +58,7 @@ impl StreamRenderer {
             last_emit: Instant::now() - Duration::from_secs(3600),
             outbound,
             registry,
-            sent_first: false,
+            enqueued_first: false,
         }
     }
 
@@ -55,14 +67,17 @@ impl StreamRenderer {
             StreamEvent::Text(chunk) | StreamEvent::Reasoning(chunk) => {
                 self.buffer.push_str(&chunk);
                 if self.last_emit.elapsed() >= self.interval {
-                    self.flush(false).await?;
+                    self.flush().await?;
                 }
             }
             StreamEvent::ToolCallStart { .. } | StreamEvent::ToolCallEnd { .. } => {
-                self.flush(false).await?;
+                self.flush().await?;
             }
+            // PR-2b TODO: surface ChatResponse.finish_reason / usage on
+            // the final flush so the chat surface can render a "✓ done"
+            // footer with token counts.
             StreamEvent::Done(_) | StreamEvent::Error(_) => {
-                self.flush(true).await?;
+                self.flush().await?;
                 // Forget the anchor — turn is over.
                 self.registry.forget(&self.key);
             }
@@ -70,11 +85,11 @@ impl StreamRenderer {
         Ok(())
     }
 
-    async fn flush(&mut self, _final: bool) -> anyhow::Result<()> {
+    async fn flush(&mut self) -> anyhow::Result<()> {
         if self.buffer.is_empty() {
             return Ok(());
         }
-        let edit_target = if self.sent_first {
+        let edit_target = if self.enqueued_first {
             self.registry.anchor(&self.key)
         } else {
             None
@@ -89,7 +104,7 @@ impl StreamRenderer {
         };
         self.outbound.enqueue(msg).await?;
         self.last_emit = Instant::now();
-        self.sent_first = true;
+        self.enqueued_first = true;
         Ok(())
     }
 }

--- a/src/gateway/worker.rs
+++ b/src/gateway/worker.rs
@@ -84,6 +84,8 @@ pub async fn process_one(
                         chat_id: row.chat_id,
                         text: reply,
                         attachments: vec![],
+                        reply_to: None,
+                        edit_target: None,
                     },
                 )
                 .await?;
@@ -232,6 +234,9 @@ mod tests {
                 chat_id: "c".into(),
                 user_id: "u".into(),
                 text: "hi".into(),
+                message_id: None,
+                reply_to: None,
+                attachments: vec![],
             })
             .await
             .unwrap();
@@ -268,6 +273,9 @@ mod tests {
                 chat_id: "c".into(),
                 user_id: "u".into(),
                 text: "boom".into(),
+                message_id: None,
+                reply_to: None,
+                attachments: vec![],
             })
             .await
             .unwrap();
@@ -339,6 +347,9 @@ mod tests {
                 chat_id: "c".into(),
                 user_id: "u".into(),
                 text: "boom".into(),
+                message_id: None,
+                reply_to: None,
+                attachments: vec![],
             })
             .await
             .unwrap();
@@ -364,6 +375,9 @@ mod tests {
                 chat_id: "c".into(),
                 user_id: "u".into(),
                 text: "again".into(),
+                message_id: None,
+                reply_to: None,
+                attachments: vec![],
             })
             .await
             .unwrap();

--- a/src/memory/schema.rs
+++ b/src/memory/schema.rs
@@ -79,7 +79,14 @@ CREATE TABLE IF NOT EXISTS inbound_queue (
   -- Wallclock the worker last touched this row. claim_next sets it to now;
   -- recover_processing only resets rows whose heartbeat is stale relative
   -- to the configured threshold (YYC-137).
-  last_heartbeat_at INTEGER
+  last_heartbeat_at INTEGER,
+  -- YYC-18 PR-2a: typed attachments serialized as JSON (Vec<Attachment>).
+  attachments_json TEXT NOT NULL DEFAULT '[]',
+  -- Platform's id for the received message (Discord/Telegram); NULL for
+  -- loopback / CLI which don't have a wire concept of a message id.
+  message_id TEXT,
+  -- Platform message id this is a reply to, if the user threaded.
+  reply_to TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_inbound_lane  ON inbound_queue(platform, chat_id, state);
 CREATE INDEX IF NOT EXISTS idx_inbound_state ON inbound_queue(state, received_at);
@@ -94,7 +101,12 @@ CREATE TABLE IF NOT EXISTS outbound_queue (
   next_attempt_at INTEGER NOT NULL,
   attempts INTEGER NOT NULL DEFAULT 0,
   state    TEXT NOT NULL,  -- 'pending'|'sending'|'failed'
-  last_error TEXT
+  last_error TEXT,
+  -- YYC-18 PR-2a: anchor for edit-in-place streaming. When set, the
+  -- OutboundDispatcher routes to Platform::edit instead of Platform::send.
+  edit_target TEXT,
+  -- Reply / thread target on the platform side.
+  reply_to TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_outbound_due ON outbound_queue(state, next_attempt_at);
 "#;
@@ -113,6 +125,15 @@ pub(in crate::memory) fn initialize_conn(conn: &Connection) -> Result<()> {
         "ALTER TABLE inbound_queue ADD COLUMN last_heartbeat_at INTEGER",
         [],
     );
+    // YYC-18 PR-2a: payload extensions for outbound + inbound queues.
+    let _ = conn.execute("ALTER TABLE outbound_queue ADD COLUMN edit_target TEXT", []);
+    let _ = conn.execute("ALTER TABLE outbound_queue ADD COLUMN reply_to TEXT", []);
+    let _ = conn.execute(
+        "ALTER TABLE inbound_queue ADD COLUMN attachments_json TEXT NOT NULL DEFAULT '[]'",
+        [],
+    );
+    let _ = conn.execute("ALTER TABLE inbound_queue ADD COLUMN message_id TEXT", []);
+    let _ = conn.execute("ALTER TABLE inbound_queue ADD COLUMN reply_to TEXT", []);
     Ok(())
 }
 

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -12,6 +12,17 @@ pub struct InboundMessage {
     pub chat_id: String,
     pub user_id: String,
     pub text: String,
+    /// Platform's id for this received message. Populated when the
+    /// platform connector knows it (Discord/Telegram); `None` for
+    /// loopback/CLI which don't have a wire concept of a message id.
+    pub message_id: Option<String>,
+    /// Platform message id this is a reply to, if the user threaded
+    /// the message. Used by the agent to scope the lane's context
+    /// or by future tools that read thread state.
+    pub reply_to: Option<String>,
+    /// Media / file attachments the user sent. Empty by default.
+    /// `Platform::download_attachment` materializes blobs on demand.
+    pub attachments: Vec<Attachment>,
 }
 
 /// A message to deliver to a user
@@ -20,7 +31,19 @@ pub struct OutboundMessage {
     pub platform: String,
     pub chat_id: String,
     pub text: String,
-    pub attachments: Vec<String>,
+    /// Typed attachments to send. Empty by default. Replaces the
+    /// pre-PR-2 untyped `Vec<String>` of paths — kind drives the
+    /// platform's API choice (Telegram has separate sendPhoto /
+    /// sendDocument / sendVoice endpoints).
+    pub attachments: Vec<OutboundAttachment>,
+    /// Reply target. When set, the platform sends this message as
+    /// a reply to (or thread under) the referenced platform message.
+    pub reply_to: Option<String>,
+    /// When `Some`, the OutboundDispatcher calls `Platform::edit`
+    /// against the referenced message id instead of `Platform::send`.
+    /// Set by StreamRenderer for follow-up chunks of an in-flight
+    /// streaming response.
+    pub edit_target: Option<String>,
 }
 
 /// Result of a successful `Platform::send`. Carries the platform's

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -99,11 +99,10 @@ pub struct Attachment {
     pub original_name: Option<String>,
 }
 
-/// An attachment to send. `OutboundMessage` will gain a `Vec<Self>`
-/// in PR-2 once StreamRenderer wires media into the outbound pipeline.
-/// `path` is the local file to upload — `PathBuf` matches what
-/// `Platform::download_attachment` returns so a roundtrip
-/// (receive → re-send) is friction-free.
+/// An attachment to send. Lives on `OutboundMessage.attachments`
+/// (typed `Vec<Self>`); `path` is the local file the platform layer
+/// uploads. `PathBuf` matches what `Platform::download_attachment`
+/// returns so a roundtrip (receive → re-send) is friction-free.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct OutboundAttachment {
     pub path: std::path::PathBuf,

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -75,7 +75,7 @@ pub struct PlatformCapabilities {
 /// (Telegram has separate `send_photo` / `send_document` / `send_voice`
 /// endpoints; Discord uploads any file the same way but the kind still
 /// drives rendering hints).
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum AttachmentKind {
     Image,
     Document,
@@ -90,7 +90,7 @@ pub enum AttachmentKind {
 /// An attachment received from a platform. `local_path` is populated
 /// after `Platform::download_attachment` materializes the bytes.
 /// Receivers store these on `InboundMessage.attachments` (PR-2).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Attachment {
     pub url: Option<String>,
     pub local_path: Option<String>,
@@ -104,7 +104,7 @@ pub struct Attachment {
 /// `path` is the local file to upload — `PathBuf` matches what
 /// `Platform::download_attachment` returns so a roundtrip
 /// (receive → re-send) is friction-free.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct OutboundAttachment {
     pub path: std::path::PathBuf,
     pub kind: AttachmentKind,


### PR DESCRIPTION
YYC-18 PR-2a: extend InboundMessage + OutboundMessage with new fields

InboundMessage gains:
  * message_id: Option<String> — platform's id for the received msg
  * reply_to: Option<String>  — thread / reply context
  * attachments: Vec<Attachment> — typed media

OutboundMessage gains:
  * attachments: Vec<OutboundAttachment> — replaces the untyped
    Vec<String> path list with kind-tagged attachments
  * reply_to: Option<String> — for thread / quoted-reply rendering
  * edit_target: Option<String> — when Some, OutboundDispatcher
    will route to Platform::edit (PR-2a wires this in Task 5)

All existing call sites updated to populate the new fields with
defaults (None / vec![]) — no behavior change.

cargo test --lib passes.

YYC-18 PR-2a: schema migration for outbound + inbound queue extensions

* outbound_queue: + edit_target TEXT, + reply_to TEXT.
* inbound_queue: + attachments_json TEXT, + message_id TEXT, + reply_to TEXT.
* OutboundRow + OutboundQueue::enqueue / claim_due / peek round-trip
  the new fields. attachments_json now stores Vec<OutboundAttachment>
  (typed) — derives serde::{Serialize, Deserialize} on the
  attachment types.
* Idempotent ALTER TABLE migrations match the existing pattern at
  src/memory/schema.rs.

cargo test --lib --features gateway passes.

YYC-18 PR-2a: RenderRegistry — in-memory message-id anchors per turn

Maps (platform, chat_id, turn_id) → platform message id so the
StreamRenderer can target the first sent message of an in-flight
turn for subsequent edits. parking_lot::RwLock keeps the critical
section short; reads dominate (every chunk reads, only the first
sent of a turn writes).

PR-2b will wire the explicit purge on Done / Error so entries
don't leak across the 5-minute grace window.

cargo test --lib gateway::render_registry passes (5 tests).

YYC-18 PR-2a: StreamRenderer — chunk → OutboundMessage with edit_target

* First chunk: enqueue OutboundMessage with edit_target=None.
  OutboundDispatcher (next task) captures the returned SentMessage
  id into RenderRegistry.
* Subsequent chunks: read RenderRegistry, populate edit_target so
  the dispatcher routes to Platform::edit.
* Throttle: emit at most one OutboundMessage per
  edit_min_interval_ms. Tool-call boundaries + Done force-flush.
* On Done / Error, forget the registry anchor so the next turn
  starts fresh.

cargo test --lib gateway::stream_render passes (4 tests).

YYC-18 PR-2a: OutboundDispatcher routes to Platform::edit on edit_target

* drain_due reads OutboundRow.edit_target. When Some, calls
  Platform::edit; when None, calls Platform::send and captures the
  returned message id into RenderRegistry under the lane key.
* OutboundDispatcher::new gains Arc<RenderRegistry> param. Existing
  call sites updated.
* Two new tests: edit-route fires Platform::edit not send;
  first-send captures the anchor.

PR-2a render machinery is now live end-to-end (StreamRenderer →
OutboundQueue → OutboundDispatcher → Platform). Worker still uses
buffered run_prompt — PR-2b switches to streaming.

cargo test --lib gateway:: passes.