### PR TITLE
YYC-18 PR-2b: outbound_queue.turn_id column + payload field

### DIFF
--- a/src/gateway/loopback.rs
+++ b/src/gateway/loopback.rs
@@ -162,6 +162,7 @@ mod tests {
             attachments: vec![],
             reply_to: None,
             edit_target: None,
+            turn_id: None,
         };
         let m2 = OutboundMessage {
             text: "two".into(),
@@ -185,6 +186,7 @@ mod tests {
             attachments: vec![],
             reply_to: None,
             edit_target: None,
+            turn_id: None,
         };
         assert!(lp.send(&m).await.is_err());
         assert!(lp.send(&m).await.is_err());
@@ -203,6 +205,7 @@ mod tests {
             attachments: vec![],
             reply_to: None,
             edit_target: None,
+            turn_id: None,
         };
         let s1 = lp.send(&m).await.unwrap();
         let s2 = lp.send(&m).await.unwrap();

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -112,6 +112,8 @@ where
         Arc::clone(&inbound),
         Arc::clone(&outbound),
         Arc::clone(&agent_map),
+        Arc::clone(&render_registry),
+        Arc::clone(&registry),
     );
 
     let app = build_router(AppState {
@@ -145,17 +147,40 @@ fn spawn_inbound_dispatcher(
     inbound: Arc<InboundQueue>,
     outbound: Arc<OutboundQueue>,
     agent_map: Arc<AgentMap>,
+    render_registry: Arc<crate::gateway::render_registry::RenderRegistry>,
+    platform_registry: Arc<PlatformRegistry>,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         let handler_inbound = Arc::clone(&inbound);
         let handler_outbound = Arc::clone(&outbound);
         let handler_agent_map = Arc::clone(&agent_map);
+        let handler_render_registry = Arc::clone(&render_registry);
+        let handler_platform_registry = Arc::clone(&platform_registry);
         let handler = from_closure(move |_lane: LaneKey, row: InboundRow| {
             let inbound = Arc::clone(&handler_inbound);
             let outbound = Arc::clone(&handler_outbound);
             let agent_map = Arc::clone(&handler_agent_map);
+            let render_registry = Arc::clone(&handler_render_registry);
+            let platform_registry = Arc::clone(&handler_platform_registry);
             async move {
-                if let Err(e) = worker::process_one(row, &agent_map, &inbound, &outbound).await {
+                // Pick capabilities from the registered platform; default
+                // (zero-feature) for an unknown platform name so the
+                // worker still runs but the renderer's throttle behaves
+                // as a "no edits, single-shot send" pipeline.
+                let caps = platform_registry
+                    .get(&row.platform)
+                    .map(|p| p.capabilities())
+                    .unwrap_or_default();
+                if let Err(e) = worker::process_one(
+                    row,
+                    &agent_map,
+                    &inbound,
+                    &outbound,
+                    &render_registry,
+                    caps,
+                )
+                .await
+                {
                     tracing::error!(target: "gateway::inbound", error = %e, "inbound row failed");
                 }
             }

--- a/src/gateway/outbound.rs
+++ b/src/gateway/outbound.rs
@@ -109,6 +109,7 @@ async fn drain_due(
         };
         let id = row.id;
         let edit_target = row.edit_target.clone();
+        let turn_id = row.turn_id.clone();
         let msg = OutboundMessage {
             platform: row.platform,
             chat_id: row.chat_id,
@@ -116,6 +117,7 @@ async fn drain_due(
             attachments: row.attachments,
             reply_to: row.reply_to,
             edit_target: row.edit_target,
+            turn_id: row.turn_id,
         };
         let result = if let Some(anchor) = edit_target {
             // Route to edit; ignore SentMessage shape (edit returns ()).
@@ -137,13 +139,14 @@ async fn drain_due(
             match plat.send(&msg).await {
                 Ok(sent) => {
                     // Build the RenderKey from (platform, chat_id, turn_id).
-                    // Turn id isn't stored on the row in PR-2a — use chat_id
-                    // as a stand-in. PR-2b adds a turn_id column when it
-                    // wires the worker streaming path.
+                    // turn_id is populated by StreamRenderer for streaming
+                    // rows; non-streaming rows (CommandDispatcher replies,
+                    // /v1/inbound webhooks) fall back to chat_id so the
+                    // registry key still scopes per-lane.
                     let key = RenderKey {
                         platform: msg.platform.clone(),
                         chat_id: msg.chat_id.clone(),
-                        turn_id: msg.chat_id.clone(),
+                        turn_id: turn_id.clone().unwrap_or_else(|| msg.chat_id.clone()),
                     };
                     // PR-2b TODO: anchor write happens before mark_done.
                     // If the subsequent mark_done fails (DB pool / disk),
@@ -192,6 +195,7 @@ mod tests {
             attachments: vec![],
             reply_to: None,
             edit_target: None,
+            turn_id: None,
         }
     }
 
@@ -277,6 +281,7 @@ mod tests {
                 attachments: vec![],
                 reply_to: None,
                 edit_target: Some("anchor-1".into()),
+                turn_id: None,
             })
             .await
             .unwrap();
@@ -302,6 +307,7 @@ mod tests {
                 attachments: vec![],
                 reply_to: None,
                 edit_target: None,
+                turn_id: Some("t1".into()),
             })
             .await
             .unwrap();
@@ -309,7 +315,7 @@ mod tests {
         let anchor = render_reg.anchor(&RenderKey {
             platform: "loopback".into(),
             chat_id: "c".into(),
-            turn_id: "c".into(),
+            turn_id: "t1".into(),
         });
         assert!(anchor.is_some(), "first send should populate the registry");
     }

--- a/src/gateway/queue.rs
+++ b/src/gateway/queue.rs
@@ -152,8 +152,8 @@ impl InboundQueue {
         tx.execute(
             "INSERT INTO outbound_queue \
              (platform, chat_id, text, attachments_json, enqueued_at, next_attempt_at, state, \
-              edit_target, reply_to) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?5, 'pending', ?6, ?7)",
+              edit_target, reply_to, turn_id) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?5, 'pending', ?6, ?7, ?8)",
             params![
                 msg.platform,
                 msg.chat_id,
@@ -162,6 +162,7 @@ impl InboundQueue {
                 now,
                 msg.edit_target,
                 msg.reply_to,
+                msg.turn_id,
             ],
         )?;
         let outbound_id = tx.last_insert_rowid();
@@ -313,6 +314,9 @@ pub struct OutboundRow {
     pub edit_target: Option<String>,
     /// Reply / thread target on the platform side.
     pub reply_to: Option<String>,
+    /// YYC-18 PR-2b: per-turn id used by the dispatcher to build the
+    /// RenderKey for anchor capture. `None` for non-streaming rows.
+    pub turn_id: Option<String>,
 }
 
 // Retry waits indexed by failures-so-far: 1st → 5s, 2nd → 30s, ... clamps at 7200s.
@@ -337,8 +341,8 @@ impl OutboundQueue {
         conn.execute(
             "INSERT INTO outbound_queue \
              (platform, chat_id, text, attachments_json, enqueued_at, next_attempt_at, state, \
-              edit_target, reply_to) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?5, 'pending', ?6, ?7)",
+              edit_target, reply_to, turn_id) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?5, 'pending', ?6, ?7, ?8)",
             params![
                 msg.platform,
                 msg.chat_id,
@@ -347,6 +351,7 @@ impl OutboundQueue {
                 now,
                 msg.edit_target,
                 msg.reply_to,
+                msg.turn_id,
             ],
         )?;
         Ok(conn.last_insert_rowid())
@@ -364,7 +369,8 @@ impl OutboundQueue {
                          WHERE state='pending' AND next_attempt_at <= ?1 \
                          ORDER BY next_attempt_at ASC, id ASC LIMIT 1) \
              RETURNING id, platform, chat_id, text, attachments_json, enqueued_at, \
-                       next_attempt_at, attempts, state, last_error, edit_target, reply_to",
+                       next_attempt_at, attempts, state, last_error, edit_target, reply_to, \
+                       turn_id",
         )?;
         let mut rows = stmt.query(params![now])?;
         if let Some(row) = rows.next()? {
@@ -383,6 +389,7 @@ impl OutboundQueue {
                 last_error: row.get(9)?,
                 edit_target: row.get(10)?,
                 reply_to: row.get(11)?,
+                turn_id: row.get(12)?,
             }))
         } else {
             Ok(None)
@@ -442,7 +449,8 @@ impl OutboundQueue {
             .map_err(|e| anyhow!("queue DB pool checkout: {e}"))?;
         let mut stmt = conn.prepare(
             "SELECT id, platform, chat_id, text, attachments_json, enqueued_at, \
-                    next_attempt_at, attempts, state, last_error, edit_target, reply_to \
+                    next_attempt_at, attempts, state, last_error, edit_target, reply_to, \
+                    turn_id \
              FROM outbound_queue WHERE id = ?1",
         )?;
         let mut rows = stmt.query(params![id])?;
@@ -462,6 +470,7 @@ impl OutboundQueue {
                 last_error: row.get(9)?,
                 edit_target: row.get(10)?,
                 reply_to: row.get(11)?,
+                turn_id: row.get(12)?,
             })
         } else {
             Err(anyhow!("row not found"))
@@ -497,6 +506,7 @@ mod tests {
             attachments: vec![],
             reply_to: None,
             edit_target: None,
+            turn_id: None,
         }
     }
 
@@ -510,6 +520,7 @@ mod tests {
             attachments: vec![],
             reply_to: Some("parent-msg-1".into()),
             edit_target: Some("anchor-msg-7".into()),
+            turn_id: None,
         };
         q.enqueue(msg).await.unwrap();
         let row = q
@@ -519,6 +530,27 @@ mod tests {
             .expect("row");
         assert_eq!(row.edit_target, Some("anchor-msg-7".into()));
         assert_eq!(row.reply_to, Some("parent-msg-1".into()));
+    }
+
+    #[tokio::test]
+    async fn outbound_queue_round_trips_turn_id() {
+        let q = OutboundQueue::new(test_conn(), 5);
+        let msg = OutboundMessage {
+            platform: "loopback".into(),
+            chat_id: "c".into(),
+            text: "x".into(),
+            attachments: vec![],
+            reply_to: None,
+            edit_target: None,
+            turn_id: Some("turn-abc".into()),
+        };
+        q.enqueue(msg).await.unwrap();
+        let row = q
+            .claim_due(chrono::Utc::now().timestamp())
+            .await
+            .unwrap()
+            .expect("row");
+        assert_eq!(row.turn_id, Some("turn-abc".into()));
     }
 
     #[tokio::test]
@@ -536,6 +568,7 @@ mod tests {
             }],
             reply_to: None,
             edit_target: None,
+            turn_id: None,
         };
         q.enqueue(msg).await.unwrap();
         let row = q
@@ -822,6 +855,7 @@ mod tests {
                     attachments: vec![],
                     reply_to: None,
                     edit_target: None,
+                    turn_id: None,
                 },
             )
             .await

--- a/src/gateway/registry.rs
+++ b/src/gateway/registry.rs
@@ -54,6 +54,7 @@ mod tests {
             attachments: vec![],
             reply_to: None,
             edit_target: None,
+            turn_id: None,
         }
     }
 

--- a/src/gateway/stream_render.rs
+++ b/src/gateway/stream_render.rs
@@ -31,17 +31,22 @@ pub struct StreamRenderer {
     /// First chunk: false → emit with `edit_target = None`. Subsequent
     /// chunks: true → read RenderRegistry for the anchor.
     ///
-    /// Race window — PR-2b TODO: between `enqueued_first = true` (here)
+    /// Race window — PR-2c TODO: between `enqueued_first = true` (here)
     /// and the dispatcher writing the anchor (after Platform::send
     /// returns), a second chunk that fires inside the throttle interval
     /// reads `None` and emits another no-anchor send, producing a
     /// duplicate first message on the user's screen. The 1s Telegram
     /// edit-floor + the dispatcher's 250ms poll make this a narrow
-    /// window in practice; PR-2b should tighten it by either
+    /// window in practice; PR-2c should tighten it by either
     ///   (a) blocking subsequent enqueues until the anchor lands, or
     ///   (b) capturing the anchor synchronously inside the renderer
     ///       (skip the dispatcher round-trip for first send).
     enqueued_first: bool,
+    /// True when the buffer holds content that hasn't been flushed yet.
+    /// Without this, `Done` would always emit one final row even when
+    /// the prior throttle-driven flush already drained the buffer —
+    /// producing a duplicate row on every single-chunk turn.
+    dirty: bool,
 }
 
 impl StreamRenderer {
@@ -59,6 +64,7 @@ impl StreamRenderer {
             outbound,
             registry,
             enqueued_first: false,
+            dirty: false,
         }
     }
 
@@ -66,6 +72,7 @@ impl StreamRenderer {
         match ev {
             StreamEvent::Text(chunk) | StreamEvent::Reasoning(chunk) => {
                 self.buffer.push_str(&chunk);
+                self.dirty = true;
                 if self.last_emit.elapsed() >= self.interval {
                     self.flush().await?;
                 }
@@ -73,7 +80,7 @@ impl StreamRenderer {
             StreamEvent::ToolCallStart { .. } | StreamEvent::ToolCallEnd { .. } => {
                 self.flush().await?;
             }
-            // PR-2b TODO: surface ChatResponse.finish_reason / usage on
+            // PR-2c TODO: surface ChatResponse.finish_reason / usage on
             // the final flush so the chat surface can render a "✓ done"
             // footer with token counts.
             StreamEvent::Done(_) | StreamEvent::Error(_) => {
@@ -86,7 +93,12 @@ impl StreamRenderer {
     }
 
     async fn flush(&mut self) -> anyhow::Result<()> {
-        if self.buffer.is_empty() {
+        // Skip when the buffer is empty (turn ended with no text yet) OR
+        // when there's no new content since the last emit. The latter
+        // guard prevents `Done` from re-enqueuing the same body that the
+        // prior throttle-driven flush already drained — that would
+        // produce a duplicate row on every single-chunk turn.
+        if self.buffer.is_empty() || !self.dirty {
             return Ok(());
         }
         let edit_target = if self.enqueued_first {
@@ -106,6 +118,7 @@ impl StreamRenderer {
         self.outbound.enqueue(msg).await?;
         self.last_emit = Instant::now();
         self.enqueued_first = true;
+        self.dirty = false;
         Ok(())
     }
 }
@@ -184,6 +197,42 @@ mod tests {
         assert!(
             registry.anchor(&key()).is_none(),
             "Done should forget the anchor"
+        );
+    }
+
+    #[tokio::test]
+    async fn single_chunk_turn_enqueues_exactly_one_row() {
+        // PR-2b regression: before the `dirty` flag, a Text + Done
+        // sequence would enqueue two rows — once on the immediate
+        // throttle-cleared flush (interval=0), once again on Done's
+        // unconditional flush. With the dirty guard, Done is a no-op
+        // when nothing has changed since the last emit.
+        let outbound = fresh_outbound();
+        let registry = Arc::new(RenderRegistry::new());
+        let mut r = StreamRenderer::new(key(), 0, outbound.clone(), registry);
+        r.handle(StreamEvent::Text("hi back".into())).await.unwrap();
+        r.handle(StreamEvent::Done(crate::provider::ChatResponse {
+            content: None,
+            tool_calls: None,
+            usage: None,
+            finish_reason: None,
+            reasoning_content: None,
+        }))
+        .await
+        .unwrap();
+        let row1 = outbound
+            .claim_due(chrono::Utc::now().timestamp())
+            .await
+            .unwrap()
+            .expect("first row");
+        assert_eq!(row1.text, "hi back");
+        let row2 = outbound
+            .claim_due(chrono::Utc::now().timestamp())
+            .await
+            .unwrap();
+        assert!(
+            row2.is_none(),
+            "Done after a fully-flushed buffer must not enqueue a duplicate"
         );
     }
 

--- a/src/gateway/stream_render.rs
+++ b/src/gateway/stream_render.rs
@@ -101,6 +101,7 @@ impl StreamRenderer {
             attachments: Vec::new(),
             reply_to: None,
             edit_target,
+            turn_id: Some(self.key.turn_id.clone()),
         };
         self.outbound.enqueue(msg).await?;
         self.last_emit = Instant::now();

--- a/src/gateway/worker.rs
+++ b/src/gateway/worker.rs
@@ -70,12 +70,17 @@ pub async fn process_one(
 
     // Consumer task: pump StreamEvents through the renderer. Lives until the
     // sender side (held by run_prompt_stream) is dropped.
+    //
+    // Returns `Err(anyhow::Error)` on the first `renderer.handle` failure
+    // (e.g., outbound enqueue failed) so the worker can mark the inbound
+    // row failed instead of silently swallowing a broken render. A panic
+    // inside this task is caught by `consumer.await` returning `JoinError`
+    // — also handled below as a turn-level failure.
     let consumer = tokio::spawn(async move {
         while let Some(ev) = rx.recv().await {
-            if let Err(e) = renderer.handle(ev).await {
-                tracing::error!(target: "gateway::worker", error = %e, "renderer.handle failed");
-            }
+            renderer.handle(ev).await?;
         }
+        Ok::<_, anyhow::Error>(())
     });
 
     // AssertUnwindSafe: we don't read Agent state after a panic — we just
@@ -93,10 +98,10 @@ pub async fn process_one(
 
     // The sender was moved into run_prompt_stream; closing it lets the
     // consumer drain to completion before we mark the inbound row done.
-    let _ = consumer.await;
+    let consumer_outcome = consumer.await;
 
     let panicked = unwind.is_err();
-    let result: anyhow::Result<String> = unwind.unwrap_or_else(|payload| {
+    let mut result: anyhow::Result<String> = unwind.unwrap_or_else(|payload| {
         let msg = payload
             .downcast_ref::<&'static str>()
             .map(|s| (*s).to_string())
@@ -106,6 +111,34 @@ pub async fn process_one(
             "agent panicked while running prompt: {msg}"
         ))
     });
+
+    // Surface renderer failures the same as agent failures. Two ways the
+    // consumer can fail:
+    //   1. JoinError — task panicked. Treat as a turn failure.
+    //   2. Inner `Err` from `renderer.handle` — outbound enqueue failed,
+    //      DB pool error, etc. The user will see no message; mark the
+    //      inbound row failed so retry / DLQ semantics kick in.
+    // Don't override an existing `Err` from the agent path — the first
+    // error wins.
+    if result.is_ok() {
+        match consumer_outcome {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                result = Err(e.context("stream renderer failed"));
+            }
+            Err(join_err) => {
+                result = Err(anyhow::anyhow!("stream renderer task panicked: {join_err}"));
+            }
+        }
+    } else if let Err(join_err) = consumer_outcome {
+        // Agent already failed; just log the consumer panic so it's not
+        // silently lost.
+        tracing::warn!(
+            target: "gateway::worker",
+            error = %join_err,
+            "stream renderer task panicked (agent path also failed)",
+        );
+    }
 
     // YYC-133: if the future panicked, the Agent's internal state is
     // suspect — message buffer mid-write, tool registry mid-mutation,

--- a/src/gateway/worker.rs
+++ b/src/gateway/worker.rs
@@ -86,6 +86,7 @@ pub async fn process_one(
                         attachments: vec![],
                         reply_to: None,
                         edit_target: None,
+                        turn_id: None,
                     },
                 )
                 .await?;

--- a/src/gateway/worker.rs
+++ b/src/gateway/worker.rs
@@ -1,38 +1,82 @@
-//! Lane worker — pulls a claimed inbound row, drives the per-lane Agent,
-//! and enqueues the reply for the outbound delivery loop.
+//! Lane worker — pulls a claimed inbound row, drives the per-lane Agent in
+//! streaming mode, and pumps each `StreamEvent` through `StreamRenderer` so
+//! it lands on the outbound queue as a series of edit-in-place updates.
 //!
-//! The lane router (`lane.rs`) hands one inbound row at a time to
-//! `process_one`. We deliberately catch panics from `Agent::run_prompt` so a
-//! single wedged Agent doesn't kill the whole lane worker task — the row gets
-//! marked `failed` and the worker loop survives to claim the next row.
+//! The lane router (`mod.rs`'s inbound dispatcher) hands one inbound row at a
+//! time to `process_one`. We deliberately catch panics from
+//! `Agent::run_prompt_stream` so a single wedged Agent doesn't kill the whole
+//! lane worker task — the row gets marked `failed` and the worker loop
+//! survives to claim the next row.
+
+use std::sync::Arc;
 
 use crate::gateway::agent_map::AgentMap;
 use crate::gateway::lane::LaneKey;
 use crate::gateway::queue::{InboundQueue, InboundRow, OutboundQueue};
-use crate::platform::OutboundMessage;
+use crate::gateway::render_registry::{RenderKey, RenderRegistry};
+use crate::gateway::stream_render::StreamRenderer;
+use crate::platform::PlatformCapabilities;
 
 use futures_util::FutureExt;
 use std::panic::AssertUnwindSafe;
+use uuid::Uuid;
 
-/// Drive one inbound row through its Agent and enqueue the reply.
+/// Drive one inbound row through its Agent and pump streamed output to the
+/// outbound queue via `StreamRenderer`.
 ///
 /// Steps:
-/// 1. Look up or spawn the Agent for the row's lane.
-/// 2. Run the prompt; catch panics so the lane worker survives.
-/// 3. On success: enqueue the reply on the outbound queue and mark the
-///    inbound row `done`.
-/// 4. On failure (Err or panic): mark the inbound row `failed` and bubble
+/// 1. Mint a fresh per-turn UUID and build the `RenderKey` for this turn.
+/// 2. Look up or spawn the Agent for the row's lane.
+/// 3. Run the prompt under `run_prompt_stream`, with a consumer task draining
+///    `StreamEvent`s into the renderer.
+/// 4. Catch panics so the lane worker survives a wedged Agent; on panic, evict
+///    the lane so the next request rebuilds fresh state.
+/// 5. On success: mark the inbound row `done` (the renderer has already
+///    enqueued the streamed output, including the final flush triggered by
+///    `StreamEvent::Done`).
+/// 6. On failure (Err or panic): mark the inbound row `failed` and bubble
 ///    the error up to the lane worker for logging.
 pub async fn process_one(
     row: InboundRow,
     agent_map: &AgentMap,
     inbound_queue: &InboundQueue,
-    _outbound_queue: &OutboundQueue,
+    outbound_queue: &Arc<OutboundQueue>,
+    render_registry: &Arc<RenderRegistry>,
+    platform_caps: PlatformCapabilities,
 ) -> anyhow::Result<()> {
     let lane = LaneKey {
         platform: row.platform.clone(),
         chat_id: row.chat_id.clone(),
     };
+
+    let turn_id = Uuid::new_v4().to_string();
+    let render_key = RenderKey {
+        platform: row.platform.clone(),
+        chat_id: row.chat_id.clone(),
+        turn_id: turn_id.clone(),
+    };
+
+    // Build the renderer once; it'll be moved into the consumer task.
+    let mut renderer = StreamRenderer::new(
+        render_key,
+        platform_caps.edit_min_interval_ms,
+        outbound_queue.clone(),
+        render_registry.clone(),
+    );
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<crate::provider::StreamEvent>(
+        crate::provider::STREAM_CHANNEL_CAPACITY,
+    );
+
+    // Consumer task: pump StreamEvents through the renderer. Lives until the
+    // sender side (held by run_prompt_stream) is dropped.
+    let consumer = tokio::spawn(async move {
+        while let Some(ev) = rx.recv().await {
+            if let Err(e) = renderer.handle(ev).await {
+                tracing::error!(target: "gateway::worker", error = %e, "renderer.handle failed");
+            }
+        }
+    });
 
     // AssertUnwindSafe: we don't read Agent state after a panic — we just
     // mark the inbound row failed and drop our handle. The Agent's own state
@@ -42,10 +86,14 @@ pub async fn process_one(
     let unwind = AssertUnwindSafe(async {
         let agent = agent_map.get_or_spawn(&lane).await?;
         let mut agent = agent.lock().await;
-        agent.run_prompt(&row.text).await
+        agent.run_prompt_stream(&row.text, tx).await
     })
     .catch_unwind()
     .await;
+
+    // The sender was moved into run_prompt_stream; closing it lets the
+    // consumer drain to completion before we mark the inbound row done.
+    let _ = consumer.await;
 
     let panicked = unwind.is_err();
     let result: anyhow::Result<String> = unwind.unwrap_or_else(|payload| {
@@ -75,21 +123,11 @@ pub async fn process_one(
     }
 
     match result {
-        Ok(reply) => {
-            inbound_queue
-                .complete_with_outbound(
-                    row.id,
-                    OutboundMessage {
-                        platform: row.platform,
-                        chat_id: row.chat_id,
-                        text: reply,
-                        attachments: vec![],
-                        reply_to: None,
-                        edit_target: None,
-                        turn_id: None,
-                    },
-                )
-                .await?;
+        Ok(_final_text) => {
+            // The renderer has already enqueued the streamed output
+            // (including the final flush triggered by StreamEvent::Done).
+            // Just mark the inbound row done.
+            inbound_queue.mark_done(row.id).await?;
             Ok(())
         }
         Err(e) => {
@@ -114,9 +152,10 @@ mod tests {
     use crate::config::Config;
     use crate::gateway::agent_map::{AgentBuilder, AgentMap};
     use crate::gateway::queue::{InboundQueue, OutboundQueue};
+    use crate::gateway::render_registry::RenderRegistry;
     use crate::hooks::HookRegistry;
     use crate::memory::DbPool;
-    use crate::platform::InboundMessage;
+    use crate::platform::{InboundMessage, PlatformCapabilities};
     use crate::provider::mock::MockProvider;
     use crate::provider::{ChatResponse, LLMProvider, Message, StreamEvent, ToolDefinition};
     use crate::skills::SkillRegistry;
@@ -222,11 +261,20 @@ mod tests {
         AgentMap::with_builder(test_config(), Duration::from_secs(60), builder)
     }
 
+    fn streaming_caps() -> PlatformCapabilities {
+        PlatformCapabilities {
+            supports_edit: true,
+            edit_min_interval_ms: 0,
+            ..PlatformCapabilities::default()
+        }
+    }
+
     #[tokio::test]
     async fn worker_runs_agent_and_enqueues_reply() {
         let db = fresh_db();
         let inbound = InboundQueue::new(db.clone());
-        let outbound = OutboundQueue::new(db.clone(), 5);
+        let outbound = Arc::new(OutboundQueue::new(db.clone(), 5));
+        let render_registry = Arc::new(RenderRegistry::new());
         let agent_map = agent_map_with_canned_reply("hi back");
 
         let id = inbound
@@ -244,18 +292,32 @@ mod tests {
         let row = inbound.claim_next().await.unwrap().expect("row");
         assert_eq!(row.id, id);
 
-        process_one(row, &agent_map, &inbound, &outbound)
-            .await
-            .unwrap();
+        process_one(
+            row,
+            &agent_map,
+            &inbound,
+            &outbound,
+            &render_registry,
+            streaming_caps(),
+        )
+        .await
+        .unwrap();
 
+        // The streaming pipeline emits one (or more) outbound rows for
+        // the canned "hi back" reply via the renderer. The first row
+        // should carry the streamed text; pin that.
         let row = outbound
             .claim_due(chrono::Utc::now().timestamp())
             .await
             .unwrap()
-            .expect("outbound row");
+            .expect("outbound row from renderer");
         assert_eq!(row.text, "hi back");
         assert_eq!(row.platform, "loopback");
         assert_eq!(row.chat_id, "c");
+        assert!(
+            row.turn_id.is_some(),
+            "streaming row should carry a per-turn id"
+        );
     }
 
     #[tokio::test]
@@ -265,7 +327,8 @@ mod tests {
         // looping back to 'pending'.
         let db = fresh_db();
         let inbound = crate::gateway::queue::InboundQueue::with_policy(db.clone(), 1, 60);
-        let outbound = OutboundQueue::new(db.clone(), 5);
+        let outbound = Arc::new(OutboundQueue::new(db.clone(), 5));
+        let render_registry = Arc::new(RenderRegistry::new());
         let agent_map = agent_map_with_panicking_provider();
 
         inbound
@@ -282,7 +345,15 @@ mod tests {
             .unwrap();
         let row = inbound.claim_next().await.unwrap().expect("row");
 
-        let res = process_one(row, &agent_map, &inbound, &outbound).await;
+        let res = process_one(
+            row,
+            &agent_map,
+            &inbound,
+            &outbound,
+            &render_registry,
+            streaming_caps(),
+        )
+        .await;
         assert!(
             res.is_err(),
             "process_one should propagate the panic as Err"
@@ -292,7 +363,8 @@ mod tests {
         assert!(inbound.claim_next().await.unwrap().is_none());
         assert_eq!(inbound.count_dead().await.unwrap(), 1);
 
-        // Outbound should be empty (no reply enqueued).
+        // Outbound should be empty (no reply enqueued — the panic fires
+        // before any StreamEvent reaches the renderer).
         assert!(
             outbound
                 .claim_due(chrono::Utc::now().timestamp())
@@ -304,13 +376,14 @@ mod tests {
 
     #[tokio::test]
     async fn worker_panic_evicts_lane_so_next_request_builds_fresh_agent() {
-        // YYC-133 acceptance pin: a panic during run_prompt should
+        // YYC-133 acceptance pin: a panic during run_prompt_stream should
         // remove the lane's cached Agent. The next inbound row for the
         // same lane gets a freshly built Agent and runs cleanly.
         use std::sync::atomic::{AtomicUsize, Ordering};
         let db = fresh_db();
         let inbound = InboundQueue::new(db.clone());
-        let outbound = OutboundQueue::new(db.clone(), 5);
+        let outbound = Arc::new(OutboundQueue::new(db.clone(), 5));
+        let render_registry = Arc::new(RenderRegistry::new());
 
         // Builder counts how many Agents it constructs. First call →
         // panicking provider; second call → canned-reply provider.
@@ -355,7 +428,15 @@ mod tests {
             .await
             .unwrap();
         let row = inbound.claim_next().await.unwrap().expect("row");
-        let res = process_one(row, &agent_map, &inbound, &outbound).await;
+        let res = process_one(
+            row,
+            &agent_map,
+            &inbound,
+            &outbound,
+            &render_registry,
+            streaming_caps(),
+        )
+        .await;
         assert!(res.is_err());
 
         // Lane should now be empty in the AgentMap (evicted).
@@ -369,7 +450,7 @@ mod tests {
         );
 
         // Second row: builder fires a second time, returns a clean
-        // Agent, and the worker drives it to a Continue + reply.
+        // Agent, and the worker drives it to a streamed reply.
         inbound
             .enqueue(InboundMessage {
                 platform: "loopback".into(),
@@ -383,9 +464,16 @@ mod tests {
             .await
             .unwrap();
         let row = inbound.claim_next().await.unwrap().expect("row");
-        process_one(row, &agent_map, &inbound, &outbound)
-            .await
-            .unwrap();
+        process_one(
+            row,
+            &agent_map,
+            &inbound,
+            &outbound,
+            &render_registry,
+            streaming_caps(),
+        )
+        .await
+        .unwrap();
 
         let reply = outbound
             .claim_due(chrono::Utc::now().timestamp())

--- a/src/memory/schema.rs
+++ b/src/memory/schema.rs
@@ -106,7 +106,11 @@ CREATE TABLE IF NOT EXISTS outbound_queue (
   -- OutboundDispatcher routes to Platform::edit instead of Platform::send.
   edit_target TEXT,
   -- Reply / thread target on the platform side.
-  reply_to TEXT
+  reply_to TEXT,
+  -- YYC-18 PR-2b: per-turn id used by RenderRegistry to scope
+  -- edit-in-place anchors. NULL for non-streaming rows
+  -- (CommandDispatcher replies, /v1/inbound webhooks).
+  turn_id TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_outbound_due ON outbound_queue(state, next_attempt_at);
 "#;
@@ -128,6 +132,8 @@ pub(in crate::memory) fn initialize_conn(conn: &Connection) -> Result<()> {
     // YYC-18 PR-2a: payload extensions for outbound + inbound queues.
     let _ = conn.execute("ALTER TABLE outbound_queue ADD COLUMN edit_target TEXT", []);
     let _ = conn.execute("ALTER TABLE outbound_queue ADD COLUMN reply_to TEXT", []);
+    // YYC-18 PR-2b: per-turn id column for streaming RenderKey routing.
+    let _ = conn.execute("ALTER TABLE outbound_queue ADD COLUMN turn_id TEXT", []);
     let _ = conn.execute(
         "ALTER TABLE inbound_queue ADD COLUMN attachments_json TEXT NOT NULL DEFAULT '[]'",
         [],

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -44,6 +44,11 @@ pub struct OutboundMessage {
     /// Set by StreamRenderer for follow-up chunks of an in-flight
     /// streaming response.
     pub edit_target: Option<String>,
+    /// Per-turn id used by RenderRegistry to scope edit-in-place
+    /// anchors. `None` for non-streaming rows (CommandDispatcher
+    /// replies, /v1/inbound webhooks); the dispatcher then falls
+    /// back to chat_id for the registry key.
+    pub turn_id: Option<String>,
 }
 
 /// Result of a successful `Platform::send`. Carries the platform's


### PR DESCRIPTION
YYC-18 PR-2b: outbound_queue.turn_id column + payload field

Replaces the PR-2a chat_id stand-in in RenderKey with a real
per-turn id. StreamRenderer enqueues OutboundMessages with
turn_id populated from its RenderKey; OutboundDispatcher reads
row.turn_id (falling back to chat_id when None for command
replies / webhook bodies) to build the registry key.

* OutboundMessage gains turn_id: Option<String>.
* outbound_queue + idempotent ALTER TABLE adds turn_id TEXT.
* OutboundRow + enqueue / claim_due / complete_with_outbound
  round-trip the new field.
* OutboundDispatcher.drain_due drops the chat_id stand-in.
* StreamRenderer.flush sets turn_id from the key.
* Existing dispatcher_captures_send_anchor test updated to use
  a real turn_id; new round-trip test pins the column.

cargo test --lib --features gateway passes.

YYC-18 PR-2b: worker streaming via StreamRenderer

process_one switches from buffered Agent::run_prompt to streaming
Agent::run_prompt_stream. A StreamRenderer consumer task pumps
each StreamEvent through, throttled by the platform's
edit_min_interval_ms capability. The renderer enqueues
OutboundMessage rows directly (with the turn_id from PR-2b Task
1); the dispatcher routes first-send to Platform::send and
captures the anchor, subsequent edit chunks to Platform::edit.

* New process_one args: outbound_queue, render_registry,
  platform_caps. The inbound dispatcher in gateway::mod threads
  them through, picking the row's platform's capabilities from
  the PlatformRegistry (default for unknown platforms).
* Per-turn UUID generated in process_one and threaded into the
  RenderKey + every OutboundMessage the renderer enqueues.
* Panic recovery + lane eviction unchanged from PR-1
  (AssertUnwindSafe catches panics from run_prompt_stream
  identically).
* Existing 3 worker tests updated for the new signature; the
  canned-reply test now exercises the streaming pipeline
  (MockProvider emits Text + Done; renderer flushes a single
  outbound row carrying the turn_id).

cargo test --lib --features gateway passes.