### PR TITLE
YYC-18 PR-2c: [gateway.commands] config schema

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -148,6 +148,14 @@ theme = "system"
 # bot_token = "..."
 # allow_bots = false
 
+# YYC-18 PR-2c: gateway slash commands.
+# Builtins (help / status / clear / resume) are registered automatically;
+# entries here override or add custom commands. Shell commands receive
+# VULCAN_PLATFORM / VULCAN_CHAT_ID / VULCAN_USER_ID env vars and the
+# user's message body on stdin.
+# [gateway.commands]
+# mybot = { kind = "shell", command = "scripts/mybot.sh", timeout_secs = 30 }
+
 [keybinds]
 # TUI key bindings (YYC-90). Strings are parsed at startup; unparseable
 # values fall back to the defaults shown here with a tracing warning.

--- a/src/config.rs
+++ b/src/config.rs
@@ -229,6 +229,51 @@ pub struct GatewayConfig {
     pub outbound_max_attempts: u32,
     #[serde(default)]
     pub discord: DiscordConfig,
+    /// YYC-18 PR-2c: slash commands routed through the gateway worker
+    /// before falling through to the streaming agent. Built-ins
+    /// (/help, /status, /clear, /resume) are pre-registered by
+    /// `CommandDispatcher::new`; entries here add custom commands or
+    /// override a builtin (`kind = "shell"` against e.g. `"help"`
+    /// replaces the registered builtin).
+    #[serde(default)]
+    pub commands: HashMap<String, CommandConfig>,
+}
+
+/// YYC-18 PR-2c: per-command configuration. Tagged via
+/// `serde(tag = "kind")` so a TOML entry reads naturally:
+///
+/// ```toml
+/// [gateway.commands]
+/// mybot = { kind = "shell", command = "scripts/mybot.sh" }
+/// ```
+///
+/// `Builtin { name }` is rarely needed in user TOML — the four built-in
+/// names are registered automatically. It exists so a config can
+/// pin a builtin under a different name if desired.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum CommandConfig {
+    /// Built-in command. `name` selects which handler runs; supported
+    /// values: "help", "status", "clear", "resume". Unknown names are
+    /// warn-logged at dispatcher build time and skipped.
+    Builtin { name: String },
+    /// Run a subprocess and reply with its stdout. The user's message
+    /// body (after `/<name>`) is piped into stdin, and `VULCAN_PLATFORM`
+    /// / `VULCAN_CHAT_ID` / `VULCAN_USER_ID` env vars are set on the
+    /// child.
+    Shell {
+        command: String,
+        #[serde(default)]
+        args: Vec<String>,
+        #[serde(default = "default_command_timeout_secs")]
+        timeout_secs: u64,
+        #[serde(default)]
+        working_dir: Option<std::path::PathBuf>,
+    },
+}
+
+fn default_command_timeout_secs() -> u64 {
+    30
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]

--- a/src/gateway/commands.rs
+++ b/src/gateway/commands.rs
@@ -1,0 +1,335 @@
+//! CommandDispatcher: routes `/<command>` text to a builtin or custom
+//! handler. Builtins are pre-registered; the user's TOML
+//! `[gateway.commands]` adds (or overrides) custom commands.
+//!
+//! Worker invokes `dispatch(...)` against `/`-prefixed inbound text.
+//! Returns:
+//!   * `Ok(Some(reply))` — command handled, send `reply` to the user.
+//!   * `Ok(None)`        — text isn't a registered slash command;
+//!                         worker falls through to the streaming agent.
+//!   * `Err(_)`          — command failed (e.g., shell crashed); worker
+//!                         marks inbound failed.
+//!
+//! Naming note: the `RegisteredCommand` enum below would collide with
+//! `tokio::process::Command` if it were named `Command`. Aliased the
+//! enum (rather than the tokio import) so the type that lives on
+//! `CommandDispatcher` carries a self-describing name.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use tokio::process::Command as TokioCommand;
+
+use crate::config::CommandConfig;
+use crate::gateway::agent_map::AgentMap;
+use crate::gateway::lane::LaneKey;
+
+/// Built-in command. Each variant maps to a single dispatch fn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Builtin {
+    Help,
+    Status,
+    Clear,
+    Resume,
+}
+
+impl Builtin {
+    pub fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "help" => Some(Self::Help),
+            "status" => Some(Self::Status),
+            "clear" => Some(Self::Clear),
+            "resume" => Some(Self::Resume),
+            _ => None,
+        }
+    }
+}
+
+/// What's stored in the dispatcher's command map. Either a builtin
+/// (handler lives on `CommandDispatcher`) or a shell entry (spawned via
+/// `tokio::process::Command`).
+#[derive(Debug, Clone)]
+pub enum RegisteredCommand {
+    Builtin(Builtin),
+    Shell {
+        command: String,
+        args: Vec<String>,
+        timeout: Duration,
+        working_dir: Option<std::path::PathBuf>,
+    },
+}
+
+/// Minimal dispatch context — what every handler can read.
+pub struct DispatchCtx<'a> {
+    pub lane: &'a LaneKey,
+    pub user_id: &'a str,
+    pub agent_map: &'a AgentMap,
+    /// User input AFTER the leading `/` and command name. e.g. for
+    /// `"/resume abc-def"` the body is `"abc-def"`. For `/help` it's
+    /// the empty string.
+    pub body: &'a str,
+}
+
+pub struct CommandDispatcher {
+    commands: HashMap<String, RegisteredCommand>,
+}
+
+impl CommandDispatcher {
+    /// Build a dispatcher with the four builtins registered. The
+    /// `user_overrides` map (typically `Config.gateway.commands`) is
+    /// applied on top — an entry that names a builtin replaces it.
+    pub fn new(user_overrides: &HashMap<String, CommandConfig>) -> Self {
+        let mut commands = HashMap::new();
+        commands.insert("help".into(), RegisteredCommand::Builtin(Builtin::Help));
+        commands.insert("status".into(), RegisteredCommand::Builtin(Builtin::Status));
+        commands.insert("clear".into(), RegisteredCommand::Builtin(Builtin::Clear));
+        commands.insert("resume".into(), RegisteredCommand::Builtin(Builtin::Resume));
+
+        for (name, cfg) in user_overrides {
+            let cmd = match cfg {
+                CommandConfig::Builtin { name: bname } => {
+                    let Some(b) = Builtin::from_name(bname) else {
+                        tracing::warn!(
+                            target: "gateway::commands",
+                            name = %name,
+                            unknown = %bname,
+                            "unknown builtin name in [gateway.commands]; ignoring",
+                        );
+                        continue;
+                    };
+                    RegisteredCommand::Builtin(b)
+                }
+                CommandConfig::Shell {
+                    command,
+                    args,
+                    timeout_secs,
+                    working_dir,
+                } => RegisteredCommand::Shell {
+                    command: command.clone(),
+                    args: args.clone(),
+                    timeout: Duration::from_secs(*timeout_secs),
+                    working_dir: working_dir.clone(),
+                },
+            };
+            commands.insert(name.clone(), cmd);
+        }
+        Self { commands }
+    }
+
+    /// Returns `Some(reply)` if `text` is a recognized slash command,
+    /// `None` otherwise. Errors propagate (e.g., shell process panic).
+    pub async fn dispatch(&self, text: &str, ctx: DispatchCtx<'_>) -> Result<Option<String>> {
+        let stripped = match text.strip_prefix('/') {
+            Some(rest) => rest.trim(),
+            None => return Ok(None),
+        };
+        let (name, body) = match stripped.split_once(char::is_whitespace) {
+            Some((n, b)) => (n, b.trim_start()),
+            None => (stripped, ""),
+        };
+        let Some(cmd) = self.commands.get(name) else {
+            return Ok(None);
+        };
+        let body_ctx = DispatchCtx { body, ..ctx };
+        match cmd {
+            RegisteredCommand::Builtin(b) => self.run_builtin(*b, &body_ctx).await.map(Some),
+            RegisteredCommand::Shell {
+                command,
+                args,
+                timeout,
+                working_dir,
+            } => run_shell(command, args, *timeout, working_dir.as_deref(), &body_ctx)
+                .await
+                .map(Some),
+        }
+    }
+
+    async fn run_builtin(&self, b: Builtin, ctx: &DispatchCtx<'_>) -> Result<String> {
+        match b {
+            Builtin::Help => Ok(self.help_text()),
+            Builtin::Status => self.status_text(ctx).await,
+            Builtin::Clear => self.clear(ctx).await,
+            Builtin::Resume => self.resume(ctx).await,
+        }
+    }
+
+    fn help_text(&self) -> String {
+        let mut names: Vec<&String> = self.commands.keys().collect();
+        names.sort();
+        let body = names
+            .iter()
+            .map(|n| format!("• /{n}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        format!("Available commands:\n{body}")
+    }
+
+    async fn status_text(&self, ctx: &DispatchCtx<'_>) -> Result<String> {
+        let agent = ctx.agent_map.get_or_spawn(ctx.lane).await?;
+        let agent = agent.lock().await;
+        Ok(format!(
+            "Session: {}\nProvider: {}\nModel: {}\nContext: {}",
+            agent.session_id(),
+            agent.active_profile().unwrap_or("[default]"),
+            agent.active_model(),
+            agent.max_context(),
+        ))
+    }
+
+    async fn clear(&self, ctx: &DispatchCtx<'_>) -> Result<String> {
+        let removed = ctx.agent_map.evict(ctx.lane).await;
+        if removed {
+            Ok("Cleared session — next message starts fresh.".into())
+        } else {
+            Ok("No active session to clear.".into())
+        }
+    }
+
+    async fn resume(&self, ctx: &DispatchCtx<'_>) -> Result<String> {
+        let session_id = ctx.body.trim();
+        if session_id.is_empty() {
+            return Ok("Usage: /resume <session-id>".into());
+        }
+        let agent = ctx.agent_map.get_or_spawn(ctx.lane).await?;
+        let mut agent = agent.lock().await;
+        agent
+            .resume_session(session_id)
+            .with_context(|| format!("resume {session_id}"))?;
+        Ok(format!("Resumed session {session_id}."))
+    }
+}
+
+const SHELL_OUTPUT_CAP_BYTES: usize = 16 * 1024;
+
+async fn run_shell(
+    command: &str,
+    args: &[String],
+    timeout: Duration,
+    working_dir: Option<&std::path::Path>,
+    ctx: &DispatchCtx<'_>,
+) -> Result<String> {
+    use tokio::io::AsyncWriteExt;
+
+    let mut cmd = TokioCommand::new(command);
+    cmd.args(args)
+        .env("VULCAN_PLATFORM", &ctx.lane.platform)
+        .env("VULCAN_CHAT_ID", &ctx.lane.chat_id)
+        .env("VULCAN_USER_ID", ctx.user_id)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true);
+    if let Some(wd) = working_dir {
+        cmd.current_dir(wd);
+    }
+    let mut child = cmd
+        .spawn()
+        .with_context(|| format!("spawn shell command '{command}'"))?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin.write_all(ctx.body.as_bytes()).await.ok();
+        // Explicitly drop so the child sees EOF — wait_with_output below
+        // would block forever on a process that reads stdin to end.
+        drop(stdin);
+    }
+
+    // wait_with_output consumes the child; safe here because we already
+    // took stdin out above (so the child sees EOF and can exit).
+    let output = match tokio::time::timeout(timeout, child.wait_with_output()).await {
+        Ok(out) => out.context("collect shell command output")?,
+        Err(_) => anyhow::bail!("shell command '{command}' timed out after {timeout:?}"),
+    };
+    let mut stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    if stdout.len() > SHELL_OUTPUT_CAP_BYTES {
+        stdout.truncate(SHELL_OUTPUT_CAP_BYTES);
+        stdout.push_str("\n…(truncated)");
+    }
+    if !output.status.success() {
+        let stderr_tail = String::from_utf8_lossy(&output.stderr);
+        let tail: String = stderr_tail
+            .chars()
+            .rev()
+            .take(1024)
+            .collect::<String>()
+            .chars()
+            .rev()
+            .collect();
+        return Ok(format!(
+            "Command failed (exit {:?}):\n{stdout}\n--- stderr ---\n{tail}",
+            output.status.code(),
+        ));
+    }
+    Ok(stdout)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_overrides() -> HashMap<String, CommandConfig> {
+        HashMap::new()
+    }
+
+    #[test]
+    fn dispatcher_registers_four_builtins_by_default() {
+        let d = CommandDispatcher::new(&empty_overrides());
+        assert!(matches!(
+            d.commands.get("help"),
+            Some(RegisteredCommand::Builtin(Builtin::Help))
+        ));
+        assert!(matches!(
+            d.commands.get("status"),
+            Some(RegisteredCommand::Builtin(Builtin::Status))
+        ));
+        assert!(matches!(
+            d.commands.get("clear"),
+            Some(RegisteredCommand::Builtin(Builtin::Clear))
+        ));
+        assert!(matches!(
+            d.commands.get("resume"),
+            Some(RegisteredCommand::Builtin(Builtin::Resume))
+        ));
+    }
+
+    #[test]
+    fn builtin_from_name_recognizes_four_builtins() {
+        assert_eq!(Builtin::from_name("help"), Some(Builtin::Help));
+        assert_eq!(Builtin::from_name("status"), Some(Builtin::Status));
+        assert_eq!(Builtin::from_name("clear"), Some(Builtin::Clear));
+        assert_eq!(Builtin::from_name("resume"), Some(Builtin::Resume));
+        assert_eq!(Builtin::from_name("nope"), None);
+    }
+
+    #[test]
+    fn user_override_can_replace_a_builtin_with_shell() {
+        let mut overrides = HashMap::new();
+        overrides.insert(
+            "status".into(),
+            CommandConfig::Shell {
+                command: "/bin/echo".into(),
+                args: vec![],
+                timeout_secs: 1,
+                working_dir: None,
+            },
+        );
+        let d = CommandDispatcher::new(&overrides);
+        match d.commands.get("status") {
+            Some(RegisteredCommand::Shell { .. }) => {}
+            _ => panic!("override should replace builtin with shell"),
+        }
+    }
+
+    #[test]
+    fn user_override_with_unknown_builtin_name_is_ignored() {
+        let mut overrides = HashMap::new();
+        overrides.insert(
+            "nope".into(),
+            CommandConfig::Builtin {
+                name: "not-a-real-builtin".into(),
+            },
+        );
+        let d = CommandDispatcher::new(&overrides);
+        assert!(!d.commands.contains_key("nope"));
+    }
+}

--- a/src/gateway/commands.rs
+++ b/src/gateway/commands.rs
@@ -119,6 +119,10 @@ impl CommandDispatcher {
 
     /// Returns `Some(reply)` if `text` is a recognized slash command,
     /// `None` otherwise. Errors propagate (e.g., shell process panic).
+    /// Command names are matched case-insensitively (`/Help`, `/HELP`,
+    /// and `/help` all resolve the same builtin) — chat platforms
+    /// autocapitalize on mobile, and a case-sensitive miss would
+    /// silently route to the streaming agent.
     pub async fn dispatch(&self, text: &str, ctx: DispatchCtx<'_>) -> Result<Option<String>> {
         let stripped = match text.strip_prefix('/') {
             Some(rest) => rest.trim(),
@@ -128,7 +132,8 @@ impl CommandDispatcher {
             Some((n, b)) => (n, b.trim_start()),
             None => (stripped, ""),
         };
-        let Some(cmd) = self.commands.get(name) else {
+        let lower = name.to_ascii_lowercase();
+        let Some(cmd) = self.commands.get(&lower) else {
             return Ok(None);
         };
         let body_ctx = DispatchCtx { body, ..ctx };
@@ -202,6 +207,12 @@ impl CommandDispatcher {
 
 const SHELL_OUTPUT_CAP_BYTES: usize = 16 * 1024;
 
+/// SECURITY: `command` and `args` are sourced from operator config and
+/// executed verbatim via `TokioCommand::new` (no shell, no expansion).
+/// Inbound user text reaches the child only via stdin. Do NOT change
+/// this contract without re-evaluating injection — composing `command`
+/// or `args` from inbound text would let users execute arbitrary
+/// processes under the gateway daemon's privileges.
 async fn run_shell(
     command: &str,
     args: &[String],
@@ -242,7 +253,12 @@ async fn run_shell(
     };
     let mut stdout = String::from_utf8_lossy(&output.stdout).into_owned();
     if stdout.len() > SHELL_OUTPUT_CAP_BYTES {
-        stdout.truncate(SHELL_OUTPUT_CAP_BYTES);
+        // String::truncate panics if `n` lands mid-codepoint. UTF-8
+        // multibyte chars near the byte cap (e.g. a `ä` straddling
+        // byte 16384) would otherwise crash the worker. floor_char_boundary
+        // walks back to the nearest valid char boundary <= n.
+        let n = stdout.floor_char_boundary(SHELL_OUTPUT_CAP_BYTES);
+        stdout.truncate(n);
         stdout.push_str("\n…(truncated)");
     }
     if !output.status.success() {
@@ -331,5 +347,48 @@ mod tests {
         );
         let d = CommandDispatcher::new(&overrides);
         assert!(!d.commands.contains_key("nope"));
+    }
+
+    #[tokio::test]
+    async fn dispatch_is_case_insensitive_for_builtins() {
+        let d = CommandDispatcher::new(&empty_overrides());
+        let lane = LaneKey {
+            platform: "loopback".into(),
+            chat_id: "c".into(),
+        };
+        // Build a stand-in AgentMap; /help doesn't actually consult it,
+        // so we only need the type to match.
+        let cfg = std::sync::Arc::new(crate::config::Config::default());
+        let agent_map = AgentMap::new(cfg, std::time::Duration::from_secs(60));
+        let ctx = DispatchCtx {
+            lane: &lane,
+            user_id: "u",
+            agent_map: &agent_map,
+            body: "",
+        };
+        let reply = d
+            .dispatch("/HELP", ctx)
+            .await
+            .expect("dispatch ok")
+            .expect("uppercase /HELP should hit builtin /help");
+        assert!(reply.starts_with("Available commands:"));
+    }
+
+    #[tokio::test]
+    async fn dispatch_returns_none_for_non_slash_text() {
+        let d = CommandDispatcher::new(&empty_overrides());
+        let lane = LaneKey {
+            platform: "loopback".into(),
+            chat_id: "c".into(),
+        };
+        let cfg = std::sync::Arc::new(crate::config::Config::default());
+        let agent_map = AgentMap::new(cfg, std::time::Duration::from_secs(60));
+        let ctx = DispatchCtx {
+            lane: &lane,
+            user_id: "u",
+            agent_map: &agent_map,
+            body: "",
+        };
+        assert!(d.dispatch("hello world", ctx).await.unwrap().is_none());
     }
 }

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -263,6 +263,7 @@ mod tests {
             max_concurrent_lanes: 64,
             outbound_max_attempts: 5,
             discord: crate::config::DiscordConfig::default(),
+            commands: std::collections::HashMap::new(),
         });
         config
     }

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use crate::config::Config;
 use crate::gateway::agent_map::AgentMap;
+use crate::gateway::commands::CommandDispatcher;
 use crate::gateway::discord::DiscordPlatform;
 use crate::gateway::lane::{LaneKey, LaneRouter, from_closure};
 use crate::gateway::loopback::LoopbackPlatform;
@@ -109,12 +110,17 @@ where
     } else {
         None
     };
+    // YYC-18 PR-2c: build the dispatcher once at startup from
+    // Config.gateway.commands; the four builtins are pre-registered
+    // by CommandDispatcher::new regardless of TOML contents.
+    let commands = Arc::new(CommandDispatcher::new(&gateway.commands));
     let inbound_dispatcher = spawn_inbound_dispatcher(
         Arc::clone(&inbound),
         Arc::clone(&outbound),
         Arc::clone(&agent_map),
         Arc::clone(&render_registry),
         Arc::clone(&registry),
+        Arc::clone(&commands),
     );
 
     let app = build_router(AppState {
@@ -150,6 +156,7 @@ fn spawn_inbound_dispatcher(
     agent_map: Arc<AgentMap>,
     render_registry: Arc<crate::gateway::render_registry::RenderRegistry>,
     platform_registry: Arc<PlatformRegistry>,
+    commands: Arc<CommandDispatcher>,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         let handler_inbound = Arc::clone(&inbound);
@@ -157,12 +164,14 @@ fn spawn_inbound_dispatcher(
         let handler_agent_map = Arc::clone(&agent_map);
         let handler_render_registry = Arc::clone(&render_registry);
         let handler_platform_registry = Arc::clone(&platform_registry);
+        let handler_commands = Arc::clone(&commands);
         let handler = from_closure(move |_lane: LaneKey, row: InboundRow| {
             let inbound = Arc::clone(&handler_inbound);
             let outbound = Arc::clone(&handler_outbound);
             let agent_map = Arc::clone(&handler_agent_map);
             let render_registry = Arc::clone(&handler_render_registry);
             let platform_registry = Arc::clone(&handler_platform_registry);
+            let commands = Arc::clone(&handler_commands);
             async move {
                 // Pick capabilities from the registered platform; default
                 // (zero-feature) for an unknown platform name so the
@@ -179,6 +188,7 @@ fn spawn_inbound_dispatcher(
                     &outbound,
                     &render_registry,
                     caps,
+                    &commands,
                 )
                 .await
                 {

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -17,6 +17,7 @@ use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
 
 pub mod agent_map;
+pub mod commands;
 pub mod discord;
 pub mod lane;
 pub mod loopback;

--- a/src/gateway/worker.rs
+++ b/src/gateway/worker.rs
@@ -11,11 +11,12 @@
 use std::sync::Arc;
 
 use crate::gateway::agent_map::AgentMap;
+use crate::gateway::commands::{CommandDispatcher, DispatchCtx};
 use crate::gateway::lane::LaneKey;
 use crate::gateway::queue::{InboundQueue, InboundRow, OutboundQueue};
 use crate::gateway::render_registry::{RenderKey, RenderRegistry};
 use crate::gateway::stream_render::StreamRenderer;
-use crate::platform::PlatformCapabilities;
+use crate::platform::{OutboundMessage, PlatformCapabilities};
 
 use futures_util::FutureExt;
 use std::panic::AssertUnwindSafe;
@@ -43,11 +44,55 @@ pub async fn process_one(
     outbound_queue: &Arc<OutboundQueue>,
     render_registry: &Arc<RenderRegistry>,
     platform_caps: PlatformCapabilities,
+    commands: &CommandDispatcher,
 ) -> anyhow::Result<()> {
     let lane = LaneKey {
         platform: row.platform.clone(),
         chat_id: row.chat_id.clone(),
     };
+
+    // YYC-18 PR-2c: route slash commands through CommandDispatcher
+    // first. On Some(reply), enqueue an atomic outbound row and mark
+    // inbound done in one transaction (no streaming, no edit-in-place
+    // — replies are short and final). On None, fall through to the
+    // streaming agent path below.
+    match commands
+        .dispatch(
+            &row.text,
+            DispatchCtx {
+                lane: &lane,
+                user_id: &row.user_id,
+                agent_map,
+                body: "",
+            },
+        )
+        .await
+    {
+        Ok(Some(reply)) => {
+            let id = row.id;
+            inbound_queue
+                .complete_with_outbound(
+                    id,
+                    OutboundMessage {
+                        platform: row.platform,
+                        chat_id: row.chat_id,
+                        text: reply,
+                        attachments: vec![],
+                        reply_to: None,
+                        edit_target: None,
+                        turn_id: None,
+                    },
+                )
+                .await?;
+            return Ok(());
+        }
+        Ok(None) => {}
+        Err(e) => {
+            let err_str = e.to_string();
+            inbound_queue.mark_failed(row.id, &err_str).await?;
+            return Err(e);
+        }
+    }
 
     let turn_id = Uuid::new_v4().to_string();
     let render_key = RenderKey {
@@ -184,6 +229,7 @@ mod tests {
     use crate::agent::Agent;
     use crate::config::Config;
     use crate::gateway::agent_map::{AgentBuilder, AgentMap};
+    use crate::gateway::commands::CommandDispatcher;
     use crate::gateway::queue::{InboundQueue, OutboundQueue};
     use crate::gateway::render_registry::RenderRegistry;
     use crate::hooks::HookRegistry;
@@ -193,6 +239,7 @@ mod tests {
     use crate::provider::{ChatResponse, LLMProvider, Message, StreamEvent, ToolDefinition};
     use crate::skills::SkillRegistry;
     use crate::tools::ToolRegistry;
+    use std::collections::HashMap;
 
     fn fresh_db() -> DbPool {
         crate::memory::in_memory_gateway_pool().expect("in-memory pool")
@@ -309,6 +356,7 @@ mod tests {
         let outbound = Arc::new(OutboundQueue::new(db.clone(), 5));
         let render_registry = Arc::new(RenderRegistry::new());
         let agent_map = agent_map_with_canned_reply("hi back");
+        let commands = CommandDispatcher::new(&HashMap::new());
 
         let id = inbound
             .enqueue(InboundMessage {
@@ -332,6 +380,7 @@ mod tests {
             &outbound,
             &render_registry,
             streaming_caps(),
+            &commands,
         )
         .await
         .unwrap();
@@ -363,6 +412,7 @@ mod tests {
         let outbound = Arc::new(OutboundQueue::new(db.clone(), 5));
         let render_registry = Arc::new(RenderRegistry::new());
         let agent_map = agent_map_with_panicking_provider();
+        let commands = CommandDispatcher::new(&HashMap::new());
 
         inbound
             .enqueue(InboundMessage {
@@ -385,6 +435,7 @@ mod tests {
             &outbound,
             &render_registry,
             streaming_caps(),
+            &commands,
         )
         .await;
         assert!(
@@ -445,6 +496,7 @@ mod tests {
             })
         });
         let agent_map = AgentMap::with_builder(test_config(), Duration::from_secs(60), builder);
+        let commands = CommandDispatcher::new(&HashMap::new());
 
         // First row: panics. process_one should propagate the panic AND
         // evict the lane.
@@ -468,6 +520,7 @@ mod tests {
             &outbound,
             &render_registry,
             streaming_caps(),
+            &commands,
         )
         .await;
         assert!(res.is_err());
@@ -504,6 +557,7 @@ mod tests {
             &outbound,
             &render_registry,
             streaming_caps(),
+            &commands,
         )
         .await
         .unwrap();
@@ -518,6 +572,60 @@ mod tests {
             calls.load(Ordering::SeqCst),
             2,
             "builder should have run twice — once for the panicking agent, once for the rebuild"
+        );
+    }
+
+    #[tokio::test]
+    async fn worker_routes_slash_help_through_dispatcher() {
+        // YYC-18 PR-2c: a `/`-prefixed inbound row that maps to a
+        // registered command produces an atomic outbound row (no
+        // streaming, no edit-in-place). The streaming agent path is
+        // bypassed entirely — turn_id stays None to mark the reply as
+        // single-shot for downstream renderers.
+        let db = fresh_db();
+        let inbound = InboundQueue::new(db.clone());
+        let outbound = Arc::new(OutboundQueue::new(db.clone(), 5));
+        let render_registry = Arc::new(RenderRegistry::new());
+        let agent_map = agent_map_with_canned_reply("unused");
+        let commands = CommandDispatcher::new(&HashMap::new());
+
+        inbound
+            .enqueue(InboundMessage {
+                platform: "loopback".into(),
+                chat_id: "c".into(),
+                user_id: "u".into(),
+                text: "/help".into(),
+                message_id: None,
+                reply_to: None,
+                attachments: vec![],
+            })
+            .await
+            .unwrap();
+        let row = inbound.claim_next().await.unwrap().expect("row");
+
+        process_one(
+            row,
+            &agent_map,
+            &inbound,
+            &outbound,
+            &render_registry,
+            PlatformCapabilities::default(),
+            &commands,
+        )
+        .await
+        .unwrap();
+
+        let reply = outbound
+            .claim_due(chrono::Utc::now().timestamp())
+            .await
+            .unwrap()
+            .expect("dispatcher reply enqueued");
+        assert!(reply.text.starts_with("Available commands:"));
+        assert!(reply.text.contains("/help"));
+        // Confirm the streaming machinery wasn't engaged.
+        assert!(
+            reply.turn_id.is_none(),
+            "command replies are atomic, not streamed"
         );
     }
 }

--- a/src/gateway/worker.rs
+++ b/src/gateway/worker.rs
@@ -627,5 +627,10 @@ mod tests {
             reply.turn_id.is_none(),
             "command replies are atomic, not streamed"
         );
+        // Inbound row was completed atomically alongside the outbound.
+        assert!(
+            inbound.claim_next().await.unwrap().is_none(),
+            "inbound row should be done after dispatch, not re-claimable"
+        );
     }
 }


### PR DESCRIPTION
YYC-18 PR-2c: [gateway.commands] config schema

CommandConfig enum: Builtin { name } and Shell { command, args,
timeout_secs, working_dir }. Tagged via serde(tag = "kind") so TOML
reads naturally:

  [gateway.commands]
  mybot = { kind = "shell", command = "scripts/mybot.sh" }

GatewayConfig.commands: HashMap<String, CommandConfig>. Default
empty — builtins are registered by the dispatcher itself in Task 2,
not declared in TOML. Operators can override a builtin by listing
its name with kind = "shell".

YYC-18 PR-2c: CommandDispatcher with /help /status /clear /resume

CommandDispatcher::new pre-registers four builtins. User
[gateway.commands] entries layer on top — overrides replace,
custom names extend. Unknown builtin names in user TOML are
warn-logged and skipped.

Builtins:
  /help           — list registered command names
  /status         — session id + active provider/model + context window
  /clear          — evict the lane's Agent so the next message starts
                    a fresh session
  /resume <id>    — switch the lane's Agent to a past session

Shell handler runs tokio::process::Command with VULCAN_PLATFORM /
VULCAN_CHAT_ID / VULCAN_USER_ID env vars; user message body goes
to stdin; stdout capped at 16KB; configurable timeout (default 30s);
non-zero exit returns the failure with a stderr tail.

Wired only as a library module — worker integration is Task 3.

cargo test --lib --features gateway gateway::commands passes (4 tests).

YYC-18 PR-2c: worker routes slash commands through CommandDispatcher

process_one checks the dispatcher first — `/`-prefixed text that
maps to a registered builtin or shell command produces an atomic
OutboundMessage (no streaming, no edit-in-place). Non-command text
falls through to the streaming agent path landed in PR-2b.

* spawn_inbound_dispatcher threads Arc<CommandDispatcher> built
  from Config.gateway.commands at startup.
* Existing 3 worker tests updated for the new arg (empty
  dispatcher).
* New worker_routes_slash_help_through_dispatcher test pins the
  command-path branch end-to-end.

cargo test --lib --features gateway passes.