### PR TITLE
YYC-18 PR-3: telegram cargo feature + [gateway.telegram] config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "ar_archive_writer"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
+dependencies = [
+ "object",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,7 +630,7 @@ checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
  "bitflags 2.11.1",
  "crossterm_winapi",
- "derive_more",
+ "derive_more 2.1.1",
  "document-features",
  "mio",
  "parking_lot",
@@ -732,11 +741,32 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl 1.0.0",
+]
+
+[[package]]
+name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
- "derive_more-impl",
+ "derive_more-impl 2.1.1",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -850,6 +880,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,6 +911,16 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erasable"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "437cfb75878119ed8265685c41a115724eae43fb7cc5a0bf0e4ecc3b803af1c4"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "errno"
@@ -1044,6 +1090,7 @@ checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -1065,6 +1112,17 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -2131,7 +2189,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2146,6 +2204,12 @@ checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -2500,6 +2564,17 @@ dependencies = [
  "same-file",
  "walkdir",
  "winapi-util",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -3200,6 +3275,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3299,6 +3394,16 @@ dependencies = [
  "bytesize",
  "human_format",
  "parking_lot",
+]
+
+[[package]]
+name = "psm"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
 ]
 
 [[package]]
@@ -3562,12 +3667,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rc-box"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897fecc9fac6febd4408f9e935e86df739b0023b625e610e0357535b9c8adad0"
+dependencies = [
+ "erasable",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.11.1",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3688,6 +3822,15 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.5.0",
  "web-sys",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -3910,6 +4053,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3999,7 +4166,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -4048,6 +4215,37 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4252,6 +4450,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "stacker"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4357,6 +4568,50 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "take_mut"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
+
+[[package]]
+name = "takecell"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20f34339676cdcab560c9a82300c4c2581f68b9369aedf0fae86f2ff9565ff3e"
+
+[[package]]
+name = "teloxide-core"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7a34ca8e971fa892e633858c07547fe138ef4a02e4a4eaa1d35e517d6e0bc4"
+dependencies = [
+ "bitflags 2.11.1",
+ "bytes",
+ "chrono",
+ "derive_more 1.0.0",
+ "either",
+ "futures",
+ "log",
+ "mime",
+ "once_cell",
+ "pin-project",
+ "rc-box",
+ "reqwest 0.12.28",
+ "rgb",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "stacker",
+ "take_mut",
+ "takecell",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -4658,7 +4913,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -4691,7 +4946,7 @@ version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -5123,6 +5378,7 @@ dependencies = [
  "sha2",
  "strsim",
  "subtle",
+ "teloxide-core",
  "tempfile",
  "thiserror 2.0.18",
  "tiktoken-rs",
@@ -5258,7 +5514,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -5297,7 +5553,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -5739,7 +5995,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -5770,7 +6026,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -5789,7 +6045,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ gateway = [
     "dep:r2d2",
     "dep:r2d2_sqlite",
 ]
+# Telegram connector (YYC-18 PR-3). Gated separately from `gateway` so
+# operators who only need Discord don't pay the teloxide-core dep cost.
+telegram = ["gateway", "dep:teloxide-core"]
 
 [dependencies]
 # Async runtime
@@ -128,6 +131,12 @@ subtle = { version = "2.6.1", optional = true }
 hmac = { version = "0.12.1", optional = true }
 sha2 = { version = "0.10.9", optional = true }
 serenity = { version = "0.12", default-features = false, features = ["client", "gateway", "http", "model", "rustls_backend"], optional = true }
+# Telegram Bot API client + types. We use teloxide-core (HTTP + types
+# only) rather than full teloxide so the dispatcher framework's macro
+# DSL doesn't infect the build. Long-poll + webhook are driven by our
+# own gateway plumbing. Pinned to 0.13.0 (latest stable on crates.io
+# 2026-04-27); `rustls` feature reuses our existing rustls TLS stack.
+teloxide-core = { version = "0.13.0", default-features = false, features = ["rustls"], optional = true }
 # Connection pool for the gateway daemon's SQLite store (YYC-113). Replaces
 # the global Arc<Mutex<Connection>> that serialized every concurrent agent
 # lane through one lock. Versions verified at crates.io latest stable.

--- a/config.example.toml
+++ b/config.example.toml
@@ -141,7 +141,9 @@ theme = "system"
 # [gateway.telegram]
 # enabled = false
 # bot_token = "..."
-# webhook_secret = "..."
+# webhook_secret = ""              # empty disables webhook receive
+# allowed_chat_ids = []            # empty = open
+# poll_interval_secs = 25
 
 # [gateway.discord]
 # enabled = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -229,6 +229,12 @@ pub struct GatewayConfig {
     pub outbound_max_attempts: u32,
     #[serde(default)]
     pub discord: DiscordConfig,
+    /// YYC-18 PR-3: Telegram connector. Behind the `telegram` cargo
+    /// feature at the wiring layer; the config struct itself lives
+    /// unconditionally so TOML round-trips cleanly regardless of the
+    /// feature set the binary was built with.
+    #[serde(default)]
+    pub telegram: TelegramConfig,
     /// YYC-18 PR-2c: slash commands routed through the gateway worker
     /// before falling through to the streaming agent. Built-ins
     /// (/help, /status, /clear, /resume) are pre-registered by
@@ -284,6 +290,36 @@ pub struct DiscordConfig {
     pub bot_token: String,
     #[serde(default)]
     pub allow_bots: bool,
+}
+
+/// YYC-18 PR-3: Telegram connector configuration.
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct TelegramConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub bot_token: String,
+    /// When set, the gateway accepts webhook POSTs at
+    /// `/webhook/telegram` and verifies the
+    /// `X-Telegram-Bot-Api-Secret-Token` header against this value.
+    /// Empty means webhooks disabled — gateway only receives via
+    /// long-poll.
+    #[serde(default)]
+    pub webhook_secret: String,
+    /// Chat ids allowed to talk to the bot. Empty = open (every chat
+    /// the bot is added to is served). Telegram chat ids are i64;
+    /// negative for groups, positive for DMs.
+    #[serde(default)]
+    pub allowed_chat_ids: Vec<i64>,
+    /// How many seconds the long-poll `getUpdates` request waits for
+    /// new messages. 0 = short-poll (busy loop). Telegram caps at 50;
+    /// 25 is a reasonable middle.
+    #[serde(default = "default_telegram_poll_interval_secs")]
+    pub poll_interval_secs: u32,
+}
+
+fn default_telegram_poll_interval_secs() -> u32 {
+    25
 }
 
 fn default_gateway_bind() -> String {

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -274,6 +274,7 @@ mod tests {
             max_concurrent_lanes: 64,
             outbound_max_attempts: 5,
             discord: crate::config::DiscordConfig::default(),
+            telegram: crate::config::TelegramConfig::default(),
             commands: std::collections::HashMap::new(),
         });
         config

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -59,6 +59,23 @@ where
             Arc::new(DiscordPlatform::new(&gateway.discord.bot_token)?),
         );
     }
+    #[cfg(feature = "telegram")]
+    if gateway.telegram.enabled {
+        use crate::gateway::telegram::TelegramPlatform;
+        let webhook_secret = if gateway.telegram.webhook_secret.is_empty() {
+            None
+        } else {
+            Some(gateway.telegram.webhook_secret.clone())
+        };
+        registry.register(
+            "telegram",
+            Arc::new(TelegramPlatform::new(
+                gateway.telegram.bot_token.clone(),
+                gateway.telegram.allowed_chat_ids.clone(),
+                webhook_secret,
+            )?),
+        );
+    }
     let registry = Arc::new(registry);
     let agent_map = Arc::new(AgentMap::new(
         Arc::new(config),
@@ -112,6 +129,21 @@ where
     } else {
         None
     };
+    // YYC-18 PR-3: Telegram long-poll runs alongside the Axum server.
+    // Mirrors Discord's enable-and-spawn pattern, gated on the
+    // `telegram` cargo feature so default builds stay free of
+    // teloxide-core.
+    #[cfg(feature = "telegram")]
+    let telegram_dispatcher = if gateway.telegram.enabled {
+        Some(crate::gateway::telegram::TelegramPlatform::spawn_long_poll(
+            gateway.telegram.bot_token.clone(),
+            gateway.telegram.allowed_chat_ids.clone(),
+            gateway.telegram.poll_interval_secs,
+            Arc::clone(&inbound),
+        )?)
+    } else {
+        None
+    };
     // YYC-18 PR-2c: build the dispatcher once at startup from
     // Config.gateway.commands; the four builtins are pre-registered
     // by CommandDispatcher::new regardless of TOML contents.
@@ -144,6 +176,10 @@ where
 
     inbound_dispatcher.abort();
     if let Some(handle) = discord_dispatcher {
+        handle.abort();
+    }
+    #[cfg(feature = "telegram")]
+    if let Some(handle) = telegram_dispatcher {
         handle.abort();
     }
     drop(outbound_dispatcher);

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -29,6 +29,8 @@ pub mod render_registry;
 pub mod routes;
 pub mod server;
 pub mod stream_render;
+#[cfg(feature = "telegram")]
+pub mod telegram;
 pub mod worker;
 
 pub async fn run(config: &Config, bind_override: Option<String>) -> Result<()> {

--- a/src/gateway/telegram.rs
+++ b/src/gateway/telegram.rs
@@ -1,18 +1,23 @@
 //! Telegram platform connector powered by teloxide-core.
 //!
-//! `TelegramPlatform` implements `Platform` against teloxide-core's
-//! HTTP client + types. Webhook receive: `verify_webhook` reads
-//! `X-Telegram-Bot-Api-Secret-Token` and constant-time compares via
-//! `subtle`. The /webhook/:platform route is shared with other
-//! platforms.
+//! Two receive paths feed the same `InboundQueue`:
 //!
-//! Inbound parsing flows through `inbound_from_value` (serde_json
+//!   * Long-poll: `spawn_long_poll` runs `bot.get_updates()` with
+//!     offset-based ack in a tokio task. Mirrors Discord's
+//!     `spawn_gateway_client` — fire-and-forget JoinHandle.
+//!   * Webhook: `verify_webhook` reads
+//!     `X-Telegram-Bot-Api-Secret-Token` and constant-time compares
+//!     via `subtle`. The /webhook/:platform route is shared with
+//!     other platforms.
+//!
+//! Both paths normalize through `inbound_from_value` (serde_json
 //! Update shape parser) -> `inbound_from_update_parts` (parts +
 //! allow-list filter) so the shape and filter logic lives in one
-//! place. The long-poll receive task lives in a separate file-local
-//! impl block and feeds the same helpers.
+//! place. Live HTTP path is exercised by integration tests / manual
+//! smoke; the parsing helpers are unit-tested.
 
 use std::collections::HashSet;
+use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use teloxide_core::{
@@ -20,7 +25,9 @@ use teloxide_core::{
     prelude::Requester,
     types::{ChatId, MessageId, ReplyParameters},
 };
+use tokio::task::JoinHandle;
 
+use crate::gateway::queue::InboundQueue;
 use crate::platform::{
     InboundMessage, OutboundMessage, Platform, PlatformCapabilities, SentMessage,
 };
@@ -116,6 +123,26 @@ impl TelegramPlatform {
             .map(MessageId)
             .with_context(|| format!("invalid Telegram message_id '{id}'"))
     }
+
+    /// Spawn the long-poll loop. Returns a JoinHandle the gateway can
+    /// abort on shutdown. Errors inside the loop are logged + the loop
+    /// continues — Telegram's getUpdates is idempotent (offset-based)
+    /// so transient failures self-heal on the next call.
+    pub fn spawn_long_poll(
+        bot_token: String,
+        allowed_chat_ids: Vec<i64>,
+        poll_interval_secs: u32,
+        inbound: Arc<InboundQueue>,
+    ) -> Result<JoinHandle<()>> {
+        if bot_token.trim().is_empty() {
+            anyhow::bail!("gateway.telegram.bot_token is required when Telegram is enabled");
+        }
+        let allowed = allowed_set(allowed_chat_ids);
+        let bot = Bot::new(bot_token);
+        Ok(tokio::spawn(async move {
+            run_long_poll(bot, allowed, poll_interval_secs, inbound).await;
+        }))
+    }
 }
 
 fn allowed_set(ids: Vec<i64>) -> Option<HashSet<i64>> {
@@ -205,6 +232,59 @@ impl Platform for TelegramPlatform {
             // Telegram caps edits to ~1/sec/chat. The renderer's
             // throttle reads this to space out streaming chunks.
             edit_min_interval_ms: 1000,
+        }
+    }
+}
+
+async fn run_long_poll(
+    bot: Bot,
+    allowed: Option<HashSet<i64>>,
+    poll_interval_secs: u32,
+    inbound: Arc<InboundQueue>,
+) {
+    use teloxide_core::payloads::GetUpdatesSetters;
+    let mut offset: i32 = 0;
+    loop {
+        let req = bot.get_updates().offset(offset).timeout(poll_interval_secs);
+        match req.await {
+            Ok(updates) => {
+                for u in updates {
+                    // UpdateId is u32; cast saturating to i32 because the
+                    // GetUpdates `offset` parameter is i32. Telegram's
+                    // update ids are monotonically increasing but bounded
+                    // well below i32::MAX in practice.
+                    offset = (u.id.0 as i32).saturating_add(1);
+                    let val = match serde_json::to_value(&u) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            tracing::warn!(
+                                target: "gateway::telegram",
+                                error = %e,
+                                "could not serialize Update to value",
+                            );
+                            continue;
+                        }
+                    };
+                    let Some(inb) = TelegramPlatform::inbound_from_value(&val, &allowed) else {
+                        continue;
+                    };
+                    if let Err(e) = inbound.enqueue(inb).await {
+                        tracing::error!(
+                            target: "gateway::telegram",
+                            error = %e,
+                            "failed to enqueue telegram inbound",
+                        );
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "gateway::telegram",
+                    error = %e,
+                    "telegram getUpdates failed; backing off",
+                );
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            }
         }
     }
 }

--- a/src/gateway/telegram.rs
+++ b/src/gateway/telegram.rs
@@ -10,20 +10,22 @@
 //!     via `subtle`. The /webhook/:platform route is shared with
 //!     other platforms.
 //!
-//! Both paths normalize through `inbound_from_value` (serde_json
-//! Update shape parser) -> `inbound_from_update_parts` (parts +
-//! allow-list filter) so the shape and filter logic lives in one
-//! place. Live HTTP path is exercised by integration tests / manual
-//! smoke; the parsing helpers are unit-tested.
+//! Both paths normalize through `inbound_from_update_parts` (parts +
+//! allow-list filter) so the filter logic lives in one place. The
+//! long-poll path uses `inbound_from_update` (typed `Update`) and the
+//! webhook path uses `inbound_from_value` (serde_json `Value`, since
+//! the body arrives as bytes). Live HTTP path is exercised by
+//! integration tests / manual smoke; the parsing helpers are
+//! unit-tested.
 
 use std::collections::HashSet;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use teloxide_core::{
-    Bot,
+    ApiError, Bot, RequestError,
     prelude::Requester,
-    types::{ChatId, MessageId, ReplyParameters},
+    types::{ChatId, MessageId, ReplyParameters, Update, UpdateKind},
 };
 use tokio::task::JoinHandle;
 
@@ -89,10 +91,32 @@ impl TelegramPlatform {
         })
     }
 
+    /// Walk a typed `Update` (from `Bot::get_updates`) into the parts
+    /// `inbound_from_update_parts` consumes. Long-poll path uses this
+    /// rather than a `to_value` round trip — cheaper and type-safe.
+    /// Webhook path stays on `inbound_from_value` because the body
+    /// arrives as bytes.
+    pub(crate) fn inbound_from_update(
+        update: &Update,
+        allowed: &Option<HashSet<i64>>,
+    ) -> Option<InboundMessage> {
+        let m = match &update.kind {
+            UpdateKind::Message(m) | UpdateKind::EditedMessage(m) => m,
+            _ => return None,
+        };
+        let chat_id = m.chat.id.0;
+        let user_id = m.from.as_ref()?.id.0;
+        let message_id = m.id.0;
+        let text = m.text()?;
+        let reply_to = m.reply_to_message().map(|r| r.id.0);
+        Self::inbound_from_update_parts(chat_id, user_id, message_id, text, reply_to, allowed)
+    }
+
     /// Pull (chat_id, user_id, message_id, text, reply_to) out of a
     /// `serde_json::Value`-shaped Update and forward to
-    /// `inbound_from_update_parts`. Used by both webhook and long-poll
-    /// paths so JSON-shape parsing lives in one place.
+    /// `inbound_from_update_parts`. Used by the webhook path (body
+    /// arrives as bytes); long-poll uses `inbound_from_update` against
+    /// the typed `Update` instead.
     pub(crate) fn inbound_from_value(
         update: &serde_json::Value,
         allowed: &Option<HashSet<i64>>,
@@ -181,14 +205,13 @@ impl Platform for TelegramPlatform {
         let chat = Self::chat_id_from_chat(chat_id)?;
         let id = Self::message_id_from_str(message_id)?;
         let result = self.bot.edit_message_text(chat, id, text.to_string()).await;
-        if let Err(err) = &result {
-            // Telegram returns 400 "message is not modified" when the
-            // new text matches the existing text byte-for-byte. That's
-            // an idempotency win on our side, not a failure to surface.
-            let s = err.to_string();
-            if s.contains("message is not modified") {
-                return Ok(());
-            }
+        // Telegram returns 400 "message is not modified" when the new text
+        // matches the existing text byte-for-byte. That's an idempotency
+        // win on our side, not a failure to surface. Match the typed
+        // ApiError variant so unrelated errors (network, JSON, etc.) can
+        // never trip this branch.
+        if let Err(RequestError::Api(ApiError::MessageNotModified)) = &result {
+            return Ok(());
         }
         result
             .map(|_| ())
@@ -249,23 +272,13 @@ async fn run_long_poll(
         match req.await {
             Ok(updates) => {
                 for u in updates {
-                    // UpdateId is u32; cast saturating to i32 because the
-                    // GetUpdates `offset` parameter is i32. Telegram's
+                    // UpdateId is u32; the GetUpdates `offset` parameter is
+                    // i32. `try_from` converts cleanly when in range and
+                    // saturates to i32::MAX otherwise, then +1. Telegram's
                     // update ids are monotonically increasing but bounded
                     // well below i32::MAX in practice.
-                    offset = (u.id.0 as i32).saturating_add(1);
-                    let val = match serde_json::to_value(&u) {
-                        Ok(v) => v,
-                        Err(e) => {
-                            tracing::warn!(
-                                target: "gateway::telegram",
-                                error = %e,
-                                "could not serialize Update to value",
-                            );
-                            continue;
-                        }
-                    };
-                    let Some(inb) = TelegramPlatform::inbound_from_value(&val, &allowed) else {
+                    offset = i32::try_from(u.id.0).unwrap_or(i32::MAX).saturating_add(1);
+                    let Some(inb) = TelegramPlatform::inbound_from_update(&u, &allowed) else {
                         continue;
                     };
                     if let Err(e) = inbound.enqueue(inb).await {
@@ -407,5 +420,136 @@ mod tests {
         assert_eq!(inb.text, "hello bot");
         assert_eq!(inb.chat_id, "42");
         assert_eq!(inb.message_id.as_deref(), Some("100"));
+    }
+
+    /// Typed-Update sibling of `inbound_from_value_extracts_text_message`.
+    /// Constructs a real `teloxide_core::types::Update` via JSON round
+    /// trip (its derived Deserialize is the supported public API for
+    /// fixture construction) and asserts the typed walker pulls the
+    /// same parts the JSON walker does.
+    #[test]
+    fn inbound_from_update_extracts_text_message() {
+        let json = r#"{
+            "update_id": 1,
+            "message": {
+                "message_id": 100,
+                "from": {
+                    "id": 7,
+                    "is_bot": false,
+                    "first_name": "tester"
+                },
+                "chat": {
+                    "id": 42,
+                    "first_name": "tester",
+                    "type": "private"
+                },
+                "date": 1700000000,
+                "text": "hello bot"
+            }
+        }"#;
+        let update: teloxide_core::types::Update =
+            serde_json::from_str(json).expect("deserialize Update");
+        let inb = TelegramPlatform::inbound_from_update(&update, &allowed(&[])).expect("parse");
+        assert_eq!(inb.text, "hello bot");
+        assert_eq!(inb.chat_id, "42");
+        assert_eq!(inb.user_id, "7");
+        assert_eq!(inb.message_id.as_deref(), Some("100"));
+    }
+
+    /// Typed-error path for "message is not modified": construct a
+    /// `RequestError::Api(ApiError::MessageNotModified)` directly (the
+    /// teloxide-core 0.13 variants we matched on at the call site) and
+    /// confirm the discriminant pattern matches it. We can't easily
+    /// drive `TelegramPlatform::edit` to return this without a live
+    /// network round trip, but matching the pattern here is enough to
+    /// catch a future teloxide-core rename.
+    #[test]
+    fn typed_message_not_modified_pattern_matches() {
+        let err: Result<(), RequestError> = Err(RequestError::Api(ApiError::MessageNotModified));
+        let swallowed = matches!(&err, Err(RequestError::Api(ApiError::MessageNotModified)));
+        assert!(
+            swallowed,
+            "expected typed MessageNotModified pattern to match"
+        );
+    }
+
+    fn webhook_body() -> Vec<u8> {
+        serde_json::to_vec(&serde_json::json!({
+            "update_id": 1,
+            "message": {
+                "message_id": 100,
+                "from": { "id": 7 },
+                "chat": { "id": 42 },
+                "text": "hi via webhook",
+            },
+        }))
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn verify_webhook_accepts_matching_secret() {
+        let p = TelegramPlatform::new("123:abc", vec![], Some("s3cret".into())).expect("ctor");
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            "x-telegram-bot-api-secret-token",
+            http::HeaderValue::from_static("s3cret"),
+        );
+        let inb = p
+            .verify_webhook(&headers, &webhook_body())
+            .await
+            .expect("accepted");
+        assert_eq!(inb.text, "hi via webhook");
+        assert_eq!(inb.chat_id, "42");
+    }
+
+    #[tokio::test]
+    async fn verify_webhook_rejects_mismatched_secret() {
+        let p = TelegramPlatform::new("123:abc", vec![], Some("s3cret".into())).expect("ctor");
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            "x-telegram-bot-api-secret-token",
+            http::HeaderValue::from_static("wrong"),
+        );
+        let err = p
+            .verify_webhook(&headers, &webhook_body())
+            .await
+            .expect_err("must reject");
+        assert!(
+            err.to_string().contains("invalid webhook secret"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn verify_webhook_rejects_missing_header() {
+        let p = TelegramPlatform::new("123:abc", vec![], Some("s3cret".into())).expect("ctor");
+        let headers = http::HeaderMap::new();
+        let err = p
+            .verify_webhook(&headers, &webhook_body())
+            .await
+            .expect_err("must reject");
+        assert!(
+            err.to_string()
+                .contains("missing X-Telegram-Bot-Api-Secret-Token"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn verify_webhook_rejects_when_not_configured() {
+        let p = TelegramPlatform::new("123:abc", vec![], None).expect("ctor");
+        let mut headers = http::HeaderMap::new();
+        headers.insert(
+            "x-telegram-bot-api-secret-token",
+            http::HeaderValue::from_static("anything"),
+        );
+        let err = p
+            .verify_webhook(&headers, &webhook_body())
+            .await
+            .expect_err("must reject");
+        assert!(
+            err.to_string().contains("webhook not configured"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/src/gateway/telegram.rs
+++ b/src/gateway/telegram.rs
@@ -1,0 +1,331 @@
+//! Telegram platform connector powered by teloxide-core.
+//!
+//! `TelegramPlatform` implements `Platform` against teloxide-core's
+//! HTTP client + types. Webhook receive: `verify_webhook` reads
+//! `X-Telegram-Bot-Api-Secret-Token` and constant-time compares via
+//! `subtle`. The /webhook/:platform route is shared with other
+//! platforms.
+//!
+//! Inbound parsing flows through `inbound_from_value` (serde_json
+//! Update shape parser) -> `inbound_from_update_parts` (parts +
+//! allow-list filter) so the shape and filter logic lives in one
+//! place. The long-poll receive task lives in a separate file-local
+//! impl block and feeds the same helpers.
+
+use std::collections::HashSet;
+
+use anyhow::{Context, Result};
+use teloxide_core::{
+    Bot,
+    prelude::Requester,
+    types::{ChatId, MessageId, ReplyParameters},
+};
+
+use crate::platform::{
+    InboundMessage, OutboundMessage, Platform, PlatformCapabilities, SentMessage,
+};
+
+#[derive(Debug, Clone)]
+pub struct TelegramPlatform {
+    bot: Bot,
+    allowed_chat_ids: Option<HashSet<i64>>,
+    webhook_secret: Option<String>,
+}
+
+impl TelegramPlatform {
+    pub fn new(
+        bot_token: impl Into<String>,
+        allowed_chat_ids: Vec<i64>,
+        webhook_secret: Option<String>,
+    ) -> Result<Self> {
+        let bot_token = bot_token.into();
+        if bot_token.trim().is_empty() {
+            anyhow::bail!("gateway.telegram.bot_token is required when Telegram is enabled");
+        }
+        let allowed = allowed_set(allowed_chat_ids);
+        Ok(Self {
+            bot: Bot::new(bot_token),
+            allowed_chat_ids: allowed,
+            webhook_secret,
+        })
+    }
+
+    /// Build an InboundMessage from a Telegram Update's pieces. Centralized
+    /// so the long-poll and webhook paths can share parsing + the
+    /// allow-list filter. Returns None when the message should be
+    /// dropped (allow-list miss, empty text).
+    pub(crate) fn inbound_from_update_parts(
+        chat_id: i64,
+        user_id: u64,
+        message_id: i32,
+        text: &str,
+        reply_to: Option<i32>,
+        allowed: &Option<HashSet<i64>>,
+    ) -> Option<InboundMessage> {
+        let trimmed = text.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+        if let Some(set) = allowed
+            && !set.contains(&chat_id)
+        {
+            return None;
+        }
+        Some(InboundMessage {
+            platform: "telegram".into(),
+            chat_id: chat_id.to_string(),
+            user_id: user_id.to_string(),
+            text: trimmed.to_string(),
+            message_id: Some(message_id.to_string()),
+            reply_to: reply_to.map(|r| r.to_string()),
+            attachments: Vec::new(),
+        })
+    }
+
+    /// Pull (chat_id, user_id, message_id, text, reply_to) out of a
+    /// `serde_json::Value`-shaped Update and forward to
+    /// `inbound_from_update_parts`. Used by both webhook and long-poll
+    /// paths so JSON-shape parsing lives in one place.
+    pub(crate) fn inbound_from_value(
+        update: &serde_json::Value,
+        allowed: &Option<HashSet<i64>>,
+    ) -> Option<InboundMessage> {
+        let msg = update
+            .get("message")
+            .or_else(|| update.get("edited_message"))?;
+        let chat_id = msg.get("chat")?.get("id")?.as_i64()?;
+        let user_id = msg.get("from")?.get("id")?.as_u64()?;
+        let message_id = msg.get("message_id")?.as_i64()? as i32;
+        let text = msg.get("text")?.as_str()?;
+        let reply_to = msg
+            .get("reply_to_message")
+            .and_then(|r| r.get("message_id"))
+            .and_then(|v| v.as_i64())
+            .map(|n| n as i32);
+        Self::inbound_from_update_parts(chat_id, user_id, message_id, text, reply_to, allowed)
+    }
+
+    fn chat_id_from_chat(chat: &str) -> Result<ChatId> {
+        chat.parse::<i64>()
+            .map(ChatId)
+            .with_context(|| format!("invalid Telegram chat_id '{chat}'"))
+    }
+
+    fn message_id_from_str(id: &str) -> Result<MessageId> {
+        id.parse::<i32>()
+            .map(MessageId)
+            .with_context(|| format!("invalid Telegram message_id '{id}'"))
+    }
+}
+
+fn allowed_set(ids: Vec<i64>) -> Option<HashSet<i64>> {
+    if ids.is_empty() {
+        None
+    } else {
+        Some(ids.into_iter().collect())
+    }
+}
+
+#[async_trait::async_trait]
+impl Platform for TelegramPlatform {
+    fn name(&self) -> &str {
+        "telegram"
+    }
+
+    async fn start(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn send(&self, msg: &OutboundMessage) -> Result<SentMessage> {
+        use teloxide_core::payloads::SendMessageSetters;
+        let chat_id = Self::chat_id_from_chat(&msg.chat_id)?;
+        let mut req = self.bot.send_message(chat_id, msg.text.clone());
+        if let Some(reply_to) = &msg.reply_to {
+            let reply_id = Self::message_id_from_str(reply_to)?;
+            req = req.reply_parameters(ReplyParameters::new(reply_id));
+        }
+        let sent = req.await.context("telegram send_message failed")?;
+        Ok(SentMessage {
+            message_id: sent.id.0.to_string(),
+        })
+    }
+
+    async fn edit(&self, chat_id: &str, message_id: &str, text: &str) -> Result<()> {
+        let chat = Self::chat_id_from_chat(chat_id)?;
+        let id = Self::message_id_from_str(message_id)?;
+        let result = self.bot.edit_message_text(chat, id, text.to_string()).await;
+        if let Err(err) = &result {
+            // Telegram returns 400 "message is not modified" when the
+            // new text matches the existing text byte-for-byte. That's
+            // an idempotency win on our side, not a failure to surface.
+            let s = err.to_string();
+            if s.contains("message is not modified") {
+                return Ok(());
+            }
+        }
+        result
+            .map(|_| ())
+            .context("telegram edit_message_text failed")
+    }
+
+    async fn recv(&self) -> Result<InboundMessage> {
+        anyhow::bail!("telegram receives messages through the long-poll task or webhook")
+    }
+
+    async fn verify_webhook(
+        &self,
+        headers: &http::HeaderMap,
+        body: &[u8],
+    ) -> Result<InboundMessage> {
+        let Some(expected) = &self.webhook_secret else {
+            anyhow::bail!("telegram webhook not configured (no secret)");
+        };
+        let provided = headers
+            .get("x-telegram-bot-api-secret-token")
+            .and_then(|v| v.to_str().ok())
+            .ok_or_else(|| anyhow::anyhow!("missing X-Telegram-Bot-Api-Secret-Token header"))?;
+        use subtle::ConstantTimeEq;
+        if provided.as_bytes().ct_eq(expected.as_bytes()).unwrap_u8() == 0 {
+            anyhow::bail!("invalid webhook secret");
+        }
+        let update: serde_json::Value = serde_json::from_slice(body)
+            .map_err(|e| anyhow::anyhow!("invalid Update JSON: {e}"))?;
+        Self::inbound_from_value(&update, &self.allowed_chat_ids)
+            .ok_or_else(|| anyhow::anyhow!("Update did not parse to a usable InboundMessage"))
+    }
+
+    fn capabilities(&self) -> PlatformCapabilities {
+        PlatformCapabilities {
+            supports_edit: true,
+            // PR-3 is text-only; the supports_media_* flags + send_photo /
+            // send_document / download_attachment wiring land in PR-3b.
+            supports_media_send: false,
+            supports_media_recv: false,
+            supports_threads: true,
+            // Telegram caps edits to ~1/sec/chat. The renderer's
+            // throttle reads this to space out streaming chunks.
+            edit_min_interval_ms: 1000,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn allowed(ids: &[i64]) -> Option<HashSet<i64>> {
+        if ids.is_empty() {
+            None
+        } else {
+            Some(ids.iter().copied().collect())
+        }
+    }
+
+    #[test]
+    fn inbound_parts_uses_chat_as_chat_id_and_carries_message_id() {
+        let inb =
+            TelegramPlatform::inbound_from_update_parts(42, 7, 100, "hello", None, &allowed(&[]))
+                .expect("accepted");
+        assert_eq!(inb.platform, "telegram");
+        assert_eq!(inb.chat_id, "42");
+        assert_eq!(inb.user_id, "7");
+        assert_eq!(inb.message_id.as_deref(), Some("100"));
+        assert!(inb.reply_to.is_none());
+        assert_eq!(inb.text, "hello");
+    }
+
+    #[test]
+    fn inbound_parts_handles_negative_chat_id_for_groups() {
+        let inb = TelegramPlatform::inbound_from_update_parts(
+            -1001234,
+            7,
+            100,
+            "in a group",
+            None,
+            &allowed(&[]),
+        )
+        .expect("accepted");
+        assert_eq!(inb.chat_id, "-1001234");
+    }
+
+    #[test]
+    fn inbound_parts_carries_reply_to() {
+        let inb = TelegramPlatform::inbound_from_update_parts(
+            42,
+            7,
+            100,
+            "thread reply",
+            Some(99),
+            &allowed(&[]),
+        )
+        .expect("accepted");
+        assert_eq!(inb.reply_to.as_deref(), Some("99"));
+    }
+
+    #[test]
+    fn inbound_parts_drops_empty_text() {
+        let inb =
+            TelegramPlatform::inbound_from_update_parts(42, 7, 100, "   ", None, &allowed(&[]));
+        assert!(inb.is_none());
+    }
+
+    #[test]
+    fn inbound_parts_drops_chat_not_in_allow_list() {
+        let inb = TelegramPlatform::inbound_from_update_parts(
+            42,
+            7,
+            100,
+            "hi",
+            None,
+            &allowed(&[99, 100]),
+        );
+        assert!(inb.is_none());
+    }
+
+    #[test]
+    fn inbound_parts_passes_chat_in_allow_list() {
+        let inb = TelegramPlatform::inbound_from_update_parts(
+            42,
+            7,
+            100,
+            "hi",
+            None,
+            &allowed(&[42, 99]),
+        );
+        assert!(inb.is_some());
+    }
+
+    #[test]
+    fn new_rejects_empty_bot_token() {
+        let err = TelegramPlatform::new("", vec![], None).expect_err("empty token must fail");
+        assert!(err.to_string().contains("bot_token"));
+    }
+
+    #[test]
+    fn capabilities_declare_edit_and_threads_true_media_false() {
+        let p = TelegramPlatform::new("Bot 123:abc", vec![], None).expect("ctor");
+        let caps = p.capabilities();
+        assert!(caps.supports_edit);
+        assert!(caps.supports_threads);
+        assert!(!caps.supports_media_send);
+        assert!(!caps.supports_media_recv);
+        assert_eq!(caps.edit_min_interval_ms, 1000);
+    }
+
+    #[test]
+    fn inbound_from_value_extracts_text_message() {
+        let update = serde_json::json!({
+            "update_id": 1,
+            "message": {
+                "message_id": 100,
+                "from": { "id": 7 },
+                "chat": { "id": 42 },
+                "text": "hello bot",
+            },
+        });
+        let inb = TelegramPlatform::inbound_from_value(&update, &allowed(&[])).expect("parse");
+        assert_eq!(inb.text, "hello bot");
+        assert_eq!(inb.chat_id, "42");
+        assert_eq!(inb.message_id.as_deref(), Some("100"));
+    }
+}


### PR DESCRIPTION
YYC-18 PR-3: telegram cargo feature + [gateway.telegram] config

* New cargo feature `telegram` = gateway + teloxide-core. Discord
  stays bundled with `gateway` (existing coupling); Telegram is
  opt-in so operators who only need Discord don't pay the
  teloxide-core dep cost.
* TelegramConfig struct on GatewayConfig: enabled, bot_token,
  webhook_secret (empty = webhook disabled), allowed_chat_ids
  (empty = open), poll_interval_secs (default 25).
* config.example.toml documents the block.

Pinned teloxide-core 0.13.0 (latest stable on crates.io 2026-04-27),
default-features = false + features = ["rustls"] to reuse the
rustls TLS stack already in the dep graph (avoids pulling
native-tls / OpenSSL). Dep delta over `--features gateway`: +23
unique transitive crates, +60 cargo-tree lines.

Implementation lands in Tasks 2-5.

YYC-18 PR-3: TelegramPlatform — Platform impl (text-only)

src/gateway/telegram.rs (gated on cargo feature `telegram`).

* TelegramPlatform: teloxide-core::Bot + optional allow-list +
  optional webhook secret.
* Platform impl:
  - send: bot.send_message + ReplyParameters when reply_to is set.
    Note: teloxide-core 0.13 retired the `reply_to_message_id`
    setter in favor of the `ReplyParameters` builder.
  - edit: bot.edit_message_text. Telegram's "message is not
    modified" 400 swallowed (idempotency).
  - recv: bails — long-poll task / webhook drives inbound.
  - verify_webhook: constant-time secret compare via subtle.
  - capabilities: edit + threads true, media false,
    edit_min_interval_ms = 1000.
* inbound_from_update_parts: shared parsing/filter helper.
  Negative chat_ids supported (groups). Empty text dropped.
* inbound_from_value: serde_json Update shape parser, used by
  webhook today and by the long-poll task in Task 3.

cargo test --lib --features telegram gateway::telegram passes
(9 tests).

Long-poll task lands in Task 3.

YYC-18 PR-3: telegram long-poll task

spawn_long_poll spawns a tokio task that runs getUpdates with
offset-based ack. Per-update flow:

  serialize → serde_json::Value → inbound_from_value →
  allow-list filter → InboundQueue::enqueue.

Loop survives transient errors: getUpdates failures back off 5s
then continue from the same offset (Telegram dedupe is
offset-based, so retries are idempotent).

UpdateId is u32 in teloxide-core 0.13; we saturating-cast to i32
to feed the GetUpdates `offset` parameter (also i32). Telegram's
update ids are monotonically increasing but bounded well below
i32::MAX in practice — saturating_add is the conservative guard.

Live HTTP path is exercised in integration tests / manual smoke;
the parsing helper is covered by inbound_from_value tests in
Task 2.

cargo build --all-targets --features telegram passes.

YYC-18 PR-3: register TelegramPlatform on gateway startup

Mirror Discord's enable-and-register pattern, gated on the
`telegram` cargo feature so default builds stay free of
teloxide-core.

* Construct TelegramPlatform from [gateway.telegram] config and
  register under platform name "telegram" so OutboundDispatcher
  routes telegram-bound messages through it.
* Spawn long-poll task in the background alongside the gateway
  HTTP server. JoinHandle held in `telegram_dispatcher` and
  aborted on graceful shutdown — same shape as `discord_dispatcher`.
* Webhook receive uses the existing /webhook/:platform route +
  Platform::verify_webhook (already implemented in Task 2).

cargo build / test under both --features gateway and
--features telegram pass (413 / 422 lib tests).