### PR TITLE
YYC-18 PR-3b: Telegram media recv via typed walker

### DIFF
--- a/src/gateway/telegram.rs
+++ b/src/gateway/telegram.rs
@@ -25,13 +25,14 @@ use anyhow::{Context, Result};
 use teloxide_core::{
     ApiError, Bot, RequestError,
     prelude::Requester,
-    types::{ChatId, MessageId, ReplyParameters, Update, UpdateKind},
+    types::{ChatId, FileId, MessageId, ReplyParameters, Update, UpdateKind},
 };
 use tokio::task::JoinHandle;
 
 use crate::gateway::queue::InboundQueue;
 use crate::platform::{
-    InboundMessage, OutboundMessage, Platform, PlatformCapabilities, SentMessage,
+    Attachment, AttachmentKind, InboundMessage, OutboundMessage, Platform, PlatformCapabilities,
+    SentMessage,
 };
 
 #[derive(Debug, Clone)]
@@ -59,20 +60,102 @@ impl TelegramPlatform {
         })
     }
 
+    /// Pick the largest `PhotoSize` from the slice. Telegram returns
+    /// multiple sizes per photo; the last is conventionally the
+    /// largest, but `max_by_key` on the byte size is the robust pick.
+    fn largest_photo_size(
+        sizes: &[teloxide_core::types::PhotoSize],
+    ) -> Option<&teloxide_core::types::PhotoSize> {
+        sizes.iter().max_by_key(|p| p.file.size)
+    }
+
+    /// Extract attachments from a typed `Message`. At most one
+    /// attachment per Message — Telegram doesn't multi-attach in one
+    /// message the way Discord does. Order: photo → document → voice
+    /// → video → audio → sticker.
+    ///
+    /// **Telegram-specific contract:** `Attachment.url` carries the
+    /// opaque `file_id`, NOT a CDN URL. Telegram has no public CDN —
+    /// `download_attachment` resolves the file_id via `bot.get_file`
+    /// and streams the body. Discord stores real HTTPS URLs in the
+    /// same field; same shape, platform-specific interpretation.
+    fn attachments_from_message(msg: &teloxide_core::types::Message) -> Vec<Attachment> {
+        use teloxide_core::types::{MediaKind, MessageKind};
+        let common = match &msg.kind {
+            MessageKind::Common(c) => c,
+            _ => return Vec::new(),
+        };
+        let att = match &common.media_kind {
+            MediaKind::Photo(p) => {
+                let Some(largest) = Self::largest_photo_size(&p.photo) else {
+                    return Vec::new();
+                };
+                Attachment {
+                    url: Some(largest.file.id.0.clone()),
+                    local_path: None,
+                    mime: Some("image/jpeg".into()),
+                    kind: AttachmentKind::Image,
+                    original_name: None,
+                }
+            }
+            MediaKind::Document(d) => Attachment {
+                url: Some(d.document.file.id.0.clone()),
+                local_path: None,
+                mime: d.document.mime_type.as_ref().map(|m| m.to_string()),
+                kind: AttachmentKind::Document,
+                original_name: d.document.file_name.clone(),
+            },
+            MediaKind::Voice(v) => Attachment {
+                url: Some(v.voice.file.id.0.clone()),
+                local_path: None,
+                mime: v.voice.mime_type.as_ref().map(|m| m.to_string()),
+                kind: AttachmentKind::Voice,
+                original_name: None,
+            },
+            MediaKind::Video(v) => Attachment {
+                url: Some(v.video.file.id.0.clone()),
+                local_path: None,
+                mime: v.video.mime_type.as_ref().map(|m| m.to_string()),
+                kind: AttachmentKind::Video,
+                original_name: v.video.file_name.clone(),
+            },
+            MediaKind::Audio(a) => Attachment {
+                url: Some(a.audio.file.id.0.clone()),
+                local_path: None,
+                mime: a.audio.mime_type.as_ref().map(|m| m.to_string()),
+                kind: AttachmentKind::Audio,
+                original_name: a.audio.file_name.clone(),
+            },
+            MediaKind::Sticker(s) => Attachment {
+                url: Some(s.sticker.file.id.0.clone()),
+                local_path: None,
+                mime: None,
+                kind: AttachmentKind::Sticker,
+                original_name: None,
+            },
+            _ => return Vec::new(),
+        };
+        vec![att]
+    }
+
     /// Build an InboundMessage from a Telegram Update's pieces. Centralized
     /// so the long-poll and webhook paths can share parsing + the
     /// allow-list filter. Returns None when the message should be
-    /// dropped (allow-list miss, empty text).
+    /// dropped (allow-list miss, no content).
     pub(crate) fn inbound_from_update_parts(
         chat_id: i64,
         user_id: u64,
         message_id: i32,
         text: &str,
         reply_to: Option<i32>,
+        attachments: Vec<Attachment>,
         allowed: &Option<HashSet<i64>>,
     ) -> Option<InboundMessage> {
         let trimmed = text.trim();
-        if trimmed.is_empty() {
+        // Allow empty text when there's at least one attachment — sending
+        // an image-only message is normal Telegram usage. Mirrors the
+        // PR-4 Discord behavior.
+        if trimmed.is_empty() && attachments.is_empty() {
             return None;
         }
         if let Some(set) = allowed
@@ -87,15 +170,16 @@ impl TelegramPlatform {
             text: trimmed.to_string(),
             message_id: Some(message_id.to_string()),
             reply_to: reply_to.map(|r| r.to_string()),
-            attachments: Vec::new(),
+            attachments,
         })
     }
 
     /// Walk a typed `Update` (from `Bot::get_updates`) into the parts
     /// `inbound_from_update_parts` consumes. Long-poll path uses this
     /// rather than a `to_value` round trip — cheaper and type-safe.
-    /// Webhook path stays on `inbound_from_value` because the body
-    /// arrives as bytes.
+    /// Webhook path also routes through this (after typed
+    /// deserialization in `inbound_from_value`) so media extraction
+    /// lives in one place.
     pub(crate) fn inbound_from_update(
         update: &Update,
         allowed: &Option<HashSet<i64>>,
@@ -107,33 +191,40 @@ impl TelegramPlatform {
         let chat_id = m.chat.id.0;
         let user_id = m.from.as_ref()?.id.0;
         let message_id = m.id.0;
-        let text = m.text()?;
+        // `Message::text()` returns `None` for media-only messages
+        // (no caption AND no plain text). Default to "" so the
+        // attachments-only path passes through `inbound_from_update_parts`.
+        let text = m.text().unwrap_or("");
         let reply_to = m.reply_to_message().map(|r| r.id.0);
-        Self::inbound_from_update_parts(chat_id, user_id, message_id, text, reply_to, allowed)
+        let attachments = Self::attachments_from_message(m);
+        Self::inbound_from_update_parts(
+            chat_id,
+            user_id,
+            message_id,
+            text,
+            reply_to,
+            attachments,
+            allowed,
+        )
     }
 
-    /// Pull (chat_id, user_id, message_id, text, reply_to) out of a
-    /// `serde_json::Value`-shaped Update and forward to
-    /// `inbound_from_update_parts`. Used by the webhook path (body
-    /// arrives as bytes); long-poll uses `inbound_from_update` against
-    /// the typed `Update` instead.
+    /// Webhook path: bytes arrive as JSON. PR-3b routes through the
+    /// typed `Update` deserializer so media extraction stays in one
+    /// place (`inbound_from_update` / `attachments_from_message`).
+    /// If the body isn't a parseable Update we drop it via `None`.
     pub(crate) fn inbound_from_value(
         update: &serde_json::Value,
         allowed: &Option<HashSet<i64>>,
     ) -> Option<InboundMessage> {
-        let msg = update
-            .get("message")
-            .or_else(|| update.get("edited_message"))?;
-        let chat_id = msg.get("chat")?.get("id")?.as_i64()?;
-        let user_id = msg.get("from")?.get("id")?.as_u64()?;
-        let message_id = msg.get("message_id")?.as_i64()? as i32;
-        let text = msg.get("text")?.as_str()?;
-        let reply_to = msg
-            .get("reply_to_message")
-            .and_then(|r| r.get("message_id"))
-            .and_then(|v| v.as_i64())
-            .map(|n| n as i32);
-        Self::inbound_from_update_parts(chat_id, user_id, message_id, text, reply_to, allowed)
+        // teloxide-core 0.13's `UpdateKind` Deserialize visitor uses
+        // `next_key::<&str>()` first, which fails on `serde_json::Value`
+        // (its keys are owned `String`s) — the visitor then falls into
+        // `Error(Value)` and our match drops the update. Round-trip
+        // through bytes (`to_vec` + `from_slice`) sidesteps the issue
+        // and gives us a "real" deserializer driving the visitor.
+        let bytes = serde_json::to_vec(update).ok()?;
+        let typed: Update = serde_json::from_slice(&bytes).ok()?;
+        Self::inbound_from_update(&typed, allowed)
     }
 
     fn chat_id_from_chat(chat: &str) -> Result<ChatId> {
@@ -316,15 +407,23 @@ mod tests {
 
     #[test]
     fn inbound_parts_uses_chat_as_chat_id_and_carries_message_id() {
-        let inb =
-            TelegramPlatform::inbound_from_update_parts(42, 7, 100, "hello", None, &allowed(&[]))
-                .expect("accepted");
+        let inb = TelegramPlatform::inbound_from_update_parts(
+            42,
+            7,
+            100,
+            "hello",
+            None,
+            vec![],
+            &allowed(&[]),
+        )
+        .expect("accepted");
         assert_eq!(inb.platform, "telegram");
         assert_eq!(inb.chat_id, "42");
         assert_eq!(inb.user_id, "7");
         assert_eq!(inb.message_id.as_deref(), Some("100"));
         assert!(inb.reply_to.is_none());
         assert_eq!(inb.text, "hello");
+        assert!(inb.attachments.is_empty());
     }
 
     #[test]
@@ -335,6 +434,7 @@ mod tests {
             100,
             "in a group",
             None,
+            vec![],
             &allowed(&[]),
         )
         .expect("accepted");
@@ -349,6 +449,7 @@ mod tests {
             100,
             "thread reply",
             Some(99),
+            vec![],
             &allowed(&[]),
         )
         .expect("accepted");
@@ -357,8 +458,15 @@ mod tests {
 
     #[test]
     fn inbound_parts_drops_empty_text() {
-        let inb =
-            TelegramPlatform::inbound_from_update_parts(42, 7, 100, "   ", None, &allowed(&[]));
+        let inb = TelegramPlatform::inbound_from_update_parts(
+            42,
+            7,
+            100,
+            "   ",
+            None,
+            vec![],
+            &allowed(&[]),
+        );
         assert!(inb.is_none());
     }
 
@@ -370,6 +478,7 @@ mod tests {
             100,
             "hi",
             None,
+            vec![],
             &allowed(&[99, 100]),
         );
         assert!(inb.is_none());
@@ -383,9 +492,49 @@ mod tests {
             100,
             "hi",
             None,
+            vec![],
             &allowed(&[42, 99]),
         );
         assert!(inb.is_some());
+    }
+
+    #[test]
+    fn inbound_parts_accepts_empty_text_with_attachment() {
+        let att = Attachment {
+            url: Some("file_id_xyz".into()),
+            local_path: None,
+            mime: Some("image/jpeg".into()),
+            kind: AttachmentKind::Image,
+            original_name: None,
+        };
+        let inb = TelegramPlatform::inbound_from_update_parts(
+            42,
+            7,
+            100,
+            "",
+            None,
+            vec![att],
+            &allowed(&[]),
+        )
+        .expect("photo-only message should pass");
+        assert_eq!(inb.text, "");
+        assert_eq!(inb.attachments.len(), 1);
+        assert_eq!(inb.attachments[0].kind, AttachmentKind::Image);
+        assert_eq!(inb.attachments[0].url.as_deref(), Some("file_id_xyz"));
+    }
+
+    #[test]
+    fn inbound_parts_drops_when_text_empty_and_no_attachments() {
+        let inb = TelegramPlatform::inbound_from_update_parts(
+            42,
+            7,
+            100,
+            "",
+            None,
+            vec![],
+            &allowed(&[]),
+        );
+        assert!(inb.is_none());
     }
 
     #[test]
@@ -407,12 +556,16 @@ mod tests {
 
     #[test]
     fn inbound_from_value_extracts_text_message() {
+        // PR-3b: inbound_from_value now deserializes into a typed
+        // `Update`, so the fixture must be a complete Update shape
+        // (update_id, full from, chat.type, date).
         let update = serde_json::json!({
             "update_id": 1,
             "message": {
                 "message_id": 100,
-                "from": { "id": 7 },
-                "chat": { "id": 42 },
+                "from": { "id": 7, "is_bot": false, "first_name": "tester" },
+                "chat": { "id": 42, "first_name": "tester", "type": "private" },
+                "date": 1700000000,
                 "text": "hello bot",
             },
         });
@@ -474,12 +627,15 @@ mod tests {
     }
 
     fn webhook_body() -> Vec<u8> {
+        // PR-3b: must be a complete Update shape so the typed
+        // deserializer in `inbound_from_value` accepts it.
         serde_json::to_vec(&serde_json::json!({
             "update_id": 1,
             "message": {
                 "message_id": 100,
-                "from": { "id": 7 },
-                "chat": { "id": 42 },
+                "from": { "id": 7, "is_bot": false, "first_name": "tester" },
+                "chat": { "id": 42, "first_name": "tester", "type": "private" },
+                "date": 1700000000,
                 "text": "hi via webhook",
             },
         }))

--- a/src/gateway/telegram.rs
+++ b/src/gateway/telegram.rs
@@ -213,18 +213,18 @@ impl TelegramPlatform {
     /// typed `Update` deserializer so media extraction stays in one
     /// place (`inbound_from_update` / `attachments_from_message`).
     /// If the body isn't a parseable Update we drop it via `None`.
-    pub(crate) fn inbound_from_value(
-        update: &serde_json::Value,
+    ///
+    /// Takes raw bytes — webhook handlers call this with the request
+    /// body directly. teloxide-core 0.13's `UpdateKind` Deserialize
+    /// visitor uses `next_key::<&str>()` and falls back to
+    /// `Error(Value)` when driven from `serde_json::Value`'s owned-
+    /// String keys, so we deserialize from `&[u8]` once and avoid the
+    /// double round-trip through Value.
+    pub(crate) fn inbound_from_webhook_body(
+        body: &[u8],
         allowed: &Option<HashSet<i64>>,
     ) -> Option<InboundMessage> {
-        // teloxide-core 0.13's `UpdateKind` Deserialize visitor uses
-        // `next_key::<&str>()` first, which fails on `serde_json::Value`
-        // (its keys are owned `String`s) — the visitor then falls into
-        // `Error(Value)` and our match drops the update. Round-trip
-        // through bytes (`to_vec` + `from_slice`) sidesteps the issue
-        // and gives us a "real" deserializer driving the visitor.
-        let bytes = serde_json::to_vec(update).ok()?;
-        let typed: Update = serde_json::from_slice(&bytes).ok()?;
+        let typed: Update = serde_json::from_slice(body).ok()?;
         Self::inbound_from_update(&typed, allowed)
     }
 
@@ -357,6 +357,14 @@ impl Platform for TelegramPlatform {
 
     async fn send(&self, msg: &OutboundMessage) -> Result<SentMessage> {
         use teloxide_core::payloads::SendMessageSetters;
+        // Telegram rejects send_message with empty text, so harden the
+        // contract upfront. StreamRenderer / OutboundDispatcher already
+        // short-circuits empty buffers, but a future caller bypassing
+        // them would otherwise see a generic "send_message failed"
+        // anyhow chain instead of an actionable error.
+        if msg.attachments.is_empty() && msg.text.trim().is_empty() {
+            anyhow::bail!("telegram send: empty text and no attachments");
+        }
         let chat_id = Self::chat_id_from_chat(&msg.chat_id)?;
         let reply_params = if let Some(reply_to) = &msg.reply_to {
             let reply_id = Self::message_id_from_str(reply_to)?;
@@ -507,9 +515,7 @@ impl Platform for TelegramPlatform {
         if provided.as_bytes().ct_eq(expected.as_bytes()).unwrap_u8() == 0 {
             anyhow::bail!("invalid webhook secret");
         }
-        let update: serde_json::Value = serde_json::from_slice(body)
-            .map_err(|e| anyhow::anyhow!("invalid Update JSON: {e}"))?;
-        Self::inbound_from_value(&update, &self.allowed_chat_ids)
+        Self::inbound_from_webhook_body(body, &self.allowed_chat_ids)
             .ok_or_else(|| anyhow::anyhow!("Update did not parse to a usable InboundMessage"))
     }
 
@@ -735,24 +741,59 @@ mod tests {
     }
 
     #[test]
-    fn inbound_from_value_extracts_text_message() {
-        // PR-3b: inbound_from_value now deserializes into a typed
-        // `Update`, so the fixture must be a complete Update shape
-        // (update_id, full from, chat.type, date).
-        let update = serde_json::json!({
+    fn inbound_from_webhook_body_extracts_text_message() {
+        // PR-3b: inbound_from_webhook_body deserializes raw bytes
+        // straight into a typed `Update` — fixture must be a complete
+        // Update shape (update_id, full from, chat.type, date).
+        let body = br#"{
             "update_id": 1,
             "message": {
                 "message_id": 100,
                 "from": { "id": 7, "is_bot": false, "first_name": "tester" },
                 "chat": { "id": 42, "first_name": "tester", "type": "private" },
                 "date": 1700000000,
-                "text": "hello bot",
-            },
-        });
-        let inb = TelegramPlatform::inbound_from_value(&update, &allowed(&[])).expect("parse");
+                "text": "hello bot"
+            }
+        }"#;
+        let inb = TelegramPlatform::inbound_from_webhook_body(body, &allowed(&[])).expect("parse");
         assert_eq!(inb.text, "hello bot");
         assert_eq!(inb.chat_id, "42");
         assert_eq!(inb.message_id.as_deref(), Some("100"));
+    }
+
+    #[test]
+    fn inbound_from_webhook_body_extracts_photo_attachment() {
+        // PR-3b: webhook bodies carrying photo media route through the
+        // typed Update walker — the file_id of the largest PhotoSize
+        // lands in Attachment.url, mime is "image/jpeg" (Telegram
+        // doesn't expose actual mime per PhotoSize), kind is Image.
+        let body = br#"{
+            "update_id": 2,
+            "message": {
+                "message_id": 200,
+                "from": { "id": 7, "is_bot": false, "first_name": "tester" },
+                "chat": { "id": 42, "first_name": "tester", "type": "private" },
+                "date": 1700000000,
+                "photo": [
+                    { "file_id": "small", "file_unique_id": "u1", "width": 90,  "height": 90,  "file_size": 100 },
+                    { "file_id": "large", "file_unique_id": "u2", "width": 800, "height": 800, "file_size": 9999 }
+                ]
+            }
+        }"#;
+        let inb = TelegramPlatform::inbound_from_webhook_body(body, &allowed(&[]))
+            .expect("photo-only message should parse");
+        assert_eq!(inb.text, "");
+        assert_eq!(inb.attachments.len(), 1);
+        assert_eq!(
+            inb.attachments[0].url.as_deref(),
+            Some("large"),
+            "largest PhotoSize wins",
+        );
+        assert_eq!(
+            inb.attachments[0].kind,
+            crate::platform::AttachmentKind::Image
+        );
+        assert_eq!(inb.attachments[0].mime.as_deref(), Some("image/jpeg"));
     }
 
     /// Typed-Update sibling of `inbound_from_value_extracts_text_message`.
@@ -885,6 +926,30 @@ mod tests {
             .expect_err("must reject");
         assert!(
             err.to_string().contains("webhook not configured"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_rejects_empty_text_and_no_attachments() {
+        // Defensive contract: Telegram rejects send_message with empty
+        // text. Caller (StreamRenderer / OutboundDispatcher) already
+        // short-circuits empty buffers, but the platform shouldn't
+        // surface a generic "send_message failed" anyhow chain when a
+        // future caller bypasses them.
+        let p = TelegramPlatform::new("123:abc", vec![], None).expect("ctor");
+        let msg = OutboundMessage {
+            platform: "telegram".into(),
+            chat_id: "42".into(),
+            text: "   ".into(),
+            attachments: vec![],
+            reply_to: None,
+            edit_target: None,
+            turn_id: None,
+        };
+        let err = p.send(&msg).await.expect_err("empty send must bail");
+        assert!(
+            err.to_string().contains("empty text and no attachments"),
             "unexpected error: {err}"
         );
     }

--- a/src/gateway/telegram.rs
+++ b/src/gateway/telegram.rs
@@ -227,6 +227,82 @@ impl TelegramPlatform {
         Self::inbound_from_update(&typed, allowed)
     }
 
+    /// Dispatch a single `OutboundAttachment` to the kind-specific
+    /// send_* endpoint. Returns the platform's id for the sent
+    /// message - the caller chains the first id into SentMessage so
+    /// StreamRenderer's edit-in-place anchors target the right
+    /// message.
+    async fn send_attachment(
+        &self,
+        chat_id: ChatId,
+        att: &crate::platform::OutboundAttachment,
+        caption: Option<String>,
+        reply: Option<ReplyParameters>,
+    ) -> Result<String> {
+        use teloxide_core::payloads::{
+            SendAudioSetters, SendDocumentSetters, SendPhotoSetters, SendVideoSetters,
+            SendVoiceSetters,
+        };
+        use teloxide_core::types::InputFile;
+        let file = InputFile::file(&att.path);
+        let sent = match att.kind {
+            AttachmentKind::Image => {
+                let mut req = self.bot.send_photo(chat_id, file);
+                if let Some(c) = caption {
+                    req = req.caption(c);
+                }
+                if let Some(rp) = reply {
+                    req = req.reply_parameters(rp);
+                }
+                req.await.context("telegram send_photo failed")?
+            }
+            AttachmentKind::Voice => {
+                let mut req = self.bot.send_voice(chat_id, file);
+                if let Some(c) = caption {
+                    req = req.caption(c);
+                }
+                if let Some(rp) = reply {
+                    req = req.reply_parameters(rp);
+                }
+                req.await.context("telegram send_voice failed")?
+            }
+            AttachmentKind::Video => {
+                let mut req = self.bot.send_video(chat_id, file);
+                if let Some(c) = caption {
+                    req = req.caption(c);
+                }
+                if let Some(rp) = reply {
+                    req = req.reply_parameters(rp);
+                }
+                req.await.context("telegram send_video failed")?
+            }
+            AttachmentKind::Audio => {
+                let mut req = self.bot.send_audio(chat_id, file);
+                if let Some(c) = caption {
+                    req = req.caption(c);
+                }
+                if let Some(rp) = reply {
+                    req = req.reply_parameters(rp);
+                }
+                req.await.context("telegram send_audio failed")?
+            }
+            // Document / Sticker / Other -> send_document. Telegram has
+            // no generic "any blob" endpoint; send_document accepts
+            // arbitrary file types.
+            AttachmentKind::Document | AttachmentKind::Sticker | AttachmentKind::Other => {
+                let mut req = self.bot.send_document(chat_id, file);
+                if let Some(c) = caption {
+                    req = req.caption(c);
+                }
+                if let Some(rp) = reply {
+                    req = req.reply_parameters(rp);
+                }
+                req.await.context("telegram send_document failed")?
+            }
+        };
+        Ok(sent.id.0.to_string())
+    }
+
     fn chat_id_from_chat(chat: &str) -> Result<ChatId> {
         chat.parse::<i64>()
             .map(ChatId)
@@ -281,14 +357,53 @@ impl Platform for TelegramPlatform {
     async fn send(&self, msg: &OutboundMessage) -> Result<SentMessage> {
         use teloxide_core::payloads::SendMessageSetters;
         let chat_id = Self::chat_id_from_chat(&msg.chat_id)?;
-        let mut req = self.bot.send_message(chat_id, msg.text.clone());
-        if let Some(reply_to) = &msg.reply_to {
+        let reply_params = if let Some(reply_to) = &msg.reply_to {
             let reply_id = Self::message_id_from_str(reply_to)?;
-            req = req.reply_parameters(ReplyParameters::new(reply_id));
+            Some(ReplyParameters::new(reply_id))
+        } else {
+            None
+        };
+
+        // Telegram doesn't combine text + multiple media in a single
+        // send the way Discord does. Strategy:
+        //   * No attachments -> send_message (text only).
+        //   * Attachments    -> send the first attachment with msg.text
+        //                       as its caption (or the attachment's own
+        //                       caption when msg.text is empty). Any
+        //                       remaining attachments fire as separate
+        //                       follow-up messages with their own
+        //                       captions.
+        // SentMessage carries the id of the FIRST sent message - that's
+        // the anchor StreamRenderer/edit-in-place will target.
+        if msg.attachments.is_empty() {
+            let mut req = self.bot.send_message(chat_id, msg.text.clone());
+            if let Some(rp) = reply_params {
+                req = req.reply_parameters(rp);
+            }
+            let sent = req.await.context("telegram send_message failed")?;
+            return Ok(SentMessage {
+                message_id: sent.id.0.to_string(),
+            });
         }
-        let sent = req.await.context("telegram send_message failed")?;
+
+        let mut iter = msg.attachments.iter();
+        let first = iter.next().expect("non-empty checked above");
+        let first_caption = if msg.text.is_empty() {
+            first.caption.clone()
+        } else {
+            Some(msg.text.clone())
+        };
+        let first_id = self
+            .send_attachment(chat_id, first, first_caption, reply_params)
+            .await?;
+        for att in iter {
+            let _ = self
+                .send_attachment(chat_id, att, att.caption.clone(), None)
+                .await
+                .context("telegram follow-up attachment send failed")?;
+        }
         Ok(SentMessage {
-            message_id: sent.id.0.to_string(),
+            message_id: first_id,
         })
     }
 

--- a/src/gateway/telegram.rs
+++ b/src/gateway/telegram.rs
@@ -11,12 +11,13 @@
 //!     other platforms.
 //!
 //! Both paths normalize through `inbound_from_update_parts` (parts +
-//! allow-list filter) so the filter logic lives in one place. The
-//! long-poll path uses `inbound_from_update` (typed `Update`) and the
-//! webhook path uses `inbound_from_value` (serde_json `Value`, since
-//! the body arrives as bytes). Live HTTP path is exercised by
-//! integration tests / manual smoke; the parsing helpers are
-//! unit-tested.
+//! allow-list filter) so the filter logic lives in one place. Long-
+//! poll feeds typed `Update`s straight into `inbound_from_update`;
+//! the webhook path round-trips `serde_json::Value` -> typed `Update`
+//! via `inbound_from_value` and then dispatches to the same typed
+//! walker, so media extraction lives in one place. Live HTTP is
+//! exercised by integration tests / manual smoke; the parsing
+//! helpers are unit-tested.
 
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -428,6 +429,68 @@ impl Platform for TelegramPlatform {
         anyhow::bail!("telegram receives messages through the long-poll task or webhook")
     }
 
+    async fn download_attachment(
+        &self,
+        att: &crate::platform::Attachment,
+    ) -> Result<std::path::PathBuf> {
+        use teloxide_core::net::Download;
+        // Telegram-specific contract: Attachment.url stores the opaque
+        // file_id (Telegram has no public CDN URL until bot.get_file
+        // resolves it). Discord stores real HTTPS URLs in the same
+        // field; same shape, platform-specific interpretation.
+        let file_id = att.url.as_ref().ok_or_else(|| {
+            anyhow::anyhow!("telegram attachment has no file_id (url field empty)")
+        })?;
+        let file = self
+            .bot
+            .get_file(FileId(file_id.clone()))
+            .await
+            .with_context(|| format!("telegram get_file({file_id}) failed"))?;
+
+        let dir = crate::config::vulcan_home()
+            .join("attachments")
+            .join("telegram");
+        tokio::fs::create_dir_all(&dir)
+            .await
+            .context("create attachments dir")?;
+        // Filename strategy mirrors Discord's PR-4 hardening: take
+        // Path::file_name() of the user-supplied original_name to
+        // defang `../etc/passwd` style traversal. If the result is
+        // None or degenerate (empty / "." / ".."), fall through to a
+        // UUID so adversarial names can't collide on a literal landing
+        // pad.
+        let raw = att.original_name.as_deref();
+        let stripped = raw
+            .and_then(|n| std::path::Path::new(n).file_name())
+            .and_then(|s| s.to_str())
+            .filter(|s| !s.is_empty() && *s != "." && *s != "..");
+        let filename = match stripped {
+            Some(n) => n.to_string(),
+            None => format!("att-{}.bin", uuid::Uuid::new_v4()),
+        };
+        let path = dir.join(&filename);
+
+        let mut f = tokio::fs::File::create(&path)
+            .await
+            .with_context(|| format!("create {}", path.display()))?;
+        self.bot
+            .download_file(&file.path, &mut f)
+            .await
+            .with_context(|| format!("telegram download_file({}) failed", file.path))?;
+
+        // Best-effort sync; log on failure so flaky-disk diagnostics
+        // are tractable but don't fail the agent.
+        if let Err(e) = f.sync_all().await {
+            tracing::warn!(
+                target: "gateway::telegram",
+                error = %e,
+                path = %path.display(),
+                "fsync failed during download_attachment; continuing",
+            );
+        }
+        Ok(path)
+    }
+
     async fn verify_webhook(
         &self,
         headers: &http::HeaderMap,
@@ -451,12 +514,14 @@ impl Platform for TelegramPlatform {
     }
 
     fn capabilities(&self) -> PlatformCapabilities {
+        // PR-3b flips media on: send dispatches by AttachmentKind to
+        // send_photo / send_voice / send_video / send_audio /
+        // send_document; download_attachment resolves file_id via
+        // bot.get_file and streams the body via bot.download_file.
         PlatformCapabilities {
             supports_edit: true,
-            // PR-3 is text-only; the supports_media_* flags + send_photo /
-            // send_document / download_attachment wiring land in PR-3b.
-            supports_media_send: false,
-            supports_media_recv: false,
+            supports_media_send: true,
+            supports_media_recv: true,
             supports_threads: true,
             // Telegram caps edits to ~1/sec/chat. The renderer's
             // throttle reads this to space out streaming chunks.
@@ -659,13 +724,13 @@ mod tests {
     }
 
     #[test]
-    fn capabilities_declare_edit_and_threads_true_media_false() {
+    fn capabilities_declare_edit_threads_and_media_true() {
         let p = TelegramPlatform::new("Bot 123:abc", vec![], None).expect("ctor");
         let caps = p.capabilities();
         assert!(caps.supports_edit);
         assert!(caps.supports_threads);
-        assert!(!caps.supports_media_send);
-        assert!(!caps.supports_media_recv);
+        assert!(caps.supports_media_send);
+        assert!(caps.supports_media_recv);
         assert_eq!(caps.edit_min_interval_ms, 1000);
     }
 


### PR DESCRIPTION
YYC-18 PR-3b: Telegram media recv via typed walker

* attachments_from_message: typed `Message` -> Vec<Attachment>.
  Maps Photo/Document/Voice/Video/Audio/Sticker MediaKind variants
  into our Attachment. file_id stashed in url (no CDN URL until
  bot.get_file resolves it; download_attachment knows the contract).
  Picks the largest PhotoSize per Telegram convention.
* inbound_from_update threads attachments through to
  inbound_from_update_parts. Falls back to "" text when only
  attachments are present (Message::text() returns None for
  media-only messages).
* inbound_from_update_parts accepts empty text when an attachment
  is present (mirrors PR-4 Discord behavior - image-only messages
  are normal usage).
* inbound_from_value now routes through the typed Update path so
  media parsing has a single source of truth. Goes through
  to_vec/from_slice (not from_value) because teloxide-core 0.13's
  UpdateKind visitor calls next_key::<&str>() first, which fails
  on Value's owned-String keys and falls into UpdateKind::Error.

Webhook fixture JSON updated to a complete Update shape (update_id,
full from with is_bot/first_name, chat with type/first_name, date)
so the typed deserializer accepts it.

Existing 7 inbound_parts_* tests updated for the new attachments
arg; 2 new tests pin the empty-text-with-attachment + drop-on-no-
content paths.

teloxide-core 0.13 API note: FileMeta.id is `FileId(pub String)`,
a newtype - we clone via `.id.0.clone()` to materialize the bare
String for Attachment.url.

cargo test --lib --features telegram gateway::telegram passes (17).

YYC-18 PR-3b: Telegram media send via typed endpoints

OutboundMessage.attachments dispatches by AttachmentKind:
  Image                       -> bot.send_photo
  Voice                       -> bot.send_voice
  Video                       -> bot.send_video
  Audio                       -> bot.send_audio
  Document / Sticker / Other  -> bot.send_document

Single-message strategy: Telegram doesn't combine text + multiple
media in a single send the way Discord does. Send the first
attachment with msg.text as its caption (or its own caption if
msg.text is empty); follow-up attachments fire as separate
messages with their own captions. SentMessage.message_id carries
the anchor of the first send so StreamRenderer's edit-in-place
targets the right message.

Each send_* call honors reply_parameters when msg.reply_to is set
(only on the first message of a multi-attachment burst).

cargo build --features telegram clean.
cargo test --lib --features telegram all green (436 tests).

YYC-18 PR-3b: Telegram download_attachment + capabilities flip

Telegram-specific contract: Attachment.url stores the opaque
file_id (Telegram has no public CDN URL until bot.get_file
resolves it). download_attachment:

  1. bot.get_file(FileId(file_id)) -> File { path, ... }
  2. bot.download_file(&path, &mut tokio::fs::File) - streams
     the body directly into a tokio::fs::File at
     ~/.vulcan/attachments/telegram/<filename>.

Filename strategy mirrors Discord's PR-4 hardening: original_name
sanitized via Path::file_name + reject empty/"."/"..", fall through
to UUID otherwise. fsync best-effort with tracing::warn on failure.

Capabilities flipped: supports_media_send + supports_media_recv
both true. Existing capabilities test renamed
(declare_edit_and_threads_true_media_false ->
declare_edit_threads_and_media_true) and assertions inverted.

teloxide-core 0.13 API note: Bot::get_file takes a `FileId`
(newtype), not a `&str` - we wrap via FileId(file_id.clone()).
Download::download_file destination is `&mut (dyn AsyncWrite +
Unpin + Send)`; tokio::fs::File satisfies the trait bounds.

cargo build --features {telegram,gateway} clean.
cargo test --lib --features telegram all green (436 tests).
fmt + clippy --all-features clean.