### PR TITLE
YYC-149: SessionStore busy_timeout to absorb DB contention

### DIFF
--- a/src/gateway/queue.rs
+++ b/src/gateway/queue.rs
@@ -508,6 +508,20 @@ mod tests {
         crate::memory::in_memory_gateway_pool().expect("in-memory pool")
     }
 
+    // YYC-149: every checkout from the gateway pool must inherit the
+    // busy_timeout. r2d2's `with_init` runs once per fresh
+    // connection; this test guards against a future regression where
+    // the customizer is dropped or inadvertently bypassed.
+    #[test]
+    fn gateway_pool_checkout_has_busy_timeout() {
+        let pool = test_conn();
+        let conn = pool.get().expect("checkout");
+        let timeout: i64 = conn
+            .query_row("PRAGMA busy_timeout", [], |row| row.get(0))
+            .expect("query busy_timeout");
+        assert_eq!(timeout, 5_000);
+    }
+
     fn sample_msg() -> InboundMessage {
         InboundMessage {
             platform: "loopback".into(),

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -42,6 +42,19 @@ pub(crate) use schema::{DbPool, open_gateway_pool};
 use codec::{decode_message, encode_message};
 use schema::{initialize_conn, upsert_session_metadata, upsert_session_provider_profile};
 
+/// Persistent session storage.
+///
+/// CRUD methods are synchronous and run rusqlite operations behind a
+/// `parking_lot::Mutex`. Every connection is initialized with a
+/// 5-second `busy_timeout` (YYC-149) so transient WAL contention or
+/// brief writer overlap does not surface `SQLITE_BUSY` immediately —
+/// the writer waits up to 5s before failing rather than pinning the
+/// caller's tokio worker thread on a synchronous error retry loop.
+///
+/// Heavier write paths could be moved to `tokio::task::spawn_blocking`
+/// in the future if profiling shows the agent loop awaiting the mutex
+/// for measurable time, but the busy_timeout fix lands the immediate
+/// safety net without churning the call sites.
 pub struct SessionStore {
     conn: Mutex<Connection>,
 }

--- a/src/memory/schema.rs
+++ b/src/memory/schema.rs
@@ -8,6 +8,15 @@
 use anyhow::Context;
 use anyhow::Result;
 use rusqlite::{Connection, params};
+use std::time::Duration;
+
+/// YYC-149: every SQLite connection used by `SessionStore` and the
+/// gateway pool gets this busy timeout so blocking writes don't pin a
+/// tokio worker thread on transient lock contention. 5s is generous
+/// enough to absorb a WAL checkpoint or a slow disk burst without
+/// surfacing `SQLITE_BUSY`, and short enough that a wedged connection
+/// surfaces an error rather than stalling indefinitely.
+pub(in crate::memory) const BUSY_TIMEOUT: Duration = Duration::from_millis(5_000);
 
 /// Connection pool used by the gateway daemon (YYC-113). Replaces the
 /// previous `Arc<Mutex<Connection>>` that serialized every gateway worker
@@ -115,7 +124,17 @@ CREATE TABLE IF NOT EXISTS outbound_queue (
 CREATE INDEX IF NOT EXISTS idx_outbound_due ON outbound_queue(state, next_attempt_at);
 "#;
 
+/// Apply per-connection PRAGMAs. SQLite's `busy_timeout` is connection
+/// scoped, so this must run on every fresh connection — not just the
+/// one that ran schema init (YYC-149).
+pub(in crate::memory) fn apply_connection_pragmas(conn: &Connection) -> Result<()> {
+    conn.busy_timeout(BUSY_TIMEOUT)?;
+    conn.execute_batch("PRAGMA foreign_keys = ON;")?;
+    Ok(())
+}
+
 pub(in crate::memory) fn initialize_conn(conn: &Connection) -> Result<()> {
+    apply_connection_pragmas(conn)?;
     conn.execute_batch(SCHEMA)?;
 
     // Idempotent migrations for DBs created before additive columns landed.
@@ -148,7 +167,17 @@ pub(crate) fn open_gateway_pool() -> Result<DbPool> {
     let dir = crate::config::vulcan_home();
     std::fs::create_dir_all(&dir).ok();
     let path = dir.join("sessions.db");
-    let manager = r2d2_sqlite::SqliteConnectionManager::file(&path);
+    // YYC-149: `with_init` runs on every fresh connection r2d2
+    // instantiates so the busy_timeout (5s) is applied on every
+    // checkout, not just the one that ran schema migrations.
+    let manager = r2d2_sqlite::SqliteConnectionManager::file(&path).with_init(|conn| {
+        apply_connection_pragmas(conn).map_err(|e| {
+            rusqlite::Error::SqliteFailure(
+                rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_ERROR),
+                Some(format!("apply_connection_pragmas: {e}")),
+            )
+        })
+    });
     let pool = r2d2::Pool::builder()
         .build(manager)
         .with_context(|| format!("Failed to build gateway DB pool at {}", path.display()))?;
@@ -165,7 +194,16 @@ pub(crate) fn open_gateway_pool() -> Result<DbPool> {
 /// `open_gateway_pool` against a temp file.
 #[cfg(all(test, feature = "gateway"))]
 pub(crate) fn in_memory_gateway_pool() -> Result<DbPool> {
-    let manager = r2d2_sqlite::SqliteConnectionManager::memory();
+    // YYC-149: same per-connection busy_timeout treatment as the
+    // production pool so test parity matches runtime behavior.
+    let manager = r2d2_sqlite::SqliteConnectionManager::memory().with_init(|conn| {
+        apply_connection_pragmas(conn).map_err(|e| {
+            rusqlite::Error::SqliteFailure(
+                rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_ERROR),
+                Some(format!("apply_connection_pragmas: {e}")),
+            )
+        })
+    });
     let pool = r2d2::Pool::builder()
         .max_size(1)
         .build(manager)

--- a/src/memory/tests.rs
+++ b/src/memory/tests.rs
@@ -351,3 +351,69 @@ fn reasoning_content_round_trips() {
         other => panic!("expected Assistant, got {other:?}"),
     }
 }
+
+// YYC-149: every connection used by SessionStore should have the
+// 5-second busy_timeout applied so a contended writer doesn't fail
+// immediately with SQLITE_BUSY and pin a tokio worker thread.
+#[test]
+fn session_store_connection_has_busy_timeout() {
+    let dir = TempDir::new().unwrap();
+    let store = store_in(&dir);
+    let conn = store.conn.lock();
+    let timeout: i64 = conn
+        .query_row("PRAGMA busy_timeout", [], |row| row.get(0))
+        .expect("query busy_timeout");
+    assert_eq!(timeout, 5_000, "expected 5000ms busy_timeout");
+}
+
+// YYC-149: a writer holding a transaction must not lock out a
+// second writer immediately. The busy_timeout absorbs short
+// contention. Spawns a thread that holds a write transaction for a
+// brief moment, kicks off a competing write on the main thread,
+// and asserts it succeeds — without the timeout this would return
+// SQLITE_BUSY synchronously.
+#[test]
+fn busy_timeout_absorbs_short_writer_contention() {
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+    use std::time::Duration;
+
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("contend.db");
+    let primary = Connection::open(&path).unwrap();
+    initialize_conn(&primary).unwrap();
+    drop(primary);
+
+    let path_thread = path.clone();
+    let barrier = Arc::new(Barrier::new(2));
+    let barrier_thread = Arc::clone(&barrier);
+    let holder = thread::spawn(move || {
+        let mut conn = Connection::open(&path_thread).unwrap();
+        initialize_conn(&conn).unwrap();
+        let tx = conn.transaction().unwrap();
+        tx.execute(
+            "INSERT INTO sessions (id, created_at, last_active) VALUES ('hold', 0, 0)",
+            [],
+        )
+        .unwrap();
+        // Signal the contender to attempt its write, then hold the
+        // transaction briefly so the other thread has to wait inside
+        // busy_timeout.
+        barrier_thread.wait();
+        thread::sleep(Duration::from_millis(150));
+        tx.commit().unwrap();
+    });
+
+    barrier.wait();
+    let conn = Connection::open(&path).unwrap();
+    initialize_conn(&conn).unwrap();
+    let result = conn.execute(
+        "INSERT INTO sessions (id, created_at, last_active) VALUES ('contender', 0, 0)",
+        [],
+    );
+    holder.join().unwrap();
+    assert!(
+        result.is_ok(),
+        "busy_timeout should absorb short writer contention; got {result:?}",
+    );
+}


### PR DESCRIPTION
Apply a 5-second `PRAGMA busy_timeout` on every SQLite connection
used by `SessionStore` and the gateway r2d2 pool. The previous
setup let SQLITE_BUSY surface immediately on transient WAL
checkpointing or short writer overlap, which would propagate up
through the agent loop as a synchronous error and (in retry-loop
code paths) pin the calling tokio worker. The timeout is connection
scoped so r2d2's `with_init` runs the new pragmas on every fresh
connection, not just the one that ran schema init. Tests cover the
SessionStore connection, every gateway pool checkout, and a
thread-spawned contention scenario where a brief writer hold
doesn't kick the contender out with BUSY. Document spawn_blocking
as future work if profiling shows the mutex blocking the loop.