### PR TITLE
YYC-150: SessionStore::try_new fallible constructor

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -274,7 +274,7 @@ impl Agent {
             }
         }
         let skills = Arc::new(SkillRegistry::new(&config.skills_dir));
-        let memory = SessionStore::new();
+        let memory = SessionStore::try_new()?;
         let context =
             ContextManager::with_config(provider.max_context(), config.compaction.clone());
         let session_id = Uuid::new_v4().to_string();
@@ -289,7 +289,7 @@ impl Agent {
         // FTS read doesn't contend with the agent's main message-write
         // path on the existing memory mutex.
         if config.recall.enabled {
-            let recall_memory = Arc::new(SessionStore::new());
+            let recall_memory = Arc::new(SessionStore::try_new()?);
             hooks.register(Arc::new(RecallHook::new(recall_memory, config.recall)));
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,7 @@ async fn main() -> anyhow::Result<()> {
         }
         Some(Command::Search { query, limit }) => {
             init_cli_logging();
-            let store = vulcan::memory::SessionStore::new();
+            let store = vulcan::memory::SessionStore::try_new()?;
             let hits = store.search_messages(&query, limit)?;
             if hits.is_empty() {
                 println!("No matches.");

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -87,23 +87,38 @@ pub struct SessionSummary {
 }
 
 impl SessionStore {
-    /// Open (or create) the session store at `~/.vulcan/sessions.db`. Panics
-    /// on fatal DB initialization errors — matches the existing pattern in
-    /// `AgentBuilder::build` (api key, provider).
-    pub fn new() -> Self {
+    /// Open (or create) the session store at `~/.vulcan/sessions.db`,
+    /// returning an error instead of panicking when the DB directory
+    /// can't be created, the file can't be opened, or schema
+    /// migrations fail. Production startup paths (gateway, TUI, CLI)
+    /// use this so misconfigured hosts surface an actionable message
+    /// rather than aborting the process (YYC-150).
+    pub fn try_new() -> Result<Self> {
         let dir = crate::config::vulcan_home();
-        std::fs::create_dir_all(&dir).ok();
+        std::fs::create_dir_all(&dir)
+            .with_context(|| format!("create vulcan_home at {}", dir.display()))?;
         let path = dir.join("sessions.db");
+        Self::try_open_at(&path)
+    }
 
-        let conn = Connection::open(&path)
-            .unwrap_or_else(|e| panic!("Failed to open session DB at {}: {e}", path.display()));
-
+    /// Open the session store at an arbitrary path. Used by
+    /// `try_new` after resolving `vulcan_home`, and by tests that
+    /// need to point at a temp directory.
+    pub fn try_open_at(path: &std::path::Path) -> Result<Self> {
+        let conn = Connection::open(path)
+            .with_context(|| format!("open session DB at {}", path.display()))?;
         initialize_conn(&conn)
-            .unwrap_or_else(|e| panic!("Failed to initialize session DB schema: {e}"));
-
-        Self {
+            .with_context(|| format!("initialize session DB schema at {}", path.display()))?;
+        Ok(Self {
             conn: Mutex::new(conn),
-        }
+        })
+    }
+
+    /// Panicking shim around `try_new`. Kept so existing test code
+    /// and the `Default` impl don't need to thread `Result` through;
+    /// production paths should call `try_new` (YYC-150).
+    pub fn new() -> Self {
+        Self::try_new().expect("SessionStore::new failed; use try_new() to handle the error")
     }
 
     /// Most recently active session, by `last_active`. `None` if there are no

--- a/src/memory/tests.rs
+++ b/src/memory/tests.rs
@@ -352,6 +352,45 @@ fn reasoning_content_round_trips() {
     }
 }
 
+// YYC-150: try_open_at must return an Err (not panic) when the DB
+// path can't be opened. Pointing at a nonexistent parent directory
+// triggers SQLite's open-with-create to fail; we assert the error
+// chain includes the path so operators see actionable context.
+#[test]
+fn try_open_at_returns_err_when_parent_missing() {
+    let dir = TempDir::new().unwrap();
+    let bogus = dir.path().join("does_not_exist").join("sessions.db");
+    let err = match SessionStore::try_open_at(&bogus) {
+        Ok(_) => panic!("expected open to fail"),
+        Err(e) => e,
+    };
+    let chain = format!("{err:#}");
+    assert!(
+        chain.contains("open session DB"),
+        "error chain should mention the failing op, got: {chain}",
+    );
+    assert!(
+        chain.contains("sessions.db"),
+        "error chain should include the DB path, got: {chain}",
+    );
+}
+
+// YYC-150: try_open_at must succeed for a normal path and produce a
+// store that round-trips data — guards against a future regression
+// where the new API is broken in some subtle way that the panic
+// path didn't exercise.
+#[test]
+fn try_open_at_returns_ok_for_writable_path() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join("ok.db");
+    let store = SessionStore::try_open_at(&path).expect("open ok");
+    let id = uuid::Uuid::new_v4().to_string();
+    store
+        .save_session_metadata(&id, None, None)
+        .expect("save metadata");
+    assert_eq!(store.last_session_id().as_deref(), Some(id.as_str()));
+}
+
 // YYC-149: every connection used by SessionStore should have the
 // 5-second busy_timeout applied so a contended writer doesn't fail
 // immediately with SQLITE_BUSY and pin a tokio worker thread.


### PR DESCRIPTION
Add `SessionStore::try_new` (and `try_open_at` for an explicit
path) that return an actionable Result instead of panicking when
the vulcan_home dir can't be created, the SQLite file can't be
opened, or schema migrations fail. Production startup paths
(main.rs Search, AgentBuilder::build, recall hook) propagate the
error so misconfigured hosts surface a clear message including the
DB path and the failing op rather than aborting the process. The
panicking `new()` shim is preserved for tests and Default. New
tests cover both the err path (parent dir missing) and the ok
path (round-trip via try_open_at).