### PR TITLE
YYC-148: audit + lock down save_messages O(n) paths

### DIFF
--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -191,13 +191,18 @@ impl SessionStore {
         Ok(Some(messages))
     }
 
-    /// Save the full message history for `session_id`. The session row is
+    /// Replace the full message history for `session_id`. The session row is
     /// upserted (`last_active` bumped); existing messages for the session are
-    /// deleted and replaced with `messages` — full-snapshot semantics matching
-    /// the per-prompt save the agent emits.
+    /// deleted and replaced with `messages` — O(n) in total history.
     ///
-    /// Prefer `append_messages` when only new messages need saving — this
-    /// does a full DELETE + re-INSERT which is O(n) in the total message count.
+    /// **Use only for intentional full rewrites** — compaction, sanitization,
+    /// or `Agent::replace_history`. Per-turn persistence MUST go through
+    /// `Agent::save_messages`, which routes growth-only saves to
+    /// `append_messages` and falls back to this method only when the
+    /// in-memory `messages` Vec has shrunk below the persisted snapshot
+    /// (the YYC-138 compaction defense). YYC-148 audit confirmed the
+    /// non-compaction call sites are tests; production hot paths take the
+    /// O(new messages) route via `append_messages`.
     pub fn save_messages(&self, session_id: &str, messages: &[Message]) -> Result<()> {
         let now = Utc::now().timestamp();
 

--- a/src/memory/tests.rs
+++ b/src/memory/tests.rs
@@ -352,6 +352,114 @@ fn reasoning_content_round_trips() {
     }
 }
 
+// YYC-148: append_messages must add only the new tail and leave
+// the autoincrement row IDs of prior messages untouched. A
+// regression that secretly DELETEd would surface here as
+// reassigned IDs after the second save.
+#[test]
+fn append_messages_preserves_prior_row_ids() {
+    let dir = TempDir::new().unwrap();
+    let store = store_in(&dir);
+    let id = uuid::Uuid::new_v4().to_string();
+    store
+        .append_messages(
+            &id,
+            &[Message::User {
+                content: "first".into(),
+            }],
+        )
+        .unwrap();
+    let initial_id: i64 = {
+        let conn = store.conn.lock();
+        conn.query_row(
+            "SELECT id FROM messages WHERE session_id = ?1 ORDER BY position",
+            params![id],
+            |row| row.get(0),
+        )
+        .unwrap()
+    };
+    store
+        .append_messages(
+            &id,
+            &[Message::Assistant {
+                content: Some("second".into()),
+                tool_calls: None,
+                reasoning_content: None,
+            }],
+        )
+        .unwrap();
+    let ids_after: Vec<i64> = {
+        let conn = store.conn.lock();
+        let mut stmt = conn
+            .prepare("SELECT id FROM messages WHERE session_id = ?1 ORDER BY position")
+            .unwrap();
+        let rows = stmt
+            .query_map(params![id], |row| row.get(0))
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<i64>>>()
+            .unwrap();
+        rows
+    };
+    assert_eq!(
+        ids_after.len(),
+        2,
+        "append should produce 2 rows, got {ids_after:?}",
+    );
+    assert_eq!(
+        ids_after[0], initial_id,
+        "first message's row ID must survive the append",
+    );
+}
+
+// YYC-148: save_messages is the full-rewrite path and IS expected
+// to reissue row IDs (DELETE + re-INSERT). This test is a guard so
+// nobody quietly replaces save_messages with append-only semantics
+// and breaks the compaction contract.
+#[test]
+fn save_messages_does_replace_existing_rows() {
+    let dir = TempDir::new().unwrap();
+    let store = store_in(&dir);
+    let id = uuid::Uuid::new_v4().to_string();
+    store
+        .save_messages(
+            &id,
+            &[Message::User {
+                content: "v1".into(),
+            }],
+        )
+        .unwrap();
+    let initial_id: i64 = {
+        let conn = store.conn.lock();
+        conn.query_row(
+            "SELECT id FROM messages WHERE session_id = ?1",
+            params![id],
+            |row| row.get(0),
+        )
+        .unwrap()
+    };
+    store
+        .save_messages(
+            &id,
+            &[Message::User {
+                content: "v2".into(),
+            }],
+        )
+        .unwrap();
+    let post_id: i64 = {
+        let conn = store.conn.lock();
+        conn.query_row(
+            "SELECT id FROM messages WHERE session_id = ?1",
+            params![id],
+            |row| row.get(0),
+        )
+        .unwrap()
+    };
+    assert_ne!(
+        post_id, initial_id,
+        "save_messages should DELETE+INSERT — row ID must change",
+    );
+}
+
 // YYC-150: try_open_at must return an Err (not panic) when the DB
 // path can't be opened. Pointing at a nonexistent parent directory
 // triggers SQLite's open-with-create to fail; we assert the error


### PR DESCRIPTION
Audit confirms `Agent::save_messages` already smart-routes growth
to `append_messages` and only falls back to the full-rewrite
`SessionStore::save_messages` for compaction (the YYC-138 defense)
and the explicit `replace_history` reset. The remaining
production call sites are tests. Tighten the doc on
`SessionStore::save_messages` to mark it for full rewrites only
and point per-turn callers at `append_messages` via
`Agent::save_messages`. Add contract tests that prove
`append_messages` preserves prior autoincrement row IDs (proof of
no DELETE) and that `save_messages` does reissue them — a guard
against either side silently flipping semantics.