### PR TITLE
YYC-147: expose stream channel capacity as provider config

### DIFF
--- a/src/agent/run.rs
+++ b/src/agent/run.rs
@@ -605,10 +605,11 @@ impl Agent {
         cancel: CancellationToken,
         iteration: usize,
     ) -> Result<ChatResponse> {
-        let (inner_tx, mut inner_rx) =
-            mpsc::channel::<StreamEvent>(crate::provider::STREAM_CHANNEL_CAPACITY);
-        let (priv_tx, mut priv_rx) =
-            mpsc::channel::<StreamEvent>(crate::provider::STREAM_CHANNEL_CAPACITY);
+        // YYC-147: capacity comes from the active provider config so
+        // operators can tune it for slow renderers / fast providers.
+        let stream_cap = self.provider_config.effective_stream_channel_capacity();
+        let (inner_tx, mut inner_rx) = mpsc::channel::<StreamEvent>(stream_cap);
+        let (priv_tx, mut priv_rx) = mpsc::channel::<StreamEvent>(stream_cap);
 
         let ui_tx_clone = ui_tx.clone();
         tokio::spawn(async move {

--- a/src/config.rs
+++ b/src/config.rs
@@ -483,6 +483,39 @@ pub struct ProviderConfig {
     /// out room for the prompt; raise it for models with long-form output.
     #[serde(default)]
     pub max_output_tokens: Option<usize>,
+    /// YYC-147: bounded mpsc capacity for the provider stream
+    /// channel. The historical default is 1024 — generous enough that
+    /// typical bursts never block, small enough that a stuck consumer
+    /// surfaces as backpressure within seconds. Tuneable for slow
+    /// renderers (raise it) or memory-constrained hosts (lower it).
+    /// Clamped to [16, 65536] at read time to avoid pathological
+    /// settings.
+    #[serde(default = "default_stream_channel_capacity")]
+    pub stream_channel_capacity: usize,
+}
+
+/// Clamp on `ProviderConfig::stream_channel_capacity` (YYC-147).
+/// 16 is small enough to surface backpressure on a stalled consumer;
+/// 65536 is well past the point where unbounded growth is the real
+/// problem. The clamp is applied at read time via `effective_stream_channel_capacity`.
+pub const STREAM_CHANNEL_CAPACITY_MIN: usize = 16;
+pub const STREAM_CHANNEL_CAPACITY_MAX: usize = 65_536;
+pub const STREAM_CHANNEL_CAPACITY_DEFAULT: usize = 1024;
+
+fn default_stream_channel_capacity() -> usize {
+    STREAM_CHANNEL_CAPACITY_DEFAULT
+}
+
+impl ProviderConfig {
+    /// YYC-147: clamped stream channel capacity for this provider.
+    /// Anything outside `[STREAM_CHANNEL_CAPACITY_MIN,
+    /// STREAM_CHANNEL_CAPACITY_MAX]` is pulled into range so a
+    /// misconfigured value can't OOM the host or starve the
+    /// renderer.
+    pub fn effective_stream_channel_capacity(&self) -> usize {
+        self.stream_channel_capacity
+            .clamp(STREAM_CHANNEL_CAPACITY_MIN, STREAM_CHANNEL_CAPACITY_MAX)
+    }
 }
 
 #[derive(Debug, Deserialize, Clone, Default)]
@@ -626,6 +659,7 @@ impl Default for ProviderConfig {
             debug: ProviderDebugMode::Off,
             max_iterations: 0,
             max_output_tokens: None,
+            stream_channel_capacity: default_stream_channel_capacity(),
         }
     }
 }
@@ -1063,6 +1097,46 @@ toggle_tools = "F2"
 
         assert!(ProviderDebugMode::Wire.logs_wire());
         assert!(ProviderDebugMode::Wire.logs_tool_fallback());
+    }
+
+    // YYC-147: stream_channel_capacity defaults to 1024 when not
+    // configured, preserving prior behavior.
+    #[test]
+    fn provider_stream_channel_capacity_defaults_to_legacy_value() {
+        let cfg = ProviderConfig::default();
+        assert_eq!(cfg.stream_channel_capacity, STREAM_CHANNEL_CAPACITY_DEFAULT);
+        assert_eq!(
+            cfg.effective_stream_channel_capacity(),
+            STREAM_CHANNEL_CAPACITY_DEFAULT,
+        );
+    }
+
+    // YYC-147: explicit user override flows through.
+    #[test]
+    fn provider_stream_channel_capacity_honors_user_override() {
+        let toml = r#"
+            [provider]
+            stream_channel_capacity = 4096
+        "#;
+        let cfg: Config = toml::from_str(toml).expect("parse");
+        assert_eq!(cfg.provider.effective_stream_channel_capacity(), 4096,);
+    }
+
+    // YYC-147: nonsensical values clamp into the documented bounds
+    // so a typo can't OOM the host or starve the renderer.
+    #[test]
+    fn provider_stream_channel_capacity_clamps_to_bounds() {
+        let mut cfg = ProviderConfig::default();
+        cfg.stream_channel_capacity = 1;
+        assert_eq!(
+            cfg.effective_stream_channel_capacity(),
+            STREAM_CHANNEL_CAPACITY_MIN,
+        );
+        cfg.stream_channel_capacity = 10_000_000;
+        assert_eq!(
+            cfg.effective_stream_channel_capacity(),
+            STREAM_CHANNEL_CAPACITY_MAX,
+        );
     }
 
     // YYC-161: a clean canonical config should produce no

--- a/src/gateway/agent_map.rs
+++ b/src/gateway/agent_map.rs
@@ -224,6 +224,14 @@ impl AgentMap {
         self.inner.lock().remove(lane).is_some()
     }
 
+    /// YYC-147: clamped stream channel capacity for gateway workers
+    /// that need to size an mpsc before they hold an Agent. Sourced
+    /// from the active provider config so operators can tune
+    /// backpressure without recompiling.
+    pub fn stream_channel_capacity(&self) -> usize {
+        self.config.provider.effective_stream_channel_capacity()
+    }
+
     /// Spawn a background task that periodically evicts lanes idle longer
     /// than `self.idle_ttl`. The returned `EvictorHandle` aborts the loop on
     /// drop, so callers don't need to remember to call `.abort()` on shutdown.

--- a/src/gateway/worker.rs
+++ b/src/gateway/worker.rs
@@ -109,8 +109,11 @@ pub async fn process_one(
         render_registry.clone(),
     );
 
+    // YYC-147: capacity sourced from the agent map's active provider
+    // config so gateway streaming respects the same tuning knob as
+    // the TUI / one-shot paths.
     let (tx, mut rx) = tokio::sync::mpsc::channel::<crate::provider::StreamEvent>(
-        crate::provider::STREAM_CHANNEL_CAPACITY,
+        agent_map.stream_channel_capacity(),
     );
 
     // Consumer task: pump StreamEvents through the renderer. Lives until the

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -83,9 +83,11 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
         }
     });
 
-    // streaming
+    // streaming. YYC-147: capacity sourced from the active provider
+    // config so users can tune for slow renderers (raise) or
+    // memory-constrained hosts (lower).
     let (stream_tx, mut stream_rx) =
-        mpsc::channel::<StreamEvent>(crate::provider::STREAM_CHANNEL_CAPACITY);
+        mpsc::channel::<StreamEvent>(config.provider.effective_stream_channel_capacity());
 
     // ── Hook registry: audit-log + (room for safety-gate, etc.). Built-in
     // hooks (skills) are registered by AgentBuilder.


### PR DESCRIPTION
Add `stream_channel_capacity` to `ProviderConfig` (default 1024 to
preserve current behavior) plus an `effective_stream_channel_capacity`
accessor that clamps the value to [16, 65536] so a typo can't OOM
the host or starve the renderer. The TUI, one-shot agent runtime,
and gateway worker all source the channel size from this config
instead of the previously-hardcoded `STREAM_CHANNEL_CAPACITY`
constant. `AgentMap` exposes a thin `stream_channel_capacity()`
accessor so the gateway worker, which sizes its mpsc before
holding an Agent, can read the same tuning knob. Tests cover the
default, an explicit user override, and the clamp at both ends.