### PR TITLE
YYC-158: doc SessionStore::in_memory as test-only

### DIFF
--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -400,6 +400,19 @@ impl SessionStore {
         Ok(hits)
     }
 
+    /// **Test-only.** Build a `SessionStore` backed by SQLite's
+    /// `:memory:` database — every byte written here is **lost when
+    /// the process exits**. The function exists so unit tests can
+    /// exercise the CRUD surface without touching `~/.vulcan/`; it
+    /// must not be used as a production fallback. Production code
+    /// paths should call `try_new` (or, in the panic-acceptable
+    /// CLI path, `new`) so failures surface a real DB error
+    /// instead of silently routing turn history into a volatile
+    /// store (YYC-158).
+    ///
+    /// `#[doc(hidden)]` keeps it off the public docs page; the
+    /// audit in YYC-158 confirmed every caller is in a test or
+    /// `Agent::for_test` test helper.
     #[doc(hidden)]
     pub fn in_memory() -> Self {
         let conn = Connection::open_in_memory().expect("open in-memory session DB");


### PR DESCRIPTION
Replace the empty `#[doc(hidden)]` placeholder with an explicit
test-only warning that flags the volatile semantics. Audit
confirmed every caller is in a `#[test]`/`#[tokio::test]` block or
`Agent::for_test` test helper — no production fallback path uses
it, so the data-loss risk that YYC-158 worried about is purely a
documentation gap. The new doc points readers at `try_new` /
`new` for real persistence.