### PR TITLE
YYC-17 PR-1: cron scheduler config schema + validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,6 +420,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf 0.12.1",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,6 +599,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cron"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5877d3fbf742507b66bc2a1945106bd30dd8504019d596901ddd012a4dd01740"
+dependencies = [
+ "chrono",
+ "once_cell",
+ "winnow 0.6.26",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,7 +687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
- "phf",
+ "phf 0.11.3",
 ]
 
 [[package]]
@@ -3229,7 +3250,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
 ]
 
 [[package]]
@@ -3239,7 +3269,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -3248,7 +3278,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.6",
 ]
 
@@ -3259,7 +3289,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3270,6 +3300,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
 ]
@@ -4645,7 +4684,7 @@ checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
  "nom",
- "phf",
+ "phf 0.11.3",
  "phf_codegen",
 ]
 
@@ -4682,7 +4721,7 @@ dependencies = [
  "ordered-float",
  "pest",
  "pest_derive",
- "phf",
+ "phf 0.11.3",
  "sha2",
  "signal-hook 0.3.18",
  "siphasher",
@@ -5351,7 +5390,9 @@ dependencies = [
  "async-trait",
  "axum",
  "chrono",
+ "chrono-tz",
  "clap",
+ "cron",
  "crossterm",
  "dhat",
  "dialoguer",
@@ -5934,6 +5975,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.6.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,13 @@ reqwest = { version = "0.13", features = ["json", "stream"] }
 # IPv4-mapped IPv6 addresses.
 url = "2"
 
+# Cron expression parsing for the scheduled-task runtime (YYC-17).
+# Pure-Rust parser; we drive the schedule on top of tokio's own
+# timer rather than pulling in `tokio-cron-scheduler` so the
+# scheduler shares lifecycle + persistence with the gateway pieces.
+cron = "0.15"
+chrono-tz = "0.10"
+
 # Async trait support (needed for dyn-compatible tool/provider traits)
 async-trait = "0.1"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -183,6 +183,117 @@ pub struct Config {
     /// the system prompt and are visible to the model).
     #[serde(default)]
     pub recall: RecallConfig,
+
+    /// YYC-17: scheduled jobs the gateway scheduler enqueues into
+    /// the inbound queue at their cron firing times. Empty in the
+    /// default config; jobs are parsed but their semantics are
+    /// validated lazily so the rest of the runtime is unaffected.
+    #[serde(default)]
+    pub scheduler: SchedulerConfig,
+}
+
+/// YYC-17: top-level scheduler configuration. Each job entry
+/// declares a cron expression, a target platform/lane, and the
+/// prompt to fire on schedule. Jobs run only when the gateway is
+/// enabled; the TUI / one-shot paths ignore them.
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct SchedulerConfig {
+    #[serde(default)]
+    pub jobs: Vec<SchedulerJobConfig>,
+}
+
+/// YYC-17: declarative job spec. `id` is operator-supplied so jobs
+/// survive config edits/reorders; `name` is the human label that
+/// shows up in tracing. The cron expression is parsed at startup
+/// and any failure surfaces as a hard validation error before the
+/// gateway binds a listener.
+#[derive(Debug, Deserialize, Clone)]
+pub struct SchedulerJobConfig {
+    pub id: String,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default = "default_scheduler_job_enabled")]
+    pub enabled: bool,
+    pub cron: String,
+    #[serde(default = "default_scheduler_job_timezone")]
+    pub timezone: String,
+    pub platform: String,
+    pub lane: String,
+    pub prompt: String,
+    /// Hard wall-clock cap on a single job run, in seconds. `None`
+    /// means no cap; the run finishes whenever the agent finishes.
+    #[serde(default)]
+    pub max_runtime_secs: Option<u64>,
+    /// Policy when a job's previous run is still active when its
+    /// next firing arrives. Default `skip` matches the design doc
+    /// recommendation.
+    #[serde(default)]
+    pub overlap_policy: OverlapPolicy,
+}
+
+/// YYC-17: how the scheduler should handle a firing whose previous
+/// run is still active.
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum OverlapPolicy {
+    /// Skip the new firing, leave the previous run alone.
+    #[default]
+    Skip,
+    /// Enqueue anyway — both runs proceed in parallel.
+    Enqueue,
+    /// Drop any pending firings and replace with the new one.
+    Replace,
+}
+
+fn default_scheduler_job_enabled() -> bool {
+    true
+}
+
+fn default_scheduler_job_timezone() -> String {
+    "UTC".into()
+}
+
+impl SchedulerConfig {
+    /// YYC-17: validate every job's cron expression and timezone
+    /// before the gateway runtime touches them. Returns the first
+    /// actionable error so operators see the bad job by id.
+    pub fn validate(&self) -> Result<()> {
+        for job in &self.jobs {
+            job.validate()
+                .with_context(|| format!("scheduler job '{}'", job.id))?;
+        }
+        Ok(())
+    }
+}
+
+impl SchedulerJobConfig {
+    /// YYC-17: surface bad cron expressions, unknown timezones,
+    /// empty platform/lane/prompt, and zero max_runtime_secs as
+    /// hard validation errors.
+    pub fn validate(&self) -> Result<()> {
+        use std::str::FromStr;
+        if self.id.trim().is_empty() {
+            anyhow::bail!("id is required");
+        }
+        if self.platform.trim().is_empty() {
+            anyhow::bail!("platform is required");
+        }
+        if self.lane.trim().is_empty() {
+            anyhow::bail!("lane is required");
+        }
+        if self.prompt.trim().is_empty() {
+            anyhow::bail!("prompt is required");
+        }
+        // cron 0.15: parses 6- or 7-field expressions (with seconds).
+        cron::Schedule::from_str(&self.cron)
+            .with_context(|| format!("invalid cron expression `{}`", self.cron))?;
+        chrono_tz::Tz::from_str(&self.timezone)
+            .map_err(|e| anyhow::anyhow!("invalid timezone `{}`: {e}", self.timezone))?;
+        if matches!(self.max_runtime_secs, Some(0)) {
+            anyhow::bail!("max_runtime_secs must be > 0 when set");
+        }
+        Ok(())
+    }
 }
 
 /// Auto-recall config (YYC-42). Drives the `RecallHook` BeforePrompt
@@ -769,6 +880,7 @@ impl Default for Config {
             gateway: None,
             keybinds: KeybindsConfig::default(),
             recall: RecallConfig::default(),
+            scheduler: SchedulerConfig::default(),
         }
     }
 }
@@ -854,6 +966,7 @@ impl Config {
             "gateway",
             "keybinds",
             "recall",
+            "scheduler",
         ];
         let Ok(value) = toml::from_str::<toml::Value>(raw) else {
             return Vec::new();
@@ -1187,6 +1300,110 @@ toggle_tools = "F2"
 
         assert!(ProviderDebugMode::Wire.logs_wire());
         assert!(ProviderDebugMode::Wire.logs_tool_fallback());
+    }
+
+    fn sample_job(id: &str, cron: &str) -> SchedulerJobConfig {
+        SchedulerJobConfig {
+            id: id.into(),
+            name: "test".into(),
+            enabled: true,
+            cron: cron.into(),
+            timezone: "UTC".into(),
+            platform: "loopback".into(),
+            lane: "c1".into(),
+            prompt: "do thing".into(),
+            max_runtime_secs: None,
+            overlap_policy: OverlapPolicy::Skip,
+        }
+    }
+
+    // YYC-17: well-formed jobs validate cleanly.
+    #[test]
+    fn scheduler_job_validate_accepts_minimal() {
+        sample_job("daily", "0 8 * * * *").validate().expect("ok");
+    }
+
+    // YYC-17: bad cron expression bubbles up with the offending input.
+    #[test]
+    fn scheduler_job_validate_rejects_bad_cron() {
+        let mut job = sample_job("bad", "obviously not a cron");
+        let err = job.validate().expect_err("bad cron must error");
+        assert!(format!("{err:#}").contains("invalid cron expression"));
+        // Whitespace cron also rejected (parser treats it as empty).
+        job.cron = "   ".into();
+        assert!(job.validate().is_err());
+    }
+
+    // YYC-17: unknown timezone surfaces a typed error.
+    #[test]
+    fn scheduler_job_validate_rejects_unknown_timezone() {
+        let mut job = sample_job("tz", "0 8 * * * *");
+        job.timezone = "Mars/Olympus_Mons".into();
+        let err = job.validate().expect_err("bad tz");
+        assert!(format!("{err:#}").contains("invalid timezone"));
+    }
+
+    // YYC-17: required fields cannot be empty.
+    #[test]
+    fn scheduler_job_validate_requires_non_empty_fields() {
+        let mut job = sample_job("ok", "0 8 * * * *");
+        job.id = "".into();
+        assert!(job.validate().is_err());
+        let mut job = sample_job("ok", "0 8 * * * *");
+        job.platform = "".into();
+        assert!(job.validate().is_err());
+        let mut job = sample_job("ok", "0 8 * * * *");
+        job.lane = "".into();
+        assert!(job.validate().is_err());
+        let mut job = sample_job("ok", "0 8 * * * *");
+        job.prompt = "".into();
+        assert!(job.validate().is_err());
+    }
+
+    // YYC-17: max_runtime_secs = 0 is meaningless.
+    #[test]
+    fn scheduler_job_validate_rejects_zero_runtime_cap() {
+        let mut job = sample_job("ok", "0 8 * * * *");
+        job.max_runtime_secs = Some(0);
+        assert!(job.validate().is_err());
+    }
+
+    // YYC-17: parse a [[scheduler.jobs]] block from TOML and round-
+    // trip through validate.
+    #[test]
+    fn scheduler_section_parses_from_toml() {
+        let toml = r#"
+            [[scheduler.jobs]]
+            id = "daily-summary"
+            cron = "0 8 * * * *"
+            platform = "telegram"
+            lane = "personal"
+            prompt = "Summarize yesterday's work."
+        "#;
+        let cfg: Config = toml::from_str(toml).expect("parse");
+        assert_eq!(cfg.scheduler.jobs.len(), 1);
+        let job = &cfg.scheduler.jobs[0];
+        assert_eq!(job.id, "daily-summary");
+        assert!(job.enabled);
+        assert_eq!(job.timezone, "UTC");
+        assert_eq!(job.overlap_policy, OverlapPolicy::Skip);
+        cfg.scheduler.validate().expect("validate ok");
+    }
+
+    // YYC-17: overlap_policy parses kebab-case variants.
+    #[test]
+    fn scheduler_overlap_policy_parses_kebab_case() {
+        let toml = r#"
+            [[scheduler.jobs]]
+            id = "j"
+            cron = "0 * * * * *"
+            platform = "p"
+            lane = "l"
+            prompt = "x"
+            overlap_policy = "replace"
+        "#;
+        let cfg: Config = toml::from_str(toml).expect("parse");
+        assert_eq!(cfg.scheduler.jobs[0].overlap_policy, OverlapPolicy::Replace);
     }
 
     // YYC-156: stale backup files are pruned by retention age.


### PR DESCRIPTION
Add `[[scheduler.jobs]]` to the config tree with `cron`, timezone,
platform, lane, prompt, optional max_runtime_secs, and an
overlap_policy enum (`skip` default, `enqueue`, `replace`).
`SchedulerJobConfig::validate` parses each cron expression
through the `cron` crate, validates the timezone via
`chrono-tz`, and rejects empty required fields plus
`max_runtime_secs = 0`. `SchedulerConfig::validate` walks every
job and surfaces the first failure with the offending job id.
Known-keys list (YYC-161) gains `scheduler` so the new section
doesn't trigger an unknown-key warning. Tests cover happy-path
parse, bad cron, unknown timezone, empty required fields, zero
runtime cap, full TOML round-trip, and kebab-case overlap_policy
parsing. Runtime + persistence ride in follow-up PRs.