### PR TITLE
YYC-17 PR-3: persist scheduler runs to SQLite

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -55,7 +55,12 @@ pub(in crate::agent) fn is_local_base_url(base_url: &str) -> bool {
         Some(url::Host::Ipv4(ip)) => is_local_ipv4(ip),
 
         Some(url::Host::Ipv6(ip)) => {
-            if ip.is_loopback() || ip.is_unspecified() || ip.is_unique_local() || ip.is_link_local() {
+            if ip.is_loopback() || ip.is_unspecified() || ip.is_unique_local() {
+                return true;
+            }
+            // YYC-152: fe80::/10 unicast link-local. `Ipv6Addr::is_unicast_link_local`
+            // is unstable, so check the prefix bits manually.
+            if (ip.segments()[0] & 0xffc0) == 0xfe80 {
                 return true;
             }
             if let Some(v4) = ip.to_ipv4_mapped() {

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -28,6 +28,7 @@ pub mod registry;
 pub mod render_registry;
 pub mod routes;
 pub mod scheduler;
+pub mod scheduler_store;
 pub mod server;
 pub mod stream_render;
 #[cfg(feature = "telegram")]
@@ -177,7 +178,15 @@ where
     // expression can't slip past startup. The handle drops with
     // the function scope so the loop is reaped on shutdown.
     let scheduler_handle = if !scheduler_config.jobs.is_empty() {
-        let scheduler = scheduler::Scheduler::from_config(&scheduler_config, Arc::clone(&inbound))?;
+        // YYC-17 PR-3: persist run history alongside the gateway
+        // queues so operator tooling can read `scheduler_runs`
+        // without coordinating two databases.
+        let store = scheduler_store::SchedulerStore::new(db.clone());
+        let scheduler = scheduler::Scheduler::from_config_with_store(
+            &scheduler_config,
+            Arc::clone(&inbound),
+            Some(store),
+        )?;
         if scheduler.enabled_jobs() > 0 {
             Some(scheduler.spawn())
         } else {

--- a/src/gateway/scheduler.rs
+++ b/src/gateway/scheduler.rs
@@ -29,8 +29,9 @@ use anyhow::{Context, Result};
 use chrono::Utc;
 use tokio::task::JoinHandle;
 
-use crate::config::{SchedulerConfig, SchedulerJobConfig};
+use crate::config::{OverlapPolicy, SchedulerConfig, SchedulerJobConfig};
 use crate::gateway::queue::InboundQueue;
+use crate::gateway::scheduler_store::SchedulerStore;
 use crate::platform::InboundMessage;
 
 /// Synthetic `user_id` stamped on scheduler firings so downstream
@@ -41,6 +42,7 @@ pub const SCHEDULER_USER_ID: &str = "scheduler";
 pub struct Scheduler {
     jobs: Vec<RunningJob>,
     inbound: Arc<InboundQueue>,
+    store: Option<SchedulerStore>,
 }
 
 #[derive(Clone)]
@@ -48,6 +50,14 @@ struct RunningJob {
     config: SchedulerJobConfig,
     schedule: cron::Schedule,
     tz: chrono_tz::Tz,
+    /// YYC-17 PR-3: in-process flag the overlap-policy gate
+    /// consults. Spawning the agent for a firing flips this to
+    /// true; the worker pipeline doesn't currently report
+    /// completion back, so for now the flag is cleared
+    /// immediately after enqueue. PR-C-4 will replace this with
+    /// a query against the inbound row's state so `Skip` /
+    /// `Replace` get teeth.
+    running: Arc<std::sync::atomic::AtomicBool>,
 }
 
 pub struct SchedulerHandle {
@@ -66,6 +76,17 @@ impl Scheduler {
     /// before we spawn anything. Disabled jobs are filtered here so
     /// the runtime loop only ever sees ones it should fire.
     pub fn from_config(config: &SchedulerConfig, inbound: Arc<InboundQueue>) -> Result<Self> {
+        Self::from_config_with_store(config, inbound, None)
+    }
+
+    /// YYC-17 PR-3: same as `from_config` but with an explicit
+    /// store handle. `None` skips persistence (used by tests that
+    /// don't want a SQLite pool).
+    pub fn from_config_with_store(
+        config: &SchedulerConfig,
+        inbound: Arc<InboundQueue>,
+        store: Option<SchedulerStore>,
+    ) -> Result<Self> {
         config.validate()?;
         let mut jobs = Vec::new();
         for job in config.jobs.iter().filter(|j| j.enabled) {
@@ -78,9 +99,14 @@ impl Scheduler {
                 config: job.clone(),
                 schedule,
                 tz,
+                running: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             });
         }
-        Ok(Self { jobs, inbound })
+        Ok(Self {
+            jobs,
+            inbound,
+            store,
+        })
     }
 
     /// Number of enabled jobs. Used by the gateway runtime to skip
@@ -140,9 +166,45 @@ impl Scheduler {
     }
 
     async fn fire(&mut self, idx: usize) {
+        use std::sync::atomic::Ordering;
         let job = &self.jobs[idx];
+        let now = Utc::now().timestamp();
+
+        // YYC-17 PR-3: overlap policy. Skip suppresses the firing
+        // when the job's running flag is set; Enqueue and Replace
+        // both proceed (Replace becomes meaningful in PR-C-4 once
+        // the scheduler can drop pending rows).
+        if job.config.overlap_policy == OverlapPolicy::Skip && job.running.load(Ordering::Acquire) {
+            tracing::warn!(
+                target: "gateway::scheduler",
+                job_id = %job.config.id,
+                job_name = %job.config.name,
+                "previous firing still active; skipping",
+            );
+            if let Some(store) = &self.store
+                && let Err(e) = store.record_skipped(&job.config.id, now)
+            {
+                tracing::warn!(
+                    target: "gateway::scheduler",
+                    job_id = %job.config.id,
+                    error = %e,
+                    "could not record skipped fire",
+                );
+            }
+            return;
+        }
+
+        job.running.store(true, Ordering::Release);
         let msg = build_inbound_message_for_job(&job.config);
-        match self.inbound.enqueue(msg).await {
+        let result = self.inbound.enqueue(msg).await;
+        // The inbound row is queued; the worker pipeline owns the
+        // run from here. Without a completion signal we clear the
+        // running flag immediately so subsequent fires aren't
+        // permanently suppressed. A real durable in-flight check
+        // ships in PR-C-4.
+        job.running.store(false, Ordering::Release);
+
+        match result {
             Ok(row_id) => {
                 tracing::info!(
                     target: "gateway::scheduler",
@@ -153,6 +215,16 @@ impl Scheduler {
                     row_id,
                     "scheduler firing enqueued",
                 );
+                if let Some(store) = &self.store
+                    && let Err(e) = store.record_enqueued(&job.config.id, now, row_id)
+                {
+                    tracing::warn!(
+                        target: "gateway::scheduler",
+                        job_id = %job.config.id,
+                        error = %e,
+                        "could not record enqueued fire",
+                    );
+                }
             }
             Err(e) => {
                 tracing::error!(
@@ -161,6 +233,17 @@ impl Scheduler {
                     error = %e,
                     "scheduler enqueue failed",
                 );
+                if let Some(store) = &self.store
+                    && let Err(store_err) =
+                        store.record_enqueue_failed(&job.config.id, now, &e.to_string())
+                {
+                    tracing::warn!(
+                        target: "gateway::scheduler",
+                        job_id = %job.config.id,
+                        error = %store_err,
+                        "could not record failed fire",
+                    );
+                }
             }
         }
     }
@@ -240,6 +323,49 @@ mod tests {
         config.jobs.push(j);
         let scheduler = Scheduler::from_config(&config, inbound).expect("ok");
         assert_eq!(scheduler.enabled_jobs(), 0);
+    }
+
+    // YYC-17 PR-3: a manual fire records to the store and enqueues
+    // an inbound row.
+    #[tokio::test]
+    async fn fire_records_enqueued_run() {
+        let pool = crate::memory::in_memory_gateway_pool().expect("pool");
+        let inbound = Arc::new(InboundQueue::new(pool.clone()));
+        let store = SchedulerStore::new(pool);
+        let mut config = SchedulerConfig::default();
+        config.jobs.push(job("fire-test", "0 8 * * * *"));
+        let mut scheduler =
+            Scheduler::from_config_with_store(&config, Arc::clone(&inbound), Some(store.clone()))
+                .expect("ok");
+        scheduler.fire(0).await;
+        let row = store.get("fire-test").unwrap().expect("row");
+        assert_eq!(row.last_status.as_deref(), Some("enqueued"));
+        assert_eq!(row.total_fires, 1);
+        assert!(row.last_inbound_id.is_some());
+    }
+
+    // YYC-17 PR-3: with overlap_policy = Skip, a second fire while
+    // the first is still flagged as running records as skipped.
+    #[tokio::test]
+    async fn fire_skip_policy_records_skipped() {
+        use std::sync::atomic::Ordering;
+        let pool = crate::memory::in_memory_gateway_pool().expect("pool");
+        let inbound = Arc::new(InboundQueue::new(pool.clone()));
+        let store = SchedulerStore::new(pool);
+        let mut config = SchedulerConfig::default();
+        let mut j = job("skip-test", "0 8 * * * *");
+        j.overlap_policy = OverlapPolicy::Skip;
+        config.jobs.push(j);
+        let mut scheduler =
+            Scheduler::from_config_with_store(&config, Arc::clone(&inbound), Some(store.clone()))
+                .expect("ok");
+        // Manually flip the running flag to simulate an in-flight run.
+        scheduler.jobs[0].running.store(true, Ordering::Release);
+        scheduler.fire(0).await;
+        let row = store.get("skip-test").unwrap().expect("row");
+        assert_eq!(row.last_status.as_deref(), Some("skipped"));
+        assert_eq!(row.skipped_fires, 1);
+        assert_eq!(row.total_fires, 1);
     }
 
     // YYC-17 PR-2: a configured + enabled job round-trips through

--- a/src/gateway/scheduler_store.rs
+++ b/src/gateway/scheduler_store.rs
@@ -1,0 +1,271 @@
+//! YYC-17 PR-3: persistence for scheduler job runs.
+//!
+//! The job *definitions* live in `Config.scheduler` (TOML), so a
+//! re-deploy with updated cron text or prompt body takes effect on
+//! restart. This module is for the *mutable* counterpart: per-job
+//! run history (last fire timestamp, last status, total / skipped /
+//! failed fire counts) plus the running-flag the overlap-policy
+//! gate consults.
+//!
+//! Storage is the same SQLite file the gateway queues use. The
+//! scheduler holds a `SchedulerStore` that hands out short-lived
+//! sync DB ops via the gateway pool's `with_init` busy_timeout, so
+//! a contended writer doesn't pin the runtime thread.
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use rusqlite::{OptionalExtension, params};
+
+use crate::memory::DbPool;
+
+/// Status code stamped on `scheduler_runs.last_status` for the
+/// most recent firing of a job. Kept narrow + symbolic so the
+/// admin endpoint (PR-C-4) can present it without rendering free-
+/// form prose.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScheduledFireStatus {
+    /// Firing was enqueued onto the inbound queue.
+    Enqueued,
+    /// Firing was suppressed because the previous run is still
+    /// active and `overlap_policy = "skip"`.
+    Skipped,
+    /// Firing was attempted but enqueueing failed (DB unavailable,
+    /// queue corruption, etc.). `last_error` carries the message.
+    EnqueueFailed,
+}
+
+impl ScheduledFireStatus {
+    /// String form persisted in `scheduler_runs.last_status`. The
+    /// `record_*` methods write the literals directly today, but
+    /// the admin endpoint in PR-C-4 will format these for display.
+    #[allow(dead_code)]
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Enqueued => "enqueued",
+            Self::Skipped => "skipped",
+            Self::EnqueueFailed => "enqueue_failed",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ScheduledRun {
+    pub job_id: String,
+    pub last_fired_at: Option<i64>,
+    pub last_status: Option<String>,
+    pub last_error: Option<String>,
+    pub last_inbound_id: Option<i64>,
+    pub total_fires: u64,
+    pub skipped_fires: u64,
+    pub failed_fires: u64,
+}
+
+/// Thin wrapper that owns the `DbPool` handle and exposes the
+/// scheduler's persistence operations as short, sync critical
+/// sections.
+#[derive(Clone)]
+pub struct SchedulerStore {
+    pool: Arc<DbPool>,
+}
+
+impl SchedulerStore {
+    pub fn new(pool: DbPool) -> Self {
+        Self {
+            pool: Arc::new(pool),
+        }
+    }
+
+    fn conn(&self) -> Result<r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionManager>> {
+        self.pool.get().context("scheduler DB pool checkout")
+    }
+
+    /// Record an enqueued firing. Bumps `total_fires`, sets
+    /// `last_status = 'enqueued'`, and stamps the row with the
+    /// inbound queue id so observability can join the two tables.
+    pub fn record_enqueued(&self, job_id: &str, fired_at: i64, inbound_id: i64) -> Result<()> {
+        let conn = self.conn()?;
+        conn.execute(
+            "INSERT INTO scheduler_runs \
+                 (job_id, last_fired_at, last_status, last_error, last_inbound_id, total_fires, skipped_fires, failed_fires) \
+             VALUES (?1, ?2, 'enqueued', NULL, ?3, 1, 0, 0) \
+             ON CONFLICT(job_id) DO UPDATE SET \
+                 last_fired_at = excluded.last_fired_at, \
+                 last_status = excluded.last_status, \
+                 last_error = NULL, \
+                 last_inbound_id = excluded.last_inbound_id, \
+                 total_fires = scheduler_runs.total_fires + 1",
+            params![job_id, fired_at, inbound_id],
+        )?;
+        Ok(())
+    }
+
+    /// Record a firing that was skipped by overlap policy. Bumps
+    /// `total_fires` + `skipped_fires` so reporting can show
+    /// suppression rates without a separate query.
+    pub fn record_skipped(&self, job_id: &str, fired_at: i64) -> Result<()> {
+        let conn = self.conn()?;
+        conn.execute(
+            "INSERT INTO scheduler_runs \
+                 (job_id, last_fired_at, last_status, total_fires, skipped_fires, failed_fires) \
+             VALUES (?1, ?2, 'skipped', 1, 1, 0) \
+             ON CONFLICT(job_id) DO UPDATE SET \
+                 last_fired_at = excluded.last_fired_at, \
+                 last_status = excluded.last_status, \
+                 last_error = NULL, \
+                 total_fires = scheduler_runs.total_fires + 1, \
+                 skipped_fires = scheduler_runs.skipped_fires + 1",
+            params![job_id, fired_at],
+        )?;
+        Ok(())
+    }
+
+    /// Record an enqueue failure. Carries the error message verbatim
+    /// so operators can read what went wrong without trawling logs.
+    pub fn record_enqueue_failed(&self, job_id: &str, fired_at: i64, error: &str) -> Result<()> {
+        let conn = self.conn()?;
+        conn.execute(
+            "INSERT INTO scheduler_runs \
+                 (job_id, last_fired_at, last_status, last_error, total_fires, skipped_fires, failed_fires) \
+             VALUES (?1, ?2, 'enqueue_failed', ?3, 1, 0, 1) \
+             ON CONFLICT(job_id) DO UPDATE SET \
+                 last_fired_at = excluded.last_fired_at, \
+                 last_status = excluded.last_status, \
+                 last_error = excluded.last_error, \
+                 total_fires = scheduler_runs.total_fires + 1, \
+                 failed_fires = scheduler_runs.failed_fires + 1",
+            params![job_id, fired_at, error],
+        )?;
+        Ok(())
+    }
+
+    /// Read the persisted row for a job, if any. Returns `None`
+    /// for a job that has never fired.
+    pub fn get(&self, job_id: &str) -> Result<Option<ScheduledRun>> {
+        let conn = self.conn()?;
+        let row = conn
+            .query_row(
+                "SELECT job_id, last_fired_at, last_status, last_error, last_inbound_id, \
+                        total_fires, skipped_fires, failed_fires \
+                 FROM scheduler_runs WHERE job_id = ?1",
+                params![job_id],
+                |row| {
+                    Ok(ScheduledRun {
+                        job_id: row.get(0)?,
+                        last_fired_at: row.get(1)?,
+                        last_status: row.get(2)?,
+                        last_error: row.get(3)?,
+                        last_inbound_id: row.get(4)?,
+                        total_fires: row.get::<_, i64>(5)?.max(0) as u64,
+                        skipped_fires: row.get::<_, i64>(6)?.max(0) as u64,
+                        failed_fires: row.get::<_, i64>(7)?.max(0) as u64,
+                    })
+                },
+            )
+            .optional()
+            .context("scheduler_runs SELECT")?;
+        Ok(row)
+    }
+
+    /// Snapshot every job's run history. Sorted by `job_id` so the
+    /// admin endpoint output is stable.
+    pub fn list(&self) -> Result<Vec<ScheduledRun>> {
+        let conn = self.conn()?;
+        let mut stmt = conn.prepare(
+            "SELECT job_id, last_fired_at, last_status, last_error, last_inbound_id, \
+                    total_fires, skipped_fires, failed_fires \
+             FROM scheduler_runs ORDER BY job_id ASC",
+        )?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok(ScheduledRun {
+                    job_id: row.get(0)?,
+                    last_fired_at: row.get(1)?,
+                    last_status: row.get(2)?,
+                    last_error: row.get(3)?,
+                    last_inbound_id: row.get(4)?,
+                    total_fires: row.get::<_, i64>(5)?.max(0) as u64,
+                    skipped_fires: row.get::<_, i64>(6)?.max(0) as u64,
+                    failed_fires: row.get::<_, i64>(7)?.max(0) as u64,
+                })
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .context("scheduler_runs collect")?;
+        Ok(rows)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store() -> SchedulerStore {
+        let pool = crate::memory::in_memory_gateway_pool().expect("pool");
+        SchedulerStore::new(pool)
+    }
+
+    // YYC-17 PR-3: enqueued firing inserts a fresh row and bumps
+    // counters; reading it back round-trips the fields.
+    #[test]
+    fn record_enqueued_inserts_and_increments() {
+        let s = store();
+        s.record_enqueued("daily", 100, 7).unwrap();
+        let row = s.get("daily").unwrap().expect("row");
+        assert_eq!(row.last_status.as_deref(), Some("enqueued"));
+        assert_eq!(row.last_fired_at, Some(100));
+        assert_eq!(row.last_inbound_id, Some(7));
+        assert_eq!(row.total_fires, 1);
+        assert_eq!(row.skipped_fires, 0);
+        assert_eq!(row.failed_fires, 0);
+
+        s.record_enqueued("daily", 200, 8).unwrap();
+        let row = s.get("daily").unwrap().unwrap();
+        assert_eq!(row.last_fired_at, Some(200));
+        assert_eq!(row.total_fires, 2);
+    }
+
+    // YYC-17 PR-3: skipped firings increment skipped_fires + total.
+    #[test]
+    fn record_skipped_increments_skip_counter() {
+        let s = store();
+        s.record_skipped("hourly", 100).unwrap();
+        s.record_skipped("hourly", 200).unwrap();
+        let row = s.get("hourly").unwrap().unwrap();
+        assert_eq!(row.last_status.as_deref(), Some("skipped"));
+        assert_eq!(row.total_fires, 2);
+        assert_eq!(row.skipped_fires, 2);
+        assert_eq!(row.failed_fires, 0);
+    }
+
+    // YYC-17 PR-3: enqueue failures carry the error text.
+    #[test]
+    fn record_enqueue_failed_carries_error() {
+        let s = store();
+        s.record_enqueue_failed("nightly", 100, "queue offline")
+            .unwrap();
+        let row = s.get("nightly").unwrap().unwrap();
+        assert_eq!(row.last_status.as_deref(), Some("enqueue_failed"));
+        assert_eq!(row.last_error.as_deref(), Some("queue offline"));
+        assert_eq!(row.failed_fires, 1);
+        assert_eq!(row.total_fires, 1);
+    }
+
+    // YYC-17 PR-3: list returns all rows sorted by job_id.
+    #[test]
+    fn list_returns_jobs_sorted_by_id() {
+        let s = store();
+        s.record_enqueued("zeta", 1, 1).unwrap();
+        s.record_enqueued("alpha", 2, 2).unwrap();
+        s.record_enqueued("middle", 3, 3).unwrap();
+        let rows = s.list().unwrap();
+        let ids: Vec<&str> = rows.iter().map(|r| r.job_id.as_str()).collect();
+        assert_eq!(ids, vec!["alpha", "middle", "zeta"]);
+    }
+
+    // YYC-17 PR-3: missing job returns None, not an error.
+    #[test]
+    fn get_returns_none_for_missing_job() {
+        let s = store();
+        assert!(s.get("never-fired").unwrap().is_none());
+    }
+}

--- a/src/memory/schema.rs
+++ b/src/memory/schema.rs
@@ -122,6 +122,21 @@ CREATE TABLE IF NOT EXISTS outbound_queue (
   turn_id TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_outbound_due ON outbound_queue(state, next_attempt_at);
+
+-- YYC-17 PR-3: scheduler job runs. The scheduler config is the
+-- authoritative job list (so re-deploys with updated cron/prompt
+-- text take effect on restart); this table only carries the
+-- mutable run-time state per job_id.
+CREATE TABLE IF NOT EXISTS scheduler_runs (
+    job_id           TEXT PRIMARY KEY,
+    last_fired_at    INTEGER,
+    last_status      TEXT, -- 'enqueued' | 'skipped' | 'enqueue_failed'
+    last_error       TEXT,
+    last_inbound_id  INTEGER,
+    total_fires      INTEGER NOT NULL DEFAULT 0,
+    skipped_fires    INTEGER NOT NULL DEFAULT 0,
+    failed_fires     INTEGER NOT NULL DEFAULT 0
+);
 "#;
 
 /// Apply per-connection PRAGMAs. SQLite's `busy_timeout` is connection


### PR DESCRIPTION
Add a `scheduler_runs` table (job_id PK plus last_fired_at,
last_status, last_error, last_inbound_id, total_fires,
skipped_fires, failed_fires) and a `SchedulerStore` wrapping the
shared gateway DbPool with three short, sync write paths
(`record_enqueued` / `record_skipped` / `record_enqueue_failed`)
and symmetric read helpers (`get` / `list`).

`Scheduler` gains an optional `SchedulerStore` and an in-process
`running` flag per job. `OverlapPolicy::Skip` now actually
suppresses overlapping fires (the running flag is set on enqueue
and cleared immediately afterwards — a real durable in-flight
check against the inbound queue lands in PR-C-4). On every
fire, the matching record_* call writes the firing's outcome.
Failures during persistence log a warning but never block the
fire path.

Folds in a YYC-152 follow-up: the IPv6 branch of
`is_local_base_url` had grown a call to the unstable
`Ipv6Addr::is_link_local`; replace it with an explicit fe80::/10
prefix mask so the build stays on stable rust.

Tests cover the store CRUD (insert + increment, skipped /
failed counters, error-text round-trip, list ordering, missing
job → None) and the scheduler integration (fire records
enqueued; with running flag set, fire records skipped).