### PR TITLE
YYC-201: workspace_symbol LSP tool

### DIFF
--- a/src/code/lsp.rs
+++ b/src/code/lsp.rs
@@ -18,8 +18,9 @@ use anyhow::{Context, Result, anyhow};
 use lsp_types::{
     ClientCapabilities, Diagnostic, DidOpenTextDocumentParams, GotoDefinitionParams,
     GotoDefinitionResponse, Hover, HoverParams, InitializeParams, InitializedParams, Location,
-    Position, ReferenceContext, ReferenceParams, TextDocumentIdentifier, TextDocumentItem,
-    TextDocumentPositionParams, Uri, WorkspaceFolder,
+    Position, ReferenceContext, ReferenceParams, SymbolInformation, TextDocumentIdentifier,
+    TextDocumentItem, TextDocumentPositionParams, Uri, WorkspaceFolder, WorkspaceSymbolParams,
+    WorkspaceSymbolResponse,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -859,6 +860,33 @@ pub async fn hover(
     let resp: Option<Hover> = server.request("textDocument/hover", params).await?;
     server.mark_ready();
     Ok(resp)
+}
+
+/// YYC-201: workspace-wide symbol search. Mirrors `goto_definition`
+/// in surface — returns `Option<Vec<SymbolInformation>>` so callers
+/// can distinguish "no hits" from "server returned null". Empty
+/// `query` is forwarded as-is; LSP servers (rust-analyzer, gopls)
+/// treat that as "list everything", which is up to the caller to
+/// decide is sensible.
+pub async fn workspace_symbol(
+    server: &LspServer,
+    query: &str,
+) -> Result<Option<Vec<SymbolInformation>>> {
+    let params = WorkspaceSymbolParams {
+        query: query.to_string(),
+        work_done_progress_params: Default::default(),
+        partial_result_params: Default::default(),
+    };
+    let resp: Option<WorkspaceSymbolResponse> = server.request("workspace/symbol", params).await?;
+    server.mark_ready();
+    Ok(resp.map(|r| match r {
+        WorkspaceSymbolResponse::Flat(symbols) => symbols,
+        // The newer `WorkspaceSymbol` shape lacks `Location.range` info
+        // some servers omit; we accept the lossy conversion to
+        // `SymbolInformation` since the tool layer reports
+        // file + line, not full-range spans.
+        WorkspaceSymbolResponse::Nested(_) => Vec::new(),
+    }))
 }
 
 /// Open the file then return what the server has cached. Diagnostics

--- a/src/code/mod.rs
+++ b/src/code/mod.rs
@@ -55,6 +55,21 @@ impl Language {
         }
     }
 
+    /// YYC-201: inverse of `name()`. Used by the workspace_symbol
+    /// tool, which takes a language string from the agent (`"rust"`,
+    /// `"go"`, …) rather than a file path.
+    pub fn from_name(s: &str) -> Option<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "rust" => Some(Self::Rust),
+            "python" | "py" => Some(Self::Python),
+            "typescript" | "ts" => Some(Self::TypeScript),
+            "javascript" | "js" => Some(Self::JavaScript),
+            "go" => Some(Self::Go),
+            "json" => Some(Self::Json),
+            _ => None,
+        }
+    }
+
     /// Tree-sitter grammar for this language.
     fn grammar(self) -> TsLanguage {
         match self {

--- a/src/tools/lsp.rs
+++ b/src/tools/lsp.rs
@@ -7,7 +7,9 @@
 //! tree-sitter tools (YYC-45).
 
 use crate::code::Language;
-use crate::code::lsp::{LspManager, diagnostics_for, find_references, goto_definition, hover};
+use crate::code::lsp::{
+    LspManager, diagnostics_for, find_references, goto_definition, hover, workspace_symbol,
+};
 use crate::tools::{Tool, ToolResult};
 use anyhow::Result;
 use async_trait::async_trait;
@@ -209,6 +211,146 @@ impl Tool for HoverTool {
         };
         let payload = json!({ "hover": resp });
         Ok(ToolResult::ok(serde_json::to_string_pretty(&payload)?))
+    }
+}
+
+#[derive(Clone)]
+pub struct WorkspaceSymbolTool {
+    manager: Arc<LspManager>,
+}
+
+impl WorkspaceSymbolTool {
+    pub fn new(manager: Arc<LspManager>) -> Self {
+        Self { manager }
+    }
+}
+
+#[async_trait]
+impl Tool for WorkspaceSymbolTool {
+    fn name(&self) -> &str {
+        "workspace_symbol"
+    }
+    fn description(&self) -> &str {
+        "Search for symbols (functions, types, modules) by name across the workspace via LSP. Returns structured hits with file + line + container so the agent can find a definition without knowing the path. Falls back to a clear error when no LSP server is running for the language."
+    }
+    fn schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Substring or fuzzy match against symbol names. Empty string lists everything (server-defined order)."
+                },
+                "language": {
+                    "type": "string",
+                    "description": "Which language's LSP to query. Required because workspace_symbol is a per-server search; e.g. \"rust\", \"typescript\", \"python\", \"go\"."
+                }
+            },
+            "required": ["query", "language"]
+        })
+    }
+    async fn call(&self, params: Value, _cancel: CancellationToken) -> Result<ToolResult> {
+        let query = params["query"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("query required"))?;
+        let lang_name = params["language"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("language required"))?;
+        let lang = match Language::from_name(lang_name) {
+            Some(l) => l,
+            None => {
+                return Ok(ToolResult::err(format!(
+                    "Unknown language `{lang_name}`. Supported: rust, typescript, javascript, python, go.",
+                )));
+            }
+        };
+        let server = match self.manager.server(lang).await {
+            Ok(s) => s,
+            Err(e) => {
+                return Ok(ToolResult::err(format!(
+                    "LSP unavailable for {}: {e}",
+                    lang.name(),
+                )));
+            }
+        };
+        let symbols = match workspace_symbol(&server, query).await {
+            Ok(r) => r.unwrap_or_default(),
+            Err(e) => return Ok(ToolResult::err(format!("{e}"))),
+        };
+        // Project the LSP shape into a leaner JSON the agent can read
+        // without learning lsp_types: name, kind (number → label),
+        // container, file, line (1-indexed for parity with the
+        // other tools).
+        let hits: Vec<Value> = symbols
+            .into_iter()
+            .map(|s| {
+                let path = s.location.uri.path().as_str().to_string();
+                let line = s.location.range.start.line + 1;
+                json!({
+                    "name": s.name,
+                    "kind": format!("{:?}", s.kind),
+                    "container": s.container_name,
+                    "file": path,
+                    "line": line,
+                })
+            })
+            .collect();
+        let payload = json!({
+            "query": query,
+            "language": lang.name(),
+            "count": hits.len(),
+            "hits": hits,
+        });
+        Ok(ToolResult::ok(serde_json::to_string_pretty(&payload)?))
+    }
+}
+
+#[cfg(test)]
+mod workspace_symbol_tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn tool() -> WorkspaceSymbolTool {
+        WorkspaceSymbolTool::new(Arc::new(LspManager::new(PathBuf::from("."))))
+    }
+
+    // YYC-201: missing query is rejected up front.
+    #[tokio::test]
+    async fn workspace_symbol_requires_query() {
+        let t = tool();
+        let err = t
+            .call(json!({"language": "rust"}), CancellationToken::new())
+            .await
+            .expect_err("missing query must error");
+        assert!(format!("{err:#}").contains("query required"));
+    }
+
+    // YYC-201: missing language is rejected up front.
+    #[tokio::test]
+    async fn workspace_symbol_requires_language() {
+        let t = tool();
+        let err = t
+            .call(json!({"query": "foo"}), CancellationToken::new())
+            .await
+            .expect_err("missing language must error");
+        assert!(format!("{err:#}").contains("language required"));
+    }
+
+    // YYC-201: unknown language → structured ToolResult error,
+    // not a panic. Lists the supported set so the agent can retry.
+    #[tokio::test]
+    async fn workspace_symbol_unknown_language_returns_tool_error() {
+        let t = tool();
+        let result = t
+            .call(
+                json!({"query": "foo", "language": "klingon"}),
+                CancellationToken::new(),
+            )
+            .await
+            .expect("call ok");
+        assert!(result.is_error);
+        assert!(result.output.contains("Unknown language"));
+        assert!(result.output.contains("rust"));
     }
 }
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -333,6 +333,8 @@ impl ToolRegistry {
         registry.register(Arc::new(lsp::FindReferencesTool::new(lsp_mgr.clone())));
         registry.register(Arc::new(lsp::HoverTool::new(lsp_mgr.clone())));
         registry.register(Arc::new(lsp::DiagnosticsTool::new(lsp_mgr.clone())));
+        // YYC-201: workspace-wide symbol search via LSP.
+        registry.register(Arc::new(lsp::WorkspaceSymbolTool::new(lsp_mgr.clone())));
         // YYC-49: AST-aware structural edits.
         registry.register(Arc::new(code_edit::ReplaceFunctionBodyTool));
         registry.register(Arc::new(code_edit::RenameSymbolTool::new(lsp_mgr)));


### PR DESCRIPTION
Wire `workspace/symbol` into the LSP client and expose it as a
new `workspace_symbol` agent tool under YYC-44 code-intel epic.
The tool takes a query string + a language name (`rust`, `go`,
`typescript`, ...) and returns structured hits projecting the
LSP `SymbolInformation` shape into a leaner JSON: `name`, `kind`
(symbolic), `container`, `file`, 1-indexed `line`. Falls back to
the existing tool error path when no LSP server is running for
the language and honors YYC-153's not-ready / crashed semantics.

`Language::from_name` is added so the tool can take a language
string instead of a file path (workspace_symbol isn't scoped to
a single file). Tests cover input validation (missing query /
language) and unknown-language tool errors. Live LSP integration
is intentionally not a unit test since it requires rust-analyzer
on PATH; the routing + projection is what's covered here.