### PR TITLE
YYC-202: type_definition + implementation LSP tools

### DIFF
--- a/src/code/lsp.rs
+++ b/src/code/lsp.rs
@@ -21,6 +21,7 @@ use lsp_types::{
     Position, ReferenceContext, ReferenceParams, SymbolInformation, TextDocumentIdentifier,
     TextDocumentItem, TextDocumentPositionParams, Uri, WorkspaceFolder, WorkspaceSymbolParams,
     WorkspaceSymbolResponse,
+    request::{GotoImplementationResponse, GotoTypeDefinitionResponse},
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -860,6 +861,75 @@ pub async fn hover(
     let resp: Option<Hover> = server.request("textDocument/hover", params).await?;
     server.mark_ready();
     Ok(resp)
+}
+
+/// YYC-202: jump to the type definition of the expression at the
+/// given position. Same response shape as `goto_definition` so the
+/// tool layer can reuse the same projection code path.
+pub async fn type_definition(
+    server: &LspServer,
+    path: &Path,
+    line: u32,
+    character: u32,
+) -> Result<Option<Vec<Location>>> {
+    prepare_request(server, path).await?;
+    let uri = path_to_uri(path)?;
+    let params = GotoDefinitionParams {
+        text_document_position_params: TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier { uri },
+            position: Position { line, character },
+        },
+        work_done_progress_params: Default::default(),
+        partial_result_params: Default::default(),
+    };
+    let resp: Option<GotoTypeDefinitionResponse> = server
+        .request("textDocument/typeDefinition", params)
+        .await?;
+    server.mark_ready();
+    Ok(resp.map(flatten_goto_response))
+}
+
+/// YYC-202: list every implementation of the trait/interface at the
+/// given position. Mirrors `goto_definition` for the response shape.
+pub async fn implementation(
+    server: &LspServer,
+    path: &Path,
+    line: u32,
+    character: u32,
+) -> Result<Option<Vec<Location>>> {
+    prepare_request(server, path).await?;
+    let uri = path_to_uri(path)?;
+    let params = GotoDefinitionParams {
+        text_document_position_params: TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier { uri },
+            position: Position { line, character },
+        },
+        work_done_progress_params: Default::default(),
+        partial_result_params: Default::default(),
+    };
+    let resp: Option<GotoImplementationResponse> = server
+        .request("textDocument/implementation", params)
+        .await?;
+    server.mark_ready();
+    Ok(resp.map(flatten_goto_response))
+}
+
+/// YYC-202: shared collapse for the three shapes
+/// `GotoDefinitionResponse` (and its type/impl aliases) can take.
+/// Pulled into a helper because typeDefinition + implementation
+/// reuse the same projection.
+fn flatten_goto_response(r: GotoDefinitionResponse) -> Vec<Location> {
+    match r {
+        GotoDefinitionResponse::Scalar(loc) => vec![loc],
+        GotoDefinitionResponse::Array(v) => v,
+        GotoDefinitionResponse::Link(links) => links
+            .into_iter()
+            .map(|l| Location {
+                uri: l.target_uri,
+                range: l.target_range,
+            })
+            .collect(),
+    }
 }
 
 /// YYC-201: workspace-wide symbol search. Mirrors `goto_definition`

--- a/src/tools/lsp.rs
+++ b/src/tools/lsp.rs
@@ -8,7 +8,8 @@
 
 use crate::code::Language;
 use crate::code::lsp::{
-    LspManager, diagnostics_for, find_references, goto_definition, hover, workspace_symbol,
+    LspManager, diagnostics_for, find_references, goto_definition, hover, implementation,
+    type_definition, workspace_symbol,
 };
 use crate::tools::{Tool, ToolResult};
 use anyhow::Result;
@@ -210,6 +211,130 @@ impl Tool for HoverTool {
             Err(e) => return Ok(ToolResult::err(format!("{e}"))),
         };
         let payload = json!({ "hover": resp });
+        Ok(ToolResult::ok(serde_json::to_string_pretty(&payload)?))
+    }
+}
+
+#[derive(Clone)]
+pub struct TypeDefinitionTool {
+    manager: Arc<LspManager>,
+}
+
+impl TypeDefinitionTool {
+    pub fn new(manager: Arc<LspManager>) -> Self {
+        Self { manager }
+    }
+}
+
+#[async_trait]
+impl Tool for TypeDefinitionTool {
+    fn name(&self) -> &str {
+        "type_definition"
+    }
+    fn description(&self) -> &str {
+        "For an expression at file:line:col, jump to where its TYPE is declared. Different from goto_definition: that returns the symbol's binding site; this returns the declaration of the type. JSON locations."
+    }
+    fn schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string" },
+                "line": { "type": "integer", "description": "1-indexed source line" },
+                "character": { "type": "integer", "description": "0-indexed column" }
+            },
+            "required": ["path", "line", "character"]
+        })
+    }
+    async fn call(&self, params: Value, _cancel: CancellationToken) -> Result<ToolResult> {
+        let path = params["path"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("path required"))?;
+        let line = params["line"]
+            .as_u64()
+            .ok_or_else(|| anyhow::anyhow!("line required"))?;
+        let character = params["character"].as_u64().unwrap_or(0);
+        let lang = match lang_for(path) {
+            Ok(l) => l,
+            Err(e) => return Ok(ToolResult::err(e.to_string())),
+        };
+        let server = match self.manager.server(lang).await {
+            Ok(s) => s,
+            Err(e) => {
+                return Ok(ToolResult::err(format!(
+                    "LSP unavailable for {}: {e}",
+                    lang.name()
+                )));
+            }
+        };
+        let pb = PathBuf::from(path);
+        let line0 = (line as u32).saturating_sub(1);
+        let resp = match type_definition(&server, &pb, line0, character as u32).await {
+            Ok(r) => r,
+            Err(e) => return Ok(ToolResult::err(format!("{e}"))),
+        };
+        let payload = json!({ "locations": resp.unwrap_or_default() });
+        Ok(ToolResult::ok(serde_json::to_string_pretty(&payload)?))
+    }
+}
+
+#[derive(Clone)]
+pub struct ImplementationTool {
+    manager: Arc<LspManager>,
+}
+
+impl ImplementationTool {
+    pub fn new(manager: Arc<LspManager>) -> Self {
+        Self { manager }
+    }
+}
+
+#[async_trait]
+impl Tool for ImplementationTool {
+    fn name(&self) -> &str {
+        "implementation"
+    }
+    fn description(&self) -> &str {
+        "For a trait or interface at file:line:col, list every implementation site as JSON locations. In Rust this finds `impl Trait for Type` blocks; in Go/TS, the implementing types of an interface."
+    }
+    fn schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string" },
+                "line": { "type": "integer", "description": "1-indexed source line" },
+                "character": { "type": "integer", "description": "0-indexed column" }
+            },
+            "required": ["path", "line", "character"]
+        })
+    }
+    async fn call(&self, params: Value, _cancel: CancellationToken) -> Result<ToolResult> {
+        let path = params["path"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("path required"))?;
+        let line = params["line"]
+            .as_u64()
+            .ok_or_else(|| anyhow::anyhow!("line required"))?;
+        let character = params["character"].as_u64().unwrap_or(0);
+        let lang = match lang_for(path) {
+            Ok(l) => l,
+            Err(e) => return Ok(ToolResult::err(e.to_string())),
+        };
+        let server = match self.manager.server(lang).await {
+            Ok(s) => s,
+            Err(e) => {
+                return Ok(ToolResult::err(format!(
+                    "LSP unavailable for {}: {e}",
+                    lang.name()
+                )));
+            }
+        };
+        let pb = PathBuf::from(path);
+        let line0 = (line as u32).saturating_sub(1);
+        let locs = match implementation(&server, &pb, line0, character as u32).await {
+            Ok(r) => r.unwrap_or_default(),
+            Err(e) => return Ok(ToolResult::err(format!("{e}"))),
+        };
+        let payload = json!({ "implementations": locs });
         Ok(ToolResult::ok(serde_json::to_string_pretty(&payload)?))
     }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -335,6 +335,9 @@ impl ToolRegistry {
         registry.register(Arc::new(lsp::DiagnosticsTool::new(lsp_mgr.clone())));
         // YYC-201: workspace-wide symbol search via LSP.
         registry.register(Arc::new(lsp::WorkspaceSymbolTool::new(lsp_mgr.clone())));
+        // YYC-202: type-of-expression + trait/interface implementation lookup.
+        registry.register(Arc::new(lsp::TypeDefinitionTool::new(lsp_mgr.clone())));
+        registry.register(Arc::new(lsp::ImplementationTool::new(lsp_mgr.clone())));
         // YYC-49: AST-aware structural edits.
         registry.register(Arc::new(code_edit::ReplaceFunctionBodyTool));
         registry.register(Arc::new(code_edit::RenameSymbolTool::new(lsp_mgr)));


### PR DESCRIPTION
Wire `textDocument/typeDefinition` and `textDocument/implementation`
into the LSP client and expose them as two new agent tools under
the YYC-44 code-intel epic. Both share the position-based schema
(path + 1-indexed line + character) used by `goto_definition` and
the response shape — the existing flatten of
GotoDefinitionResponse's three variants is extracted into a shared
helper so the new tools reuse it.

`type_definition` answers "what type is this expression?";
`implementation` answers "what implements this trait/interface?".
Crash + not-ready semantics ride through the existing
`LspManager::server` path. No silent nulls — server-not-ready
still surfaces as `LspError::NotReady`.