### PR TITLE
YYC-203: call_hierarchy LSP tool

### DIFF
--- a/src/code/lsp.rs
+++ b/src/code/lsp.rs
@@ -16,6 +16,8 @@
 use crate::code::Language;
 use anyhow::{Context, Result, anyhow};
 use lsp_types::{
+    CallHierarchyIncomingCall, CallHierarchyIncomingCallsParams, CallHierarchyItem,
+    CallHierarchyOutgoingCall, CallHierarchyOutgoingCallsParams, CallHierarchyPrepareParams,
     ClientCapabilities, Diagnostic, DidOpenTextDocumentParams, GotoDefinitionParams,
     GotoDefinitionResponse, Hover, HoverParams, InitializeParams, InitializedParams, Location,
     Position, ReferenceContext, ReferenceParams, SymbolInformation, TextDocumentIdentifier,
@@ -930,6 +932,72 @@ fn flatten_goto_response(r: GotoDefinitionResponse) -> Vec<Location> {
             })
             .collect(),
     }
+}
+
+/// YYC-203: prepare a call-hierarchy item at the given position.
+/// LSP's call hierarchy is a two-step query: first resolve the
+/// symbol at the cursor to a `CallHierarchyItem`, then ask the
+/// server for its incoming or outgoing calls. Returns an empty
+/// vec when the position doesn't resolve to a callable symbol.
+pub async fn prepare_call_hierarchy(
+    server: &LspServer,
+    path: &Path,
+    line: u32,
+    character: u32,
+) -> Result<Vec<CallHierarchyItem>> {
+    prepare_request(server, path).await?;
+    let uri = path_to_uri(path)?;
+    let params = CallHierarchyPrepareParams {
+        text_document_position_params: TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier { uri },
+            position: Position { line, character },
+        },
+        work_done_progress_params: Default::default(),
+    };
+    let resp: Option<Vec<CallHierarchyItem>> = server
+        .request("textDocument/prepareCallHierarchy", params)
+        .await?;
+    server.mark_ready();
+    Ok(resp.unwrap_or_default())
+}
+
+/// YYC-203: resolve incoming calls for an already-prepared call-
+/// hierarchy item. The `from` field on each result is the calling
+/// function; `from_ranges` are the call sites within it.
+pub async fn call_hierarchy_incoming(
+    server: &LspServer,
+    item: CallHierarchyItem,
+) -> Result<Vec<CallHierarchyIncomingCall>> {
+    let params = CallHierarchyIncomingCallsParams {
+        item,
+        work_done_progress_params: Default::default(),
+        partial_result_params: Default::default(),
+    };
+    let resp: Option<Vec<CallHierarchyIncomingCall>> = server
+        .request("callHierarchy/incomingCalls", params)
+        .await?;
+    server.mark_ready();
+    Ok(resp.unwrap_or_default())
+}
+
+/// YYC-203: resolve outgoing calls for an already-prepared call-
+/// hierarchy item. The `to` field on each result is the called
+/// function; `from_ranges` are the call sites within the prepared
+/// item that reach it.
+pub async fn call_hierarchy_outgoing(
+    server: &LspServer,
+    item: CallHierarchyItem,
+) -> Result<Vec<CallHierarchyOutgoingCall>> {
+    let params = CallHierarchyOutgoingCallsParams {
+        item,
+        work_done_progress_params: Default::default(),
+        partial_result_params: Default::default(),
+    };
+    let resp: Option<Vec<CallHierarchyOutgoingCall>> = server
+        .request("callHierarchy/outgoingCalls", params)
+        .await?;
+    server.mark_ready();
+    Ok(resp.unwrap_or_default())
 }
 
 /// YYC-201: workspace-wide symbol search. Mirrors `goto_definition`

--- a/src/tools/lsp.rs
+++ b/src/tools/lsp.rs
@@ -8,8 +8,9 @@
 
 use crate::code::Language;
 use crate::code::lsp::{
-    LspManager, diagnostics_for, find_references, goto_definition, hover, implementation,
-    type_definition, workspace_symbol,
+    LspManager, call_hierarchy_incoming, call_hierarchy_outgoing, diagnostics_for, find_references,
+    goto_definition, hover, implementation, prepare_call_hierarchy, type_definition,
+    workspace_symbol,
 };
 use crate::tools::{Tool, ToolResult};
 use anyhow::Result;
@@ -335,6 +336,132 @@ impl Tool for ImplementationTool {
             Err(e) => return Ok(ToolResult::err(format!("{e}"))),
         };
         let payload = json!({ "implementations": locs });
+        Ok(ToolResult::ok(serde_json::to_string_pretty(&payload)?))
+    }
+}
+
+#[derive(Clone)]
+pub struct CallHierarchyTool {
+    manager: Arc<LspManager>,
+}
+
+impl CallHierarchyTool {
+    pub fn new(manager: Arc<LspManager>) -> Self {
+        Self { manager }
+    }
+}
+
+#[async_trait]
+impl Tool for CallHierarchyTool {
+    fn name(&self) -> &str {
+        "call_hierarchy"
+    }
+    fn description(&self) -> &str {
+        "Find functions that call (`incoming`) or are called by (`outgoing`) the symbol at file:line:col. Stricter than find_references — type uses and imports don't show up here. Returns each call's name + file + line + container."
+    }
+    fn schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string" },
+                "line": { "type": "integer", "description": "1-indexed source line" },
+                "character": { "type": "integer", "description": "0-indexed column" },
+                "direction": {
+                    "type": "string",
+                    "enum": ["incoming", "outgoing"],
+                    "description": "`incoming` lists callers; `outgoing` lists callees."
+                }
+            },
+            "required": ["path", "line", "character", "direction"]
+        })
+    }
+    async fn call(&self, params: Value, _cancel: CancellationToken) -> Result<ToolResult> {
+        let path = params["path"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("path required"))?;
+        let line = params["line"]
+            .as_u64()
+            .ok_or_else(|| anyhow::anyhow!("line required"))?;
+        let character = params["character"].as_u64().unwrap_or(0);
+        let direction = params["direction"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("direction required"))?;
+        if direction != "incoming" && direction != "outgoing" {
+            return Ok(ToolResult::err(format!(
+                "direction must be \"incoming\" or \"outgoing\"; got `{direction}`",
+            )));
+        }
+        let lang = match lang_for(path) {
+            Ok(l) => l,
+            Err(e) => return Ok(ToolResult::err(e.to_string())),
+        };
+        let server = match self.manager.server(lang).await {
+            Ok(s) => s,
+            Err(e) => {
+                return Ok(ToolResult::err(format!(
+                    "LSP unavailable for {}: {e}",
+                    lang.name()
+                )));
+            }
+        };
+        let pb = PathBuf::from(path);
+        let line0 = (line as u32).saturating_sub(1);
+        let items = match prepare_call_hierarchy(&server, &pb, line0, character as u32).await {
+            Ok(items) => items,
+            Err(e) => return Ok(ToolResult::err(format!("{e}"))),
+        };
+        if items.is_empty() {
+            let payload = json!({
+                "direction": direction,
+                "calls": [],
+                "note": "No callable symbol at this position.",
+            });
+            return Ok(ToolResult::ok(serde_json::to_string_pretty(&payload)?));
+        }
+        // The spec returns a `Vec` because some servers resolve a
+        // position to multiple callable items (overloads). Expand
+        // each into its own incoming/outgoing query and concatenate.
+        let mut hits: Vec<Value> = Vec::new();
+        for item in items {
+            if direction == "incoming" {
+                let calls = match call_hierarchy_incoming(&server, item).await {
+                    Ok(c) => c,
+                    Err(e) => return Ok(ToolResult::err(format!("{e}"))),
+                };
+                for call in calls {
+                    let from = call.from;
+                    hits.push(json!({
+                        "name": from.name,
+                        "kind": format!("{:?}", from.kind),
+                        "container": from.detail,
+                        "file": from.uri.path().as_str(),
+                        "line": from.range.start.line + 1,
+                        "call_sites": call.from_ranges.len(),
+                    }));
+                }
+            } else {
+                let calls = match call_hierarchy_outgoing(&server, item).await {
+                    Ok(c) => c,
+                    Err(e) => return Ok(ToolResult::err(format!("{e}"))),
+                };
+                for call in calls {
+                    let to = call.to;
+                    hits.push(json!({
+                        "name": to.name,
+                        "kind": format!("{:?}", to.kind),
+                        "container": to.detail,
+                        "file": to.uri.path().as_str(),
+                        "line": to.range.start.line + 1,
+                        "call_sites": call.from_ranges.len(),
+                    }));
+                }
+            }
+        }
+        let payload = json!({
+            "direction": direction,
+            "count": hits.len(),
+            "calls": hits,
+        });
         Ok(ToolResult::ok(serde_json::to_string_pretty(&payload)?))
     }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -338,6 +338,8 @@ impl ToolRegistry {
         // YYC-202: type-of-expression + trait/interface implementation lookup.
         registry.register(Arc::new(lsp::TypeDefinitionTool::new(lsp_mgr.clone())));
         registry.register(Arc::new(lsp::ImplementationTool::new(lsp_mgr.clone())));
+        // YYC-203: incoming/outgoing call hierarchy.
+        registry.register(Arc::new(lsp::CallHierarchyTool::new(lsp_mgr.clone())));
         // YYC-49: AST-aware structural edits.
         registry.register(Arc::new(code_edit::ReplaceFunctionBodyTool));
         registry.register(Arc::new(code_edit::RenameSymbolTool::new(lsp_mgr)));


### PR DESCRIPTION
Add `prepare_call_hierarchy` + `call_hierarchy_incoming` +
`call_hierarchy_outgoing` helpers in `code::lsp` and expose them
through a single `call_hierarchy` agent tool that takes a
position + direction (`incoming` | `outgoing`). Returns a
flattened JSON list with name, kind, container, file, 1-indexed
line, and the number of call sites within each caller/callee.

Stricter than `find_references`: type uses, imports, and other
symbol references don't show up in call hierarchy output. Helps
the agent answer 'who calls this function' / 'what does this
function call' without filtering through reference noise. Honors
the existing not-ready / crashed semantics; an empty `prepare`
result surfaces as `{calls: [], note: "No callable symbol at this
position."}` so the agent gets actionable feedback instead of
a silent null.