### PR TITLE
YYC-204: code_action LSP tool

### DIFF
--- a/src/code/lsp/requests.rs
+++ b/src/code/lsp/requests.rs
@@ -14,8 +14,9 @@ use anyhow::Result;
 use lsp_types::{
     CallHierarchyIncomingCall, CallHierarchyIncomingCallsParams, CallHierarchyItem,
     CallHierarchyOutgoingCall, CallHierarchyOutgoingCallsParams, CallHierarchyPrepareParams,
-    Diagnostic, GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverParams, Location,
-    Position, ReferenceContext, ReferenceParams, SymbolInformation, TextDocumentIdentifier,
+    CodeActionContext, CodeActionOrCommand, CodeActionParams, CodeActionResponse, Diagnostic,
+    GotoDefinitionParams, GotoDefinitionResponse, Hover, HoverParams, Location, Position, Range,
+    ReferenceContext, ReferenceParams, SymbolInformation, TextDocumentIdentifier,
     TextDocumentPositionParams, WorkspaceSymbolParams, WorkspaceSymbolResponse,
     request::{GotoImplementationResponse, GotoTypeDefinitionResponse},
 };
@@ -252,6 +253,37 @@ pub async fn workspace_symbol(
         // file + line, not full-range spans.
         WorkspaceSymbolResponse::Nested(_) => Vec::new(),
     }))
+}
+
+/// YYC-204: list available code actions (fix-its + refactors) for a
+/// line range. Input range is 0-indexed half-open per LSP spec.
+/// Pass any diagnostics the caller wants the server to consider —
+/// rust-analyzer / pyright surface different actions when a
+/// diagnostic is in scope (e.g. "import this name", "remove unused").
+pub async fn code_action(
+    server: &LspServer,
+    path: &Path,
+    start: Position,
+    end: Position,
+    diagnostics: Vec<Diagnostic>,
+) -> Result<Vec<CodeActionOrCommand>> {
+    prepare_request(server, path).await?;
+    let uri = path_to_uri(path)?;
+    let params = CodeActionParams {
+        text_document: TextDocumentIdentifier { uri },
+        range: Range { start, end },
+        context: CodeActionContext {
+            diagnostics,
+            only: None,
+            trigger_kind: None,
+        },
+        work_done_progress_params: Default::default(),
+        partial_result_params: Default::default(),
+    };
+    let resp: Option<CodeActionResponse> =
+        server.request("textDocument/codeAction", params).await?;
+    server.mark_ready();
+    Ok(resp.unwrap_or_default())
 }
 
 /// Open the file then return what the server has cached. Diagnostics

--- a/src/tools/lsp.rs
+++ b/src/tools/lsp.rs
@@ -8,9 +8,9 @@
 
 use crate::code::Language;
 use crate::code::lsp::{
-    LspManager, call_hierarchy_incoming, call_hierarchy_outgoing, diagnostics_for, find_references,
-    goto_definition, hover, implementation, prepare_call_hierarchy, type_definition,
-    workspace_symbol,
+    LspManager, call_hierarchy_incoming, call_hierarchy_outgoing, code_action, diagnostics_for,
+    find_references, goto_definition, hover, implementation, prepare_call_hierarchy,
+    type_definition, workspace_symbol,
 };
 use crate::tools::{Tool, ToolResult};
 use anyhow::Result;
@@ -336,6 +336,121 @@ impl Tool for ImplementationTool {
             Err(e) => return Ok(ToolResult::err(format!("{e}"))),
         };
         let payload = json!({ "implementations": locs });
+        Ok(ToolResult::ok(serde_json::to_string_pretty(&payload)?))
+    }
+}
+
+#[derive(Clone)]
+pub struct CodeActionTool {
+    manager: Arc<LspManager>,
+}
+
+impl CodeActionTool {
+    pub fn new(manager: Arc<LspManager>) -> Self {
+        Self { manager }
+    }
+}
+
+#[async_trait]
+impl Tool for CodeActionTool {
+    fn name(&self) -> &str {
+        "code_action"
+    }
+    fn description(&self) -> &str {
+        "List the LSP code actions (fix-its + refactors) available for a line range. Returns each action's title, kind, whether it's marked preferred by the server, and whether it carries an edit. This tool is read-only; applying the edit is a separate step."
+    }
+    fn schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string" },
+                "start_line": {
+                    "type": "integer",
+                    "description": "1-indexed source line where the range starts"
+                },
+                "end_line": {
+                    "type": "integer",
+                    "description": "1-indexed source line where the range ends (inclusive). Defaults to start_line."
+                },
+                "start_character": {
+                    "type": "integer",
+                    "description": "0-indexed column at start. Default 0."
+                },
+                "end_character": {
+                    "type": "integer",
+                    "description": "0-indexed column at end. Default 0; the server treats line-only ranges as the whole line."
+                }
+            },
+            "required": ["path", "start_line"]
+        })
+    }
+    async fn call(&self, params: Value, _cancel: CancellationToken) -> Result<ToolResult> {
+        use lsp_types::Position as LspPosition;
+        let path = params["path"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("path required"))?;
+        let start_line = params["start_line"]
+            .as_u64()
+            .ok_or_else(|| anyhow::anyhow!("start_line required"))?;
+        let end_line = params["end_line"].as_u64().unwrap_or(start_line);
+        let start_char = params["start_character"].as_u64().unwrap_or(0) as u32;
+        let end_char = params["end_character"].as_u64().unwrap_or(0) as u32;
+        let lang = match lang_for(path) {
+            Ok(l) => l,
+            Err(e) => return Ok(ToolResult::err(e.to_string())),
+        };
+        let server = match self.manager.server(lang).await {
+            Ok(s) => s,
+            Err(e) => {
+                return Ok(ToolResult::err(format!(
+                    "LSP unavailable for {}: {e}",
+                    lang.name()
+                )));
+            }
+        };
+        let pb = PathBuf::from(path);
+        let start = LspPosition {
+            line: (start_line as u32).saturating_sub(1),
+            character: start_char,
+        };
+        let end = LspPosition {
+            line: (end_line as u32).saturating_sub(1),
+            character: end_char,
+        };
+        // Pull current cached diagnostics so the server can offer
+        // diagnostic-keyed fixes (e.g. rust-analyzer's "import this
+        // name"). Empty diagnostics are valid; the server still
+        // returns refactors that don't depend on errors.
+        let diags = server.cached_diagnostics(&pb).await;
+        let actions = match code_action(&server, &pb, start, end, diags).await {
+            Ok(a) => a,
+            Err(e) => return Ok(ToolResult::err(format!("{e}"))),
+        };
+        // Project the LSP shape into a flat agent-friendly list.
+        let hits: Vec<Value> = actions
+            .into_iter()
+            .map(|a| match a {
+                lsp_types::CodeActionOrCommand::Command(cmd) => json!({
+                    "title": cmd.title,
+                    "kind": "command",
+                    "is_preferred": false,
+                    "has_edit": false,
+                    "command": cmd.command,
+                }),
+                lsp_types::CodeActionOrCommand::CodeAction(action) => json!({
+                    "title": action.title,
+                    "kind": action.kind.map(|k| k.as_str().to_string()),
+                    "is_preferred": action.is_preferred.unwrap_or(false),
+                    "has_edit": action.edit.is_some(),
+                    "command": action.command.map(|c| c.command),
+                }),
+            })
+            .collect();
+        let payload = json!({
+            "path": path,
+            "count": hits.len(),
+            "actions": hits,
+        });
         Ok(ToolResult::ok(serde_json::to_string_pretty(&payload)?))
     }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -340,6 +340,8 @@ impl ToolRegistry {
         registry.register(Arc::new(lsp::ImplementationTool::new(lsp_mgr.clone())));
         // YYC-203: incoming/outgoing call hierarchy.
         registry.register(Arc::new(lsp::CallHierarchyTool::new(lsp_mgr.clone())));
+        // YYC-204: code actions (fix-its + refactors).
+        registry.register(Arc::new(lsp::CodeActionTool::new(lsp_mgr.clone())));
         // YYC-49: AST-aware structural edits.
         registry.register(Arc::new(code_edit::ReplaceFunctionBodyTool));
         registry.register(Arc::new(code_edit::RenameSymbolTool::new(lsp_mgr)));


### PR DESCRIPTION
Wire `textDocument/codeAction` into the LSP request layer and
expose it as a new agent tool. Takes a path + line range and
returns a flat JSON list of available fix-its / refactors. Each
entry carries title, kind (e.g. `quickfix`, `refactor.extract`),
`is_preferred`, whether it ships an edit, and the optional
command id. The server's view of current cached diagnostics is
passed in `CodeActionContext.diagnostics` so diagnostic-keyed
actions (rust-analyzer's `import this name`, pyright's
`add to __all__`) show up.

This PR is read-only: it lists actions but does not apply them.
Applying a `WorkspaceEdit` through the diff sink + approval flow
is tracked separately so it can lean on the same audit + diff
pipeline as `write_file` / `edit_file`.