### PR TITLE
YYC-207: TUI binding for orchestration store

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -166,6 +166,9 @@ pub async fn run_tui(config: &Config, resume: ResumeTarget) -> Result<()> {
         app.model_label = a.active_model().to_string();
         app.token_max = a.max_context() as u32;
         app.provider_label = a.active_profile().map(str::to_string);
+        // YYC-207: share the agent's orchestration store so subagent
+        // tiles + tree nodes render real child runs as they happen.
+        app.orchestration_store = Some(a.orchestration());
     }
     events::refresh_sessions(&agent, &mut app).await;
 

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -205,6 +205,12 @@ pub struct AppState {
     /// When the TUI session started — used for elapsed-time displays.
     pub session_started: std::time::Instant,
     pub orchestration: OrchestrationState,
+    /// YYC-207: live snapshot store for child agent runs. When
+    /// populated, `subagent_tiles` / `tree_nodes` consult it for
+    /// real records; when `None`, those methods fall back to the
+    /// legacy single-"main" tile shape so demo / test paths still
+    /// render coherently.
+    pub orchestration_store: Option<std::sync::Arc<crate::orchestration::OrchestrationStore>>,
 
     /// Optional shared handle to the audit-log hook's ring buffer. When
     /// present, the trading-floor tool-log pane renders from it; otherwise it
@@ -366,6 +372,7 @@ impl AppState {
             provider_errors_total: 0,
             session_started: std::time::Instant::now(),
             orchestration: OrchestrationState::default(),
+            orchestration_store: None,
 
             audit_log: None,
             pending_pause: None,
@@ -671,6 +678,8 @@ impl AppState {
     }
 
     pub fn subagent_tiles(&self) -> Vec<SubAgentTile> {
+        // Build the orchestrator's own tile from current phase /
+        // task / events.
         let mut log = Vec::new();
         log.push(self.orchestration.active_task.clone());
         if let Some(tool) = &self.orchestration.current_tool {
@@ -682,14 +691,24 @@ impl AppState {
         if let Some(reasoning) = self.latest_reasoning() {
             log.push(format!("reasoning · {}", short_text(reasoning, 48)));
         }
-        vec![SubAgentTile {
+        let mut tiles = vec![SubAgentTile {
             name: "main".into(),
             role: "orchestrator".into(),
             state: self.orchestration.phase.label().into(),
             color: self.orchestration.phase.color(),
             log,
             cpu: Vec::new(),
-        }]
+        }];
+
+        // YYC-207: append a tile per recent child run from the
+        // orchestration store, when wired. Newest first so active
+        // children show up at the top of the mesh.
+        if let Some(store) = &self.orchestration_store {
+            for record in store.recent(8) {
+                tiles.push(child_tile_from(&record));
+            }
+        }
+        tiles
     }
 
     pub fn ticker_cells(&self) -> Vec<TickerCell> {
@@ -736,11 +755,27 @@ impl AppState {
                 active: true,
             });
         }
+        // YYC-207: append child runs as depth-1 nodes under root.
+        // Active (non-terminal) records highlight; terminal ones
+        // surface their final status symbol.
+        if let Some(store) = &self.orchestration_store {
+            for record in store.recent(8) {
+                nodes.push(child_tree_node(&record));
+            }
+        }
         nodes
     }
 
     pub fn delegated_worker_count(&self) -> usize {
-        0
+        // YYC-207: live child count — non-terminal records only.
+        match &self.orchestration_store {
+            Some(store) => store
+                .list()
+                .iter()
+                .filter(|r| !r.status.is_terminal())
+                .count(),
+            None => 0,
+        }
     }
 
     pub fn branch_count(&self) -> usize {
@@ -869,6 +904,69 @@ fn short_text(text: &str, max: usize) -> String {
         let mut out: String = text.chars().take(max).collect();
         out.push('…');
         out
+    }
+}
+
+/// YYC-207: project a `ChildAgentRecord` into the SubAgentTile
+/// shape the TiledMesh view renders.
+fn child_tile_from(record: &crate::orchestration::ChildAgentRecord) -> SubAgentTile {
+    use crate::orchestration::ChildStatus;
+    let (state_label, color) = match record.status {
+        ChildStatus::Pending => ("pending", Palette::MUTED),
+        ChildStatus::Running => ("running", Palette::BLUE),
+        ChildStatus::Blocked => ("blocked", Palette::YELLOW),
+        ChildStatus::Completed => ("done", Palette::GREEN),
+        ChildStatus::Failed => ("error", Palette::RED),
+        ChildStatus::Cancelled => ("cancelled", Palette::MUTED),
+    };
+    let mut log = Vec::new();
+    log.push(short_text(&record.task_summary, 60).to_string());
+    if let Some(phase) = &record.current_phase {
+        log.push(format!("phase · {phase}"));
+    }
+    log.push(format!(
+        "budget · {}/{}",
+        record.iterations_used, record.max_iterations
+    ));
+    if let Some(err) = &record.error {
+        log.push(format!("error · {}", short_text(err, 48)));
+    } else if let Some(summary) = &record.final_summary {
+        log.push(format!("summary · {}", short_text(summary, 48)));
+    }
+    let id_short: String = record.id.to_string().chars().take(8).collect();
+    SubAgentTile {
+        name: format!("child:{id_short}"),
+        role: "subagent".into(),
+        state: state_label.into(),
+        color,
+        log,
+        cpu: Vec::new(),
+    }
+}
+
+/// YYC-207: project a `ChildAgentRecord` into a TreeNode for the
+/// TreeOfThought view. Non-terminal records are marked active so
+/// the tree highlights the live frontier.
+fn child_tree_node(record: &crate::orchestration::ChildAgentRecord) -> TreeNode {
+    use crate::orchestration::ChildStatus;
+    let (symbol, color) = match record.status {
+        ChildStatus::Pending => ("○", Palette::MUTED),
+        ChildStatus::Running => ("●", Palette::BLUE),
+        ChildStatus::Blocked => ("⏸", Palette::YELLOW),
+        ChildStatus::Completed => ("✓", Palette::GREEN),
+        ChildStatus::Failed => ("✗", Palette::RED),
+        ChildStatus::Cancelled => ("⊘", Palette::MUTED),
+    };
+    let id_short: String = record.id.to_string().chars().take(8).collect();
+    TreeNode {
+        depth: 1,
+        label: format!(
+            "└─ child:{id_short} · {}",
+            short_text(&record.task_summary, 40)
+        ),
+        state: symbol.into(),
+        color,
+        active: !record.status.is_terminal(),
     }
 }
 

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -359,6 +359,77 @@ fn push_tool_start_with_carries_params_summary() {
     }
 }
 
+// YYC-207: with no orchestration store wired, subagent_tiles
+// returns the legacy single "main" tile so demo / first-launch
+// rendering stays coherent.
+#[test]
+fn subagent_tiles_legacy_when_no_store() {
+    let app = AppState::new("test-model".into(), 128_000);
+    let tiles = app.subagent_tiles();
+    assert_eq!(tiles.len(), 1);
+    assert_eq!(tiles[0].name, "main");
+}
+
+// YYC-207: a populated store surfaces one tile per recent record
+// alongside the orchestrator's "main" tile.
+#[test]
+fn subagent_tiles_include_child_records_from_store() {
+    use crate::orchestration::OrchestrationStore;
+    use std::sync::Arc;
+    let store = Arc::new(OrchestrationStore::new());
+    let r1 = store.register(None, "summarize provider parser", 8);
+    store.update_status(r1.id, crate::orchestration::ChildStatus::Running);
+    store.update_phase(r1.id, "thinking");
+    let r2 = store.register(None, "review hooks", 4);
+    store.mark_completed(r2.id, "no hot spots", 3);
+
+    let mut app = AppState::new("test-model".into(), 128_000);
+    app.orchestration_store = Some(store);
+    let tiles = app.subagent_tiles();
+    assert_eq!(tiles.len(), 3, "main + 2 children");
+    assert_eq!(tiles[0].name, "main");
+    // Newest first: r2 (completed) before r1 (running) since
+    // recent() reverses insertion order.
+    assert!(tiles[1].name.starts_with("child:"));
+    assert_eq!(tiles[1].state, "done");
+    assert_eq!(tiles[2].state, "running");
+}
+
+// YYC-207: tree_nodes appends child records as depth-1 nodes; the
+// non-terminal record is marked active.
+#[test]
+fn tree_nodes_include_child_records_from_store() {
+    use crate::orchestration::OrchestrationStore;
+    use std::sync::Arc;
+    let store = Arc::new(OrchestrationStore::new());
+    let r = store.register(None, "review", 4);
+    store.update_status(r.id, crate::orchestration::ChildStatus::Running);
+    let mut app = AppState::new("test-model".into(), 128_000);
+    app.orchestration_store = Some(store);
+    let nodes = app.tree_nodes();
+    let child = nodes
+        .iter()
+        .find(|n| n.label.contains("child:"))
+        .expect("child node");
+    assert_eq!(child.depth, 1);
+    assert!(child.active);
+}
+
+// YYC-207: delegated_worker_count counts only non-terminal records.
+#[test]
+fn delegated_worker_count_filters_terminal_records() {
+    use crate::orchestration::OrchestrationStore;
+    use std::sync::Arc;
+    let store = Arc::new(OrchestrationStore::new());
+    let r1 = store.register(None, "live", 4);
+    store.update_status(r1.id, crate::orchestration::ChildStatus::Running);
+    let r2 = store.register(None, "done", 4);
+    store.mark_completed(r2.id, "ok", 1);
+    let mut app = AppState::new("test-model".into(), 128_000);
+    app.orchestration_store = Some(store);
+    assert_eq!(app.delegated_worker_count(), 1);
+}
+
 #[test]
 fn finish_tool_with_stamps_preview_and_timing() {
     let mut m = ChatMessage::new(ChatRole::Agent, "");


### PR DESCRIPTION
`AppState` gains an optional `Arc<OrchestrationStore>` populated
at TUI startup from `Agent::orchestration()`. When wired,
`subagent_tiles()` and `tree_nodes()` consult the store and emit
one entry per recent child run alongside the existing
orchestrator tile / root node; `delegated_worker_count()` counts
only non-terminal records. With no store wired (legacy demo /
test paths), the methods fall back to the previous single-tile
shape so existing rendering stays coherent.

Projection helpers `child_tile_from` and `child_tree_node` map
`ChildStatus` onto the existing palette + symbol vocabulary
(`◌` pending, `●` running, `✓` done, `✗` error, `⊘` cancelled,
`⏸` blocked) so the TiledMesh and TreeOfThought views show
truthful child state instead of demo data. Tests cover the
fallback path, real-record projection, tree depth / active-flag
behavior, and the worker count filter.