### PR TITLE
YYC-209: per-child cancellation handles + kill-by-id action

### DIFF
--- a/src/orchestration/mod.rs
+++ b/src/orchestration/mod.rs
@@ -18,11 +18,12 @@
 //! session anyway. SQLite-backed history is a follow-up if/when
 //! cross-session inspection becomes a real ask.
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use parking_lot::Mutex;
+use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 /// Cap on the number of records kept in the store. Old records
@@ -120,6 +121,11 @@ struct StoreInner {
     records: VecDeque<ChildAgentRecord>,
     /// Bounded length; a push past `capacity` evicts the front.
     capacity: usize,
+    /// YYC-209: per-active-child cancellation tokens, keyed by id.
+    /// Inserted by `register_cancel_handle` on child spawn,
+    /// removed at terminal transition. `cancel(id)` looks up and
+    /// fires.
+    cancel_handles: HashMap<ChildAgentId, CancellationToken>,
 }
 
 impl OrchestrationStore {
@@ -134,6 +140,7 @@ impl OrchestrationStore {
             inner: Mutex::new(StoreInner {
                 records: VecDeque::with_capacity(capacity.min(1024)),
                 capacity: capacity.max(1),
+                cancel_handles: HashMap::new(),
             }),
         }
     }
@@ -271,6 +278,57 @@ impl OrchestrationStore {
         inner.records.iter().rev().take(n).cloned().collect()
     }
 
+    /// YYC-209: register the cancellation token for an in-flight
+    /// child. Looked up by `cancel(id)` to fire the matching
+    /// child's cancel signal. The spawn tool calls this on child
+    /// start and `forget_cancel_handle` on terminal transition so
+    /// the map doesn't accumulate dead tokens.
+    pub fn register_cancel_handle(&self, id: ChildAgentId, token: CancellationToken) {
+        let mut inner = self.inner.lock();
+        inner.cancel_handles.insert(id, token);
+    }
+
+    /// YYC-209: drop a cancel handle without firing it. Called at
+    /// terminal transition so the map stays bounded by the count
+    /// of in-flight children, not lifetime-of-process.
+    pub fn forget_cancel_handle(&self, id: ChildAgentId) {
+        let mut inner = self.inner.lock();
+        inner.cancel_handles.remove(&id);
+    }
+
+    /// YYC-209: cancel a specific child by id. Looks up the
+    /// registered token, fires it, removes it from the map, and
+    /// flips the record to `Cancelled`. Returns true when a token
+    /// was registered and fired; false when the id is unknown or
+    /// already terminal.
+    pub fn cancel(&self, id: ChildAgentId) -> bool {
+        let token = {
+            let mut inner = self.inner.lock();
+            inner.cancel_handles.remove(&id)
+        };
+        match token {
+            Some(t) => {
+                t.cancel();
+                self.mark_cancelled(id);
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// YYC-209: snapshot every record whose `parent_id` equals
+    /// `parent`. Used by tree-of-thought rendering to walk the
+    /// child hierarchy. Returned in insertion order.
+    pub fn children_of(&self, parent: ChildAgentId) -> Vec<ChildAgentRecord> {
+        let inner = self.inner.lock();
+        inner
+            .records
+            .iter()
+            .filter(|r| r.parent_id == Some(parent))
+            .cloned()
+            .collect()
+    }
+
     pub fn len(&self) -> usize {
         self.inner.lock().records.len()
     }
@@ -385,6 +443,59 @@ mod tests {
         let snap = s.get(r.id).unwrap();
         assert_eq!(snap.status, ChildStatus::Cancelled);
         assert!(snap.ended_at.is_some());
+    }
+
+    // YYC-209: cancel(id) fires the registered token + flips the
+    // record to Cancelled.
+    #[test]
+    fn cancel_fires_registered_token_and_marks_record() {
+        let s = store();
+        let r = s.register(None, "task", 4);
+        let token = CancellationToken::new();
+        s.register_cancel_handle(r.id, token.clone());
+        assert!(s.cancel(r.id));
+        assert!(token.is_cancelled());
+        let snap = s.get(r.id).unwrap();
+        assert_eq!(snap.status, ChildStatus::Cancelled);
+    }
+
+    // YYC-209: cancel on an unknown id returns false without
+    // panicking.
+    #[test]
+    fn cancel_unknown_id_returns_false() {
+        let s = store();
+        let phantom = ChildAgentId::new();
+        assert!(!s.cancel(phantom));
+    }
+
+    // YYC-209: forget_cancel_handle removes without firing.
+    #[test]
+    fn forget_cancel_handle_does_not_fire() {
+        let s = store();
+        let r = s.register(None, "task", 4);
+        let token = CancellationToken::new();
+        s.register_cancel_handle(r.id, token.clone());
+        s.forget_cancel_handle(r.id);
+        // Subsequent cancel returns false (handle gone) and the
+        // token stays uncancelled.
+        assert!(!s.cancel(r.id));
+        assert!(!token.is_cancelled());
+    }
+
+    // YYC-209: children_of returns only direct children.
+    #[test]
+    fn children_of_returns_direct_descendants() {
+        let s = store();
+        let parent = s.register(None, "parent", 8);
+        let c1 = s.register(Some(parent.id), "c1", 4);
+        let c2 = s.register(Some(parent.id), "c2", 4);
+        let _grandchild = s.register(Some(c1.id), "gc", 2);
+        let _unrelated = s.register(None, "other", 4);
+        let kids = s.children_of(parent.id);
+        let ids: Vec<ChildAgentId> = kids.iter().map(|r| r.id).collect();
+        assert_eq!(ids.len(), 2);
+        assert!(ids.contains(&c1.id));
+        assert!(ids.contains(&c2.id));
     }
 
     #[test]

--- a/src/tools/spawn.rs
+++ b/src/tools/spawn.rs
@@ -202,12 +202,20 @@ impl Tool for SpawnSubagentTool {
         // YYC-208: fork a child cancellation token from the parent's
         // so cancelling the parent turn aborts the child's loop.
         // `child_token` cancels when the parent's token cancels and
-        // can also be cancelled independently for a future
-        // per-child kill action.
+        // can also be cancelled independently — which YYC-209
+        // hands to the orchestration store so a TUI kill action
+        // can target this specific child by id.
         let child_cancel = cancel.child_token();
+        self.orchestration
+            .register_cancel_handle(child_id, child_cancel.clone());
         let run_result = child
             .run_prompt_with_cancel(&task, child_cancel.clone())
             .await;
+        // YYC-209: child run finished one way or another; drop the
+        // handle so the store's cancel map only carries live
+        // children. Done before the cancellation check below so
+        // even the cancelled-by-parent path forgets the handle.
+        self.orchestration.forget_cancel_handle(child_id);
         let iterations = child.iterations();
         // If parent cancelled, mark Cancelled regardless of how the
         // child's run_prompt happened to surface — its Err shape on


### PR DESCRIPTION
OrchestrationStore gains a `HashMap<ChildAgentId, CancellationToken>`
holding active child tokens. New API:

* `register_cancel_handle(id, token)` — spawn_subagent calls this
  on child start.
* `forget_cancel_handle(id)` — spawn_subagent calls on terminal
  transition so the map only carries live children.
* `cancel(id)` — looks up the token, fires it, marks the record
  Cancelled. Returns true on success, false for unknown ids.
* `children_of(parent_id)` — query helper for tree-of-thought
  rendering, returns direct children only.

spawn_subagent now registers its forked child token under the
record id and forgets it after run_prompt returns. A future TUI
kill action will call `cancel(id)` on a hovered record and fire
the right token without touching internals. Tests cover token
firing on cancel, false return on unknown id, forget-without-fire,
and children_of returning only direct descendants.