### PR TITLE
YYC-210: tool card summarizers for new LSP + subagent tools

### DIFF
--- a/src/agent/dispatch.rs
+++ b/src/agent/dispatch.rs
@@ -109,7 +109,8 @@ pub(in crate::agent) fn summarize_tool_args(name: &str, raw_args: &str) -> Optio
         "code_outline" | "code_extract" => s("path").map(|p| tail(p, 60)),
         "find_symbol" => s("name"),
         // Code semantics — file:line.
-        "goto_definition" | "find_references" | "hover" | "diagnostics" => {
+        "goto_definition" | "find_references" | "hover" | "diagnostics" | "type_definition"
+        | "implementation" => {
             let p = s("path").map(|x| tail(x, 40));
             let line = args.get("line").and_then(|v| v.as_u64());
             match (p, line) {
@@ -118,6 +119,39 @@ pub(in crate::agent) fn summarize_tool_args(name: &str, raw_args: &str) -> Optio
                 _ => None,
             }
         }
+        // YYC-210: workspace symbol search — query + language.
+        "workspace_symbol" => {
+            let q = s("query").map(|x| truncate(x, 32));
+            let lang = s("language");
+            match (q, lang) {
+                (Some(q), Some(l)) => Some(format!("{q} [{l}]")),
+                (Some(q), None) => Some(q),
+                _ => None,
+            }
+        }
+        // YYC-210: call hierarchy — file:line + direction.
+        "call_hierarchy" => {
+            let p = s("path").map(|x| tail(x, 40));
+            let line = args.get("line").and_then(|v| v.as_u64());
+            let dir = s("direction").unwrap_or_else(|| "incoming".into());
+            match (p, line) {
+                (Some(p), Some(l)) => Some(format!("{p}:{l} ({dir})")),
+                (Some(p), None) => Some(format!("{p} ({dir})")),
+                _ => Some(dir),
+            }
+        }
+        // YYC-210: code action — file:start_line.
+        "code_action" => {
+            let p = s("path").map(|x| tail(x, 40));
+            let line = args.get("start_line").and_then(|v| v.as_u64());
+            match (p, line) {
+                (Some(p), Some(l)) => Some(format!("{p}:{l}")),
+                (Some(p), None) => Some(p),
+                _ => None,
+            }
+        }
+        // YYC-210: spawn_subagent — task prefix.
+        "spawn_subagent" => s("task").map(|t| truncate(t, 60)),
         "rename_symbol" => {
             let p = s("path").map(|x| tail(x, 40));
             let new = s("new_name");
@@ -275,6 +309,60 @@ pub(in crate::agent) fn summarize_tool_result(name: &str, output: &str) -> Optio
             .ok()
             .and_then(|v| v.get("count")?.as_u64())
             .map(|n| format!("{n} diagnostic{}", if n == 1 { "" } else { "s" })),
+        // YYC-210: workspace_symbol — JSON `count`.
+        "workspace_symbol" => serde_json::from_str::<serde_json::Value>(text)
+            .ok()
+            .and_then(|v| v.get("count")?.as_u64())
+            .map(|n| format!("{n} symbol{}", if n == 1 { "" } else { "s" })),
+        // YYC-210: type_definition / implementation — count
+        // entries in `locations` / `implementations`.
+        "type_definition" | "implementation" => serde_json::from_str::<serde_json::Value>(text)
+            .ok()
+            .and_then(|v| {
+                let arr = v
+                    .get("locations")
+                    .or_else(|| v.get("implementations"))?
+                    .as_array()?;
+                Some(format!(
+                    "{} hit{}",
+                    arr.len(),
+                    if arr.len() == 1 { "" } else { "s" }
+                ))
+            }),
+        // YYC-210: call_hierarchy — count + direction.
+        "call_hierarchy" => serde_json::from_str::<serde_json::Value>(text)
+            .ok()
+            .and_then(|v| {
+                let count = v.get("count")?.as_u64()?;
+                let dir = v.get("direction").and_then(|d| d.as_str()).unwrap_or("");
+                Some(format!(
+                    "{count} {} call{}",
+                    dir,
+                    if count == 1 { "" } else { "s" }
+                ))
+            }),
+        // YYC-210: code_action — JSON `count`.
+        "code_action" => serde_json::from_str::<serde_json::Value>(text)
+            .ok()
+            .and_then(|v| v.get("count")?.as_u64())
+            .map(|n| format!("{n} action{}", if n == 1 { "" } else { "s" })),
+        // YYC-210: spawn_subagent — child status + iterations.
+        "spawn_subagent" => serde_json::from_str::<serde_json::Value>(text)
+            .ok()
+            .and_then(|v| {
+                let status = v.get("status")?.as_str()?;
+                let used = v
+                    .get("budget_used")
+                    .and_then(|b| b.get("iterations"))
+                    .and_then(|i| i.as_u64())
+                    .unwrap_or(0);
+                let max = v
+                    .get("budget_used")
+                    .and_then(|b| b.get("max_iterations"))
+                    .and_then(|i| i.as_u64())
+                    .unwrap_or(0);
+                Some(format!("{status} · {used}/{max} iters"))
+            }),
         // Generic fallback so even an unknown tool gets *something*.
         _ => {
             if lines == 1 {

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -708,6 +708,107 @@ fn summarize_tool_args_picks_meaningful_field_per_tool() {
     );
 }
 
+// YYC-210: per-tool summarizers for new LSP + subagent tools.
+#[test]
+fn summarize_tool_args_handles_new_tools() {
+    assert_eq!(
+        summarize_tool_args(
+            "workspace_symbol",
+            r#"{"query":"parse_config","language":"rust"}"#
+        )
+        .as_deref(),
+        Some("parse_config [rust]"),
+    );
+    assert_eq!(
+        summarize_tool_args(
+            "type_definition",
+            r#"{"path":"src/foo.rs","line":12,"character":4}"#
+        )
+        .as_deref(),
+        Some("src/foo.rs:12"),
+    );
+    assert_eq!(
+        summarize_tool_args(
+            "implementation",
+            r#"{"path":"src/foo.rs","line":42,"character":0}"#
+        )
+        .as_deref(),
+        Some("src/foo.rs:42"),
+    );
+    assert_eq!(
+        summarize_tool_args(
+            "call_hierarchy",
+            r#"{"path":"src/foo.rs","line":7,"character":2,"direction":"outgoing"}"#
+        )
+        .as_deref(),
+        Some("src/foo.rs:7 (outgoing)"),
+    );
+    assert_eq!(
+        summarize_tool_args("code_action", r#"{"path":"src/foo.rs","start_line":3}"#).as_deref(),
+        Some("src/foo.rs:3"),
+    );
+    assert_eq!(
+        summarize_tool_args(
+            "spawn_subagent",
+            r#"{"task":"Review the provider streaming parser"}"#
+        )
+        .as_deref(),
+        Some("Review the provider streaming parser"),
+    );
+}
+
+#[test]
+fn summarize_tool_result_handles_new_tools() {
+    assert_eq!(
+        summarize_tool_result(
+            "workspace_symbol",
+            r#"{"query":"x","language":"rust","count":3,"hits":[]}"#
+        )
+        .as_deref(),
+        Some("3 symbols"),
+    );
+    assert_eq!(
+        summarize_tool_result(
+            "type_definition",
+            r#"{"locations":[{"uri":"file:///x"},{"uri":"file:///y"}]}"#
+        )
+        .as_deref(),
+        Some("2 hits"),
+    );
+    assert_eq!(
+        summarize_tool_result(
+            "implementation",
+            r#"{"implementations":[{"uri":"file:///x"}]}"#
+        )
+        .as_deref(),
+        Some("1 hit"),
+    );
+    assert_eq!(
+        summarize_tool_result(
+            "call_hierarchy",
+            r#"{"direction":"incoming","count":4,"calls":[]}"#
+        )
+        .as_deref(),
+        Some("4 incoming calls"),
+    );
+    assert_eq!(
+        summarize_tool_result(
+            "code_action",
+            r#"{"path":"src/foo.rs","count":2,"actions":[]}"#
+        )
+        .as_deref(),
+        Some("2 actions"),
+    );
+    assert_eq!(
+        summarize_tool_result(
+            "spawn_subagent",
+            r#"{"status":"completed","summary":"ok","budget_used":{"iterations":3,"max_iterations":8}}"#
+        )
+        .as_deref(),
+        Some("completed · 3/8 iters"),
+    );
+}
+
 #[test]
 fn preview_output_caps_to_twelve_lines_and_one_kb() {
     // YYC-78 raised the cap so collapsed cards still show useful


### PR DESCRIPTION
Extend `summarize_tool_args` + `summarize_tool_result` so the
recently-added tools produce structured card-friendly summaries
instead of falling through to the generic `N lines · K bytes`
fallback.

New arg summaries:
* `workspace_symbol` → `query [language]`
* `type_definition` / `implementation` → `path:line` (joined with
  the existing goto/find_references / hover branch)
* `call_hierarchy` → `path:line (direction)`
* `code_action` → `path:start_line`
* `spawn_subagent` → task prefix

New result summaries decode the tools' JSON payloads:
* `workspace_symbol` → `N symbols` from `count`
* `type_definition` / `implementation` → `N hits` from
  `locations` / `implementations`
* `call_hierarchy` → `N {direction} calls`
* `code_action` → `N actions`
* `spawn_subagent` → `{status} · used/max iters`

Tests cover one positive case per arg branch and one per result
branch.