### PR TITLE
YYC-211: cumulative token tracking + spawn_subagent reports tokens

### DIFF
--- a/src/agent/dispatch.rs
+++ b/src/agent/dispatch.rs
@@ -346,7 +346,7 @@ pub(in crate::agent) fn summarize_tool_result(name: &str, output: &str) -> Optio
             .ok()
             .and_then(|v| v.get("count")?.as_u64())
             .map(|n| format!("{n} action{}", if n == 1 { "" } else { "s" })),
-        // YYC-210: spawn_subagent — child status + iterations.
+        // YYC-210 / YYC-211: spawn_subagent — status + iterations + tokens.
         "spawn_subagent" => serde_json::from_str::<serde_json::Value>(text)
             .ok()
             .and_then(|v| {
@@ -361,7 +361,16 @@ pub(in crate::agent) fn summarize_tool_result(name: &str, output: &str) -> Optio
                     .and_then(|b| b.get("max_iterations"))
                     .and_then(|i| i.as_u64())
                     .unwrap_or(0);
-                Some(format!("{status} · {used}/{max} iters"))
+                let tokens = v
+                    .get("budget_used")
+                    .and_then(|b| b.get("tokens"))
+                    .and_then(|t| t.as_u64())
+                    .unwrap_or(0);
+                if tokens > 0 {
+                    Some(format!("{status} · {used}/{max} iters · {tokens} tok"))
+                } else {
+                    Some(format!("{status} · {used}/{max} iters"))
+                }
             }),
         // Generic fallback so even an unknown tool gets *something*.
         _ => {

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -135,6 +135,13 @@ pub struct Agent {
     /// `SpawnSubagentTool` writes to this so the TUI can render
     /// a real subagent timeline (YYC-205).
     pub(in crate::agent) orchestration: Arc<crate::orchestration::OrchestrationStore>,
+    /// YYC-211: cumulative `total_tokens` across every provider
+    /// response in the agent's lifetime. Distinct from
+    /// `ContextManager::current_tokens`, which tracks the last
+    /// prompt's size for compaction decisions. This counter only
+    /// grows; readers diff snapshots if they want per-run usage
+    /// (e.g. spawn_subagent computes `after - before`).
+    pub(in crate::agent) tokens_consumed: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -396,6 +403,7 @@ impl Agent {
             max_iterations: max_iterations.unwrap_or(config.provider.max_iterations),
             auto_create_skills: config.auto_create_skills,
             orchestration: Arc::clone(&orchestration),
+            tokens_consumed: 0,
         })
     }
 
@@ -457,6 +465,13 @@ impl Agent {
         Arc::clone(&self.orchestration)
     }
 
+    /// YYC-211: cumulative `total_tokens` across every provider
+    /// response since this Agent was built. Monotonic — readers
+    /// diff snapshots for per-run usage.
+    pub fn tokens_consumed(&self) -> u64 {
+        self.tokens_consumed
+    }
+
     pub fn for_test(
         provider: Box<dyn LLMProvider>,
         tools: ToolRegistry,
@@ -491,6 +506,7 @@ impl Agent {
             ),
             auto_create_skills: false,
             orchestration: Arc::new(crate::orchestration::OrchestrationStore::new()),
+            tokens_consumed: 0,
         }
     }
 

--- a/src/agent/run.rs
+++ b/src/agent/run.rs
@@ -184,6 +184,13 @@ impl Agent {
             if let Some(usage) = &response.usage {
                 self.context
                     .record_usage(usage.prompt_tokens, usage.completion_tokens);
+                // YYC-211: accumulate across the whole run so
+                // spawn_subagent (and future budget enforcement)
+                // can see the real token cost, not just the last
+                // prompt's size.
+                self.tokens_consumed = self
+                    .tokens_consumed
+                    .saturating_add(usage.total_tokens as u64);
             }
 
             if let Some(tool_calls) = &response.tool_calls {
@@ -335,6 +342,10 @@ impl Agent {
             if let Some(usage) = &response.usage {
                 self.context
                     .record_usage(usage.prompt_tokens, usage.completion_tokens);
+                // YYC-211: cumulative tally across the run.
+                self.tokens_consumed = self
+                    .tokens_consumed
+                    .saturating_add(usage.total_tokens as u64);
                 last_usage = Some(usage.clone());
             }
 

--- a/src/orchestration/mod.rs
+++ b/src/orchestration/mod.rs
@@ -102,6 +102,11 @@ pub struct ChildAgentRecord {
     /// spawn-time budget so the TUI can show fraction-used
     /// without joining against the spawn config.
     pub max_iterations: u32,
+    /// YYC-211: cumulative `total_tokens` the child consumed
+    /// across every provider response in its run. Reported by
+    /// `mark_completed` / `mark_failed`; observability surfaces
+    /// it alongside iterations.
+    pub tokens_consumed: u64,
     /// Final summary text the child returned. `None` until the
     /// child reaches `Completed`.
     pub final_summary: Option<String>,
@@ -171,6 +176,7 @@ impl OrchestrationStore {
             current_phase: None,
             iterations_used: 0,
             max_iterations,
+            tokens_consumed: 0,
             final_summary: None,
             error: None,
         };
@@ -211,6 +217,17 @@ impl OrchestrationStore {
         self.with_mut(id, |r| {
             if !r.status.is_terminal() {
                 r.iterations_used = iterations;
+            }
+        });
+    }
+
+    /// YYC-211: stamp the cumulative token total for an in-flight
+    /// child. Pre-terminal only — once a record is terminal the
+    /// final value was captured by `mark_completed` / `mark_failed`.
+    pub fn update_tokens(&self, id: ChildAgentId, tokens: u64) {
+        self.with_mut(id, |r| {
+            if !r.status.is_terminal() {
+                r.tokens_consumed = tokens;
             }
         });
     }
@@ -443,6 +460,21 @@ mod tests {
         let snap = s.get(r.id).unwrap();
         assert_eq!(snap.status, ChildStatus::Cancelled);
         assert!(snap.ended_at.is_some());
+    }
+
+    // YYC-211: tokens_consumed defaults to 0 + update_tokens
+    // mutates pre-terminal records only.
+    #[test]
+    fn update_tokens_records_pre_terminal_only() {
+        let s = store();
+        let r = s.register(None, "task", 4);
+        assert_eq!(s.get(r.id).unwrap().tokens_consumed, 0);
+        s.update_tokens(r.id, 4242);
+        assert_eq!(s.get(r.id).unwrap().tokens_consumed, 4242);
+        s.mark_completed(r.id, "ok", 1);
+        // Post-terminal update is a no-op.
+        s.update_tokens(r.id, 9_999);
+        assert_eq!(s.get(r.id).unwrap().tokens_consumed, 4242);
     }
 
     // YYC-209: cancel(id) fires the registered token + flips the

--- a/src/tools/spawn.rs
+++ b/src/tools/spawn.rs
@@ -216,6 +216,12 @@ impl Tool for SpawnSubagentTool {
         // children. Done before the cancellation check below so
         // even the cancelled-by-parent path forgets the handle.
         self.orchestration.forget_cancel_handle(child_id);
+        // YYC-211: snapshot the child's cumulative token total
+        // for the orchestration record + tool payload. Read once
+        // because subsequent calls would observe the same fresh
+        // child agent's lifetime tally.
+        let tokens_consumed = child.tokens_consumed();
+        self.orchestration.update_tokens(child_id, tokens_consumed);
         let iterations = child.iterations();
         // If parent cancelled, mark Cancelled regardless of how the
         // child's run_prompt happened to surface — its Err shape on
@@ -229,6 +235,7 @@ impl Tool for SpawnSubagentTool {
                 "budget_used": {
                     "iterations": iterations,
                     "max_iterations": max_iter,
+                    "tokens": tokens_consumed,
                 },
             });
             return Ok(ToolResult::ok(serde_json::to_string_pretty(&payload)?));
@@ -249,6 +256,7 @@ impl Tool for SpawnSubagentTool {
                     "budget_used": {
                         "iterations": iterations,
                         "max_iterations": max_iter,
+                        "tokens": tokens_consumed,
                     },
                     "tools_granted": allowed.len(),
                 });
@@ -265,6 +273,7 @@ impl Tool for SpawnSubagentTool {
                     "budget_used": {
                         "iterations": iterations,
                         "max_iterations": max_iter,
+                        "tokens": tokens_consumed,
                     },
                 });
                 Ok(ToolResult::ok(serde_json::to_string_pretty(&payload)?))


### PR DESCRIPTION
Agent gains a `tokens_consumed: u64` accumulator updated alongside
the existing `ContextManager::record_usage` call sites in both
the non-streaming and streaming run loops. Distinct from the
context manager's `current_tokens` (which tracks only the last
prompt's size for compaction decisions); this counter is
monotonic across the agent's lifetime so callers diff snapshots
for per-run usage. New `Agent::tokens_consumed()` accessor
exposes it.

`ChildAgentRecord` adds a `tokens_consumed: u64` field;
`OrchestrationStore::update_tokens(id, total)` writes it for in-
flight records. `SpawnSubagentTool` reads the child's total
after run_prompt returns, stamps it on the orchestration record,
and surfaces it in the tool's JSON payload under
`budget_used.tokens`. The YYC-210 spawn_subagent result
summarizer extends the card metadata to `status · used/max
iters · N tok` when tokens are present.

No enforcement — budget gates still live in `max_iterations`. A
real token-cap with mid-run abort lands when there's signal
it's needed.