### PR TITLE
YYC-194 PR-2: knowledge purge with confirmation + WAL/SHM cleanup

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -108,6 +108,24 @@ pub enum KnowledgeSubcommand {
     /// List all discovered local knowledge stores with size +
     /// last-modified time.
     List,
+    /// Permanently delete one or more local knowledge stores.
+    /// Asks for confirmation unless `--yes` is set.
+    Purge {
+        /// Index kind to purge. Required for safety — purging all
+        /// stores is a separate `--all` opt-in.
+        #[arg(long)]
+        kind: Option<String>,
+        /// Workspace key (filename stem) when targeting a single
+        /// per-workspace store.
+        #[arg(long)]
+        workspace: Option<String>,
+        /// Purge every discovered store regardless of kind.
+        #[arg(long, conflicts_with_all = ["kind", "workspace"])]
+        all: bool,
+        /// Skip the confirmation prompt.
+        #[arg(long)]
+        yes: bool,
+    },
 }
 
 /// YYC-180: subcommands under `vulcan artifact`.

--- a/src/cli_knowledge.rs
+++ b/src/cli_knowledge.rs
@@ -2,7 +2,7 @@
 //! stores with size + last-modified.
 
 use anyhow::{Result, anyhow};
-use std::io::{self, BufRead, Write};
+use std::io::{self, BufRead as _, Write};
 
 use crate::cli::KnowledgeSubcommand;
 use crate::knowledge::{self, KnowledgeStoreInfo};

--- a/src/cli_knowledge.rs
+++ b/src/cli_knowledge.rs
@@ -1,14 +1,21 @@
 //! YYC-194: `vulcan knowledge list` — display local knowledge
 //! stores with size + last-modified.
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
+use std::io::{self, BufRead, Write};
 
 use crate::cli::KnowledgeSubcommand;
-use crate::knowledge;
+use crate::knowledge::{self, KnowledgeStoreInfo};
 
 pub async fn run(cmd: KnowledgeSubcommand) -> Result<()> {
     match cmd {
         KnowledgeSubcommand::List => list(),
+        KnowledgeSubcommand::Purge {
+            kind,
+            workspace,
+            all,
+            yes,
+        } => purge(kind.as_deref(), workspace.as_deref(), all, yes),
     }
 }
 
@@ -38,6 +45,86 @@ fn list() -> Result<()> {
     println!();
     println!("{} stores · total {}", stores.len(), format_bytes(total));
     Ok(())
+}
+
+fn purge(kind: Option<&str>, workspace: Option<&str>, all: bool, skip_prompt: bool) -> Result<()> {
+    if !all && kind.is_none() {
+        return Err(anyhow!(
+            "specify --kind <name>, --all, or both --kind + --workspace"
+        ));
+    }
+    let stores = knowledge::discover()?;
+    if stores.is_empty() {
+        println!("No local knowledge stores found.");
+        return Ok(());
+    }
+    let targets: Vec<KnowledgeStoreInfo> = stores
+        .into_iter()
+        .filter(|s| {
+            if all {
+                return true;
+            }
+            if let Some(k) = kind {
+                if s.kind.as_str() != k {
+                    return false;
+                }
+            }
+            if let Some(w) = workspace {
+                if s.workspace_key.as_deref() != Some(w) {
+                    return false;
+                }
+            }
+            true
+        })
+        .collect();
+    if targets.is_empty() {
+        println!("No stores matched.");
+        return Ok(());
+    }
+    println!("About to purge {} store(s):", targets.len());
+    let mut total: u64 = 0;
+    for t in &targets {
+        let ws = t.workspace_key.clone().unwrap_or_else(|| "-".into());
+        println!(
+            "  {}  {}  {}  {}",
+            t.kind.as_str(),
+            ws,
+            format_bytes(t.size_bytes),
+            t.path.display()
+        );
+        total += t.size_bytes;
+    }
+    println!("Total: {}", format_bytes(total));
+    if !skip_prompt && !confirm("Proceed? Type `purge` to confirm: ", "purge")? {
+        println!("Aborted.");
+        return Ok(());
+    }
+    let mut freed: u64 = 0;
+    let mut errors: Vec<String> = Vec::new();
+    for t in &targets {
+        match knowledge::purge(t) {
+            Ok(n) => freed += n,
+            Err(e) => errors.push(format!("{}: {e}", t.path.display())),
+        }
+    }
+    println!("Purged {}.", format_bytes(freed));
+    if !errors.is_empty() {
+        eprintln!("Errors:");
+        for e in &errors {
+            eprintln!("  {e}");
+        }
+        return Err(anyhow!("{} purge failure(s)", errors.len()));
+    }
+    Ok(())
+}
+
+fn confirm(prompt: &str, expect: &str) -> Result<bool> {
+    let mut stdout = io::stdout().lock();
+    stdout.write_all(prompt.as_bytes())?;
+    stdout.flush()?;
+    let mut line = String::new();
+    io::stdin().lock().read_line(&mut line)?;
+    Ok(line.trim() == expect)
 }
 
 fn format_bytes(n: u64) -> String {

--- a/src/knowledge/mod.rs
+++ b/src/knowledge/mod.rs
@@ -114,6 +114,26 @@ pub fn discover_in(home: &Path) -> Result<Vec<KnowledgeStoreInfo>> {
     Ok(out)
 }
 
+/// YYC-194 PR-2: delete the on-disk store backing one
+/// [`KnowledgeStoreInfo`]. Returns the number of bytes freed.
+/// Caller is responsible for confirmation prompts.
+pub fn purge(info: &KnowledgeStoreInfo) -> Result<u64> {
+    let bytes = info.size_bytes;
+    if !info.path.exists() {
+        return Ok(0);
+    }
+    std::fs::remove_file(&info.path)?;
+    // For SQLite WAL mode databases there can also be `*-wal` and
+    // `*-shm` siblings. Best-effort cleanup so the next session
+    // doesn't reattach to a half-removed store.
+    let path_str = info.path.to_string_lossy().to_string();
+    for suffix in ["-wal", "-shm"] {
+        let sibling = std::path::PathBuf::from(format!("{path_str}{suffix}"));
+        let _ = std::fs::remove_file(sibling);
+    }
+    Ok(bytes)
+}
+
 fn probe_store(
     kind: KnowledgeIndex,
     path: PathBuf,
@@ -158,6 +178,32 @@ mod tests {
         assert_eq!(kinds, vec!["artifacts", "run_records", "sessions"]);
         let sizes: u64 = stores.iter().map(|s| s.size_bytes).sum();
         assert_eq!(sizes, 1 + 2 + 3);
+    }
+
+    #[test]
+    fn purge_removes_file_and_returns_bytes() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("artifacts.db");
+        std::fs::write(&path, b"hello world").unwrap();
+        let stores = discover_in(dir.path()).unwrap();
+        assert_eq!(stores.len(), 1);
+        let bytes = purge(&stores[0]).unwrap();
+        assert_eq!(bytes, 11);
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn purge_cleans_up_wal_and_shm_siblings() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("sessions.db");
+        std::fs::write(&path, b"db").unwrap();
+        std::fs::write(dir.path().join("sessions.db-wal"), b"wal").unwrap();
+        std::fs::write(dir.path().join("sessions.db-shm"), b"shm").unwrap();
+        let stores = discover_in(dir.path()).unwrap();
+        purge(&stores[0]).unwrap();
+        assert!(!dir.path().join("sessions.db").exists());
+        assert!(!dir.path().join("sessions.db-wal").exists());
+        assert!(!dir.path().join("sessions.db-shm").exists());
     }
 
     #[test]


### PR DESCRIPTION
YYC-194 PR-2: knowledge purge with confirmation + WAL/SHM cleanup

fix: BufRead unused-name warning in cli_knowledge purge prompt