### PR TITLE
YYC-243: adopt agentskills.io SKILL.md format with project-root + XDG search

### DIFF
--- a/.agents/skills/find-skills/SKILL.md
+++ b/.agents/skills/find-skills/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: find-skills
+description: Helps users discover and install agent skills when they ask questions like "how do I do X", "find a skill for X", "is there a skill that can...", or express interest in extending capabilities. This skill should be used when the user is looking for functionality that might exist as an installable skill.
+---
+
+# Find Skills
+
+This skill helps you discover and install skills from the open agent skills ecosystem.
+
+## When to Use This Skill
+
+Use this skill when the user:
+
+- Asks "how do I do X" where X might be a common task with an existing skill
+- Says "find a skill for X" or "is there a skill for X"
+- Asks "can you do X" where X is a specialized capability
+- Expresses interest in extending agent capabilities
+- Wants to search for tools, templates, or workflows
+- Mentions they wish they had help with a specific domain (design, testing, deployment, etc.)
+
+## What is the Skills CLI?
+
+The Skills CLI (`npx skills`) is the package manager for the open agent skills ecosystem. Skills are modular packages that extend agent capabilities with specialized knowledge, workflows, and tools.
+
+**Key commands:**
+
+- `npx skills find [query]` - Search for skills interactively or by keyword
+- `npx skills add <package>` - Install a skill from GitHub or other sources
+- `npx skills check` - Check for skill updates
+- `npx skills update` - Update all installed skills
+
+**Browse skills at:** https://skills.sh/
+
+## How to Help Users Find Skills
+
+### Step 1: Understand What They Need
+
+When a user asks for help with something, identify:
+
+1. The domain (e.g., React, testing, design, deployment)
+2. The specific task (e.g., writing tests, creating animations, reviewing PRs)
+3. Whether this is a common enough task that a skill likely exists
+
+### Step 2: Check the Leaderboard First
+
+Before running a CLI search, check the [skills.sh leaderboard](https://skills.sh/) to see if a well-known skill already exists for the domain. The leaderboard ranks skills by total installs, surfacing the most popular and battle-tested options.
+
+For example, top skills for web development include:
+- `vercel-labs/agent-skills` — React, Next.js, web design (100K+ installs each)
+- `anthropics/skills` — Frontend design, document processing (100K+ installs)
+
+### Step 3: Search for Skills
+
+If the leaderboard doesn't cover the user's need, run the find command:
+
+```bash
+npx skills find [query]
+```
+
+For example:
+
+- User asks "how do I make my React app faster?" → `npx skills find react performance`
+- User asks "can you help me with PR reviews?" → `npx skills find pr review`
+- User asks "I need to create a changelog" → `npx skills find changelog`
+
+### Step 4: Verify Quality Before Recommending
+
+**Do not recommend a skill based solely on search results.** Always verify:
+
+1. **Install count** — Prefer skills with 1K+ installs. Be cautious with anything under 100.
+2. **Source reputation** — Official sources (`vercel-labs`, `anthropics`, `microsoft`) are more trustworthy than unknown authors.
+3. **GitHub stars** — Check the source repository. A skill from a repo with <100 stars should be treated with skepticism.
+
+### Step 5: Present Options to the User
+
+When you find relevant skills, present them to the user with:
+
+1. The skill name and what it does
+2. The install count and source
+3. The install command they can run
+4. A link to learn more at skills.sh
+
+Example response:
+
+```
+I found a skill that might help! The "react-best-practices" skill provides
+React and Next.js performance optimization guidelines from Vercel Engineering.
+(185K installs)
+
+To install it:
+npx skills add vercel-labs/agent-skills@react-best-practices
+
+Learn more: https://skills.sh/vercel-labs/agent-skills/react-best-practices
+```
+
+### Step 6: Offer to Install
+
+If the user wants to proceed, you can install the skill for them:
+
+```bash
+npx skills add <owner/repo@skill> -g -y
+```
+
+The `-g` flag installs globally (user-level) and `-y` skips confirmation prompts.
+
+## Common Skill Categories
+
+When searching, consider these common categories:
+
+| Category        | Example Queries                          |
+| --------------- | ---------------------------------------- |
+| Web Development | react, nextjs, typescript, css, tailwind |
+| Testing         | testing, jest, playwright, e2e           |
+| DevOps          | deploy, docker, kubernetes, ci-cd        |
+| Documentation   | docs, readme, changelog, api-docs        |
+| Code Quality    | review, lint, refactor, best-practices   |
+| Design          | ui, ux, design-system, accessibility     |
+| Productivity    | workflow, automation, git                |
+
+## Tips for Effective Searches
+
+1. **Use specific keywords**: "react testing" is better than just "testing"
+2. **Try alternative terms**: If "deploy" doesn't work, try "deployment" or "ci-cd"
+3. **Check popular sources**: Many skills come from `vercel-labs/agent-skills` or `ComposioHQ/awesome-claude-skills`
+
+## When No Skills Are Found
+
+If no relevant skills exist:
+
+1. Acknowledge that no existing skill was found
+2. Offer to help with the task directly using your general capabilities
+3. Suggest the user could create their own skill with `npx skills init`
+
+Example:
+
+```
+I searched for skills related to "xyz" but didn't find any matches.
+I can still help you with this task directly! Would you like me to proceed?
+
+If this is something you do often, you could create your own skill:
+npx skills init my-xyz-skill
+```

--- a/benches/soak.rs
+++ b/benches/soak.rs
@@ -63,14 +63,10 @@ fn out_path() -> PathBuf {
         .join("bench-results.json")
 }
 
-/// Build an empty `SkillRegistry` by pointing at a path that doesn't exist —
-/// `SkillRegistry::new` falls through to bundled skills only when the dir
-/// it's pointed at exists, so a guaranteed-missing path yields an empty
-/// registry without touching the filesystem.
+/// Build an empty `SkillRegistry` for the soak bench so it doesn't pull
+/// in user skills or bundled defaults.
 fn empty_skills() -> Arc<SkillRegistry> {
-    Arc::new(SkillRegistry::new(&PathBuf::from(
-        "/tmp/vulcan-soak-skills-nonexistent",
-    )))
+    Arc::new(SkillRegistry::empty())
 }
 
 #[tokio::main]

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "find-skills": {
+      "source": "vercel-labs/skills",
+      "sourceType": "github",
+      "skillPath": "skills/find-skills/SKILL.md",
+      "computedHash": "9e1c8b3103f92fa8092568a44fe64858de7c5c9dc65ce4bea8f168080e889cfd"
+    }
+  }
+}

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: debug
-description: Systematic 4-phase debugging workflow
-triggers: ["debug this", "bug", "error", "doesn't work", "failing"]
+description: Systematic 4-phase debugging workflow — use when the user reports a bug, error, failure, regression, or asks for help locating a root cause
 ---
 
 ## Debugging Workflow

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -296,7 +296,7 @@ impl Agent {
         let mut tools = ToolRegistry::new_with_diff_and_lsp(
             Some(diff_sink.clone()),
             Some(lsp_manager.clone()),
-            cwd,
+            cwd.clone(),
         );
 
         // YYC-81: ask_user is only useful in interactive (TUI) mode.
@@ -355,7 +355,7 @@ impl Agent {
                 Err(e) => tracing::warn!("embedding index unavailable: {e}"),
             }
         }
-        let skills = Arc::new(SkillRegistry::new(&config.skills_dir));
+        let skills = Arc::new(SkillRegistry::default_for(&config.skills_dir, Some(&cwd)));
         let memory = SessionStore::try_new()?;
         let context =
             ContextManager::with_config(provider.max_context(), config.compaction.clone());

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -10,10 +10,7 @@ use serde_json::Value;
 use std::sync::Arc;
 
 fn empty_skills() -> Arc<SkillRegistry> {
-    // Point at a path that doesn't exist so the registry is empty.
-    Arc::new(SkillRegistry::new(&std::path::PathBuf::from(
-        "/tmp/vulcan-test-skills-nonexistent",
-    )))
+    Arc::new(SkillRegistry::empty())
 }
 
 fn asst_with_tool_calls(ids: &[&str]) -> Message {

--- a/src/gateway/agent_map.rs
+++ b/src/gateway/agent_map.rs
@@ -393,9 +393,7 @@ mod tests {
     }
 
     fn empty_skills() -> Arc<SkillRegistry> {
-        Arc::new(SkillRegistry::new(&std::path::PathBuf::from(
-            "/tmp/vulcan-test-skills-nonexistent",
-        )))
+        Arc::new(SkillRegistry::empty())
     }
 
     /// Build an Agent backed by `MockProvider` so eviction tests don't need

--- a/src/gateway/mod.rs
+++ b/src/gateway/mod.rs
@@ -390,9 +390,7 @@ mod tests {
     }
 
     fn empty_skills() -> Arc<SkillRegistry> {
-        Arc::new(SkillRegistry::new(&std::path::PathBuf::from(
-            "/tmp/vulcan-test-skills-nonexistent",
-        )))
+        Arc::new(SkillRegistry::empty())
     }
 
     struct ProviderHandle(Arc<MockProvider>);

--- a/src/gateway/routes/lanes.rs
+++ b/src/gateway/routes/lanes.rs
@@ -45,9 +45,7 @@ mod tests {
     }
 
     fn empty_skills() -> Arc<SkillRegistry> {
-        Arc::new(SkillRegistry::new(&std::path::PathBuf::from(
-            "/tmp/vulcan-test-skills-nonexistent",
-        )))
+        Arc::new(SkillRegistry::empty())
     }
 
     /// Wraps an Arc<MockProvider> so multiple Agents can share a mock

--- a/src/gateway/worker.rs
+++ b/src/gateway/worker.rs
@@ -260,9 +260,7 @@ mod tests {
     }
 
     fn empty_skills() -> Arc<SkillRegistry> {
-        Arc::new(SkillRegistry::new(&std::path::PathBuf::from(
-            "/tmp/vulcan-test-skills-nonexistent",
-        )))
+        Arc::new(SkillRegistry::empty())
     }
 
     /// Wraps an Arc<MockProvider> so multiple Agents can share the same

--- a/src/hooks/skills.rs
+++ b/src/hooks/skills.rs
@@ -1,13 +1,15 @@
-//! Built-in BeforePrompt hook that exposes the user's available skills to the
-//! LLM. Replaces the old hard-coded skills section in PromptBuilder so skills
-//! flow through the same extension surface as everything else.
+//! YYC-243: BeforePrompt hook implementing the agentskills.io activation
+//! contract. The catalog (skill name + description) is injected on every
+//! turn so the model knows what's available; full SKILL.md bodies are
+//! loaded lazily and injected only when the latest user message looks
+//! like it matches a skill's description or name.
 //!
-//! Lazy-load behavior (YYC-37 follow-up): every turn the hook injects a
-//! short catalog (name + description per skill) so the model knows what
-//! exists. The full skill body is *only* injected when the latest user
-//! message matches one of that skill's `triggers`. This avoids dumping
-//! every skill's playbook into context on every turn while still letting
-//! the model see the relevant guidance when it's actually applicable.
+//! Matching heuristic: tokens from a skill's `name` and `description` are
+//! lower-cased and stop-words filtered, then the latest user message is
+//! checked for a substring hit on at least one token of length ≥ 4. This
+//! is deliberately conservative — false positives on a token like "the"
+//! would defeat the activation gate. The agent itself has the final say
+//! once a body is in context.
 
 use std::sync::Arc;
 
@@ -20,6 +22,15 @@ use crate::skills::{Skill, SkillRegistry};
 
 use super::{HookHandler, HookOutcome, InjectPosition};
 
+const MIN_TOKEN_LEN: usize = 4;
+
+const STOP_WORDS: &[&str] = &[
+    "with", "from", "this", "that", "your", "into", "when", "what", "where", "which", "while",
+    "have", "been", "they", "them", "than", "then", "their", "there", "these", "those", "such",
+    "user", "agent", "skill", "task", "tasks", "tool", "tools", "step", "steps", "phase", "phases",
+    "use", "uses", "using",
+];
+
 pub struct SkillsHook {
     skills: Arc<SkillRegistry>,
 }
@@ -30,25 +41,42 @@ impl SkillsHook {
     }
 }
 
-/// Find skills whose `triggers` appear (case-insensitive substring) in
-/// the latest user message. The match list preserves catalog order so
-/// behavior is deterministic when multiple skills overlap.
+/// Find skills whose name or description shares a non-trivial token with
+/// the latest user message. Returns matches in catalog order.
 fn matched_skills<'a>(skills: &'a [Skill], latest_user: &str) -> Vec<&'a Skill> {
     let needle = latest_user.to_lowercase();
     skills
         .iter()
         .filter(|s| {
-            s.triggers
-                .iter()
-                .any(|t| !t.is_empty() && needle.contains(&t.to_lowercase()))
+            activation_tokens(s)
+                .into_iter()
+                .any(|tok| needle.contains(&tok))
         })
         .collect()
 }
 
+/// Tokens drawn from a skill's name + description that are eligible to
+/// trigger activation. Lower-cased, stop-word filtered, length ≥ 4.
+fn activation_tokens(skill: &Skill) -> Vec<String> {
+    let mut out = Vec::new();
+    for source in [skill.name.as_str(), skill.description.as_str()] {
+        for raw in source.split(|c: char| !c.is_alphanumeric()) {
+            let lower = raw.to_lowercase();
+            if lower.len() < MIN_TOKEN_LEN {
+                continue;
+            }
+            if STOP_WORDS.contains(&lower.as_str()) {
+                continue;
+            }
+            if !out.contains(&lower) {
+                out.push(lower);
+            }
+        }
+    }
+    out
+}
+
 /// Pull the most-recent user message text out of the running history.
-/// Skill triggers match on the user side — the assistant's own output
-/// isn't considered, which matches how a human would discover relevant
-/// playbooks (the user describes the task; the agent looks up).
 fn latest_user_message(messages: &[Message]) -> Option<&str> {
     messages.iter().rev().find_map(|m| match m {
         Message::User { content } => Some(content.as_str()),
@@ -63,8 +91,9 @@ impl HookHandler for SkillsHook {
     }
 
     fn priority(&self) -> i32 {
-        // Run before user-supplied hooks so other BeforePrompt handlers see the
-        // skills section already in place if they care to inspect it.
+        // Run before user-supplied hooks so other BeforePrompt handlers
+        // see the skills section already in place if they care to inspect
+        // it.
         10
     }
 
@@ -86,19 +115,32 @@ impl HookHandler for SkillsHook {
 
         let mut sections = vec![format!(
             "## Available Skills\n\
-             Skill playbooks load lazily — when a user message matches one of \
-             a skill's triggers the full body appears below this catalog. The \
-             rest of the time you only see the listing.\n\n{listing}",
+             Skill bodies load lazily — when a user message matches a skill's name or \
+             description the full SKILL.md body appears below this catalog. The rest \
+             of the time you only see the listing. Each skill folder may also contain \
+             `scripts/`, `references/`, or `assets/` subdirectories that you can read \
+             on demand via your file tools using the listed `skill_root`.\n\n{listing}",
         )];
 
         if let Some(user_msg) = latest_user_message(messages) {
-            let matched = matched_skills(all, user_msg);
-            for skill in matched {
+            for skill in matched_skills(all, user_msg) {
+                let body = match skill.load_body() {
+                    Ok(b) => b,
+                    Err(e) => {
+                        tracing::warn!(
+                            "load body for skill `{}` at {}: {e}",
+                            skill.name,
+                            skill.skill_root.display()
+                        );
+                        continue;
+                    }
+                };
                 sections.push(format!(
-                    "## Skill: {}\n_{description}_\n\n{body}",
-                    skill.name,
+                    "## Skill: {name}\n_{description}_\nskill_root: `{root}`\n\n{body}",
+                    name = skill.name,
                     description = skill.description,
-                    body = skill.content.trim(),
+                    root = skill.skill_root.display(),
+                    body = body.trim(),
                 ));
             }
         }
@@ -115,48 +157,59 @@ impl HookHandler for SkillsHook {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
 
-    fn skill(name: &str, triggers: &[&str], body: &str) -> Skill {
+    fn skill(name: &str, description: &str) -> Skill {
         Skill {
             name: name.into(),
-            description: format!("desc for {name}"),
-            triggers: triggers.iter().map(|t| (*t).into()).collect(),
-            content: body.into(),
+            description: description.into(),
+            version: None,
+            license: None,
+            allowed_tools: vec![],
+            skill_root: PathBuf::from("/tmp/unused"),
         }
     }
 
     #[test]
-    fn matched_skills_finds_case_insensitive_substring() {
-        let s = vec![
-            skill("debug", &["bug", "error", "doesn't work"], "DEBUG_BODY"),
-            skill("review", &["review this", "code review"], "REVIEW_BODY"),
-        ];
-        let hits = matched_skills(&s, "Help me Debug This Error in main.rs");
+    fn activation_tokens_drop_short_and_stop_words() {
+        let s = skill(
+            "debug",
+            "Systematic 4-phase debugging workflow for the user",
+        );
+        let toks = activation_tokens(&s);
+        assert!(toks.contains(&"debug".to_string()));
+        assert!(toks.contains(&"systematic".to_string()));
+        assert!(toks.contains(&"debugging".to_string()));
+        assert!(toks.contains(&"workflow".to_string()));
+        assert!(!toks.contains(&"the".to_string())); // too short
+        assert!(!toks.contains(&"user".to_string())); // stop word
+    }
+
+    #[test]
+    fn matched_skills_finds_substring_hit_on_description_token() {
+        let s = vec![skill(
+            "debug",
+            "Systematic 4-phase debugging workflow when reproducing a bug or error",
+        )];
+        let hits = matched_skills(&s, "I keep hitting an Error in main.rs and need help");
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].name, "debug");
     }
 
     #[test]
-    fn matched_skills_returns_empty_when_no_trigger_hits() {
-        let s = vec![skill("debug", &["bug", "error"], "BODY")];
-        let hits = matched_skills(&s, "What's the weather like?");
+    fn matched_skills_returns_empty_on_unrelated_message() {
+        let s = vec![skill("debug", "Systematic debugging workflow")];
+        let hits = matched_skills(&s, "What's the weather?");
         assert!(hits.is_empty());
     }
 
     #[test]
-    fn matched_skills_skips_empty_triggers() {
-        let s = vec![skill("oops", &["", "  "], "BODY")];
-        let hits = matched_skills(&s, "anything goes");
-        assert!(hits.is_empty(), "empty triggers should never match");
-    }
-
-    #[test]
-    fn matched_skills_preserves_catalog_order_for_overlapping_skills() {
+    fn matched_skills_preserves_catalog_order_for_overlap() {
         let s = vec![
-            skill("debug", &["fix"], "A"),
-            skill("review", &["fix"], "B"),
+            skill("debug", "fix workflow"),
+            skill("review", "fix review playbook"),
         ];
-        let hits = matched_skills(&s, "please fix this");
+        let hits = matched_skills(&s, "please fix this regression — call workflow review");
         assert_eq!(hits.len(), 2);
         assert_eq!(hits[0].name, "debug");
         assert_eq!(hits[1].name, "review");

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -87,31 +87,20 @@ impl SkillRegistry {
     /// 1. The bundled directory (`vulcan/skills/`).
     /// 2. The XDG location (`~/.config/vulcan/skills`).
     /// 3. The configured user `primary` (defaults to `~/.vulcan/skills`).
-    /// 4. Project-root `<project>/.vulcan/skills` (when supplied).
-    /// 5. Project-root `<project>/.agents/skills` (when supplied).
+    /// 4. `~/.agents/skills` — install location for the open `npx skills`
+    ///    CLI shared across the agentskills.io ecosystem.
+    /// 5. Project-root `<project>/.vulcan/skills` (when supplied).
+    /// 6. Project-root `<project>/.agents/skills` (when supplied).
     ///
     /// `project_root` is typically the agent's working directory. Pass
     /// `None` for callers that don't have a workspace concept.
     pub fn default_for(primary: &Path, project_root: Option<&Path>) -> Self {
-        let mut dirs: Vec<PathBuf> = Vec::new();
-        let push_unique = |dirs: &mut Vec<PathBuf>, path: PathBuf| {
-            if dirs.iter().all(|p| p != &path) {
-                dirs.push(path);
-            }
-        };
-        let bundled = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("skills");
-        if bundled.is_dir() {
-            push_unique(&mut dirs, bundled);
-        }
-        if let Some(xdg) = xdg_skills_dir() {
-            push_unique(&mut dirs, xdg);
-        }
-        push_unique(&mut dirs, primary.to_path_buf());
-        if let Some(root) = project_root {
-            push_unique(&mut dirs, root.join(".vulcan").join("skills"));
-            push_unique(&mut dirs, root.join(".agents").join("skills"));
-        }
-        Self::with_dirs(dirs)
+        Self::with_dirs(resolve_default_dirs(
+            primary,
+            project_root,
+            std::env::var("HOME").ok().as_deref(),
+            std::env::var("XDG_CONFIG_HOME").ok().as_deref(),
+        ))
     }
 
     /// Empty registry — used in tests so they don't pull in bundled or
@@ -221,14 +210,58 @@ impl SkillRegistry {
     }
 }
 
+/// Pure resolver for the standard search-root list. Takes env values
+/// as arguments so tests don't need to mutate the process environment.
+fn resolve_default_dirs(
+    primary: &Path,
+    project_root: Option<&Path>,
+    home: Option<&str>,
+    xdg_config_home: Option<&str>,
+) -> Vec<PathBuf> {
+    let mut dirs: Vec<PathBuf> = Vec::new();
+    let push_unique = |dirs: &mut Vec<PathBuf>, path: PathBuf| {
+        if dirs.iter().all(|p| p != &path) {
+            dirs.push(path);
+        }
+    };
+    let bundled = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("skills");
+    if bundled.is_dir() {
+        push_unique(&mut dirs, bundled);
+    }
+    if let Some(xdg) = xdg_skills_dir(home, xdg_config_home) {
+        push_unique(&mut dirs, xdg);
+    }
+    push_unique(&mut dirs, primary.to_path_buf());
+    if let Some(home_agents) = home_agents_skills_dir(home) {
+        push_unique(&mut dirs, home_agents);
+    }
+    if let Some(root) = project_root {
+        push_unique(&mut dirs, root.join(".vulcan").join("skills"));
+        push_unique(&mut dirs, root.join(".agents").join("skills"));
+    }
+    dirs
+}
+
+/// Resolve `~/.agents/skills` — install location for the open
+/// `npx skills` CLI. Shared with other clients in the agentskills.io
+/// ecosystem so a skill installed for one tool is visible to Vulcan
+/// automatically.
+fn home_agents_skills_dir(home: Option<&str>) -> Option<PathBuf> {
+    let home = home?;
+    if home.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(home).join(".agents").join("skills"))
+}
+
 /// Resolve `~/.config/vulcan/skills` (honoring `XDG_CONFIG_HOME`).
-fn xdg_skills_dir() -> Option<PathBuf> {
-    if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
+fn xdg_skills_dir(home: Option<&str>, xdg_config_home: Option<&str>) -> Option<PathBuf> {
+    if let Some(xdg) = xdg_config_home {
         if !xdg.is_empty() {
             return Some(PathBuf::from(xdg).join("vulcan").join("skills"));
         }
     }
-    let home = std::env::var("HOME").ok()?;
+    let home = home?;
     if home.is_empty() {
         return None;
     }
@@ -506,6 +539,46 @@ mod tests {
         let debug = reg.list().iter().find(|s| s.name == "debug").unwrap();
         assert_eq!(debug.description, "project-version");
         assert!(debug.load_body().unwrap().contains("PROJECT_BODY"));
+    }
+
+    #[test]
+    fn resolve_default_dirs_includes_home_agents_skills_dir() {
+        let home = tempdir().unwrap();
+        let primary = tempdir().unwrap();
+        let dirs = resolve_default_dirs(primary.path(), None, home.path().to_str(), None);
+        let expected = home.path().join(".agents").join("skills");
+        assert!(
+            dirs.contains(&expected),
+            "resolve_default_dirs should include {} (got {dirs:?})",
+            expected.display()
+        );
+    }
+
+    #[test]
+    fn resolve_default_dirs_honors_xdg_config_home_override() {
+        let home = tempdir().unwrap();
+        let xdg = tempdir().unwrap();
+        let primary = tempdir().unwrap();
+        let dirs = resolve_default_dirs(
+            primary.path(),
+            None,
+            home.path().to_str(),
+            xdg.path().to_str(),
+        );
+        // XDG-derived path lives under the override, not under HOME/.config.
+        let xdg_skills = xdg.path().join("vulcan").join("skills");
+        assert!(dirs.contains(&xdg_skills));
+        let default_xdg = home.path().join(".config").join("vulcan").join("skills");
+        assert!(!dirs.contains(&default_xdg));
+    }
+
+    #[test]
+    fn resolve_default_dirs_includes_project_paths_when_supplied() {
+        let primary = tempdir().unwrap();
+        let project = tempdir().unwrap();
+        let dirs = resolve_default_dirs(primary.path(), Some(project.path()), None, None);
+        assert!(dirs.contains(&project.path().join(".vulcan").join("skills")));
+        assert!(dirs.contains(&project.path().join(".agents").join("skills")));
     }
 
     #[test]

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -1,188 +1,215 @@
-use anyhow::Result;
-use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+//! YYC-243: spec-compliant Agent Skills loader (agentskills.io / Anthropic
+//! SKILL.md format).
+//!
+//! Layout per skill: `<root>/<name>/SKILL.md` with YAML frontmatter
+//! (`name`, `description`, optional `version`, `license`, `allowed-tools`)
+//! followed by a markdown body. Optional `scripts/`, `references/`, and
+//! `assets/` subdirectories are not parsed by the loader — the agent
+//! discovers and reads them on demand via existing tools, with
+//! `skill_root` exposed alongside the body.
+//!
+//! Three search roots merge into one registry, in this order:
+//!
+//! 1. The configured `skills_dir` (defaults to `~/.vulcan/skills`).
+//! 2. The XDG-compliant location `~/.config/vulcan/skills`.
+//! 3. The bundled fallback `vulcan/skills/`.
+//!
+//! Later roots shadow earlier ones by skill `name` so a user copy in
+//! `~/.config` overrides a bundled default.
+//!
+//! Discovery is metadata-only — bodies load lazily through
+//! [`Skill::load_body`] when `SkillsHook` activates a skill.
 
-/// A loaded skill — reusable knowledge for specific task types
+use anyhow::{Context, Result, anyhow};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+const SKILL_FILENAME: &str = "SKILL.md";
+
+/// One discovered skill. Body is *not* loaded at discovery — call
+/// [`Skill::load_body`] when the skill is activated.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Skill {
     pub name: String,
     pub description: String,
-    pub triggers: Vec<String>,
-    pub content: String,
+    /// Spec-optional metadata.
+    #[serde(default)]
+    pub version: Option<String>,
+    #[serde(default)]
+    pub license: Option<String>,
+    #[serde(default)]
+    pub allowed_tools: Vec<String>,
+    /// Directory containing this skill's `SKILL.md` (and any optional
+    /// `scripts/`, `references/`, `assets/` subdirs). Exposed so the
+    /// agent can load referenced files via `read_file` / `bash`.
+    pub skill_root: PathBuf,
 }
 
-/// Manages loading, listing, and auto-creating skills
+impl Skill {
+    /// Read the body of `<skill_root>/SKILL.md` with the YAML
+    /// frontmatter removed. Lazy — the registry never calls this at
+    /// discovery time.
+    pub fn load_body(&self) -> Result<String> {
+        let path = self.skill_root.join(SKILL_FILENAME);
+        let raw =
+            std::fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+        Ok(strip_frontmatter(&raw))
+    }
+}
+
+/// Discovered set of skills across configured search roots.
 pub struct SkillRegistry {
-    skills_dir: PathBuf,
+    dirs: Vec<PathBuf>,
     skills: Vec<Skill>,
 }
 
 impl SkillRegistry {
-    pub fn new(skills_dir: &PathBuf) -> Self {
-        let dir = if skills_dir.exists() {
-            skills_dir.clone()
-        } else {
-            // Fall back to bundled skills
-            let bundled = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("skills");
-            if bundled.exists() {
-                bundled
-            } else {
-                skills_dir.clone()
-            }
-        };
-
+    /// Build a registry from an explicit list of search roots. Order
+    /// matters: a skill name appearing in a later root replaces the
+    /// same name from an earlier root.
+    pub fn with_dirs(dirs: Vec<PathBuf>) -> Self {
         let mut registry = Self {
-            skills_dir: dir,
+            dirs,
             skills: Vec::new(),
         };
-        registry.load_all().ok();
+        if let Err(e) = registry.discover() {
+            tracing::warn!("skill discovery failed: {e}");
+        }
         registry
     }
 
-    /// Load all skill markdown files from the skills directory
-    fn load_all(&mut self) -> Result<()> {
-        if !self.skills_dir.exists() {
-            return Ok(());
-        }
-
-        let mut skills = Vec::new();
-
-        for entry in std::fs::read_dir(&self.skills_dir)? {
-            let entry = entry?;
-            let path = entry.path();
-            if path.extension().is_some_and(|e| e == "md")
-                && let Some(skill) = Self::load_skill(&path)?
-            {
-                skills.push(skill);
+    /// Build a registry covering the standard search locations.
+    ///
+    /// Search order (earliest is shadowed by later entries on name
+    /// collision, so the most-specific source wins):
+    ///
+    /// 1. The bundled directory (`vulcan/skills/`).
+    /// 2. The XDG location (`~/.config/vulcan/skills`).
+    /// 3. The configured user `primary` (defaults to `~/.vulcan/skills`).
+    /// 4. Project-root `<project>/.vulcan/skills` (when supplied).
+    /// 5. Project-root `<project>/.agents/skills` (when supplied).
+    ///
+    /// `project_root` is typically the agent's working directory. Pass
+    /// `None` for callers that don't have a workspace concept.
+    pub fn default_for(primary: &Path, project_root: Option<&Path>) -> Self {
+        let mut dirs: Vec<PathBuf> = Vec::new();
+        let push_unique = |dirs: &mut Vec<PathBuf>, path: PathBuf| {
+            if dirs.iter().all(|p| p != &path) {
+                dirs.push(path);
             }
+        };
+        let bundled = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("skills");
+        if bundled.is_dir() {
+            push_unique(&mut dirs, bundled);
         }
-
-        self.skills = skills;
-        Ok(())
+        if let Some(xdg) = xdg_skills_dir() {
+            push_unique(&mut dirs, xdg);
+        }
+        push_unique(&mut dirs, primary.to_path_buf());
+        if let Some(root) = project_root {
+            push_unique(&mut dirs, root.join(".vulcan").join("skills"));
+            push_unique(&mut dirs, root.join(".agents").join("skills"));
+        }
+        Self::with_dirs(dirs)
     }
 
-    /// Parse a single skill markdown file
-    fn load_skill(path: &PathBuf) -> Result<Option<Skill>> {
-        let content = std::fs::read_to_string(path)?;
-
-        // Parse YAML frontmatter
-        if let Some(frontmatter) = Self::parse_frontmatter(&content) {
-            let name = frontmatter
-                .get("name")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
-            let description = frontmatter
-                .get("description")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
-            let triggers: Vec<String> = frontmatter
-                .get("triggers")
-                .and_then(|v| v.as_array())
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|v| v.as_str().map(String::from))
-                        .collect()
-                })
-                .unwrap_or_default();
-
-            // Content is everything after the frontmatter
-            let body = Self::strip_frontmatter(&content);
-
-            if !name.is_empty() {
-                return Ok(Some(Skill {
-                    name,
-                    description,
-                    triggers,
-                    content: body,
-                }));
-            }
+    /// Empty registry — used in tests so they don't pull in bundled or
+    /// user-state skills implicitly.
+    pub fn empty() -> Self {
+        Self {
+            dirs: Vec::new(),
+            skills: Vec::new(),
         }
-
-        Ok(None)
     }
 
-    /// Parse YAML frontmatter from markdown (basic — no full YAML parser dependency)
-    fn parse_frontmatter(content: &str) -> Option<serde_json::Value> {
-        let content = content.trim();
-        if !content.starts_with("---") {
-            return None;
-        }
-
-        let end = content[3..].find("\n---")?;
-        let yaml_str = &content[3..3 + end];
-
-        // Simple YAML to JSON conversion — handles our limited skill format
-        let mut map = serde_json::Map::new();
-        for line in yaml_str.lines() {
-            if let Some((key, value)) = line.split_once(':') {
-                let key = key.trim().to_string();
-                let value = value.trim().to_string();
-
-                if value.starts_with('[') && value.ends_with(']') {
-                    // Array value
-                    let items: Vec<serde_json::Value> = value[1..value.len() - 1]
-                        .split(',')
-                        .map(|s| {
-                            serde_json::Value::String(
-                                s.trim().trim_matches('"').trim_matches('\'').to_string(),
-                            )
-                        })
-                        .collect();
-                    map.insert(key, serde_json::Value::Array(items));
-                } else {
-                    map.insert(key, serde_json::Value::String(value));
+    fn discover(&mut self) -> Result<()> {
+        let mut by_name: BTreeMap<String, Skill> = BTreeMap::new();
+        for root in &self.dirs {
+            if !root.is_dir() {
+                continue;
+            }
+            let entries = match std::fs::read_dir(root) {
+                Ok(e) => e,
+                Err(e) => {
+                    tracing::warn!("read_dir {}: {e}", root.display());
+                    continue;
+                }
+            };
+            for entry in entries.flatten() {
+                let dir = entry.path();
+                if !dir.is_dir() {
+                    continue;
+                }
+                if !dir.join(SKILL_FILENAME).is_file() {
+                    continue;
+                }
+                match Self::load_metadata(&dir) {
+                    Ok(skill) => {
+                        by_name.insert(skill.name.clone(), skill);
+                    }
+                    Err(e) => {
+                        tracing::warn!("skip skill at {}: {e}", dir.display());
+                    }
                 }
             }
         }
-
-        Some(serde_json::Value::Object(map))
+        self.skills = by_name.into_values().collect();
+        Ok(())
     }
 
-    /// Get the body text after stripping frontmatter
-    fn strip_frontmatter(content: &str) -> String {
-        let content = content.trim();
-        if content.starts_with("---")
-            && let Some(end) = content[3..].find("\n---")
-        {
-            return content[3 + end + 5..].trim().to_string();
-        }
-        content.to_string()
+    fn load_metadata(skill_root: &Path) -> Result<Skill> {
+        let path = skill_root.join(SKILL_FILENAME);
+        let raw =
+            std::fs::read_to_string(&path).with_context(|| format!("read {}", path.display()))?;
+        let fm = parse_frontmatter(&raw)
+            .ok_or_else(|| anyhow!("missing YAML frontmatter in {}", path.display()))?;
+        let name = fm
+            .get_str("name")
+            .ok_or_else(|| anyhow!("frontmatter missing `name` in {}", path.display()))?
+            .to_string();
+        let description = fm
+            .get_str("description")
+            .ok_or_else(|| anyhow!("frontmatter missing `description` in {}", path.display()))?
+            .to_string();
+        Ok(Skill {
+            name,
+            description,
+            version: fm.get_str("version").map(str::to_string),
+            license: fm.get_str("license").map(str::to_string),
+            allowed_tools: fm.get_list("allowed-tools").unwrap_or_default(),
+            skill_root: skill_root.to_path_buf(),
+        })
     }
 
-    /// Check if we have any skills loaded
-    pub fn is_empty(&self) -> bool {
-        self.skills.is_empty()
-    }
-
-    /// Where this registry reads skill files from. Used by YYC-20's
-    /// auto-creation path to write drafts under
-    /// `<skills_dir>/_pending/<name>.md`.
-    pub fn skills_dir(&self) -> &PathBuf {
-        &self.skills_dir
-    }
-
-    /// List all loaded skills
     pub fn list(&self) -> &[Skill] {
         &self.skills
     }
 
-    /// YYC-225: walk skill markdown files and return any
-    /// `extension:` metadata they declare. Skills without an
-    /// `extension:` block are silently ignored — backward
-    /// compatibility is by construction.
+    pub fn is_empty(&self) -> bool {
+        self.skills.is_empty()
+    }
+
+    /// All configured search roots, in order.
+    pub fn dirs(&self) -> &[PathBuf] {
+        &self.dirs
+    }
+
+    /// Primary path for writing new skill drafts. Falls back to
+    /// `~/.vulcan/skills` when the registry was built with no dirs.
+    pub fn skills_dir(&self) -> PathBuf {
+        self.dirs
+            .first()
+            .cloned()
+            .unwrap_or_else(|| crate::config::vulcan_home().join("skills"))
+    }
+
+    /// YYC-225: walk SKILL.md files for declared `extension:` blocks.
+    /// Skills without an `extension:` block are silently ignored.
     pub fn drafts(&self) -> Vec<crate::extensions::ExtensionMetadata> {
         let mut out = Vec::new();
-        let entries = match std::fs::read_dir(&self.skills_dir) {
-            Ok(e) => e,
-            Err(_) => return out,
-        };
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if !path.extension().is_some_and(|e| e == "md") {
-                continue;
-            }
+        for skill in &self.skills {
+            let path = skill.skill_root.join(SKILL_FILENAME);
             let Ok(content) = std::fs::read_to_string(&path) else {
                 continue;
             };
@@ -191,5 +218,308 @@ impl SkillRegistry {
             }
         }
         out
+    }
+}
+
+/// Resolve `~/.config/vulcan/skills` (honoring `XDG_CONFIG_HOME`).
+fn xdg_skills_dir() -> Option<PathBuf> {
+    if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
+        if !xdg.is_empty() {
+            return Some(PathBuf::from(xdg).join("vulcan").join("skills"));
+        }
+    }
+    let home = std::env::var("HOME").ok()?;
+    if home.is_empty() {
+        return None;
+    }
+    Some(
+        PathBuf::from(home)
+            .join(".config")
+            .join("vulcan")
+            .join("skills"),
+    )
+}
+
+#[derive(Debug, Default)]
+struct Frontmatter {
+    map: BTreeMap<String, FrontmatterValue>,
+}
+
+#[derive(Debug, Clone)]
+enum FrontmatterValue {
+    String(String),
+    List(Vec<String>),
+}
+
+impl Frontmatter {
+    fn get_str(&self, key: &str) -> Option<&str> {
+        match self.map.get(key)? {
+            FrontmatterValue::String(s) => Some(s.as_str()),
+            FrontmatterValue::List(_) => None,
+        }
+    }
+    fn get_list(&self, key: &str) -> Option<Vec<String>> {
+        match self.map.get(key)? {
+            FrontmatterValue::List(v) => Some(v.clone()),
+            FrontmatterValue::String(_) => None,
+        }
+    }
+}
+
+/// Minimal flat-YAML parser sufficient for the SKILL.md frontmatter
+/// keys defined by the spec. Strings (optionally quoted) and bracketed
+/// lists are supported. Nested blocks are not — the agent-skills spec
+/// doesn't require them.
+fn parse_frontmatter(raw: &str) -> Option<Frontmatter> {
+    let raw = raw.trim_start_matches('\u{feff}').trim_start();
+    let after = raw.strip_prefix("---")?;
+    let end = after.find("\n---")?;
+    let body = &after[..end];
+    let mut fm = Frontmatter::default();
+    for line in body.lines() {
+        let line = line.trim_end();
+        if line.trim().is_empty() || line.trim_start().starts_with('#') {
+            continue;
+        }
+        // Skip indented sub-blocks (e.g. `extension:` declarations parsed
+        // separately by `extensions::parse_skill_extension`).
+        if line.starts_with(' ') || line.starts_with('\t') {
+            continue;
+        }
+        let (key, value) = line.split_once(':')?;
+        let key = key.trim().to_string();
+        let value = value.trim();
+        if value.is_empty() {
+            continue;
+        }
+        if value.starts_with('[') && value.ends_with(']') {
+            let inner = &value[1..value.len() - 1];
+            let items: Vec<String> = inner
+                .split(',')
+                .map(|s| s.trim().trim_matches('"').trim_matches('\'').to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+            fm.map.insert(key, FrontmatterValue::List(items));
+        } else {
+            let unquoted = value.trim_matches('"').trim_matches('\'').to_string();
+            fm.map.insert(key, FrontmatterValue::String(unquoted));
+        }
+    }
+    Some(fm)
+}
+
+fn strip_frontmatter(raw: &str) -> String {
+    let trimmed = raw.trim_start_matches('\u{feff}').trim_start();
+    if let Some(rest) = trimmed.strip_prefix("---") {
+        if let Some(end) = rest.find("\n---") {
+            // `---` closer is 4 bytes including the leading newline; skip
+            // it then trim whatever leading whitespace the body has.
+            let after = &rest[end + 4..];
+            return after.trim_start().to_string();
+        }
+    }
+    raw.trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn write_skill(root: &Path, name: &str, frontmatter: &str, body: &str) {
+        let dir = root.join(name);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join(SKILL_FILENAME),
+            format!("---\n{frontmatter}\n---\n\n{body}\n"),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn discovers_folder_layout_skill() {
+        let dir = tempdir().unwrap();
+        write_skill(
+            dir.path(),
+            "debug",
+            "name: debug\ndescription: Systematic debugging workflow",
+            "## Phase 1\nReproduce.",
+        );
+        let reg = SkillRegistry::with_dirs(vec![dir.path().to_path_buf()]);
+        assert_eq!(reg.list().len(), 1);
+        assert_eq!(reg.list()[0].name, "debug");
+        assert_eq!(reg.list()[0].description, "Systematic debugging workflow");
+        assert_eq!(reg.list()[0].skill_root, dir.path().join("debug"));
+    }
+
+    #[test]
+    fn body_loads_lazily_after_metadata_discovery() {
+        let dir = tempdir().unwrap();
+        write_skill(
+            dir.path(),
+            "debug",
+            "name: debug\ndescription: d",
+            "BODY_TEXT",
+        );
+        let reg = SkillRegistry::with_dirs(vec![dir.path().to_path_buf()]);
+        let body = reg.list()[0].load_body().unwrap();
+        assert!(body.contains("BODY_TEXT"));
+        assert!(!body.contains("---"));
+    }
+
+    #[test]
+    fn parses_optional_spec_fields() {
+        let dir = tempdir().unwrap();
+        write_skill(
+            dir.path(),
+            "review",
+            "name: review\ndescription: d\nversion: 1.2.3\nlicense: MIT\nallowed-tools: [read_file, bash]",
+            "body",
+        );
+        let reg = SkillRegistry::with_dirs(vec![dir.path().to_path_buf()]);
+        let s = &reg.list()[0];
+        assert_eq!(s.version.as_deref(), Some("1.2.3"));
+        assert_eq!(s.license.as_deref(), Some("MIT"));
+        assert_eq!(
+            s.allowed_tools,
+            vec!["read_file".to_string(), "bash".to_string()]
+        );
+    }
+
+    #[test]
+    fn missing_frontmatter_is_skipped_with_warning() {
+        let dir = tempdir().unwrap();
+        let skill_dir = dir.path().join("broken");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join(SKILL_FILENAME), "# just a markdown body").unwrap();
+        // also a valid one so the registry doesn't trivially pass on emptiness
+        write_skill(dir.path(), "ok", "name: ok\ndescription: d", "body");
+        let reg = SkillRegistry::with_dirs(vec![dir.path().to_path_buf()]);
+        let names: Vec<_> = reg.list().iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["ok"]);
+    }
+
+    #[test]
+    fn directory_without_skill_md_is_ignored() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("empty-dir")).unwrap();
+        write_skill(dir.path(), "ok", "name: ok\ndescription: d", "body");
+        let reg = SkillRegistry::with_dirs(vec![dir.path().to_path_buf()]);
+        assert_eq!(reg.list().len(), 1);
+        assert_eq!(reg.list()[0].name, "ok");
+    }
+
+    #[test]
+    fn later_dir_shadows_earlier_dir_by_name() {
+        let bundled = tempdir().unwrap();
+        let user = tempdir().unwrap();
+        write_skill(
+            bundled.path(),
+            "debug",
+            "name: debug\ndescription: bundled-default",
+            "BUNDLED_BODY",
+        );
+        write_skill(
+            user.path(),
+            "debug",
+            "name: debug\ndescription: user-override",
+            "USER_BODY",
+        );
+        // bundled goes first; user's later entry should win.
+        let reg = SkillRegistry::with_dirs(vec![
+            bundled.path().to_path_buf(),
+            user.path().to_path_buf(),
+        ]);
+        assert_eq!(reg.list().len(), 1);
+        assert_eq!(reg.list()[0].description, "user-override");
+        let body = reg.list()[0].load_body().unwrap();
+        assert!(body.contains("USER_BODY"));
+    }
+
+    #[test]
+    fn empty_registry_has_no_skills() {
+        let reg = SkillRegistry::empty();
+        assert!(reg.is_empty());
+        assert_eq!(reg.list().len(), 0);
+    }
+
+    #[test]
+    fn nonexistent_dir_is_silently_skipped() {
+        let dir = tempdir().unwrap();
+        let missing = dir.path().join("nope");
+        let reg = SkillRegistry::with_dirs(vec![missing]);
+        assert!(reg.is_empty());
+    }
+
+    #[test]
+    fn default_for_includes_project_root_paths() {
+        let primary = tempdir().unwrap();
+        let project = tempdir().unwrap();
+        write_skill(
+            primary.path(),
+            "user",
+            "name: user\ndescription: user-global",
+            "USER",
+        );
+        let project_vulcan = project.path().join(".vulcan").join("skills");
+        std::fs::create_dir_all(&project_vulcan).unwrap();
+        write_skill(
+            &project_vulcan,
+            "proj-vulcan",
+            "name: proj-vulcan\ndescription: project .vulcan",
+            "P_VULCAN",
+        );
+        let project_agents = project.path().join(".agents").join("skills");
+        std::fs::create_dir_all(&project_agents).unwrap();
+        write_skill(
+            &project_agents,
+            "proj-agents",
+            "name: proj-agents\ndescription: project .agents",
+            "P_AGENTS",
+        );
+        let reg = SkillRegistry::default_for(primary.path(), Some(project.path()));
+        let names: Vec<_> = reg.list().iter().map(|s| s.name.clone()).collect();
+        assert!(names.contains(&"user".to_string()));
+        assert!(names.contains(&"proj-vulcan".to_string()));
+        assert!(names.contains(&"proj-agents".to_string()));
+    }
+
+    #[test]
+    fn project_agents_skill_overrides_user_skill_with_same_name() {
+        let primary = tempdir().unwrap();
+        let project = tempdir().unwrap();
+        write_skill(
+            primary.path(),
+            "debug",
+            "name: debug\ndescription: user-version",
+            "USER_BODY",
+        );
+        let project_agents = project.path().join(".agents").join("skills");
+        std::fs::create_dir_all(&project_agents).unwrap();
+        write_skill(
+            &project_agents,
+            "debug",
+            "name: debug\ndescription: project-version",
+            "PROJECT_BODY",
+        );
+        let reg = SkillRegistry::default_for(primary.path(), Some(project.path()));
+        let debug = reg.list().iter().find(|s| s.name == "debug").unwrap();
+        assert_eq!(debug.description, "project-version");
+        assert!(debug.load_body().unwrap().contains("PROJECT_BODY"));
+    }
+
+    #[test]
+    fn parse_frontmatter_handles_quoted_values() {
+        let raw = "---\nname: \"quoted\"\ndescription: 'single'\n---\nbody";
+        let fm = parse_frontmatter(raw).unwrap();
+        assert_eq!(fm.get_str("name"), Some("quoted"));
+        assert_eq!(fm.get_str("description"), Some("single"));
+    }
+
+    #[test]
+    fn strip_frontmatter_returns_body_only() {
+        let raw = "---\nname: x\ndescription: y\n---\n\n## Body\nhello";
+        let body = strip_frontmatter(raw);
+        assert_eq!(body, "## Body\nhello");
     }
 }

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -8,6 +8,14 @@
 //! discovers and reads them on demand via existing tools, with
 //! `skill_root` exposed alongside the body.
 //!
+//! The loader also accepts the *collection* layout the `npx skills` CLI
+//! produces, where a single package (e.g. `superpowers`) installs a
+//! whole bundle of related skills under a shared parent directory:
+//! `<root>/<collection>/<skill>/SKILL.md`. When an immediate subdir of
+//! a search root has no `SKILL.md` of its own, the loader peeks one
+//! level deeper for skill folders. Two levels is the cap — going
+//! further would over-match arbitrary repos.
+//!
 //! Three search roots merge into one registry, in this order:
 //!
 //! 1. The configured `skills_dir` (defaults to `~/.vulcan/skills`).
@@ -130,21 +138,39 @@ impl SkillRegistry {
                 if !dir.is_dir() {
                     continue;
                 }
-                if !dir.join(SKILL_FILENAME).is_file() {
+                if dir.join(SKILL_FILENAME).is_file() {
+                    Self::ingest(&dir, &mut by_name);
                     continue;
                 }
-                match Self::load_metadata(&dir) {
-                    Ok(skill) => {
-                        by_name.insert(skill.name.clone(), skill);
-                    }
-                    Err(e) => {
-                        tracing::warn!("skip skill at {}: {e}", dir.display());
+                // Collection layout: `<root>/<collection>/<skill>/SKILL.md`.
+                // The `npx skills` CLI installs packages this way (e.g.
+                // `~/.agents/skills/superpowers/<each-skill>/SKILL.md`), so
+                // peek one level deeper before giving up.
+                let inner_entries = match std::fs::read_dir(&dir) {
+                    Ok(e) => e,
+                    Err(_) => continue,
+                };
+                for inner in inner_entries.flatten() {
+                    let inner_dir = inner.path();
+                    if inner_dir.is_dir() && inner_dir.join(SKILL_FILENAME).is_file() {
+                        Self::ingest(&inner_dir, &mut by_name);
                     }
                 }
             }
         }
         self.skills = by_name.into_values().collect();
         Ok(())
+    }
+
+    fn ingest(skill_root: &Path, by_name: &mut BTreeMap<String, Skill>) {
+        match Self::load_metadata(skill_root) {
+            Ok(skill) => {
+                by_name.insert(skill.name.clone(), skill);
+            }
+            Err(e) => {
+                tracing::warn!("skip skill at {}: {e}", skill_root.display());
+            }
+        }
     }
 
     fn load_metadata(skill_root: &Path) -> Result<Skill> {
@@ -579,6 +605,72 @@ mod tests {
         let dirs = resolve_default_dirs(primary.path(), Some(project.path()), None, None);
         assert!(dirs.contains(&project.path().join(".vulcan").join("skills")));
         assert!(dirs.contains(&project.path().join(".agents").join("skills")));
+    }
+
+    #[test]
+    fn discovers_skills_in_collection_layout() {
+        // Mirrors the `npx skills` superpowers layout:
+        //   <root>/superpowers/brainstorming/SKILL.md
+        //   <root>/superpowers/executing-plans/SKILL.md
+        let dir = tempdir().unwrap();
+        let collection = dir.path().join("superpowers");
+        std::fs::create_dir_all(&collection).unwrap();
+        write_skill(
+            &collection,
+            "brainstorming",
+            "name: brainstorming\ndescription: explores ideas before implementation",
+            "BS",
+        );
+        write_skill(
+            &collection,
+            "executing-plans",
+            "name: executing-plans\ndescription: walks an implementation plan to completion",
+            "EX",
+        );
+        // Sibling top-level skill should still be picked up.
+        write_skill(
+            dir.path(),
+            "find-skills",
+            "name: find-skills\ndescription: helps find new skills to install",
+            "FS",
+        );
+        let reg = SkillRegistry::with_dirs(vec![dir.path().to_path_buf()]);
+        let mut names: Vec<_> = reg.list().iter().map(|s| s.name.clone()).collect();
+        names.sort();
+        assert_eq!(
+            names,
+            vec![
+                "brainstorming".to_string(),
+                "executing-plans".to_string(),
+                "find-skills".to_string(),
+            ]
+        );
+        let bs = reg
+            .list()
+            .iter()
+            .find(|s| s.name == "brainstorming")
+            .unwrap();
+        assert_eq!(bs.skill_root, collection.join("brainstorming"));
+    }
+
+    #[test]
+    fn collection_recursion_is_capped_at_one_level() {
+        // <root>/level1/level2/level3/SKILL.md should NOT be found —
+        // only one extra level of nesting is allowed beyond the root.
+        let dir = tempdir().unwrap();
+        let level2 = dir.path().join("level1").join("level2");
+        std::fs::create_dir_all(&level2).unwrap();
+        write_skill(
+            &level2,
+            "deep",
+            "name: deep\ndescription: too deep to discover",
+            "D",
+        );
+        let reg = SkillRegistry::with_dirs(vec![dir.path().to_path_buf()]);
+        assert!(
+            reg.list().iter().all(|s| s.name != "deep"),
+            "skill nested 3 levels deep should not be discovered"
+        );
     }
 
     #[test]

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -43,9 +43,7 @@ impl LLMProvider for ProviderHandle {
 }
 
 fn empty_skills() -> Arc<SkillRegistry> {
-    Arc::new(SkillRegistry::new(&std::path::PathBuf::from(
-        "/tmp/vulcan-integration-skills-nonexistent",
-    )))
+    Arc::new(SkillRegistry::empty())
 }
 
 fn agent_with_mock() -> (Agent, Arc<MockProvider>) {

--- a/tests/contracts.rs
+++ b/tests/contracts.rs
@@ -51,9 +51,7 @@ impl LLMProvider for ProviderHandle {
 }
 
 fn empty_skills() -> Arc<SkillRegistry> {
-    Arc::new(SkillRegistry::new(&std::path::PathBuf::from(
-        "/tmp/vulcan-contract-skills-nonexistent",
-    )))
+    Arc::new(SkillRegistry::empty())
 }
 
 /// Build a fresh agent + mock provider pair with the given tool


### PR DESCRIPTION
YYC-243: adopt agentskills.io SKILL.md format with project-root + XDG search

YYC-243 follow-up: add ~/.agents/skills to default search list

The open `npx skills` CLI installs to `~/.agents/skills`. Slot it
between the user-global `~/.vulcan/skills` and the project-root
paths so a globally installed ecosystem skill is visible to Vulcan
without explicit configuration.

Refactors `default_for` to delegate to a pure `resolve_default_dirs`
helper that takes env vars as parameters — keeps the env-mutation
out of tests (workspace bans `unsafe`, which `set_var` requires on
2024 edition).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>