### PR TITLE
YYC-248 (S3): filesystem sandbox for read/write/edit/list/search

### DIFF
--- a/src/tools/file.rs
+++ b/src/tools/file.rs
@@ -1,5 +1,5 @@
 use crate::pause::{AgentPause, AgentResume, DiffScrubHunk, PauseKind, PauseSender};
-use crate::tools::{Tool, ToolResult};
+use crate::tools::{Tool, ToolResult, fs_sandbox};
 use anyhow::Result;
 use async_trait::async_trait;
 use serde_json::{Value, json};
@@ -45,9 +45,16 @@ impl Tool for ReadFile {
         let offset = params["offset"].as_i64().unwrap_or(1);
         let limit = params["limit"].as_i64().unwrap_or(500);
 
+        // YYC-248: refuse reads of system credential / pseudo-fs paths
+        // before any I/O happens.
+        let path = match fs_sandbox::validate_read(path) {
+            Ok(p) => p,
+            Err(e) => return Ok(ToolResult::err(e.to_string())),
+        };
+
         // YYC-159: preflight the file size so multi-GB inputs are
         // refused before they hit `read_to_string` and OOM the host.
-        let metadata = tokio::fs::metadata(path).await?;
+        let metadata = tokio::fs::metadata(&path).await?;
         let size = metadata.len();
         if size > READ_FILE_MAX_BYTES {
             let mib = size as f64 / (1024.0 * 1024.0);
@@ -66,7 +73,7 @@ impl Tool for ReadFile {
         let limit = limit.max(0) as usize;
         let target_end = start.saturating_add(limit);
 
-        let file = File::open(path).await?;
+        let file = File::open(&path).await?;
         let reader = BufReader::new(file);
         let mut lines_iter = reader.lines();
         let mut collected: Vec<String> = Vec::with_capacity(limit.min(1024));
@@ -148,6 +155,12 @@ impl Tool for ListFiles {
             .get("max_entries")
             .and_then(|v| v.as_u64())
             .unwrap_or(500) as usize;
+
+        // YYC-248: refuse listing of credential / pseudo-fs roots.
+        let path = match fs_sandbox::validate_read(&path) {
+            Ok(p) => p.to_string_lossy().into_owned(),
+            Err(e) => return Ok(ToolResult::err(e.to_string())),
+        };
 
         let walker = ignore::WalkBuilder::new(&path)
             .standard_filters(true)
@@ -284,6 +297,12 @@ impl Tool for WriteFile {
             .ok_or_else(|| anyhow::anyhow!("path required"))?;
         let content = params["content"].as_str().unwrap_or("");
 
+        // YYC-248: refuse writes to system credential / pseudo-fs paths
+        // and to any user-credential or agent-state directory.
+        if let Err(e) = fs_sandbox::validate_write(path) {
+            return Ok(ToolResult::err(e.to_string()));
+        }
+
         // YYC-66: snapshot the existing content before overwriting so the
         // diff sink has a meaningful "before" — empty string for a fresh
         // file is correct (it didn't exist).
@@ -360,6 +379,14 @@ impl Tool for SearchFiles {
             .ok_or_else(|| anyhow::anyhow!("pattern required"))?;
         let path = params["path"].as_str().unwrap_or(".");
         let limit = params["limit"].as_i64().unwrap_or(20);
+
+        // YYC-248: refuse search roots inside credential / pseudo-fs
+        // directories — `rg pattern /etc/shadow` would dump shadow lines
+        // matching the pattern to the LLM.
+        let path = match fs_sandbox::validate_read(path) {
+            Ok(p) => p.to_string_lossy().into_owned(),
+            Err(e) => return Ok(ToolResult::err(e.to_string())),
+        };
 
         let mut cmd = tokio::process::Command::new("rg");
         cmd.arg("--line-number").arg("--color").arg("never");
@@ -445,6 +472,15 @@ impl Tool for PatchFile {
             .as_str()
             .ok_or_else(|| anyhow::anyhow!("old_string required"))?;
         let new = params["new_string"].as_str().unwrap_or("");
+
+        // YYC-248: edit_file reads then writes — refuse blocked paths
+        // for both directions.
+        if let Err(e) = fs_sandbox::validate_read(path) {
+            return Ok(ToolResult::err(e.to_string()));
+        }
+        if let Err(e) = fs_sandbox::validate_write(path) {
+            return Ok(ToolResult::err(e.to_string()));
+        }
 
         let content = tokio::fs::read_to_string(path).await?;
 

--- a/src/tools/fs_sandbox.rs
+++ b/src/tools/fs_sandbox.rs
@@ -1,0 +1,311 @@
+//! YYC-248: filesystem sandbox for the file tools.
+//!
+//! `read_file`, `write_file`, `edit_file`, `search_files`, and
+//! `list_files` accept arbitrary absolute paths today. With prompt
+//! injection that is enough to read `/etc/shadow`, `~/.ssh/id_rsa`,
+//! `/proc/self/environ`, or write a fresh entry into `~/.bashrc` for
+//! persistence.
+//!
+//! This module enforces a **default-deny prefix list** that covers the
+//! best-known sensitive paths on Linux/macOS. Paths are canonicalized
+//! (or, if the target doesn't exist yet, the parent is canonicalized)
+//! before the prefix check so a symlink at `cwd/escape -> /etc/passwd`
+//! cannot defeat it.
+//!
+//! Workspace-root sandboxing (only allow paths under `cwd` unless the
+//! trust profile permits otherwise) is deliberately deferred to a
+//! follow-up — too disruptive for ops/dev workflows that legitimately
+//! read outside the project. The deny prefix list catches the worst
+//! exfiltration vectors without requiring a trust-profile rewrite.
+
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum FsSandboxError {
+    #[error("blocked path `{path}`: this prefix is in the default-deny list ({reason})")]
+    BlockedPrefix { path: String, reason: &'static str },
+    #[error("path `{path}` could not be resolved: {source}")]
+    Resolve {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+/// Validate a path the tool wants to *read*. Returns the canonicalized
+/// path on success.
+pub fn validate_read(raw: &str) -> Result<PathBuf, FsSandboxError> {
+    let resolved = resolve_for_read(raw)?;
+    check_denylist(&resolved, raw)?;
+    Ok(resolved)
+}
+
+/// Validate a path the tool wants to *write* (create or overwrite).
+/// Returns the canonicalized path on success.
+pub fn validate_write(raw: &str) -> Result<PathBuf, FsSandboxError> {
+    let resolved = resolve_for_write(raw)?;
+    check_denylist(&resolved, raw)?;
+    Ok(resolved)
+}
+
+fn resolve_for_read(raw: &str) -> Result<PathBuf, FsSandboxError> {
+    let absolute = absolutize(raw);
+    match std::fs::canonicalize(&absolute) {
+        Ok(p) => Ok(p),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // Reads of non-existent paths are not the sandbox's
+            // problem — let the file tool surface its own NotFound.
+            // Still return the absolute path so the prefix check fires
+            // first (so a missing file under a blocked prefix doesn't
+            // leak the prefix as a NotFound error).
+            Ok(absolute)
+        }
+        Err(source) => Err(FsSandboxError::Resolve {
+            path: raw.to_string(),
+            source,
+        }),
+    }
+}
+
+fn resolve_for_write(raw: &str) -> Result<PathBuf, FsSandboxError> {
+    let absolute = absolutize(raw);
+    if let Ok(p) = std::fs::canonicalize(&absolute) {
+        return Ok(p);
+    }
+    // Target doesn't exist yet. Canonicalize the parent, then re-attach
+    // the filename. This is the standard symlink-defeating idiom for
+    // "where will my new file actually land?"
+    let parent = absolute.parent().ok_or_else(|| FsSandboxError::Resolve {
+        path: raw.to_string(),
+        source: std::io::Error::other("no parent directory"),
+    })?;
+    let canon_parent = std::fs::canonicalize(parent).map_err(|source| FsSandboxError::Resolve {
+        path: raw.to_string(),
+        source,
+    })?;
+    let filename = absolute
+        .file_name()
+        .ok_or_else(|| FsSandboxError::Resolve {
+            path: raw.to_string(),
+            source: std::io::Error::other("path has no filename component"),
+        })?;
+    Ok(canon_parent.join(filename))
+}
+
+fn absolutize(raw: &str) -> PathBuf {
+    let p = PathBuf::from(raw);
+    if p.is_absolute() {
+        return p;
+    }
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    cwd.join(p)
+}
+
+fn check_denylist(canonical: &Path, raw: &str) -> Result<(), FsSandboxError> {
+    if let Some(reason) = classify_blocked(canonical) {
+        return Err(FsSandboxError::BlockedPrefix {
+            path: raw.to_string(),
+            reason,
+        });
+    }
+    Ok(())
+}
+
+fn classify_blocked(path: &Path) -> Option<&'static str> {
+    let s = path.to_string_lossy();
+
+    // Pseudo-filesystems.
+    if starts_with_any(&s, &["/proc/", "/proc"]) {
+        return Some("/proc — process pseudo-fs (env vars, fds, /proc/self leaks)");
+    }
+    if starts_with_any(&s, &["/sys/", "/sys"]) {
+        return Some("/sys — kernel sysfs");
+    }
+    // /dev — allow the well-known generic sinks; refuse the rest.
+    if s == "/dev" || s.starts_with("/dev/") {
+        const SAFE_DEV: &[&str] = &[
+            "/dev/null",
+            "/dev/zero",
+            "/dev/random",
+            "/dev/urandom",
+            "/dev/stdin",
+            "/dev/stdout",
+            "/dev/stderr",
+            "/dev/tty",
+        ];
+        if !SAFE_DEV.contains(&s.as_ref()) {
+            return Some("/dev — raw device files");
+        }
+    }
+
+    // System credential / config files.
+    if s == "/etc/shadow"
+        || s == "/etc/gshadow"
+        || s.starts_with("/etc/shadow-")
+        || s.starts_with("/etc/sudoers")
+    {
+        return Some("system credential / sudo config");
+    }
+
+    // User credential / state directories. Block read AND write — `~/.aws`
+    // contains AWS keys, `~/.kube/config` has cluster admin tokens, etc.
+    if let Some(home) = home_dir() {
+        const HOME_DENY: &[&str] = &[
+            ".ssh",
+            ".gnupg",
+            ".aws",
+            ".kube",
+            ".docker",
+            ".vulcan",
+            ".config/gh",
+            ".config/anthropic",
+            ".config/op", // 1Password CLI
+            ".config/gcloud",
+            ".azure",
+            ".pgpass",
+            ".netrc",
+        ];
+        for entry in HOME_DENY {
+            let target = home.join(entry);
+            if path == target.as_path() || path.starts_with(&target) {
+                return Some("user credential / agent-state directory");
+            }
+        }
+    }
+
+    None
+}
+
+fn home_dir() -> Option<PathBuf> {
+    let home = std::env::var("HOME").ok()?;
+    if home.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(home))
+}
+
+fn starts_with_any(s: &str, prefixes: &[&str]) -> bool {
+    prefixes.iter().any(|p| s == *p || s.starts_with(p))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blocks_read_of_etc_shadow() {
+        let err = validate_read("/etc/shadow").unwrap_err();
+        assert!(matches!(err, FsSandboxError::BlockedPrefix { .. }));
+    }
+
+    #[test]
+    fn blocks_read_of_proc_self_environ() {
+        let err = validate_read("/proc/self/environ").unwrap_err();
+        match err {
+            FsSandboxError::BlockedPrefix { reason, .. } => assert!(reason.starts_with("/proc")),
+            _ => panic!("expected BlockedPrefix"),
+        }
+    }
+
+    #[test]
+    fn blocks_read_of_sys() {
+        let err = validate_read("/sys/kernel/notes").unwrap_err();
+        assert!(matches!(err, FsSandboxError::BlockedPrefix { .. }));
+    }
+
+    #[test]
+    fn blocks_read_of_dev_block_devices() {
+        for raw in ["/dev/sda", "/dev/nvme0n1", "/dev/disk0"] {
+            let err = validate_read(raw).unwrap_err();
+            assert!(
+                matches!(err, FsSandboxError::BlockedPrefix { .. }),
+                "expected block for {raw}"
+            );
+        }
+    }
+
+    #[test]
+    fn allows_read_of_safe_dev_paths() {
+        // /dev/null / /dev/urandom always exist on Linux/macOS.
+        validate_read("/dev/null").unwrap();
+        validate_read("/dev/urandom").unwrap();
+    }
+
+    #[test]
+    fn blocks_read_of_ssh_key_paths() {
+        if let Some(home) = home_dir() {
+            let bogus = home.join(".ssh").join("nope_does_not_exist");
+            let err = validate_read(bogus.to_str().unwrap()).unwrap_err();
+            assert!(matches!(err, FsSandboxError::BlockedPrefix { .. }));
+        }
+    }
+
+    #[test]
+    fn blocks_read_of_aws_credentials() {
+        if let Some(home) = home_dir() {
+            let bogus = home.join(".aws").join("credentials");
+            let err = validate_read(bogus.to_str().unwrap()).unwrap_err();
+            assert!(matches!(err, FsSandboxError::BlockedPrefix { .. }));
+        }
+    }
+
+    #[test]
+    fn blocks_read_of_vulcan_state() {
+        if let Some(home) = home_dir() {
+            let bogus = home.join(".vulcan").join("config.toml");
+            let err = validate_read(bogus.to_str().unwrap()).unwrap_err();
+            assert!(matches!(err, FsSandboxError::BlockedPrefix { .. }));
+        }
+    }
+
+    #[test]
+    fn blocks_write_to_etc_sudoers() {
+        let err = validate_write("/etc/sudoers.d/00-evil").unwrap_err();
+        assert!(matches!(err, FsSandboxError::BlockedPrefix { .. }));
+    }
+
+    #[test]
+    fn allows_write_to_temp_dir() {
+        let tmp =
+            std::env::temp_dir().join(format!("vulcan-fs-sandbox-test-{}.txt", std::process::id()));
+        let p = validate_write(tmp.to_str().unwrap()).unwrap();
+        assert!(p.is_absolute());
+    }
+
+    #[test]
+    fn blocks_symlink_escape_via_canonicalize() {
+        // tempdir + symlink → /etc → canonicalize lands on /etc → not in
+        // the deny list. But a symlink to /etc/shadow is. Build that.
+        let tmp =
+            std::env::temp_dir().join(format!("vulcan-fs-sandbox-symlink-{}", std::process::id()));
+        let _ = std::fs::remove_file(&tmp);
+        // Skip on platforms that disallow symlinking to /etc/shadow.
+        if std::os::unix::fs::symlink("/etc/shadow", &tmp).is_err() {
+            return;
+        }
+        let err = validate_read(tmp.to_str().unwrap()).unwrap_err();
+        let _ = std::fs::remove_file(&tmp);
+        assert!(matches!(err, FsSandboxError::BlockedPrefix { .. }));
+    }
+
+    #[test]
+    fn allows_read_of_unrelated_file_under_tempdir() {
+        let tmp = std::env::temp_dir().join(format!(
+            "vulcan-fs-sandbox-allow-{}.txt",
+            std::process::id()
+        ));
+        std::fs::write(&tmp, b"hello").unwrap();
+        let result = validate_read(tmp.to_str().unwrap());
+        let _ = std::fs::remove_file(&tmp);
+        result.unwrap();
+    }
+
+    #[test]
+    fn read_of_nonexistent_unblocked_path_succeeds() {
+        // Sandbox returns the absolute path; the file tool surfaces
+        // the NotFound itself.
+        let p = validate_read("/tmp/vulcan-sandbox-no-such-file-xyz123").unwrap();
+        assert!(p.is_absolute());
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -224,6 +224,7 @@ pub mod code_edit;
 pub mod code_graph;
 pub mod code_search;
 pub mod file;
+pub mod fs_sandbox;
 pub mod git;
 pub mod lsp;
 pub mod profile;


### PR DESCRIPTION
Default-deny prefix list applied to read_file, list_files,
search_files, write_file, and edit_file. Refuses any path that
canonicalizes into:

- /proc, /sys (kernel pseudo-filesystems)
- /dev/* (raw block devices); /dev/null, /dev/zero, /dev/urandom,
  /dev/random, /dev/std{in,out,err}, /dev/tty stay allowed
- /etc/shadow, /etc/gshadow, /etc/shadow-*, /etc/sudoers*
- $HOME/.ssh, $HOME/.gnupg, $HOME/.aws, $HOME/.kube, $HOME/.docker,
  $HOME/.vulcan (own creds), $HOME/.config/{gh,anthropic,op,gcloud},
  $HOME/.azure, $HOME/.pgpass, $HOME/.netrc

Symlink escape is defeated by canonicalizing the path (or its parent,
for write to a non-existent file) before the prefix check, so a
symlink at `cwd/escape -> /etc/shadow` lands on `/etc/shadow` and
is refused.

Workspace-root sandboxing (only allow paths under cwd unless the
trust profile permits otherwise) is deliberately deferred — too
disruptive to ops/dev workflows that legitimately read outside the
project. The deny prefix list catches the worst exfiltration vectors
without requiring a trust-profile rewrite.

13 tests cover each blocked class plus the symlink-escape path.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>