### PR TITLE
YYC-249 (S4): wrap Agent.provider_api_key in secrecy::SecretString

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4209,6 +4209,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4380,7 +4389,7 @@ dependencies = [
  "mime_guess",
  "percent-encoding",
  "reqwest 0.12.28",
- "secrecy",
+ "secrecy 0.8.0",
  "serde",
  "serde_cow",
  "serde_json",
@@ -5510,6 +5519,7 @@ dependencies = [
  "regex",
  "reqwest 0.13.3",
  "rusqlite",
+ "secrecy 0.10.3",
  "serde",
  "serde_json",
  "serenity",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,9 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 anyhow = "1"
 thiserror = "2"
 
+# Zeroizing wrappers for in-memory secrets (YYC-249).
+secrecy = "0.10"
+
 # Date/time
 chrono = { version = "0.4", features = ["serde"] }
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -108,7 +108,12 @@ pub struct Agent {
     /// commands can switch models without reconstructing the long-lived
     /// Agent, hook registry, tools, memory, or session state.
     pub(in crate::agent) provider_config: ProviderConfig,
-    pub(in crate::agent) provider_api_key: String,
+    /// YYC-249: provider API key wrapped in `SecretString` so the
+    /// underlying buffer is zeroed on drop. Default `Debug` impl
+    /// redacts the value, so accidental log lines don't print it.
+    /// Call sites that need the raw `&str` use `.expose_secret()`
+    /// at the moment of use rather than caching a copy.
+    pub(in crate::agent) provider_api_key: secrecy::SecretString,
     /// Name of the active named provider profile from `[providers.<name>]`,
     /// or `None` when running on the unnamed legacy `[provider]` block.
     /// Set by `switch_provider`; surfaced via `active_profile()` so the
@@ -517,7 +522,7 @@ impl Agent {
             pricing,
             compaction_config: config.compaction.clone(),
             provider_config: active_provider.clone(),
-            provider_api_key: api_key,
+            provider_api_key: secrecy::SecretString::from(api_key),
             active_profile: config.active_profile.clone(),
             lsp_manager,
             last_saved_count: 0,
@@ -691,7 +696,7 @@ impl Agent {
             pricing: None,
             compaction_config: CompactionConfig::default(),
             provider_config: ProviderConfig::default(),
-            provider_api_key: "test-key".into(),
+            provider_api_key: secrecy::SecretString::from("test-key".to_string()),
             active_profile: None,
             lsp_manager: Arc::new(crate::code::lsp::LspManager::new(
                 std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from(".")),

--- a/src/agent/provider.rs
+++ b/src/agent/provider.rs
@@ -13,7 +13,11 @@ use super::{Agent, ModelSelection, is_local_base_url};
 
 impl Agent {
     pub async fn available_models(&self) -> Result<Vec<crate::provider::catalog::ModelInfo>> {
-        Self::fetch_catalog_for(&self.provider_config, &self.provider_api_key).await
+        Self::fetch_catalog_for(
+            &self.provider_config,
+            secrecy::ExposeSecret::expose_secret(&self.provider_api_key),
+        )
+        .await
     }
 
     pub async fn switch_model(&mut self, model_id: &str) -> Result<ModelSelection> {
@@ -23,10 +27,14 @@ impl Agent {
 
         let mut next_config = self.provider_config.clone();
         next_config.model = model_id.to_string();
-        let selection = Self::resolve_model_selection(&next_config, &self.provider_api_key).await?;
+        let selection = Self::resolve_model_selection(
+            &next_config,
+            secrecy::ExposeSecret::expose_secret(&self.provider_api_key),
+        )
+        .await?;
         let provider = DefaultProviderFactory.build(
             &next_config,
-            &self.provider_api_key,
+            secrecy::ExposeSecret::expose_secret(&self.provider_api_key),
             selection.max_context,
             selection.model.features.json_mode,
         )?;
@@ -91,7 +99,7 @@ impl Agent {
 
         self.provider = provider;
         self.provider_config = next_config;
-        self.provider_api_key = api_key;
+        self.provider_api_key = secrecy::SecretString::from(api_key);
         self.context =
             ContextManager::with_config(selection.max_context, config.compaction.clone());
         self.compaction_config = config.compaction.clone();

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -927,3 +927,21 @@ fn is_local_base_url_returns_false_on_malformed_input() {
     assert!(!is_local_base_url("not a url"));
     assert!(!is_local_base_url("http://"));
 }
+
+// YYC-249: Agent.provider_api_key must be wrapped in SecretString so
+// the buffer is zeroed on drop and Debug doesn't leak the value.
+#[test]
+fn provider_api_key_is_secret_string() {
+    let _: fn(&Agent) -> &secrecy::SecretString = |a| &a.provider_api_key;
+}
+
+#[test]
+fn provider_api_key_debug_does_not_leak_value() {
+    use secrecy::SecretString;
+    let secret = SecretString::from("super-secret-key-do-not-leak".to_string());
+    let dbg = format!("{secret:?}");
+    assert!(
+        !dbg.contains("super-secret-key-do-not-leak"),
+        "SecretString Debug leaked the value: {dbg}"
+    );
+}


### PR DESCRIPTION
`Agent.provider_api_key` was a plain `String`. Rust's `String` does
not zero its heap on drop, so the API key persisted in:

- The freed heap region until reused.
- Swap files / hibernate images.
- Coredumps if the process crashed.

Wrap in `secrecy::SecretString`:

- Buffer is zeroed on drop via the `zeroize` machinery.
- Default `Debug` impl prints `Secret([REDACTED])` instead of the
  raw value, so an accidental `println!` / `tracing::info!` can't
  leak the key.
- Call sites (`available_models`, `switch_model`, the `switch_provider`
  re-build path) pull the raw `&str` via `expose_secret()` at the
  moment of use rather than caching a copy.

Tests:
- A type-level binding asserts `Agent.provider_api_key: SecretString`
  so a future regression that drops the wrapper fails to compile.
- A runtime test confirms `Debug` redacts the value.

Gateway `AppState.api_token` and the embeddings/catalog `api_key`
copies are deliberately deferred to a follow-up — those flow from
the same Agent secret but live in independent surfaces with their
own test fixtures.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>