### PR TITLE
YYC-275 (L4): drop workspace too_many_arguments allow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,9 @@ unused_must_use = "warn"
 [lints.clippy]
 # Common but noisy in this crate. Allowed at the baseline; revisit
 # per-call-site as those code paths get refactored.
-too_many_arguments = "allow"
+# YYC-275: `too_many_arguments` removed from the workspace allow.
+# Existing offenders carry `#[allow(clippy::too_many_arguments)]` at
+# the function so new code lights up clippy by default.
 field_reassign_with_default = "allow"
 doc_overindented_list_items = "allow"
 # `&PathBuf` / `&String` parameters are technically slower than `&Path`

--- a/src/artifact/mod.rs
+++ b/src/artifact/mod.rs
@@ -313,6 +313,10 @@ impl SqliteArtifactStore {
         Ok(())
     }
 
+    // YYC-275: 11 fields come straight from a SQLite row decode;
+    // collapsing them into a struct here would just rename the
+    // problem at the call site. Allowed at this site only.
+    #[allow(clippy::too_many_arguments)]
     fn row_to_artifact(
         id: String,
         kind: String,

--- a/src/gateway/discord.rs
+++ b/src/gateway/discord.rs
@@ -28,6 +28,9 @@ impl DiscordPlatform {
         })
     }
 
+    // YYC-275: maps Serenity Message fields one-to-one; refactoring
+    // to a struct would just hide the same shape. Allowed here.
+    #[allow(clippy::too_many_arguments)]
     fn inbound_from_message_parts(
         channel_id: u64,
         user_id: u64,

--- a/src/tui/chat_render.rs
+++ b/src/tui/chat_render.rs
@@ -63,6 +63,9 @@ pub struct ChatRenderStore {
 }
 
 impl ChatRenderStore {
+    // YYC-275: TUI render hot path; a builder/options struct would
+    // add allocation per draw call. Allowed at this site only.
+    #[allow(clippy::too_many_arguments)]
     pub fn visible_lines(
         &mut self,
         messages: &[ChatMessage],

--- a/src/tui/widgets.rs
+++ b/src/tui/widgets.rs
@@ -295,6 +295,9 @@ pub fn prompt_row_height(input: &str, width: u16, mode: &str) -> u16 {
     1 + input_lines + 1
 }
 
+// YYC-275: Frame + Rect + mode + input + 5 cosmetic fields per draw
+// call. A builder would allocate every frame; allowed here.
+#[allow(clippy::too_many_arguments)]
 pub fn prompt_row(
     f: &mut TuiFrame,
     area: Rect,
@@ -445,6 +448,9 @@ pub fn ticker(f: &mut TuiFrame, area: Rect, cells: &[(String, String, Color)]) {
 /// follow the active theme. Diff coloring inside the body preview also
 /// stays on the structural diff palette so `+` / `-` lines remain
 /// instantly recognizable across themes.
+// YYC-275: tool-card render takes 9 distinct cosmetic inputs every
+// draw. Allowed here; revisit if `tool_card` grows further.
+#[allow(clippy::too_many_arguments)]
 pub fn tool_card(
     name: &str,
     status: super::state::ToolStatus,


### PR DESCRIPTION
Removing the `clippy::too_many_arguments = "allow"` line from
`Cargo.toml` so new code with 7+ params trips clippy by default.
The five existing offenders carry a per-function
`#[allow(clippy::too_many_arguments)]` with a justification:

- `artifact::mod.rs:row_to_artifact` (11 args) — 1:1 SQLite row decode.
- `gateway::discord::inbound_from_message_parts` (8) — 1:1 Serenity
  `Message` field map.
- `tui::chat_render::visible_lines` (8) — render hot path; per-frame
  allocation is the alternative.
- `tui::widgets::prompt_row` (9) — same hot-path constraint.
- `tui::widgets::tool_card` (9) — same hot-path constraint.

Three are bona fide cases (data-shape mirrors) and two are render
hot paths where a struct would mean an alloc per draw. Refactoring
those is out of scope; the per-site allow surfaces them as
intentional and the lint now binds new code.

`cargo clippy --all-targets --features gateway` — 0 hits for
`too_many_arguments`. Test suite green (858 pass).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>