### PR TITLE
YYC-276 (R7): drop stale "deferred" comment for subagent cancellation

### DIFF
--- a/src/tools/spawn.rs
+++ b/src/tools/spawn.rs
@@ -18,9 +18,14 @@
 //! ## Deliberately deferred
 //!
 //! - Token budget tracking (max_iterations is the proxy today).
-//! - Parent cancellation propagation into the child loop.
 //! - Transcript/artifact handle for inspection.
 //! - TUI subagent tile (lands with YYC-68).
+//!
+//! Parent cancellation propagation lives at the call site:
+//! `cancel.child_token()` derives a child token from the parent's,
+//! so cancelling the parent's turn aborts the child's loop within
+//! one iteration. YYC-209 also exposes the child-side handle through
+//! the orchestration store so the TUI can target a specific child.
 
 use std::sync::Arc;
 


### PR DESCRIPTION
The audit flagged `tools/spawn.rs` line 21 — "Parent cancellation
propagation into the child loop" listed as deliberately deferred —
as a known limitation. The doc comment was stale: YYC-208 already
implemented the propagation via `cancel.child_token()` at line 253,
and YYC-209 hooked the child-side handle into the orchestration
store so the TUI can target a specific child by id.

Existing test coverage (`precancelled_parent_marks_record_cancelled`)
exercises the short-circuit when the parent token is already
cancelled. The within-iteration propagation lives in
`Agent::run_prompt_with_cancel` and is exercised by the agent-loop
contract tests.

Replace the misleading "Deferred" entry with a positive note
pointing to the call site so future readers don't think this is
still open.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>