### PR TITLE
YYC-266 (A2): document TUI module-size decision; no split needed

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,3 +1,30 @@
+//! TUI entry point.
+//!
+//! ## YYC-266 — module size investigation
+//!
+//! The audit (`codebase-analysis.md` A2) flagged `tui/mod.rs` as
+//! oversized at "101 KB"; the actual figure is ~1675 lines, and
+//! the file holds `run_tui` (the event loop) plus a single small
+//! helper. Heavy decomposition has already happened — the TUI
+//! is split across 15+ submodules:
+//!
+//! - State + diffing: `state/`, `chat_message`, `chat_render`.
+//! - Rendering: `rendering`, `widgets`, `views`, `markdown`,
+//!   `theme`, `miller_columns`, `model_picker`, `picker_state`.
+//! - Input: `events`, `keybinds`, `keymap`.
+//! - Init / orchestration: `init`, `orchestration`.
+//!
+//! What's left in `mod.rs` is the orchestrator — the event loop,
+//! the streaming-event pump, slash-command dispatch, and pause /
+//! resume wiring. Every line couples to multiple submodules; a
+//! further split would mean either passing huge tuples of state
+//! across module boundaries or pulling submodules back into a
+//! shared file. Neither is a clear win.
+//!
+//! Decision: leave the orchestrator in `mod.rs`. New code that
+//! adds a *new* coherent surface (e.g. a future plugin host)
+//! lives in its own submodule from day one.
+
 use std::sync::Arc;
 use std::time::Instant;
 


### PR DESCRIPTION
A2 was filed as a research issue after the audit flagged
`tui/mod.rs` as oversized ("101 KB"). Investigation:

- Actual size is ~1675 lines, not 101 KB.
- Heavy decomposition already exists: 15+ TUI submodules
  (`state/`, `chat_message`, `chat_render`, `rendering`,
  `widgets`, `views`, `markdown`, `theme`, `miller_columns`,
  `model_picker`, `picker_state`, `events`, `keybinds`,
  `keymap`, `init`, `orchestration`).
- What's left in `mod.rs` is the orchestrator — event loop,
  streaming event pump, slash-command dispatch, pause/resume
  wiring. Every line couples to multiple submodules.
- A further split would either pass huge tuples across module
  boundaries or pull submodules back into a shared file. Neither
  is a clear win.

Decision: leave the orchestrator in `mod.rs`. New coherent
surfaces (e.g. a future plugin host) get their own submodule
from day one. The decision is documented at the top of `mod.rs`
so it's visible the next time someone reads the file.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>