### PR TITLE
YYC-257 (L6 web): fixture-driven tests for extract_ddg_results + html_to_text

### DIFF
--- a/src/tools/web.rs
+++ b/src/tools/web.rs
@@ -368,6 +368,87 @@ mod tests {
     use super::*;
 
     #[test]
+    fn yyc257_extract_ddg_results_parses_titles_urls_snippets() {
+        // Stripped-down DDG result HTML — three results, each with the
+        // class hooks the parser keys on.
+        let html = r##"
+<html><body>
+<div class="result__body">
+  <a class="result__a" href="x">First Result</a>
+  <a class="result__url" href="x">https://first.example/</a>
+  <a class="result__snippet" href="x">First snippet text.</a>
+</div>
+<div class="result__body">
+  <a class="result__a" href="x">Second Result</a>
+  <a class="result__url" href="x">https://second.example/</a>
+  <a class="result__snippet" href="x">Second snippet text.</a>
+</div>
+</body></html>
+"##;
+        let results = extract_ddg_results(html);
+        assert_eq!(results.len(), 2);
+        // The hand-rolled parser can leave a `</a` tail on extracted
+        // strings — known fragility flagged by M3. We assert the
+        // useful part is present rather than exact equality so this
+        // test isn't held hostage to the parser's quirks.
+        assert!(results[0].title.starts_with("First Result"));
+        assert!(results[0].url.contains("first.example"));
+        assert!(results[0].snippet.starts_with("First snippet text."));
+        assert!(results[1].title.starts_with("Second Result"));
+    }
+
+    #[test]
+    fn yyc257_extract_ddg_results_empty_when_no_result_blocks() {
+        let html = "<html><body><p>nothing here</p></body></html>";
+        assert!(extract_ddg_results(html).is_empty());
+    }
+
+    #[test]
+    fn yyc257_extract_ddg_results_caps_at_five() {
+        let mut html = String::new();
+        for i in 0..10 {
+            html.push_str(&format!(
+                r##"<div class="result__body">
+                <a class="result__a" href="x">Title {i}</a>
+                <a class="result__url" href="x">https://e{i}.example/</a>
+                <a class="result__snippet" href="x">Snippet {i}.</a>
+                </div>"##
+            ));
+        }
+        let results = extract_ddg_results(&html);
+        assert_eq!(results.len(), 5);
+    }
+
+    #[test]
+    fn yyc257_html_to_text_strips_tags_and_normalizes_whitespace() {
+        let html = "<p>Hello,  <b>world</b>!</p>\n  <p>Second  line.</p>";
+        let text = html_to_text(html);
+        // Tag chars stripped; runs of whitespace collapsed.
+        assert!(text.contains("Hello, world!"));
+        assert!(text.contains("Second line."));
+        assert!(!text.contains('<'));
+        assert!(!text.contains('>'));
+    }
+
+    #[test]
+    fn yyc257_html_to_text_includes_visible_paragraph_text() {
+        // The hand-rolled stripper has known quirks around <script>
+        // and <style> blocks (it scans the whole input for those
+        // tags rather than tracking nesting cleanly). M6 tracks the
+        // upgrade to a real parser. For now we pin the visible-text
+        // case rather than the script-stripping behaviour.
+        let html = "<p>visible content</p>";
+        let text = html_to_text(html);
+        assert!(text.contains("visible content"));
+        assert!(!text.contains('<'));
+    }
+
+    #[test]
+    fn yyc257_html_to_text_handles_empty_input() {
+        assert_eq!(html_to_text(""), "");
+    }
+
+    #[test]
     fn yyc256_shared_client_returns_same_pointer_each_call() {
         let a = shared_client() as *const _;
         let b = shared_client() as *const _;


### PR DESCRIPTION
The audit flagged `web_fetch` and `web_search` as having zero tests.
Adding a wiremock-style HTTP test would either need a dev-only
SSRF bypass (loopback is blocked since YYC-246) or pull in
`wiremock` plus its transitive deps. Higher cost than coverage.

Cheaper coverage: pin the parser layer with fixtures. The pure
functions `extract_ddg_results` and `html_to_text` carry the bulk
of the tool's logic and are the most fragile parts (M3 / M6
already track replacing them). Six new tests:

- DDG result fixture with two blocks → titles, urls, snippets
  populated. Assertions use `starts_with` / `contains` rather
  than equality so the parser's known tail-`</a` quirk doesn't
  hold the test hostage.
- DDG fixture with no result blocks → empty Vec.
- DDG fixture with 10 blocks → caps at 5.
- HTML fixture → tags stripped, whitespace normalized.
- Visible-paragraph happy path.
- Empty input → empty output.

Real HTTP mocking (status codes, truncation, SSRF interaction)
deferred until M3 (DDG scraper replacement) or a sandbox-aware
fixture lands.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>