### PR TITLE
YYC-270 (M5): document typed-errors spike outcome; no generic rollout

### DIFF
--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -27,6 +27,15 @@ use tokio::sync::mpsc;
 /// a structured taxonomy so callers (retry logic, TUI banner) can branch on
 /// the kind of failure, and so the user sees an actionable next-step hint
 /// instead of raw provider JSON. See YYC-41.
+///
+/// YYC-270: this is the canonical example of where typed errors earn
+/// their keep — clear taxonomy, multiple consumers (retry classifier,
+/// TUI banner, run records), and distinct remediation per variant.
+/// The spike's outcome is documented in
+/// `~/wiki/queries/typed-errors-spike.md`: do *not* roll out a
+/// generic `ToolError` / `ConfigError` enum; define local typed
+/// errors (e.g. `FsSandboxError`, `SsrfError`) only where they
+/// unlock new behavior.
 #[derive(Debug, thiserror::Error)]
 pub enum ProviderError {
     /// 401 / 403 — API key is missing, invalid, revoked, or lacks permission.


### PR DESCRIPTION
Spike conclusion: the provider path is already typed
(`ProviderError` with Auth / RateLimited / ModelNotFound /
BadRequest / ServerError / Network / Other variants), and YYC-272's
retry loop + the TUI banner both lean on it. That's the clear win.

Other paths don't earn the same:

- **Tools**: `ToolResult { is_error, output }` is already the
  user-visible structured shape. Internal anyhow::Error is fine
  for unexpected failures. Where structured failure unlocks new
  behavior (sandbox refusals, SSRF blocks), the existing
  module-local typed errors (`FsSandboxError`, `SsrfError`) work
  without a global `ToolError`.
- **Config**: validation runs once at startup; the actionable
  info is the parse offset + field name, which `anyhow` already
  carries. A typed `ConfigError` adds maintenance cost without
  changing what the operator does next.

Decision: keep `ProviderError` and the per-module sandbox enums.
Do not introduce a generic `ToolError` or `ConfigError`. Future
structured-error work lands locally where a real consumer wants
to branch on the variant.

Outcome documented in `~/wiki/queries/typed-errors-spike.md` and
referenced from the `ProviderError` doc comment so future readers
find the rationale.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>