### PR TITLE
YYC-252 (M3): replace DDG scraper string-split chain with `scraper` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,6 +725,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf 0.13.1",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "ctutils"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,6 +972,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,6 +997,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "ego-tree"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b04dc5a38e4f151a79d9f2451ae6037fb6eaf5cba34771f44781f80e508498e3"
 
 [[package]]
 name = "either"
@@ -1262,6 +1306,15 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -2366,6 +2419,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "html5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
+dependencies = [
+ "log",
+ "markup5ever",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3007,6 +3070,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "markup5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3111,6 +3185,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
@@ -3311,7 +3391,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_macros",
+ "phf_macros 0.11.3",
  "phf_shared 0.11.3",
 ]
 
@@ -3325,13 +3405,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros 0.13.1",
+ "phf_shared 0.13.1",
+ "serde",
+]
+
+[[package]]
 name = "phf_codegen"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
- "phf_generator",
+ "phf_generator 0.11.3",
  "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -3345,13 +3446,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
 name = "phf_macros"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
- "phf_generator",
+ "phf_generator 0.11.3",
  "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3371,6 +3495,15 @@ name = "phf_shared"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -3472,6 +3605,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
@@ -4199,6 +4338,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scraper"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f5297102b8b62b4454ee8561601b2d551b4913148feb4241ca9d1a04bf4526"
+dependencies = [
+ "cssparser",
+ "ego-tree",
+ "getopts",
+ "html5ever",
+ "precomputed-hash",
+ "selectors",
+ "tendril",
+]
+
+[[package]]
 name = "secrecy"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4238,6 +4392,25 @@ checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "selectors"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
+dependencies = [
+ "bitflags 2.11.1",
+ "cssparser",
+ "derive_more 2.1.1",
+ "log",
+ "new_debug_unreachable",
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "precomputed-hash",
+ "rustc-hash 2.1.2",
+ "servo_arc",
+ "smallvec",
 ]
 
 [[package]]
@@ -4410,6 +4583,15 @@ dependencies = [
  "cfg-if",
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -4627,6 +4809,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.13.1",
+ "precomputed-hash",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4780,6 +4986,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tendril"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
+dependencies = [
+ "new_debug_unreachable",
+ "utf-8",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4798,7 +5014,7 @@ dependencies = [
  "fnv",
  "nom",
  "phf 0.11.3",
- "phf_codegen",
+ "phf_codegen 0.11.3",
 ]
 
 [[package]]
@@ -5521,6 +5737,7 @@ dependencies = [
  "regex",
  "reqwest 0.13.3",
  "rusqlite",
+ "scraper",
  "secrecy 0.10.3",
  "serde",
  "serde_json",
@@ -5726,6 +5943,18 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
+dependencies = [
+ "phf 0.13.1",
+ "phf_codegen 0.13.1",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,9 @@ globset = "0.4"
 # RFC 3986 percent-encoding for query strings (YYC-253). Replaces
 # the hand-rolled urlencoding() in web.rs.
 percent-encoding = "2"
+# CSS-selector HTML parsing for the DDG scraper (YYC-252). Replaces
+# the brittle hand-rolled `.split().nth()` chain.
+scraper = "0.26"
 
 # Gateway daemon HTTP stack. Optional — only linked under `gateway`.
 axum = { version = "0.8.9", optional = true }

--- a/src/tools/web.rs
+++ b/src/tools/web.rs
@@ -69,40 +69,44 @@ struct DdgResult {
     snippet: String,
 }
 
+/// YYC-252: parse DDG search results via `scraper` CSS selectors
+/// instead of brittle `.split().nth()` chains. The new path tolerates
+/// markup variations (extra whitespace, attribute reordering, nested
+/// inline tags) that broke the prior parser whenever DDG tweaked
+/// their HTML.
 fn extract_ddg_results(html: &str) -> Vec<DdgResult> {
+    use scraper::{Html, Selector};
+
+    let document = Html::parse_document(html);
+    // Selectors are constructed once per call. Caching them across
+    // calls is possible but `scraper`'s Selector isn't trivially
+    // cacheable (no Send). Single-call cost is negligible compared
+    // to the network round trip the caller is about to do.
+    let body_sel = match Selector::parse(".result__body") {
+        Ok(s) => s,
+        Err(_) => return Vec::new(),
+    };
+    let title_sel = Selector::parse(".result__a").ok();
+    let url_sel = Selector::parse(".result__url").ok();
+    let snippet_sel = Selector::parse(".result__snippet").ok();
+
     let mut results = Vec::new();
-    // Simple parser — looks for result_<id> divs in DuckDuckGo HTML
-    for chunk in html.split(r##"<div class="result__body">"##).skip(1) {
-        // Extract title
-        let title = chunk
-            .split(r##"class="result__a"##)
-            .nth(1)
-            .and_then(|s| s.split('>').nth(1))
-            .and_then(|s| s.split("</a>").next())
-            .unwrap_or("")
-            .trim()
-            .to_string();
-
-        // Extract URL
-        let url = chunk
-            .split(r##"class="result__url"##)
-            .nth(1)
-            .and_then(|s| s.split('>').nth(1))
-            .and_then(|s| s.split("</a>").next())
-            .unwrap_or("")
-            .trim()
-            .to_string();
-
-        // Extract snippet
-        let snippet = chunk
-            .split(r##"class="result__snippet"##)
-            .nth(1)
-            .and_then(|s| s.split('>').nth(1))
-            .and_then(|s| s.split("</a>").next())
-            .unwrap_or("")
-            .trim()
-            .to_string();
-
+    for body in document.select(&body_sel) {
+        let title = title_sel
+            .as_ref()
+            .and_then(|sel| body.select(sel).next())
+            .map(|el| collapse_ws(&el.text().collect::<String>()))
+            .unwrap_or_default();
+        let url = url_sel
+            .as_ref()
+            .and_then(|sel| body.select(sel).next())
+            .map(|el| collapse_ws(&el.text().collect::<String>()))
+            .unwrap_or_default();
+        let snippet = snippet_sel
+            .as_ref()
+            .and_then(|sel| body.select(sel).next())
+            .map(|el| collapse_ws(&el.text().collect::<String>()))
+            .unwrap_or_default();
         if !title.is_empty() {
             results.push(DdgResult {
                 title,
@@ -115,6 +119,12 @@ fn extract_ddg_results(html: &str) -> Vec<DdgResult> {
         }
     }
     results
+}
+
+/// Collapse runs of whitespace + trim. DDG inserts newlines + indent
+/// inside text nodes; the agent only needs a clean single-line string.
+fn collapse_ws(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
 /// YYC-256: minimum spacing between consecutive web-tool requests
@@ -387,14 +397,32 @@ mod tests {
 "##;
         let results = extract_ddg_results(html);
         assert_eq!(results.len(), 2);
-        // The hand-rolled parser can leave a `</a` tail on extracted
-        // strings — known fragility flagged by M3. We assert the
-        // useful part is present rather than exact equality so this
-        // test isn't held hostage to the parser's quirks.
-        assert!(results[0].title.starts_with("First Result"));
-        assert!(results[0].url.contains("first.example"));
-        assert!(results[0].snippet.starts_with("First snippet text."));
-        assert!(results[1].title.starts_with("Second Result"));
+        // YYC-252: scraper-backed parser produces clean strings —
+        // no trailing `</a` tail anymore.
+        assert_eq!(results[0].title, "First Result");
+        assert_eq!(results[0].url, "https://first.example/");
+        assert_eq!(results[0].snippet, "First snippet text.");
+        assert_eq!(results[1].title, "Second Result");
+    }
+
+    #[test]
+    fn yyc252_extract_ddg_results_handles_whitespace_and_nested_tags() {
+        // Real-world DDG injects extra whitespace + inline `<b>`
+        // highlight tags inside snippets. The CSS-selector path
+        // extracts the combined text and collapses whitespace.
+        let html = r##"
+<div class="result__body">
+  <a class="result__a" href="x">
+    Search   Result   Title
+  </a>
+  <a class="result__url" href="x">https://example.com/</a>
+  <span class="result__snippet">Hello <b>highlighted</b> world.</span>
+</div>
+"##;
+        let results = extract_ddg_results(html);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].title, "Search Result Title");
+        assert_eq!(results[0].snippet, "Hello highlighted world.");
     }
 
     #[test]


### PR DESCRIPTION
The hand-rolled `extract_ddg_results` walked through three fragile
`.split().nth().split().split().next()` chains per result block.
Anything DDG tweaked — whitespace inside an anchor, attribute
reordering, an inline `<b>` inside the snippet — broke the parser
silently.

Switch to `scraper`'s CSS selector engine: parse the document,
select `.result__body`, then `.result__a` / `.result__url` /
`.result__snippet` per block. Combined text nodes get whitespace-
collapsed via a small `collapse_ws` helper so the agent sees clean
single-line strings instead of the original DDG indentation.

The fixture-based test that previously had to tolerate a `</a`
tail (relaxed in YYC-257) now asserts exact equality. A new
test exercises the harder case: extra whitespace + an inline
`<b>` highlight tag inside a snippet — the new path produces
"Hello highlighted world." cleanly.

Backend selection (Brave / DDG IA API) deferred — DDG HTML
scraping continues to work; the new parser just isn't as fragile.

Adds `scraper = "0.26"` (uses `html5ever` + `selectors` from
servo).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>