### PR TITLE
YYC-269 (A5): share session init between buffered + streaming paths

### DIFF
--- a/src/agent/run.rs
+++ b/src/agent/run.rs
@@ -202,41 +202,16 @@ impl Agent {
     async fn run_prompt_body(&mut self, input: &str) -> Result<String> {
         let cancel = self.turn_cancel.clone();
 
-        let system = self
-            .prompt_builder
-            .build_system_prompt_with_context(&self.tools, Some(&self.tool_context));
-        let tool_defs = self
-            .tools
-            .definitions_with_context(Some(&self.tool_context));
-        let mut messages = vec![Message::System { content: system }];
-
-        // Load history for *this* agent's session — set by `resume_session` or
-        // `continue_last_session`; defaults to a fresh UUID so a new agent has
-        // empty history.
-        if let Some(history) = self.memory.load_history(&self.session_id)? {
-            for msg in history {
-                messages.push(msg);
-            }
-        }
-        // YYC-138: orphan Tool rows from a truncated previous turn would
-        // make the provider reject this request with "Tool message must
-        // follow tool_calls". Drop them on read; surface a warning so
-        // the underlying truncation can still be diagnosed.
-        let dropped = sanitize_orphan_tool_messages(&mut messages);
-        if dropped > 0 {
-            tracing::warn!("agent: dropped {dropped} orphan Tool message(s) from loaded history");
-            // Persist the cleaned snapshot so subsequent loads start clean.
-            self.replace_history(&messages)?;
-        }
-        self.last_saved_count = messages.len();
-
-        messages.push(Message::User {
-            content: input.to_string(),
-        });
-
-        // YYC-106: persist the user message immediately (mirrors the streaming
-        // path) so a non-terminal exit doesn't leave the turn unrecorded.
-        self.save_messages(&messages)?;
+        // YYC-269: share session init (system prompt + tool defs +
+        // history load + orphan-Tool sanitize + user-message persist)
+        // with the streaming path. The two used to duplicate ~30
+        // lines; bug fixes in one didn't propagate. Now both call
+        // `prepare_stream_turn` (a misnomer kept for now — the body
+        // is identical for both paths).
+        let StreamTurn {
+            mut messages,
+            tool_defs,
+        } = self.prepare_stream_turn(input, cancel.clone()).await?;
 
         let max_iter = if self.max_iterations > 0 {
             self.max_iterations as usize


### PR DESCRIPTION
Both `run_prompt_body` and `run_prompt_stream_body` opened a turn
the same way: build system prompt, collect tool defs, load history,
sanitize orphan tool messages from a previous truncation, push the
user message, persist immediately. The streaming path already
factored that into `prepare_stream_turn` returning a `StreamTurn`
struct; the buffered path duplicated ~30 lines inline.

Make `run_prompt_body` call `prepare_stream_turn` too. Bug fixes
that the streaming path got over time (YYC-138 orphan-tool sanitize,
YYC-106 immediate user-message persist) now apply to the buffered
path automatically — no more drift.

The full `turn_step` extraction the audit imagined would consolidate
the *iteration body* (compaction check, BeforePrompt, provider call,
tool dispatch, AfterToolCall, persistence). That's a much bigger cut:
the streaming path threads `ui_tx` and incremental `StreamEvent`
emission through every step, while the buffered path doesn't. Doing
it cleanly needs an abstraction over the response sink (a trait or
generic), and is filed-but-deferred to keep this PR mechanical.

`StreamTurn` is now a shared session-setup record despite the
prefix; rename + further dedup land in a follow-up under YYC-143.

Tests: 878 still pass.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>