### PR TITLE
YYC-216 (knowledge exclusion): [knowledge.exclusions] config + index-time filter

### DIFF
--- a/src/code/embed.rs
+++ b/src/code/embed.rs
@@ -51,6 +51,10 @@ pub struct EmbeddingIndex {
     fallback_base_url: String,
     fallback_api_key: Option<String>,
     client: reqwest::Client,
+    /// YYC-216: knowledge-governance exclusions compiled to a
+    /// glob-set so the indexer can skip sensitive paths at reindex
+    /// time. Empty `GlobSet` (default) excludes nothing.
+    excluder: globset::GlobSet,
 }
 
 impl EmbeddingIndex {
@@ -60,6 +64,28 @@ impl EmbeddingIndex {
         cfg: EmbeddingsConfig,
         fallback_base_url: String,
         fallback_api_key: Option<String>,
+    ) -> Result<Self> {
+        Self::open_with_excluder(
+            workspace_root,
+            parsers,
+            cfg,
+            fallback_base_url,
+            fallback_api_key,
+            globset::GlobSet::empty(),
+        )
+    }
+
+    /// YYC-216: open with an explicit knowledge-exclusion glob set.
+    /// Files whose workspace-relative path matches any glob are
+    /// skipped at reindex time. The plain `open` constructor is the
+    /// no-exclusion convenience for tests + legacy callers.
+    pub fn open_with_excluder(
+        workspace_root: PathBuf,
+        parsers: Arc<ParserCache>,
+        cfg: EmbeddingsConfig,
+        fallback_base_url: String,
+        fallback_api_key: Option<String>,
+        excluder: globset::GlobSet,
     ) -> Result<Self> {
         let db_path = db_path_for(&workspace_root)?;
         if let Some(parent) = db_path.parent() {
@@ -92,6 +118,7 @@ impl EmbeddingIndex {
             fallback_base_url,
             fallback_api_key,
             client: reqwest::Client::new(),
+            excluder,
         })
     }
 
@@ -182,15 +209,20 @@ impl EmbeddingIndex {
                 Some(l) => l,
                 None => continue,
             };
+            let rel_for_check = path.strip_prefix(&self.workspace_root).unwrap_or(path);
+            // YYC-216: skip files matching any knowledge-exclusion
+            // glob so sensitive paths never enter the embedding DB.
+            // Match against the workspace-relative path so patterns
+            // like `*.pem` and `secrets/**` work intuitively.
+            if self.excluder.is_match(rel_for_check) {
+                tracing::debug!("knowledge.exclusions: skipping {}", rel_for_check.display());
+                continue;
+            }
             let source = match std::fs::read_to_string(path) {
                 Ok(s) => s,
                 Err(_) => continue,
             };
-            let rel = path
-                .strip_prefix(&self.workspace_root)
-                .unwrap_or(path)
-                .to_string_lossy()
-                .into_owned();
+            let rel = rel_for_check.to_string_lossy().into_owned();
             let chunks = chunk_file(&self.parsers, lang, &rel, &source)?;
             files += 1;
             all_chunks.extend(chunks);
@@ -409,6 +441,48 @@ fn cosine(a: &[f32], b: &[f32]) -> f32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn build_excluder(patterns: &[&str]) -> globset::GlobSet {
+        let mut b = globset::GlobSetBuilder::new();
+        for p in patterns {
+            b.add(globset::Glob::new(p).expect("test glob compiles"));
+        }
+        b.build().expect("globset builds")
+    }
+
+    #[test]
+    fn yyc216_excluder_matches_typical_secret_patterns() {
+        let g = build_excluder(&["*.pem", "secrets/**", ".env"]);
+        assert!(g.is_match(".env"));
+        assert!(g.is_match("server.pem"));
+        assert!(g.is_match("secrets/aws.toml"));
+        assert!(g.is_match("secrets/nested/deep.txt"));
+        assert!(!g.is_match("src/main.rs"));
+        assert!(!g.is_match("README.md"));
+    }
+
+    #[test]
+    fn yyc216_empty_excluder_matches_nothing() {
+        let g = globset::GlobSet::empty();
+        assert!(!g.is_match(".env"));
+        assert!(!g.is_match("anything.rs"));
+    }
+
+    #[test]
+    fn yyc216_knowledge_config_compiles_valid_globs_and_skips_invalid() {
+        let cfg = crate::config::KnowledgeConfig {
+            exclusions: vec![
+                "*.pem".to_string(),
+                // Intentionally malformed glob — must not panic.
+                "[unbalanced".to_string(),
+                ".env".to_string(),
+            ],
+        };
+        let g = cfg.build_excluder();
+        assert!(g.is_match("server.pem"));
+        assert!(g.is_match(".env"));
+        assert!(!g.is_match("ok.rs"));
+    }
 
     #[test]
     fn vec_bytes_round_trip() {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -211,6 +211,51 @@ pub struct Config {
     /// legacy `[provider]` block (today's default).
     #[serde(default)]
     pub active_profile: Option<String>,
+
+    /// YYC-216: knowledge governance — exclusions that bar
+    /// sensitive paths from being indexed by the embeddings
+    /// store, code-graph, or any future retrieval layer.
+    #[serde(default)]
+    pub knowledge: KnowledgeConfig,
+}
+
+/// YYC-216: knowledge index governance. Today the only field is
+/// `exclusions`, a list of glob patterns that the indexer skips at
+/// reindex time so sensitive files (e.g. `.env`, `*.pem`,
+/// `secrets/`) never enter the embedding/code-graph DBs in the
+/// first place. Per-workspace overrides land alongside the trust
+/// profile in a follow-up.
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct KnowledgeConfig {
+    /// Glob patterns matched against the path *relative to the
+    /// workspace root*. Standard `globset` syntax — `*` matches a
+    /// single path segment, `**` matches multiple, `?` matches one
+    /// character. Lines starting with `#` aren't supported here
+    /// (this is a TOML array, not a `.gitignore` file).
+    #[serde(default)]
+    pub exclusions: Vec<String>,
+}
+
+impl KnowledgeConfig {
+    /// Compile the exclusion patterns into a `GlobSet` for matching
+    /// during indexing. Invalid patterns are logged and skipped so
+    /// one typo doesn't stop the whole indexer.
+    pub fn build_excluder(&self) -> globset::GlobSet {
+        let mut builder = globset::GlobSetBuilder::new();
+        for pat in &self.exclusions {
+            match globset::Glob::new(pat) {
+                Ok(g) => {
+                    builder.add(g);
+                }
+                Err(e) => {
+                    tracing::warn!("knowledge.exclusions: invalid glob `{pat}`: {e}");
+                }
+            }
+        }
+        builder
+            .build()
+            .unwrap_or_else(|_| globset::GlobSet::empty())
+    }
 }
 
 impl Config {
@@ -1045,6 +1090,7 @@ impl Default for Config {
             workspace_trust: crate::trust::WorkspaceTrustConfig::default(),
             extensions: ExtensionsConfig::default(),
             active_profile: None,
+            knowledge: KnowledgeConfig::default(),
         }
     }
 }
@@ -1134,6 +1180,7 @@ impl Config {
             "workspace_trust",
             "extensions",
             "active_profile",
+            "knowledge",
         ];
         let Ok(value) = toml::from_str::<toml::Value>(raw) else {
             return Vec::new();


### PR DESCRIPTION
YYC-194 PR-1 + PR-2 shipped store discovery + purge. The remaining
governance gap was that sensitive paths could enter the embedding
DB at index time — `.env`, `*.pem`, `secrets/**` were all fair
game once `cargo run` reindexed.

This PR closes the index-side hole:

- New `KnowledgeConfig { exclusions: Vec<String> }` on `Config`,
  serialized at `[knowledge]` in `config.toml`. Standard `globset`
  syntax (matches against the workspace-relative path).
- `KnowledgeConfig::build_excluder()` compiles patterns to a
  `GlobSet`. Invalid patterns log a warning and are skipped — one
  typo doesn't kill the whole indexer.
- `EmbeddingIndex::open_with_excluder` takes the compiled set;
  `open` keeps its pre-existing signature for tests + legacy
  callers (defaults to empty set).
- `reindex` checks each candidate file against the excluder before
  reading + chunking. Skipped paths log at `debug` so an operator
  can confirm the rule fired.
- `KNOWN` top-level keys list updated so the unknown-key warning
  doesn't fire on `[knowledge]`.

Out of scope (filed as follow-up):
- `vulcan knowledge why <hit>` retrieval-provenance CLI. That
  needs richer metadata threaded through `EmbeddingHit` + a new
  CLI surface, both bigger than this PR's scope.
- Per-workspace overrides (alongside the trust profile).

3 tests cover the typical secret-pattern set, empty excluder, and
the invalid-glob graceful-skip path.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>