### PR TITLE
YYC-219 (context-pack list/show CLI): inspect packs from the command line

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -110,6 +110,14 @@ pub enum Command {
         #[command(subcommand)]
         cmd: KnowledgeSubcommand,
     },
+    /// YYC-219: inspect named context packs (curated bundles of
+    /// project files + notes used to brief the agent on a task
+    /// area). `list` shows every pack; `show <name>` prints the
+    /// resolved citation list.
+    ContextPack {
+        #[command(subcommand)]
+        cmd: ContextPackSubcommand,
+    },
     /// YYC-212: unified config CLI. List, get, and inspect every
     /// known config field by dotted path.
     Config {
@@ -396,6 +404,18 @@ pub enum ConfigSubcommand {
     Unset {
         /// Dotted field path.
         key: String,
+    },
+}
+
+/// YYC-219: subcommands under `vulcan context-pack`.
+#[derive(Subcommand, Debug)]
+pub enum ContextPackSubcommand {
+    /// List every available context pack (built-in + user-defined).
+    List,
+    /// Render a single pack's citation list to stdout.
+    Show {
+        /// Pack name. Case-insensitive match against the catalog.
+        name: String,
     },
 }
 

--- a/src/cli_context_pack.rs
+++ b/src/cli_context_pack.rs
@@ -1,0 +1,66 @@
+//! YYC-219: `vulcan context-pack list` / `vulcan context-pack show <name>`.
+//!
+//! Surfaces the built-in context pack catalog (`crate::context_pack`)
+//! so users can see what's available before adding `--context-pack`
+//! to a `vulcan prompt` invocation.
+
+use anyhow::Result;
+
+use crate::cli::ContextPackSubcommand;
+use crate::context_pack::{builtin_packs, lookup, render_pack_summary};
+
+pub async fn run(cmd: ContextPackSubcommand) -> Result<()> {
+    match cmd {
+        ContextPackSubcommand::List => list(),
+        ContextPackSubcommand::Show { name } => show(&name),
+    }
+}
+
+fn list() -> Result<()> {
+    let packs = builtin_packs();
+    if packs.is_empty() {
+        println!("(no packs)");
+        return Ok(());
+    }
+    println!("{:<16} {}", "name", "description");
+    for pack in &packs {
+        println!("{:<16} {}", pack.name, pack.description);
+    }
+    Ok(())
+}
+
+fn show(name: &str) -> Result<()> {
+    let pack = lookup(name)
+        .ok_or_else(|| anyhow::anyhow!("context pack `{name}` not found. Run `vulcan context-pack list` to see available packs."))?;
+    print!("{}", render_pack_summary(&pack));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn list_runs_without_error() {
+        run(ContextPackSubcommand::List).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn show_returns_error_for_unknown_pack() {
+        let err = run(ContextPackSubcommand::Show {
+            name: "definitely-not-a-real-pack-xyz".into(),
+        })
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn show_succeeds_for_builtin() {
+        run(ContextPackSubcommand::Show {
+            name: "gateway".into(),
+        })
+        .await
+        .unwrap();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod cli;
 pub mod cli_artifact;
 pub mod cli_auth;
 pub mod cli_config;
+pub mod cli_context_pack;
 pub mod cli_extension;
 #[cfg(feature = "gateway")]
 pub mod cli_gateway;

--- a/src/main.rs
+++ b/src/main.rs
@@ -191,6 +191,10 @@ async fn main() -> anyhow::Result<()> {
             init_cli_logging();
             vulcan::cli_knowledge::run(cmd).await?;
         }
+        Some(Command::ContextPack { cmd }) => {
+            init_cli_logging();
+            vulcan::cli_context_pack::run(cmd).await?;
+        }
         Some(Command::Config { cmd }) => {
             init_cli_logging();
             vulcan::cli_config::run(cmd).await?;


### PR DESCRIPTION
YYC-188 PR-1 (#388) shipped the `ContextPack` types + 5 built-ins
(`gateway` / `hooks` / `tui` / `provider` / `review`) plus
`render_pack_summary`. Users had no way to see the catalog without
reading source.

Add `vulcan context-pack list` (table of name + description) and
`vulcan context-pack show <name>` (renders the citation list via
`render_pack_summary`). Both honor case-insensitive name lookup
already provided by `lookup`.

Out of scope (filed for follow-up):
- `--context-pack <name>` flag wiring on `Agent::builder`.
- BeforePrompt hook injection.
- `RunEvent::ContextPackResolved` annotation on run records.
- User-defined packs in config (`[context_packs.<name>]`).
- Token-budget pruning during resolve.

Each of those touches the agent loop or the run-record schema and
is bigger than the CLI surface deserves on its own.

3 tests cover happy-path list, unknown-pack error, builtin show.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>