### PR TITLE
YYC-222 (replay safety): Tool::replay_safety() classification

### DIFF
--- a/src/tools/file.rs
+++ b/src/tools/file.rs
@@ -1,5 +1,5 @@
 use crate::pause::{AgentPause, AgentResume, DiffScrubHunk, PauseKind, PauseSender};
-use crate::tools::{Tool, ToolResult, fs_sandbox};
+use crate::tools::{ReplaySafety, Tool, ToolResult, fs_sandbox};
 use anyhow::Result;
 use async_trait::async_trait;
 use serde_json::{Value, json};
@@ -32,6 +32,10 @@ const WRITE_FILE_MAX_CONTENT_BYTES: usize = 5 * 1024 * 1024;
 impl Tool for ReadFile {
     fn name(&self) -> &str {
         "read_file"
+    }
+    fn replay_safety(&self) -> ReplaySafety {
+        // Pure file read — safe to actually run during tool-replay.
+        ReplaySafety::ReadOnly
     }
     fn description(&self) -> &str {
         "Read a file from the filesystem. Returns content with line numbers. Use this instead of `cat`, `head`, `tail`, or `sed -n` via bash."
@@ -137,6 +141,9 @@ pub struct ListFiles;
 impl Tool for ListFiles {
     fn name(&self) -> &str {
         "list_files"
+    }
+    fn replay_safety(&self) -> ReplaySafety {
+        ReplaySafety::ReadOnly
     }
     fn description(&self) -> &str {
         "List files + directories under a path as a structured tree (JSON). Respects .gitignore. Use this instead of `ls`, `tree`, or `find -type f` via bash — won't drown in target/ or node_modules/."
@@ -430,6 +437,9 @@ pub struct SearchFiles;
 impl Tool for SearchFiles {
     fn name(&self) -> &str {
         "search_files"
+    }
+    fn replay_safety(&self) -> ReplaySafety {
+        ReplaySafety::ReadOnly
     }
     fn description(&self) -> &str {
         "Search file contents using regex patterns. Ripgrep-style, gitignore-aware. Use this instead of `rg`, `grep -r`, or `grep -rn` via bash."
@@ -866,6 +876,19 @@ mod tests {
             }
         }
         false
+    }
+
+    #[test]
+    fn yyc222_replay_safety_classifies_each_file_tool() {
+        assert_eq!(ReadFile.replay_safety(), ReplaySafety::ReadOnly);
+        assert_eq!(ListFiles.replay_safety(), ReplaySafety::ReadOnly);
+        assert_eq!(SearchFiles.replay_safety(), ReplaySafety::ReadOnly);
+        // Mutating defaults — pinned so a future refactor that
+        // accidentally drops these tools' overrides still flags
+        // here as a regression. WriteFile / PatchFile use the
+        // trait default (Mutating), which is the correct posture.
+        assert_eq!(WriteFile::new(None).replay_safety(), ReplaySafety::Mutating);
+        assert_eq!(PatchFile::new(None).replay_safety(), ReplaySafety::Mutating);
     }
 
     #[tokio::test]

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -80,6 +80,39 @@ impl From<&str> for ToolResult {
     }
 }
 
+/// YYC-222: replay-safety classification for a tool.
+///
+/// `ReadOnly` — pure observation; safe to actually re-run during a
+///   tool-replay pass (file reads, list dirs, search, embeddings
+///   queries). The tool's output may differ from the recording if
+///   the workspace has changed since the original run; replay
+///   diffing surfaces that drift.
+///
+/// `Mutating` — touches local state (writes a file, edits a config,
+///   spawns a child process whose effect outlives the call). Replay
+///   refuses to re-run these live; the mock output is used.
+///
+/// `External` — reaches the network or any third-party system whose
+///   side-effects can't be undone (web fetch, gateway dispatch). A
+///   live re-run requires explicit user opt-in beyond the normal
+///   replay confirmation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReplaySafety {
+    ReadOnly,
+    Mutating,
+    External,
+}
+
+impl ReplaySafety {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ReplaySafety::ReadOnly => "read_only",
+            ReplaySafety::Mutating => "mutating",
+            ReplaySafety::External => "external",
+        }
+    }
+}
+
 #[async_trait::async_trait]
 pub trait Tool: Send + Sync {
     fn name(&self) -> &str;
@@ -103,6 +136,17 @@ pub trait Tool: Send + Sync {
     /// workspace-derived context (e.g. discovered bin targets).
     fn dynamic_description(&self, _ctx: &ToolContext) -> Option<String> {
         None
+    }
+
+    /// YYC-222: classify how a replay engine should treat this tool.
+    /// The default is the conservative one — if a tool's author
+    /// hasn't thought about replay safety, the replay machinery
+    /// should refuse to re-run it live and stick to mocked output.
+    /// Read-only tools (file reads, code-graph queries) can be
+    /// re-run safely against the recorded inputs; external tools
+    /// (web fetch, network ops) need explicit user consent.
+    fn replay_safety(&self) -> ReplaySafety {
+        ReplaySafety::Mutating
     }
 }
 

--- a/src/tools/web.rs
+++ b/src/tools/web.rs
@@ -1,4 +1,4 @@
-use crate::tools::{Tool, ToolResult, web_ssrf};
+use crate::tools::{ReplaySafety, Tool, ToolResult, web_ssrf};
 use anyhow::Result;
 use async_trait::async_trait;
 use serde_json::{Value, json};
@@ -13,6 +13,11 @@ pub struct WebSearch;
 impl Tool for WebSearch {
     fn name(&self) -> &str {
         "web_search"
+    }
+    fn replay_safety(&self) -> ReplaySafety {
+        // Hits an external service; replay should not silently
+        // re-run without explicit user opt-in.
+        ReplaySafety::External
     }
     fn description(&self) -> &str {
         "Search the web for information. Returns up to 5 results with titles, URLs, and descriptions."
@@ -235,6 +240,9 @@ impl Tool for WebFetch {
     fn name(&self) -> &str {
         "web_fetch"
     }
+    fn replay_safety(&self) -> ReplaySafety {
+        ReplaySafety::External
+    }
     fn description(&self) -> &str {
         "Fetch the content of a URL and extract it as markdown text."
     }
@@ -363,6 +371,12 @@ fn naive_strip_tags(html: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn yyc222_web_tools_are_classified_external() {
+        assert_eq!(WebSearch.replay_safety(), ReplaySafety::External);
+        assert_eq!(WebFetch.replay_safety(), ReplaySafety::External);
+    }
 
     #[test]
     fn yyc257_extract_ddg_results_parses_titles_urls_snippets() {


### PR DESCRIPTION
YYC-184's replay roadmap needed a way for the future tool-replay
engine to know which tools it can safely re-run live versus which
must use the recorded mock output. Adding the trait method now —
the classifier — unblocks that work without committing to the
replay execution machinery itself.

`ReplaySafety` enum:

- `ReadOnly` — pure observation; safe to re-run during replay
  (read_file / list_files / search_files / future code-graph
  lookups).
- `Mutating` — touches local state (write/edit, spawn). Replay
  refuses to re-run live; mock output stands.
- `External` — reaches the network or third-party systems whose
  side-effects can't be undone (web_fetch, web_search). Live
  re-run requires explicit user opt-in beyond the normal replay
  confirmation.

Default is `Mutating` — the conservative posture for any tool
whose author hasn't explicitly considered replay safety.

Per-tool overrides:
- `read_file` / `list_files` / `search_files` → `ReadOnly`.
- `web_search` / `web_fetch` → `External`.
- `write_file` / `edit_file` keep the `Mutating` default.

Tests pin both directions (read-only set + external set + the
mutating defaults haven't drifted).

The mock-replay / tool-replay execution machinery and the diff
view between original and replay records remain deferred — they
plug into this classifier in follow-up PRs.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>