### PR TITLE
ci: drop --all-targets from nextest run; benches time out as tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,13 @@ jobs:
       - uses: taiki-e/install-action@nextest
       - name: Build
         run: cargo build --all-targets --features "${{ matrix.features }}"
+      # Test target set excludes `--benches` deliberately. The divan
+      # benches (`tui_render`, `agent_core`) are measurement loops, not
+      # tests — under nextest they hit the 120s per-test timeout, retry
+      # 3x, and break the test run. Benches get exercised by `cargo bench`
+      # in `bench.yml`, not here.
       - name: Test (nextest)
-        run: cargo nextest run --profile ci --all-targets --features "${{ matrix.features }}"
+        run: cargo nextest run --profile ci --lib --bins --tests --features "${{ matrix.features }}"
       - name: Doc tests
         run: cargo test --doc --features "${{ matrix.features }}"
       - name: Upload junit


### PR DESCRIPTION
`cargo nextest run --all-targets` picks up `[[bench]] tui_render` and
`[[bench]] agent_core` as test binaries. Divan registers each
`#[divan::bench(args = ARGS)]` invocation as a libtest-shaped "test";
bench bodies are measurement loops that don't bound their runtime, so
each hits the 120s nextest timeout, retries 3x (per the `ci` profile),
and fails the whole run.

Replace `--all-targets` with the explicit `--lib --bins --tests` set
so bench targets stay out of the test runner. Benches still run via
`cargo bench` in `bench.yml`.