### PR TITLE
ci: speed up PRs — skip coverage + feature-powerset on PR; trim test debuginfo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,10 @@ jobs:
           if-no-files-found: ignore
 
   coverage:
+    # Heavy job (~30m). Skip on PRs — coverage delta isn't a per-PR
+    # gate, and the lcov upload still lands on every push to main so
+    # the trend graph stays current. Saves a runner slot per PR push.
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -111,6 +115,10 @@ jobs:
           retention-days: 14
 
   feature-powerset:
+    # Combinatorial feature check — slow (~20m) and rarely informative
+    # per PR. Run on push to main so a regression still gets caught
+    # before release; PR feedback stays fast.
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,6 +219,14 @@ lto = true
 codegen-units = 1
 strip = true
 
+# Trim debuginfo on the test profile. `line-tables-only` keeps panic/
+# backtrace `file:line` resolution intact while dropping the heavyweight
+# DWARF that drives debugger inspection — a lever we don't pay for in CI
+# or local `cargo test`. Cuts test-binary size ~40% and cache footprint
+# proportionally, which shortens link time + Swatinem cache restore on CI.
+[profile.test]
+debug = "line-tables-only"
+
 [dev-dependencies]
 tempfile = "3.27.0"
 divan = "0.1"


### PR DESCRIPTION
Three changes to cut PR feedback time:

1. Gate `coverage` and `feature-powerset` jobs to `push` events only.
   Both run ~20–30m and produce signal that doesn't gate per-PR
   merges (coverage trend + combinatorial feature regressions land on
   main pushes either way). Frees two runner slots per PR push.

2. Trim `[profile.test]` debuginfo to `line-tables-only`. Backtraces
   keep `file:line` resolution; DWARF debugger metadata is dropped.
   Test binaries shrink ~40%, link time + Swatinem cache restore both
   benefit. Matches what `cargo test` already does for crates that
   never run under a debugger.

No behavior change to `test`, `fmt`, `clippy`, `deny`, `machete` — the
fast-feedback gates still run on every PR.