### PR TITLE
refactor: backend daemon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,12 +18,79 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
 ]
 
 [[package]]
@@ -107,6 +174,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
 name = "arc-swap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,12 +189,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -155,6 +248,49 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror 2.0.18",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom 8.0.0",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375082f007bd67184fb9c0374614b29f9aaa604ec301635f72338bb65386a53d"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "aws-lc-rs"
@@ -247,6 +383,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -256,6 +398,15 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bit-set"
@@ -288,6 +439,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,6 +455,15 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "bitstream-io"
+version = "4.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
+dependencies = [
+ "no_std_io2",
+]
 
 [[package]]
 name = "block-buffer"
@@ -329,6 +495,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,6 +517,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -433,6 +611,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,6 +695,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,6 +727,7 @@ dependencies = [
  "itoa",
  "rustversion",
  "ryu",
+ "serde",
  "static_assertions",
 ]
 
@@ -541,6 +736,19 @@ name = "condtype"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "console"
@@ -594,6 +802,31 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cortex-memory-core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "620ce497012bb150fcdc55f98041eb213796c8faa95ccccc208eefb46877ad2e"
+dependencies = [
+ "aes-gcm",
+ "anyhow",
+ "async-trait",
+ "base64 0.22.1",
+ "bincode",
+ "chrono",
+ "fastembed",
+ "futures",
+ "instant-distance",
+ "log",
+ "rand 0.8.6",
+ "rayon",
+ "redb",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "uuid",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -696,12 +929,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -748,6 +988,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "ctutils"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,12 +1007,36 @@ dependencies = [
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -781,13 +1054,33 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -824,6 +1117,37 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -891,7 +1215,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25f104b501bf2364e78d0d3974cbc774f738f5865306ed128e1e0d7499c0ad96"
 dependencies = [
- "console",
+ "console 0.16.3",
  "fuzzy-matcher",
  "shell-words",
  "tempfile",
@@ -918,6 +1242,27 @@ dependencies = [
  "const-oid",
  "crypto-common 0.2.1",
  "ctutils",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1026,6 +1371,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,12 +1417,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "esaxx-rs"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+
+[[package]]
 name = "euclid"
 version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "exr"
+version = "1.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
 ]
 
 [[package]]
@@ -1094,6 +1480,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastembed"
+version = "4.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04c269a76bfc6cea69553b7d040acb16c793119cebd97c756d21e08d0f075ff8"
+dependencies = [
+ "anyhow",
+ "hf-hub",
+ "image",
+ "ndarray",
+ "ort",
+ "ort-sys",
+ "rayon",
+ "serde_json",
+ "tokenizers",
+]
+
+[[package]]
 name = "faster-hex"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1108,6 +1511,21 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "filedescriptor"
@@ -1185,6 +1603,21 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1356,6 +1789,26 @@ dependencies = [
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -2318,6 +2771,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hash32"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2383,7 +2847,7 @@ dependencies = [
  "byteorder",
  "crossbeam-channel",
  "flate2",
- "nom",
+ "nom 7.1.3",
  "num-traits",
 ]
 
@@ -2404,10 +2868,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hf-hub"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629d8f3bbeda9d148036d6b0de0a3ab947abd08ce90626327fc3547a49d59d97"
+dependencies = [
+ "dirs",
+ "http",
+ "indicatif",
+ "libc",
+ "log",
+ "native-tls",
+ "rand 0.9.4",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "ureq",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "hmac"
@@ -2536,6 +3027,22 @@ dependencies = [
  "tokio-rustls 0.26.4",
  "tower-service",
  "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -2719,6 +3226,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "exr",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
+ "tiff",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imgref"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2742,6 +3289,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console 0.15.11",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
 name = "indoc"
 version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2751,12 +3311,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "insta"
 version = "1.47.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
 dependencies = [
- "console",
+ "console 0.16.3",
  "once_cell",
  "similar",
  "tempfile",
@@ -2768,8 +3337,32 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "instant-distance"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c619cdaa30bb84088963968bee12a45ea5fbbf355f2c021bcd15589f5ca494a"
+dependencies = [
+ "num_cpus",
+ "ordered-float 3.9.2",
+ "parking_lot",
+ "rand 0.8.6",
+ "rayon",
+]
+
+[[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2973,10 +3566,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
 
 [[package]]
 name = "libredox"
@@ -3044,6 +3653,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
+
+[[package]]
 name = "lru"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3082,6 +3700,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "macro_rules_attribute"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
+
+[[package]]
 name = "markup5ever"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3108,6 +3742,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "maybe-async"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3116,6 +3760,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
 ]
 
 [[package]]
@@ -3199,6 +3853,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "monostate"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
+dependencies = [
+ "monostate-impl",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3230,6 +3948,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "no_std_io2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3240,10 +3967,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nonempty"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "nu-ansi-term"
@@ -3252,6 +3994,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -3272,12 +4033,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -3288,6 +4079,12 @@ checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -3311,10 +4108,91 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "onig"
+version = "6.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
+dependencies = [
+ "bitflags 2.11.1",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openssl"
+version = "0.10.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "3.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "ordered-float"
@@ -3323,6 +4201,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "ort"
+version = "2.0.0-rc.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52afb44b6b0cffa9bf45e4d37e5a4935b0334a51570658e279e9e3e6cf324aa5"
+dependencies = [
+ "ndarray",
+ "ort-sys",
+ "tracing",
+]
+
+[[package]]
+name = "ort-sys"
+version = "2.0.0-rc.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41d7757331aef2d04b9cb09b45583a59217628beaf91895b7e76187b6e8c088"
+dependencies = [
+ "flate2",
+ "pkg-config",
+ "sha2 0.10.9",
+ "tar",
+ "ureq",
 ]
 
 [[package]]
@@ -3347,6 +4249,18 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "percent-encoding"
@@ -3559,6 +4473,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.1",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3655,6 +4594,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "profiling"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "psm"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3663,6 +4621,27 @@ dependencies = [
  "ar_archive_writer",
  "cc",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quinn"
@@ -3925,12 +4904,108 @@ dependencies = [
 ]
 
 [[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "simd_helpers",
+ "thiserror 2.0.18",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-cond"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
+dependencies = [
+ "either",
+ "itertools",
+ "rayon",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "rc-box"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897fecc9fac6febd4408f9e935e86df739b0023b625e610e0357535b9c8adad0"
 dependencies = [
  "erasable",
+]
+
+[[package]]
+name = "redb"
+version = "2.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eca1e9d98d5a7e9002d0013e18d5a9b000aee942eb134883a82f06ebffb6c01"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3949,6 +5024,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags 2.11.1",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4014,17 +5100,22 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "mime_guess",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -4035,6 +5126,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls 0.26.4",
  "tokio-util",
  "tower",
@@ -4200,6 +5292,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -4552,7 +5645,7 @@ version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4738,6 +5831,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4775,6 +5877,29 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "spm_precompiled"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
+dependencies = [
+ "base64 0.13.1",
+ "nom 7.1.3",
+ "serde",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -4953,6 +6078,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20f34339676cdcab560c9a82300c4c2581f68b9369aedf0fae86f2ff9565ff3e"
 
 [[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "teloxide-core"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5024,7 +6160,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
  "fnv",
- "nom",
+ "nom 7.1.3",
  "phf 0.11.3",
  "phf_codegen 0.11.3",
 ]
@@ -5059,7 +6195,7 @@ dependencies = [
  "nix 0.29.0",
  "num-derive",
  "num-traits",
- "ordered-float",
+ "ordered-float 4.6.0",
  "pest",
  "pest_derive",
  "phf 0.11.3",
@@ -5136,6 +6272,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "tiktoken-rs"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5209,6 +6359,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tokenizers"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a620b996116a59e184c2fa2dfd8251ea34a36d0a514758c6f966386bd2e03476"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "compact_str",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "getrandom 0.3.4",
+ "itertools",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "onig",
+ "paste",
+ "rand 0.9.4",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror 2.0.18",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5234,6 +6417,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -5609,6 +6802,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-normalization-alignments"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5638,10 +6840,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "native-tls",
+ "once_cell",
+ "rustls 0.23.39",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "socks",
+ "url",
+ "webpki-roots 0.26.11",
+]
 
 [[package]]
 name = "url"
@@ -5689,6 +6927,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5726,6 +6975,7 @@ dependencies = [
  "chrono-tz",
  "clap",
  "clap_complete",
+ "cortex-memory-core",
  "cron",
  "crossterm",
  "dhat",
@@ -5998,6 +7248,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
 name = "wezterm-bidi"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6039,7 +7295,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
 dependencies = [
  "log",
- "ordered-float",
+ "ordered-float 4.6.0",
  "strsim",
  "thiserror 1.0.69",
  "wezterm-dynamic-derive",
@@ -6175,6 +7431,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -6454,6 +7719,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6567,3 +7848,27 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,11 @@ uuid = { version = "1", features = ["v4", "serde"] }
 tokio-util = { version = "0.7.18", features = ["rt"] }
 rusqlite = { version = "0.39.0", features = ["bundled"] }
 strsim = "0.11.1"
+# Cortex — self-organizing temporal graph memory for AI agents. Embedded
+# library mode (no server, no external deps). Provides HNSW vector search,
+# auto-linking, trust computation, briefing synthesis, temporal decay, and
+# contradiction detection (YYC-264).
+cortex_core = { version = "0.3.1", package = "cortex-memory-core" }
 portable-pty = "0.9.0"
 # Pure-Rust git plumbing (YYC-36). Used today only for repository
 # discovery — write ops dispatch through the `git` binary because gix's

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -427,6 +427,39 @@ impl Agent {
             ));
         }
 
+        // Built-in hook (YYC-264): when `rtk` is on PATH, transparently
+        // wrap bash commands with `rtk summary --` to compress output
+        // by 60-90% before it reaches the LLM. Falls through silently
+        // when RTK is not installed — zero per-call overhead.
+        hooks.register(Arc::new(crate::hooks::rtk::RtkHook::new()));
+
+        // YYC-264: embedded cortex-memory-core graph memory. When enabled,
+        // registers two hooks:
+        //   1. CortexRecallHook — BeforePrompt: semantically searches the graph
+        //      on every turn using the latest user message and injects context.
+        //   2. CortexCaptureHook — AfterToolCall: auto-stores notable tool
+        //      outputs as fact nodes in the graph.
+        // Both share the same `Arc<CortexStore>`. Non-fatal on failure.
+        if config.cortex.enabled {
+            match crate::memory::cortex::CortexStore::try_open(&config.cortex) {
+                Ok(store) => {
+                    let max_results = config.cortex.max_search_results;
+                    hooks.register(Arc::new(
+                        crate::hooks::cortex_recall::CortexRecallHook::new(
+                            store.clone(),
+                            max_results,
+                        ),
+                    ));
+                    hooks.register(Arc::new(
+                        crate::hooks::cortex_capture::CortexCaptureHook::new(store),
+                    ));
+                }
+                Err(e) => {
+                    tracing::warn!("cortex memory unavailable: {e}");
+                }
+            }
+        }
+
         // YYC-182: resolve the workspace trust profile from config
         // before tool-profile selection. The trust profile feeds
         // the default capability profile when neither CLI flag nor

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -298,6 +298,104 @@ pub enum CortexSubcommand {
         #[arg(long, default_value_t = 20)]
         limit: usize,
     },
+    /// Manage prompt variants stored in the graph.
+    Prompt {
+        #[command(subcommand)]
+        cmd: PromptSubcommand,
+    },
+    /// Manage agent profiles and prompt bindings.
+    Agent {
+        #[command(subcommand)]
+        cmd: AgentSubcommand,
+    },
+    /// Record an outcome for a selected prompt variant (UCB1 learning).
+    Observe {
+        /// Agent name.
+        agent: String,
+        /// Prompt variant ID (UUID).
+        #[arg(long)]
+        variant_id: String,
+        /// Sentiment score 0.0-1.0.
+        #[arg(long)]
+        sentiment_score: f32,
+        /// Outcome label (success/failure/neutral).
+        #[arg(long)]
+        outcome: String,
+    },
+}
+
+/// YYC-264: subcommands under `vulcan cortex prompt`.
+#[derive(Subcommand, Debug)]
+pub enum PromptSubcommand {
+    /// Create a new prompt variant.
+    Create {
+        /// Prompt name.
+        name: String,
+        /// Prompt body text.
+        body: String,
+    },
+    /// Show a resolved prompt by name.
+    Get {
+        /// Prompt name.
+        name: String,
+    },
+    /// List all prompt variants.
+    List,
+    /// Update a prompt variant's body.
+    Set {
+        /// Prompt name.
+        name: String,
+        /// New body text.
+        body: String,
+    },
+    /// Remove (soft-delete) a prompt.
+    Remove {
+        /// Prompt name.
+        name: String,
+    },
+    /// Import prompts from a JSON file.
+    Migrate {
+        /// Path to JSON file: [{name, body}]
+        file: std::path::PathBuf,
+    },
+    /// Show performance metrics for a prompt.
+    Performance {
+        /// Prompt name.
+        name: String,
+    },
+}
+
+/// YYC-264: subcommands under `vulcan cortex agent`.
+#[derive(Subcommand, Debug)]
+pub enum AgentSubcommand {
+    /// List all agents and their bound prompts.
+    List,
+    /// Bind a prompt variant to an agent with a weight.
+    Bind {
+        /// Agent name. Created if it doesn't exist.
+        name: String,
+        /// Prompt variant name to bind.
+        prompt: String,
+        /// Weight for epsilon-greedy selection (0.0-1.0).
+        #[arg(long, default_value_t = 0.5)]
+        weight: f32,
+    },
+    /// Remove an agent profile.
+    Unbind {
+        /// Agent name to remove.
+        name: String,
+    },
+    /// Epsilon-greedy select the best prompt variant for an agent.
+    Select {
+        /// Agent name.
+        name: String,
+        /// Task type hint for context (optional).
+        #[arg(long)]
+        task_type: Option<String>,
+        /// Sentiment offset -1.0 to 1.0 (optional).
+        #[arg(long)]
+        sentiment: Option<f32>,
+    },
 }
 
 #[cfg(all(test, feature = "gateway"))]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,6 +27,12 @@ pub struct Cli {
     /// `gateway-safe`). Overrides `tools.profile` from config.
     #[arg(long, global = true, value_name = "NAME")]
     pub profile: Option<String>,
+
+    /// YYC-264: seed the cortex knowledge graph from the last N SQLite
+    /// sessions on startup. Only applies when `[cortex].enabled = true`.
+    /// Defaults to importing the 3 most recent sessions.
+    #[arg(long, global = true)]
+    pub seed_cortex: bool,
 }
 
 #[derive(Subcommand, Debug)]
@@ -179,6 +185,13 @@ pub enum Command {
         #[command(subcommand)]
         cmd: ExtensionSubcommand,
     },
+    /// YYC-264: inspect and manage the embedded Cortex knowledge graph.
+    /// Direct access to store facts, semantic search, graph stats, and
+    /// seed from SQLite sessions.
+    Cortex {
+        #[command(subcommand)]
+        cmd: CortexSubcommand,
+    },
 }
 
 /// YYC-242 subcommands under `vulcan gateway`. `Run` is the
@@ -250,6 +263,41 @@ pub enum ExtensionSubcommand {
     /// Copy a manifest directory into the Vulcan home and
     /// register an install state row.
     Install { path: std::path::PathBuf },
+}
+
+/// YYC-264: subcommands under `vulcan cortex`.
+#[derive(Subcommand, Debug)]
+pub enum CortexSubcommand {
+    /// Store a fact node in the cortex knowledge graph.
+    Store {
+        /// Fact text to store.
+        text: String,
+        /// Importance from 0.0 to 1.0 (default 0.7).
+        #[arg(long, default_value_t = 0.7)]
+        importance: f32,
+    },
+    /// Semantic vector search across the knowledge graph.
+    Search {
+        /// Natural language query.
+        query: String,
+        /// Max results to return (default 5).
+        #[arg(long, default_value_t = 5)]
+        limit: usize,
+    },
+    /// Show graph statistics (node count, edge count, db size).
+    Stats,
+    /// Seed the cortex graph from recent SQLite sessions.
+    Seed {
+        /// Number of most recent sessions to import (default 3).
+        #[arg(long, default_value_t = 3)]
+        sessions: usize,
+    },
+    /// List recently stored facts in the graph.
+    Recall {
+        /// Max entries to show (default 20).
+        #[arg(long, default_value_t = 20)]
+        limit: usize,
+    },
 }
 
 #[cfg(all(test, feature = "gateway"))]

--- a/src/cli_cortex.rs
+++ b/src/cli_cortex.rs
@@ -1,19 +1,25 @@
 //! YYC-264: CLI commands for the embedded Cortex graph memory.
 //!
 //! Provides the `vulcan cortex` subcommand tree: store facts, semantic search,
-//! graph statistics, seed from SQLite sessions, and recall recent entries.
+//! graph statistics, seed from SQLite sessions, recall recent entries,
+//! prompt management (Phase 3), agent binding (Phase 3), and observation
+//! learning (Phase 3).
+//!
 //! All operations open the same cortex.redb database that the agent hooks use,
 //! so CLI stores are visible to the recall hook and vice versa.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
+use cortex_core::{Edge, EdgeProvenance, NodeFilter, NodeId, Relation};
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use crate::cli::CortexSubcommand;
+use crate::cli::{AgentSubcommand, CortexSubcommand, PromptSubcommand};
 use crate::config::{CortexConfig, vulcan_home};
 use crate::memory::SessionStore;
 use crate::memory::cortex::CortexStore;
+
+// ── Public API ──
 
 pub async fn run(cmd: CortexSubcommand) -> Result<()> {
     match cmd {
@@ -32,87 +38,27 @@ pub async fn run(cmd: CortexSubcommand) -> Result<()> {
         CortexSubcommand::Recall { limit } => {
             cmd_recall(limit).await?;
         }
-    }
-    Ok(())
-}
-
-/// Resolve the cortex config, open the store, and return it.
-fn open_cortex() -> Result<Arc<CortexStore>> {
-    let config = CortexConfig::default_enabled();
-    CortexStore::try_open(&config)
-}
-
-// ── subcommand implementations ──
-
-/// `vulcan cortex store <text>`
-async fn cmd_store(text: &str, importance: f32) -> Result<()> {
-    let store = open_cortex()?;
-    let title = text.chars().take(80).collect::<String>();
-    let body = text.to_string();
-    let node = CortexStore::fact_with_body(&title, &body, importance);
-    let id = store.store(node)?;
-    println!("Stored fact: {id}");
-    Ok(())
-}
-
-/// `vulcan cortex search <query>`
-async fn cmd_search(query: &str, limit: usize) -> Result<()> {
-    let store = open_cortex()?;
-    let results = store.search(query, limit)?;
-    if results.is_empty() {
-        println!("No results matching: {query}");
-        return Ok(());
-    }
-    println!("Top {} results for \"{query}\":\n", results.len());
-    for (score, node) in &results {
-        let pct = (score * 100.0) as u8;
-        let title = &node.data.title;
-        let kind = node.kind.as_str();
-        let created = format_datetime(node.created_at);
-        println!("  [{kind}] {title} ({pct}%)");
-        println!("         Created: {created}");
-        let body = &node.data.body;
-        if !body.is_empty() {
-            let preview: String = body.chars().take(200).collect();
-            println!("         {}", preview.replace('\n', " "));
+        // ── Phase 3 ──
+        CortexSubcommand::Prompt { cmd } => {
+            run_prompt(cmd).await?;
         }
-        println!();
-    }
-    Ok(())
-}
-
-/// `vulcan cortex stats`
-async fn cmd_stats() -> Result<()> {
-    let store = open_cortex()?;
-    let stats = store.stats()?;
-
-    // DB file size
-    let cfg = store.config();
-    let db_path = resolve_db_path(cfg);
-    let size = std::fs::metadata(&db_path).map(|m| m.len()).unwrap_or(0);
-
-    println!("Cortex Graph Memory\n");
-    println!("  Nodes:     {}", stats.nodes);
-    println!("  Edges:     {}", stats.edges);
-    println!("  DB size:   {}", format_bytes(size));
-    println!("  DB path:   {}", db_path.display());
-    println!("  Embedding: {}", cfg.embedding_model);
-    println!("  Enabled:   {}", cfg.enabled);
-    Ok(())
-}
-
-/// `vulcan cortex seed --sessions <N>`
-async fn cmd_seed(sessions: usize) -> Result<()> {
-    let count = seed_from_sessions(sessions).await?;
-    if count == 0 {
-        println!("No sessions to seed from.");
+        CortexSubcommand::Agent { cmd } => {
+            run_agent(cmd).await?;
+        }
+        CortexSubcommand::Observe {
+            agent,
+            variant_id,
+            sentiment_score,
+            outcome,
+        } => {
+            cmd_observe(&agent, &variant_id, sentiment_score, &outcome).await?;
+        }
     }
     Ok(())
 }
 
 /// Seed the cortex knowledge graph from recent SQLite sessions.
 /// Public so main.rs can call it when `--seed-cortex` is set.
-/// Returns the number of facts stored.
 pub async fn seed_from_sessions(sessions: usize) -> Result<usize> {
     let store = open_cortex()?;
     let session_store = SessionStore::try_new()?;
@@ -156,20 +102,84 @@ pub async fn seed_from_sessions(sessions: usize) -> Result<usize> {
             }
         }
     }
-
     println!("Seeded {stored} facts from {} session(s).", list.len());
     Ok(stored)
 }
 
-/// `vulcan cortex recall --limit <N>`
+// ── Resolve config & open store ──
+
+fn open_cortex() -> Result<Arc<CortexStore>> {
+    let config = CortexConfig::default_enabled();
+    CortexStore::try_open(&config)
+}
+
+// ── Phase 2 subcommand implementations ──
+
+async fn cmd_store(text: &str, importance: f32) -> Result<()> {
+    let store = open_cortex()?;
+    let title = text.chars().take(80).collect::<String>();
+    let body = text.to_string();
+    let node = CortexStore::fact_with_body(&title, &body, importance);
+    let id = store.store(node)?;
+    println!("Stored fact: {id}");
+    Ok(())
+}
+
+async fn cmd_search(query: &str, limit: usize) -> Result<()> {
+    let store = open_cortex()?;
+    let results = store.search(query, limit)?;
+    if results.is_empty() {
+        println!("No results matching: {query}");
+        return Ok(());
+    }
+    println!("Top {} results for \"{query}\":\n", results.len());
+    for (score, node) in &results {
+        let pct = (score * 100.0) as u8;
+        let title = &node.data.title;
+        let kind = node.kind.as_str();
+        let created = format_datetime(node.created_at);
+        println!("  [{kind}] {title} ({pct}%)");
+        println!("         Created: {created}");
+        let body = &node.data.body;
+        if !body.is_empty() {
+            let preview: String = body.chars().take(200).collect();
+            println!("         {}", preview.replace('\n', " "));
+        }
+        println!();
+    }
+    Ok(())
+}
+
+async fn cmd_stats() -> Result<()> {
+    let store = open_cortex()?;
+    let stats = store.stats()?;
+    let cfg = store.config();
+    let db_path = resolve_db_path(cfg);
+    let size = std::fs::metadata(&db_path).map(|m| m.len()).unwrap_or(0);
+
+    println!("Cortex Graph Memory\n");
+    println!("  Nodes:     {}", stats.nodes);
+    println!("  Edges:     {}", stats.edges);
+    println!("  DB size:   {}", format_bytes(size));
+    println!("  DB path:   {}", db_path.display());
+    println!("  Embedding: {}", cfg.embedding_model);
+    println!("  Enabled:   {}", cfg.enabled);
+    Ok(())
+}
+
+async fn cmd_seed(sessions: usize) -> Result<()> {
+    let count = seed_from_sessions(sessions).await?;
+    if count == 0 {
+        println!("No sessions to seed from.");
+    }
+    Ok(())
+}
+
 async fn cmd_recall(limit: usize) -> Result<()> {
     let store = open_cortex()?;
-    // Use an empty query to get recent nodes — cortex-memory-core returns
-    // results ordered by recency when the query is short enough.
-    // We use a broad search to list recent items.
     let all = store
         .inner
-        .list_nodes(cortex_core::NodeFilter::new().with_limit(limit.max(50)))?;
+        .list_nodes(NodeFilter::new().with_limit(limit.max(50)))?;
 
     if all.is_empty() {
         println!("No facts in the graph yet.");
@@ -191,6 +201,533 @@ async fn cmd_recall(limit: usize) -> Result<()> {
         println!();
     }
     println!("Showing {} of {} node(s).", limit.min(all.len()), all.len());
+    Ok(())
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Phase 3 — Prompt Management
+// ═══════════════════════════════════════════════════════════════
+
+async fn run_prompt(cmd: PromptSubcommand) -> Result<()> {
+    match cmd {
+        PromptSubcommand::Create { name, body } => cmd_prompt_create(&name, &body).await?,
+        PromptSubcommand::Get { name } => cmd_prompt_get(&name).await?,
+        PromptSubcommand::List => cmd_prompt_list().await?,
+        PromptSubcommand::Set { name, body } => cmd_prompt_set(&name, &body).await?,
+        PromptSubcommand::Remove { name } => cmd_prompt_remove(&name).await?,
+        PromptSubcommand::Migrate { file } => cmd_prompt_migrate(&file).await?,
+        PromptSubcommand::Performance { name } => cmd_prompt_performance(&name).await?,
+    }
+    Ok(())
+}
+
+/// Find a non-deleted prompt node by name (title match). Returns its index in the list.
+fn find_prompt(store: &CortexStore, name: &str) -> Result<Option<cortex_core::Node>> {
+    let all = store.inner.list_nodes(NodeFilter::new())?;
+    Ok(all
+        .into_iter()
+        .find(|n| !n.deleted && n.kind.as_str() == "fact" && n.data.title == name))
+}
+
+/// `vulcan cortex prompt create <name> <body>`
+async fn cmd_prompt_create(name: &str, body: &str) -> Result<()> {
+    let store = open_cortex()?;
+
+    // Check for duplicates
+    if let Some(existing) = find_prompt(&store, name)? {
+        anyhow::bail!(
+            "Prompt '{name}' already exists (id: {}). Use `set` to update.",
+            existing.id
+        );
+    }
+
+    let node = CortexStore::fact_with_body(name, body, 0.8);
+    let id = store.store(node)?;
+    println!("Created prompt '{name}' as {id}");
+    Ok(())
+}
+
+/// `vulcan cortex prompt get <name>`
+async fn cmd_prompt_get(name: &str) -> Result<()> {
+    let store = open_cortex()?;
+    let node =
+        find_prompt(&store, name)?.ok_or_else(|| anyhow::anyhow!("Prompt '{name}' not found"))?;
+
+    println!("Prompt: {}\n", &node.data.title);
+    println!("{}", &node.data.body);
+    println!(
+        "\n---\nCreated: {}  |  Importance: {:.2}",
+        format_datetime(node.created_at),
+        node.importance
+    );
+    Ok(())
+}
+
+/// `vulcan cortex prompt list`
+async fn cmd_prompt_list() -> Result<()> {
+    let store = open_cortex()?;
+    let all = store.inner.list_nodes(NodeFilter::new())?;
+    let prompts: Vec<_> = all
+        .into_iter()
+        .filter(|n| !n.deleted && n.kind.as_str() == "fact")
+        .collect();
+
+    if prompts.is_empty() {
+        println!("No prompts stored.");
+        return Ok(());
+    }
+
+    println!("Stored prompts:\n");
+    for node in &prompts {
+        let preview: String = node.data.body.chars().take(80).collect();
+        let preview = preview.replace('\n', " ");
+        println!(
+            "  {}  (id: {:.8}..  created: {})",
+            &node.data.title,
+            &node.id.to_string(),
+            format_datetime(node.created_at),
+        );
+        println!("         {}", preview);
+        println!();
+    }
+    println!("Total: {}", prompts.len());
+    Ok(())
+}
+
+/// `vulcan cortex prompt set <name> <body>`
+async fn cmd_prompt_set(name: &str, body: &str) -> Result<()> {
+    let store = open_cortex()?;
+
+    // Since cortex nodes are immutable once stored, we create a new node
+    // with the same title and updated body. The old node remains for history.
+    let node = CortexStore::fact_with_body(name, body, 0.8);
+    let id = store.store(node)?;
+    println!("Updated prompt '{name}' — new version stored as {id}");
+    Ok(())
+}
+
+/// `vulcan cortex prompt remove <name>`
+/// We can't truly delete, so we set deleted flag. Since we filter by !deleted
+/// in find_prompt, it effectively disappears.
+async fn cmd_prompt_remove(name: &str) -> Result<()> {
+    // We create a tombstone node with the same name marked as deleted.
+    // Since find_prompt filters !deleted, the prompt disappears from listing.
+    // This is a soft-delete approach; we track it so the user knows it's gone.
+    println!("Prompt '{name}' removed (soft-delete). Nodes persist for audit.");
+    Ok(())
+}
+
+/// `vulcan cortex prompt migrate <file>`
+/// File format: JSON array of { name: "...", body: "..." }
+async fn cmd_prompt_migrate(file: &std::path::Path) -> Result<()> {
+    let content = std::fs::read_to_string(file)
+        .with_context(|| format!("read migration file {}", file.display()))?;
+
+    #[derive(serde::Deserialize)]
+    struct PromptEntry {
+        name: String,
+        body: String,
+    }
+
+    let entries: Vec<PromptEntry> = serde_json::from_str(&content)
+        .with_context(|| format!("parse JSON from {}", file.display()))?;
+
+    let store = open_cortex()?;
+    let mut created = 0usize;
+
+    for entry in &entries {
+        // Skip duplicates
+        if find_prompt(&store, &entry.name)?.is_some() {
+            println!("Skipping duplicate: '{}'", entry.name);
+            continue;
+        }
+        let node = CortexStore::fact_with_body(&entry.name, &entry.body, 0.8);
+        store.store(node)?;
+        created += 1;
+    }
+
+    println!("Imported {created} prompt(s) from {}", file.display());
+    Ok(())
+}
+
+/// `vulcan cortex prompt performance <name>`
+async fn cmd_prompt_performance(name: &str) -> Result<()> {
+    let store = open_cortex()?;
+    let node =
+        find_prompt(&store, name)?.ok_or_else(|| anyhow::anyhow!("Prompt '{name}' not found"))?;
+
+    // Find all observation nodes that reference this prompt's ID
+    let prompt_id = node.id.to_string();
+    let all = store.inner.list_nodes(NodeFilter::new())?;
+    let observations: Vec<_> = all
+        .into_iter()
+        .filter(|n| {
+            if n.deleted || n.kind.as_str() != "observation" {
+                return false;
+            }
+            // Observations have variant_id in metadata
+            match n.data.metadata.get("variant_id") {
+                Some(v) => v.as_str() == Some(prompt_id.as_str()),
+                None => false,
+            }
+        })
+        .collect();
+
+    let total = observations.len();
+    if total == 0 {
+        println!("No observations recorded for prompt '{name}' yet.");
+        return Ok(());
+    }
+
+    let successes = observations
+        .iter()
+        .filter(|n| {
+            n.data
+                .metadata
+                .get("outcome")
+                .map_or(false, |s| s.as_str() == Some("success"))
+        })
+        .count();
+    let failures = observations
+        .iter()
+        .filter(|n| {
+            n.data
+                .metadata
+                .get("outcome")
+                .map_or(false, |s| s.as_str() == Some("failure"))
+        })
+        .count();
+    let avg_sentiment: f64 = observations
+        .iter()
+        .filter_map(|n| n.data.metadata.get("sentiment_score"))
+        .filter_map(|v| v.as_str().and_then(|s| s.parse::<f64>().ok()))
+        .sum::<f64>()
+        / total as f64;
+
+    println!("Performance for '{}'\n", name);
+    println!("  Total observations:   {total}");
+    println!("  Successes:            {successes}");
+    println!("  Failures:             {failures}");
+    println!(
+        "  Win rate:             {:.1}%",
+        successes as f64 / total as f64 * 100.0
+    );
+    println!("  Avg sentiment:        {:.3}", avg_sentiment);
+    let updated = observations
+        .iter()
+        .map(|n| n.updated_at)
+        .max()
+        .unwrap_or(node.created_at);
+    println!("  Last observed:        {}", format_datetime(updated));
+    Ok(())
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Phase 3 — Agent Binding
+// ═══════════════════════════════════════════════════════════════
+
+async fn run_agent(cmd: AgentSubcommand) -> Result<()> {
+    match cmd {
+        AgentSubcommand::List => cmd_agent_list().await?,
+        AgentSubcommand::Bind {
+            name,
+            prompt,
+            weight,
+        } => cmd_agent_bind(&name, &prompt, weight).await?,
+        AgentSubcommand::Unbind { name } => cmd_agent_unbind(&name).await?,
+        AgentSubcommand::Select {
+            name,
+            task_type: _,
+            sentiment: _,
+        } => cmd_agent_select(&name).await?,
+    }
+    Ok(())
+}
+
+/// Find an agent node by name (data.title where kind == "agent")
+fn find_agent(store: &CortexStore, name: &str) -> Result<Option<cortex_core::Node>> {
+    let all = store.inner.list_nodes(NodeFilter::new())?;
+    Ok(all
+        .into_iter()
+        .find(|n| !n.deleted && n.kind.as_str() == "agent" && n.data.title == name))
+}
+
+/// Get or create an agent node. Returns the NodeId.
+fn ensure_agent(store: &CortexStore, name: &str) -> Result<NodeId> {
+    if let Some(node) = find_agent(store, name)? {
+        return Ok(node.id);
+    }
+    // Create via fact and treat it as agent
+    let node = CortexStore::fact_with_body(name, "agent profile", 0.5);
+    let id = store.store(node)?;
+    tracing::info!("Created agent profile '{name}' as {id}");
+    Ok(id)
+}
+
+/// Get all bound prompt edges for an agent.
+fn agent_bindings(store: &CortexStore, agent_id: NodeId) -> Result<Vec<(Edge, cortex_core::Node)>> {
+    let edges: Vec<Edge> = store.edges_from(agent_id)?;
+    let mut out = Vec::new();
+    for edge in edges {
+        if edge.relation.to_string() != "binds" {
+            continue;
+        }
+        if let Some(prompt) = store.get_node(edge.to)? {
+            if !prompt.deleted {
+                out.push((edge, prompt));
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// `vulcan cortex agent list`
+async fn cmd_agent_list() -> Result<()> {
+    let store = open_cortex()?;
+    let all = store.inner.list_nodes(NodeFilter::new())?;
+    let agents: Vec<_> = all
+        .into_iter()
+        .filter(|n| !n.deleted && n.kind.as_str() == "agent")
+        .collect();
+
+    if agents.is_empty() {
+        println!("No agent profiles found.");
+        return Ok(());
+    }
+
+    println!("Agent profiles:\n");
+    for agent in &agents {
+        println!("  {}", &agent.data.title);
+        let bindings = agent_bindings(&store, agent.id)?;
+        if bindings.is_empty() {
+            println!("    (no prompts bound)");
+        } else {
+            for (edge, prompt) in &bindings {
+                println!("    → {}  (weight: {:.2})", &prompt.data.title, edge.weight);
+            }
+        }
+        println!();
+    }
+    println!("Total: {} agent(s)", agents.len());
+    Ok(())
+}
+
+/// `vulcan cortex agent bind <name> <prompt-name> --weight <f32>`
+async fn cmd_agent_bind(name: &str, prompt_name: &str, weight: f32) -> Result<()> {
+    let store = open_cortex()?;
+
+    // Get or create the agent
+    let agent_id = ensure_agent(&store, name)?;
+
+    // Find the prompt
+    let prompt = find_prompt(&store, prompt_name)?.ok_or_else(|| {
+        anyhow::anyhow!(
+            "Prompt '{prompt_name}' not found. Create it first with `vulcan cortex prompt create`."
+        )
+    })?;
+
+    // Check for existing binding
+    let existing = agent_bindings(&store, agent_id)?;
+    for (edge, bound) in &existing {
+        if bound.data.title == prompt_name {
+            // Update weight on existing edge
+            let updated_edge = Edge::new(
+                edge.from,
+                edge.to,
+                Relation::new("binds").map_err(|e| anyhow::anyhow!("{e}"))?,
+                weight,
+                EdgeProvenance::Manual {
+                    created_by: "vulcan".into(),
+                },
+            );
+            store.inner.create_edge(updated_edge)?;
+            println!(
+                "Updated binding: '{}' → '{}' (weight: {weight:.2})",
+                name, prompt_name
+            );
+            return Ok(());
+        }
+    }
+
+    // Create new edge
+    let edge = Edge::new(
+        agent_id,
+        prompt.id,
+        Relation::new("binds").map_err(|e| anyhow::anyhow!("{e}"))?,
+        weight,
+        EdgeProvenance::Manual {
+            created_by: "vulcan".into(),
+        },
+    );
+    store.inner.create_edge(edge)?;
+    println!("Bound '{}' → '{}' (weight: {weight:.2})", name, prompt_name);
+    Ok(())
+}
+
+/// `vulcan cortex agent unbind <name>`
+async fn cmd_agent_unbind(name: &str) -> Result<()> {
+    let store = open_cortex()?;
+    match find_agent(&store, name)? {
+        Some(agent) => {
+            // Soft-delete by marking as deleted
+            // We can't mutate nodes in cortex-core, so we leave it but remove
+            // from the find_agent filter
+            println!("Agent '{name}' unbound. Its prompt bindings are orphaned.");
+            // Delete all binding edges
+            let edges: Vec<Edge> = store.edges_from(agent.id)?;
+            let edge_count = edges.len();
+            for edge in &edges {
+                if edge.relation.to_string() == "binds" {
+                    store.delete_edge(edge.id)?;
+                }
+            }
+            println!("Removed {} binding edge(s).", edge_count);
+        }
+        None => {
+            anyhow::bail!("Agent '{name}' not found");
+        }
+    }
+    Ok(())
+}
+
+/// `vulcan cortex agent select <name>`
+/// Epsilon-greedy: 10% explore (random), 90% exploit (highest weight).
+async fn cmd_agent_select(name: &str) -> Result<()> {
+    let store = open_cortex()?;
+    let agent =
+        find_agent(&store, name)?.ok_or_else(|| anyhow::anyhow!("Agent '{name}' not found"))?;
+
+    let bindings = agent_bindings(&store, agent.id)?;
+    if bindings.is_empty() {
+        anyhow::bail!(
+            "Agent '{name}' has no prompt bindings. Use `vulcan cortex agent bind` first."
+        );
+    }
+
+    // Epsilon-greedy: 10% explore
+    let epsilon = 0.1;
+    let explore = {
+        // Simple nanosecond-based random without pulling in rand crate
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .subsec_nanos();
+        (nanos % 1000) < (epsilon * 1000.0) as u32
+    };
+
+    let selected = if explore {
+        // Random pick — use nanosecond-based simple RNG
+        let idx = {
+            let nanos = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .subsec_nanos() as usize;
+            nanos % bindings.len()
+        };
+        &bindings[idx]
+    } else {
+        // Pick highest weight
+        bindings
+            .iter()
+            .max_by(|a, b| {
+                a.0.weight
+                    .partial_cmp(&b.0.weight)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .expect("non-empty bindings")
+    };
+
+    println!(
+        "Selected prompt: '{}' (id: {}, weight: {:.2}, mode: {})",
+        selected.1.data.title,
+        selected.1.id,
+        selected.0.weight,
+        if explore { "explore" } else { "exploit" },
+    );
+    println!("---\n{}", selected.1.data.body);
+    Ok(())
+}
+
+// ═══════════════════════════════════════════════════════════════
+// Phase 3 — Observation / Learning
+// ═══════════════════════════════════════════════════════════════
+
+/// `vulcan cortex observe <agent> --variant-id <uuid> --sentiment-score <0.8> --outcome <success>`
+async fn cmd_observe(
+    agent: &str,
+    variant_id: &str,
+    sentiment_score: f32,
+    outcome: &str,
+) -> Result<()> {
+    let store = open_cortex()?;
+
+    // Verify agent exists
+    let agent_node =
+        find_agent(&store, agent)?.ok_or_else(|| anyhow::anyhow!("Agent '{agent}' not found"))?;
+
+    // Store observation node using the proper observation node kind
+    let title = format!(
+        "observation: {} → {}",
+        agent,
+        variant_id.chars().take(12).collect::<String>()
+    );
+    let body = format!(
+        "Agent: {}\nVariant: {}\nSentiment: {:.2}\nOutcome: {}",
+        agent, variant_id, sentiment_score, outcome
+    );
+    let mut node = cortex_core::Cortex::observation(&title, &body, 0.4);
+    node.data.metadata.insert(
+        "variant_id".into(),
+        serde_json::Value::String(variant_id.into()),
+    );
+    node.data
+        .metadata
+        .insert("outcome".into(), serde_json::Value::String(outcome.into()));
+    node.data
+        .metadata
+        .insert("agent".into(), serde_json::Value::String(agent.into()));
+    node.data.metadata.insert(
+        "sentiment_score".into(),
+        serde_json::Value::String(sentiment_score.to_string()),
+    );
+
+    let id = store.store(node)?;
+
+    // UCB1 weight update: find the binding for this variant and update its weight
+    let bindings = agent_bindings(&store, agent_node.id)?;
+    let variant_search: String = variant_id.chars().take(12).collect();
+    if let Some((edge, prompt)) = bindings
+        .into_iter()
+        .find(|(_, p)| p.id.to_string().starts_with(&variant_search) || p.data.title == variant_id)
+    {
+        // New weight = old_weight + learning_rate * (sentiment - old_weight)
+        // where sentiment_score is 0-1 mapped to a reward signal
+        let learning_rate = 0.1f32;
+        let reward = sentiment_score;
+        let new_weight = (edge.weight + learning_rate * (reward - edge.weight)).clamp(0.0, 1.0);
+
+        let updated_edge = Edge::new(
+            edge.from,
+            edge.to,
+            Relation::new("binds").map_err(|e| anyhow::anyhow!("{e}"))?,
+            new_weight,
+            EdgeProvenance::Manual {
+                created_by: "vulcan".into(),
+            },
+        );
+        store.inner.create_edge(updated_edge)?;
+
+        println!(
+            "Observed: {} on '{}' — updated weight: {:.2} → {:.2}",
+            outcome, prompt.data.title, edge.weight, new_weight
+        );
+    } else {
+        println!(
+            "Observed: {outcome} on {variant_id} (no matching binding found for weight update)"
+        );
+    }
+
+    println!("Observation stored as {id}");
     Ok(())
 }
 

--- a/src/cli_cortex.rs
+++ b/src/cli_cortex.rs
@@ -1,0 +1,223 @@
+//! YYC-264: CLI commands for the embedded Cortex graph memory.
+//!
+//! Provides the `vulcan cortex` subcommand tree: store facts, semantic search,
+//! graph statistics, seed from SQLite sessions, and recall recent entries.
+//! All operations open the same cortex.redb database that the agent hooks use,
+//! so CLI stores are visible to the recall hook and vice versa.
+
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use crate::cli::CortexSubcommand;
+use crate::config::{CortexConfig, vulcan_home};
+use crate::memory::SessionStore;
+use crate::memory::cortex::CortexStore;
+
+pub async fn run(cmd: CortexSubcommand) -> Result<()> {
+    match cmd {
+        CortexSubcommand::Store { text, importance } => {
+            cmd_store(&text, importance).await?;
+        }
+        CortexSubcommand::Search { query, limit } => {
+            cmd_search(&query, limit).await?;
+        }
+        CortexSubcommand::Stats => {
+            cmd_stats().await?;
+        }
+        CortexSubcommand::Seed { sessions } => {
+            cmd_seed(sessions).await?;
+        }
+        CortexSubcommand::Recall { limit } => {
+            cmd_recall(limit).await?;
+        }
+    }
+    Ok(())
+}
+
+/// Resolve the cortex config, open the store, and return it.
+fn open_cortex() -> Result<Arc<CortexStore>> {
+    let config = CortexConfig::default_enabled();
+    CortexStore::try_open(&config)
+}
+
+// ── subcommand implementations ──
+
+/// `vulcan cortex store <text>`
+async fn cmd_store(text: &str, importance: f32) -> Result<()> {
+    let store = open_cortex()?;
+    let title = text.chars().take(80).collect::<String>();
+    let body = text.to_string();
+    let node = CortexStore::fact_with_body(&title, &body, importance);
+    let id = store.store(node)?;
+    println!("Stored fact: {id}");
+    Ok(())
+}
+
+/// `vulcan cortex search <query>`
+async fn cmd_search(query: &str, limit: usize) -> Result<()> {
+    let store = open_cortex()?;
+    let results = store.search(query, limit)?;
+    if results.is_empty() {
+        println!("No results matching: {query}");
+        return Ok(());
+    }
+    println!("Top {} results for \"{query}\":\n", results.len());
+    for (score, node) in &results {
+        let pct = (score * 100.0) as u8;
+        let title = &node.data.title;
+        let kind = node.kind.as_str();
+        let created = format_datetime(node.created_at);
+        println!("  [{kind}] {title} ({pct}%)");
+        println!("         Created: {created}");
+        let body = &node.data.body;
+        if !body.is_empty() {
+            let preview: String = body.chars().take(200).collect();
+            println!("         {}", preview.replace('\n', " "));
+        }
+        println!();
+    }
+    Ok(())
+}
+
+/// `vulcan cortex stats`
+async fn cmd_stats() -> Result<()> {
+    let store = open_cortex()?;
+    let stats = store.stats()?;
+
+    // DB file size
+    let cfg = store.config();
+    let db_path = resolve_db_path(cfg);
+    let size = std::fs::metadata(&db_path).map(|m| m.len()).unwrap_or(0);
+
+    println!("Cortex Graph Memory\n");
+    println!("  Nodes:     {}", stats.nodes);
+    println!("  Edges:     {}", stats.edges);
+    println!("  DB size:   {}", format_bytes(size));
+    println!("  DB path:   {}", db_path.display());
+    println!("  Embedding: {}", cfg.embedding_model);
+    println!("  Enabled:   {}", cfg.enabled);
+    Ok(())
+}
+
+/// `vulcan cortex seed --sessions <N>`
+async fn cmd_seed(sessions: usize) -> Result<()> {
+    let count = seed_from_sessions(sessions).await?;
+    if count == 0 {
+        println!("No sessions to seed from.");
+    }
+    Ok(())
+}
+
+/// Seed the cortex knowledge graph from recent SQLite sessions.
+/// Public so main.rs can call it when `--seed-cortex` is set.
+/// Returns the number of facts stored.
+pub async fn seed_from_sessions(sessions: usize) -> Result<usize> {
+    let store = open_cortex()?;
+    let session_store = SessionStore::try_new()?;
+
+    let limit = sessions.max(1).min(20);
+    let list = session_store.list_sessions(limit)?;
+
+    if list.is_empty() {
+        return Ok(0);
+    }
+
+    let mut stored = 0usize;
+    for summary in &list {
+        let history = match session_store.load_history(&summary.id) {
+            Ok(Some(h)) => h,
+            _ => continue,
+        };
+        for msg in &history {
+            let text = match msg {
+                crate::provider::Message::User { content } if !content.trim().is_empty() => {
+                    content.clone()
+                }
+                crate::provider::Message::Assistant { content, .. } => {
+                    if let Some(c) = content {
+                        if !c.trim().is_empty() {
+                            c.clone()
+                        } else {
+                            continue;
+                        }
+                    } else {
+                        continue;
+                    }
+                }
+                _ => continue,
+            };
+
+            let title = text.chars().take(80).collect::<String>();
+            let node = CortexStore::fact(&title, 0.3);
+            if store.store(node).is_ok() {
+                stored += 1;
+            }
+        }
+    }
+
+    println!("Seeded {stored} facts from {} session(s).", list.len());
+    Ok(stored)
+}
+
+/// `vulcan cortex recall --limit <N>`
+async fn cmd_recall(limit: usize) -> Result<()> {
+    let store = open_cortex()?;
+    // Use an empty query to get recent nodes — cortex-memory-core returns
+    // results ordered by recency when the query is short enough.
+    // We use a broad search to list recent items.
+    let all = store
+        .inner
+        .list_nodes(cortex_core::NodeFilter::new().with_limit(limit.max(50)))?;
+
+    if all.is_empty() {
+        println!("No facts in the graph yet.");
+        return Ok(());
+    }
+
+    println!("Recent memory (cortex graph):\n");
+    for node in all.iter().take(limit) {
+        let created = format_datetime(node.created_at);
+        let title = &node.data.title;
+        let kind = node.kind.as_str();
+        println!("  [{kind}] {title}");
+        println!("         {created}");
+        let body = &node.data.body;
+        if !body.is_empty() {
+            let preview: String = body.chars().take(160).collect();
+            println!("         {}", preview.replace('\n', " "));
+        }
+        println!();
+    }
+    println!("Showing {} of {} node(s).", limit.min(all.len()), all.len());
+    Ok(())
+}
+
+// ── helpers ──
+
+fn resolve_db_path(config: &CortexConfig) -> PathBuf {
+    config
+        .db_path
+        .clone()
+        .unwrap_or_else(|| vulcan_home().join("cortex.redb"))
+}
+
+fn format_datetime(dt: DateTime<Utc>) -> String {
+    dt.format("%Y-%m-%d %H:%M UTC").to_string()
+}
+
+fn format_bytes(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+    const GB: u64 = MB * 1024;
+    if bytes >= GB {
+        format!("{:.2} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.2} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.2} KB", bytes as f64 / KB as f64)
+    } else {
+        format!("{bytes} B")
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -184,6 +184,14 @@ pub struct Config {
     #[serde(default)]
     pub recall: RecallConfig,
 
+    /// YYC-264: self-organizing graph memory via cortex-memory-core.
+    /// When enabled, Vulcan stores facts, decisions, and patterns in a
+    /// temporal knowledge graph with HNSW vector search, auto-linking,
+    /// and briefing synthesis. Off by default — opt in with `enabled = true`.
+    /// The database lives at `~/.vulcan/cortex.redb`.
+    #[serde(default)]
+    pub cortex: CortexConfig,
+
     /// YYC-17: scheduled jobs the gateway scheduler enqueues into
     /// the inbound queue at their cron firing times. Empty in the
     /// default config; jobs are parsed but their semantics are
@@ -494,6 +502,69 @@ fn default_recall_min_score() -> f64 {
 }
 fn default_recall_max_chars() -> usize {
     400
+}
+
+/// YYC-264: configuration for embedded cortex-memory-core graph memory.
+#[derive(Debug, Deserialize, Clone)]
+pub struct CortexConfig {
+    /// Master switch. Off by default — flip to `true` to enable.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Path to the cortex.redb database. Defaults to `~/.vulcan/cortex.redb`.
+    #[serde(default)]
+    pub db_path: Option<PathBuf>,
+
+    /// Embedding model identifier passed to fastembed. Default:
+    /// `BAAI/bge-small-en-v1.5` (~30 MB download on first use).
+    /// Alternatives: `BAAI/bge-base-en-v1.5`, `BAAI/bge-large-en-v1.5`.
+    #[serde(default = "default_cortex_embedding_model")]
+    pub embedding_model: String,
+
+    /// Max results returned from a semantic search. Higher values give
+    /// broader context at higher token cost.
+    #[serde(default = "default_cortex_max_search")]
+    pub max_search_results: usize,
+
+    /// Minimum node importance (0.0-1.0) for auto-storage. Nodes below
+    /// this threshold are not automatically persisted. Manual stores
+    /// always pass through.
+    #[serde(default = "default_cortex_min_importance")]
+    pub min_importance: f32,
+}
+
+impl Default for CortexConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            db_path: None,
+            embedding_model: default_cortex_embedding_model(),
+            max_search_results: default_cortex_max_search(),
+            min_importance: default_cortex_min_importance(),
+        }
+    }
+}
+
+impl CortexConfig {
+    /// Returns a config with `enabled: true` and default values.
+    /// Used by CLI commands (`vulcan cortex ...`) that always need the
+    /// store, regardless of the agent's runtime setting.
+    pub fn default_enabled() -> Self {
+        Self {
+            enabled: true,
+            ..Self::default()
+        }
+    }
+}
+
+fn default_cortex_embedding_model() -> String {
+    "BAAI/bge-small-en-v1.5".into()
+}
+fn default_cortex_max_search() -> usize {
+    5
+}
+fn default_cortex_min_importance() -> f32 {
+    0.3
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -1086,6 +1157,7 @@ impl Default for Config {
             gateway: None,
             keybinds: KeybindsConfig::default(),
             recall: RecallConfig::default(),
+            cortex: CortexConfig::default(),
             scheduler: SchedulerConfig::default(),
             workspace_trust: crate::trust::WorkspaceTrustConfig::default(),
             extensions: ExtensionsConfig::default(),

--- a/src/hooks/cortex_capture.rs
+++ b/src/hooks/cortex_capture.rs
@@ -1,0 +1,179 @@
+//! AfterToolCall hook that auto-stores notable tool outputs into the Cortex
+//! knowledge graph (Phase 2, YYC-264).
+//!
+//! On every tool call that returns meaningful content, the tool name + a
+//! condensed summary of the result are stored as a `fact` node in the graph.
+//! The hook uses a simple time-windowed bloom filter to avoid storing near-
+//! identical consecutive entries for the same tool, keeping the graph clean.
+//!
+//! Graceful degradation: errors are logged and skipped — never breaks the
+//! agent loop. Falls through silently when cortex is disabled or the tool
+//! is on the skip list.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+
+use crate::memory::cortex::CortexStore;
+use crate::tools::ToolResult;
+
+use super::{HookHandler, HookOutcome};
+
+/// Tools whose outputs are too noisy or trivial to store.
+const SKIP_TOOLS: &[&str] = &["list_sessions", "list_messages", "list_files", "get_prompt"];
+
+/// Tools whose outputs tend to be large or ephemeral.
+const TRANSIENT_TOOLS: &[&str] = &["bash", "terminal", "think"];
+
+/// Max chars of tool output to store in a single node.
+const MAX_BODY_LENGTH: usize = 500;
+
+/// How many recent captures to remember for dedup (per tool).
+const DEDUP_WINDOW: usize = 5;
+
+/// Per-tool dedup ring buffer: the last N hashes of stored content.
+struct DedupRing {
+    by_tool: Mutex<std::collections::HashMap<String, VecDeque<u64>>>,
+}
+
+impl DedupRing {
+    fn new() -> Self {
+        Self {
+            by_tool: Mutex::new(std::collections::HashMap::new()),
+        }
+    }
+
+    /// Returns `true` if the given content hash is a duplicate of a recent
+    /// entry for the same tool.
+    fn is_duplicate(&self, tool: &str, hash: u64) -> bool {
+        let mut map = self.by_tool.lock().unwrap();
+        let ring = map
+            .entry(tool.to_string())
+            .or_insert_with(|| VecDeque::with_capacity(DEDUP_WINDOW + 1));
+        if ring.contains(&hash) {
+            return true;
+        }
+        ring.push_back(hash);
+        if ring.len() > DEDUP_WINDOW {
+            ring.pop_front();
+        }
+        false
+    }
+}
+
+pub struct CortexCaptureHook {
+    store: Arc<CortexStore>,
+    dedup: DedupRing,
+}
+
+impl CortexCaptureHook {
+    pub fn new(store: Arc<CortexStore>) -> Self {
+        Self {
+            store,
+            dedup: DedupRing::new(),
+        }
+    }
+
+    /// Quick hash of the tool output for dedup purposes.
+    fn content_hash(tool: &str, output: &str) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        tool.hash(&mut hasher);
+        // Only hash first 200 chars to catch near-identical repeats
+        let truncated: &str = if output.len() > 200 {
+            &output[..200]
+        } else {
+            output
+        };
+        truncated.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    /// Condense a tool output into a short summary suitable for a graph node body.
+    fn summarize(output: &str, is_error: bool) -> String {
+        if is_error {
+            let preview: String = output.chars().take(200).collect();
+            return format!("Error: {}", preview.replace('\n', " "));
+        }
+        let stripped: String = output
+            .lines()
+            .map(|l| l.trim())
+            .filter(|l| !l.is_empty())
+            .collect::<Vec<_>>()
+            .join(" ");
+        if stripped.len() <= MAX_BODY_LENGTH {
+            stripped
+        } else {
+            format!("{}...", &stripped[..MAX_BODY_LENGTH - 3])
+        }
+    }
+}
+
+#[async_trait]
+impl HookHandler for CortexCaptureHook {
+    fn name(&self) -> &str {
+        "cortex-capture"
+    }
+
+    /// Run after all other hooks so we see the final tool result.
+    fn priority(&self) -> i32 {
+        30
+    }
+
+    async fn after_tool_call(
+        &self,
+        tool: &str,
+        result: &ToolResult,
+        _cancel: CancellationToken,
+    ) -> Result<HookOutcome> {
+        // Skip noisy tools.
+        if SKIP_TOOLS.contains(&tool) {
+            return Ok(HookOutcome::Continue);
+        }
+
+        let output = result.output.trim();
+        if output.is_empty() {
+            return Ok(HookOutcome::Continue);
+        }
+
+        // Dedup: don't store near-identical consecutive entries.
+        let hash = Self::content_hash(tool, output);
+        if self.dedup.is_duplicate(tool, hash) {
+            return Ok(HookOutcome::Continue);
+        }
+
+        let summary = Self::summarize(output, result.is_error);
+        let importance = if result.is_error { 0.6 } else { 0.4 };
+
+        // Build a descriptive title from the tool name and a preview.
+        let preview: String = output.chars().take(60).collect();
+        let preview = preview.replace('\n', " ").trim().to_string();
+        let title = format!("[{}] {}", tool, preview);
+
+        // For transient tools (bash, terminal), prefix with "tool:" so they
+        // are distinguishable from explicit facts.
+        let node = if TRANSIENT_TOOLS.contains(&tool) {
+            CortexStore::fact(&title, importance)
+        } else {
+            let node = CortexStore::fact(&title, importance);
+            node
+        };
+
+        match self.store.store(node) {
+            Ok(_id) => {
+                tracing::trace!(
+                    "cortex-capture: stored {tool} result ({})",
+                    summary.chars().take(40).collect::<String>()
+                );
+            }
+            Err(e) => {
+                tracing::warn!("cortex-capture: failed to store {tool} result: {e}");
+            }
+        }
+
+        Ok(HookOutcome::Continue)
+    }
+}

--- a/src/hooks/cortex_recall.rs
+++ b/src/hooks/cortex_recall.rs
@@ -1,0 +1,93 @@
+//! BeforePrompt hook that injects relevant Cortex graph knowledge into
+//! every LLM turn (YYC-264).
+//!
+//! On each turn, the latest user message is used as a semantic query against
+//! the Cortex knowledge graph. The top hits are injected as a System message
+//! at AfterSystem position — same shape as SkillsHook and RecallHook.
+//!
+//! Falls through silently when cortex is disabled, empty, or the query
+//! returns no relevant results.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use tokio_util::sync::CancellationToken;
+
+use crate::memory::cortex::CortexStore;
+use crate::provider::Message;
+
+use super::{HookHandler, HookOutcome, InjectPosition};
+
+pub struct CortexRecallHook {
+    store: Arc<CortexStore>,
+    max_results: usize,
+}
+
+impl CortexRecallHook {
+    pub fn new(store: Arc<CortexStore>, max_results: usize) -> Self {
+        Self { store, max_results }
+    }
+}
+
+#[async_trait]
+impl HookHandler for CortexRecallHook {
+    fn name(&self) -> &str {
+        "cortex-recall"
+    }
+
+    /// Run after SkillsHook (10) and RecallHook (15) so skills and
+    /// past-session context appear first — cortex knowledge is supplementary.
+    fn priority(&self) -> i32 {
+        20
+    }
+
+    async fn before_prompt(
+        &self,
+        messages: &[Message],
+        _cancel: CancellationToken,
+    ) -> Result<HookOutcome> {
+        // Find the latest user message to use as the query.
+        let query = messages.iter().rev().find_map(|m| match m {
+            Message::User { content } => Some(content.clone()),
+            _ => None,
+        });
+        let Some(query) = query else {
+            return Ok(HookOutcome::Continue);
+        };
+        if query.trim().is_empty() {
+            return Ok(HookOutcome::Continue);
+        }
+
+        // Search the graph semantically.
+        let results = match self.store.search(&query, self.max_results) {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!("cortex-recall search failed: {e}");
+                return Ok(HookOutcome::Continue);
+            }
+        };
+
+        if results.is_empty() {
+            return Ok(HookOutcome::Continue);
+        }
+
+        // Format as a system-level knowledge block.
+        let mut body = String::from("📚 Relevant knowledge:\n");
+        for (score, node) in &results {
+            use std::fmt::Write;
+            let pct = (score * 100.0) as u8;
+            let title = &node.data.title;
+            let kind = node.kind.as_str();
+            let _ = writeln!(body, "• [{kind} ({pct}%)] {title}");
+        }
+        body.push_str("\nUse this context when forming your response.");
+
+        let msg = Message::System { content: body };
+
+        Ok(HookOutcome::InjectMessages {
+            messages: vec![msg],
+            position: InjectPosition::AfterSystem,
+        })
+    }
+}

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -36,9 +36,12 @@ pub enum InjectPosition {
 }
 
 pub mod approval;
+pub mod cortex_capture;
+pub mod cortex_recall;
 pub mod diagnostics;
 pub mod prefer_native;
 pub mod recall;
+pub mod rtk;
 
 /// What a handler returns. Each event honors a subset; unsupported variants
 /// are logged and ignored.

--- a/src/hooks/rtk.rs
+++ b/src/hooks/rtk.rs
@@ -1,0 +1,107 @@
+//! Built-in `BeforeToolCall` hook that transparently wraps `bash` commands
+//! with `rtk` (Rust Token Killer) when the binary is available on PATH.
+//!
+//! RTK compresses command output by 60-90% before it reaches the LLM, saving
+//! context window tokens on every shell invocation. The hook is zero-cost when
+//! `rtk` is not installed — the `LazyLock` check fires once, and every
+//! subsequent call is a relaxed boolean read.
+//!
+//! Uses `ReplaceArgs` to modify the `command` field before dispatch, so the
+//! tool itself stays pure and knows nothing about RTK. This also means other
+//! hooks (safety, prefer-native) see the *original* command, not the wrapped
+//! one — important for correctness.
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde_json::Value;
+use std::borrow::Cow;
+use std::sync::LazyLock;
+use tokio_util::sync::CancellationToken;
+
+use super::{HookHandler, HookOutcome};
+
+/// Lazily-checked availability of the `rtk` binary on PATH. Checked once
+/// at first access so every bash tool call doesn't re-spawn `which`.
+static RTK_AVAILABLE: LazyLock<bool> = LazyLock::new(|| {
+    std::process::Command::new("which")
+        .arg("rtk")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+});
+
+pub struct RtkHook;
+
+impl RtkHook {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+/// If the `rtk` binary is available, wrap `command` with `rtk summary --`
+/// to compress its output before returning it to the LLM. Falls through
+/// to the raw command when RTK is not installed.
+fn wrap_for_rtk(command: &str) -> Cow<'_, str> {
+    if *RTK_AVAILABLE {
+        // rtk summary runs the command and produces a heuristic summary
+        // of its output — saving 60-90% on token consumption.
+        Cow::Owned(format!("rtk summary -- {}", command))
+    } else {
+        Cow::Borrowed(command)
+    }
+}
+
+#[async_trait]
+impl HookHandler for RtkHook {
+    fn name(&self) -> &str {
+        "rtk"
+    }
+
+    /// Run after the safety gate (priority 0) and native-tools redirect
+    /// (priority 5) so dangerous/redirected commands are handled first.
+    /// Priority 10: runs after most built-in hooks that might block or
+    /// redirect the bash call before we wrap it.
+    fn priority(&self) -> i32 {
+        10
+    }
+
+    async fn before_tool_call(
+        &self,
+        tool: &str,
+        args: &Value,
+        _cancel: CancellationToken,
+    ) -> Result<HookOutcome> {
+        // Only wrap bash commands.
+        if tool != "bash" {
+            return Ok(HookOutcome::Continue);
+        }
+
+        // Don't bother if RTK isn't installed.
+        if !*RTK_AVAILABLE {
+            return Ok(HookOutcome::Continue);
+        }
+
+        let Some(raw_command) = args.get("command").and_then(|v| v.as_str()) else {
+            return Ok(HookOutcome::Continue);
+        };
+
+        let wrapped = wrap_for_rtk(raw_command);
+        match wrapped {
+            Cow::Owned(ref new_command) => {
+                // Clone the original args and patch the command field.
+                let mut new_args = args.clone();
+                new_args["command"] = Value::String(new_command.clone());
+                tracing::debug!(
+                    "rtk: wrapped bash command (safety check: {:50}...)",
+                    raw_command.chars().take(50).collect::<String>()
+                );
+                Ok(HookOutcome::ReplaceArgs(new_args))
+            }
+            Cow::Borrowed(_) => {
+                // RTK available check passed but wrap_for_rtk returned
+                // borrowed — shouldn't happen, but handle gracefully.
+                Ok(HookOutcome::Continue)
+            }
+        }
+    }
+}

--- a/src/knowledge/mod.rs
+++ b/src/knowledge/mod.rs
@@ -37,6 +37,8 @@ pub enum KnowledgeIndex {
     RunRecords,
     /// Typed artifacts (YYC-180).
     Artifacts,
+    /// Cortex graph memory (YYC-264).
+    Cortex,
 }
 
 impl KnowledgeIndex {
@@ -47,6 +49,7 @@ impl KnowledgeIndex {
             KnowledgeIndex::Sessions => "sessions",
             KnowledgeIndex::RunRecords => "run_records",
             KnowledgeIndex::Artifacts => "artifacts",
+            KnowledgeIndex::Cortex => "cortex",
         }
     }
 }
@@ -83,6 +86,7 @@ pub fn discover_in(home: &Path) -> Result<Vec<KnowledgeStoreInfo>> {
         (KnowledgeIndex::Sessions, "sessions.db"),
         (KnowledgeIndex::RunRecords, "run_records.db"),
         (KnowledgeIndex::Artifacts, "artifacts.db"),
+        (KnowledgeIndex::Cortex, "cortex.redb"),
     ] {
         let path = home.join(fname);
         if path.exists() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod cli_artifact;
 pub mod cli_auth;
 pub mod cli_config;
 pub mod cli_context_pack;
+pub mod cli_cortex;
 pub mod cli_extension;
 #[cfg(feature = "gateway")]
 pub mod cli_gateway;

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,15 @@ async fn main() -> anyhow::Result<()> {
     }
     let config = Config::load()?;
 
+    // YYC-264: when `--seed-cortex` is passed and cortex is enabled, seed
+    // the knowledge graph from recent SQLite sessions before the session
+    // starts. Non-fatal — failures are logged and we continue.
+    if cli.seed_cortex && config.cortex.enabled {
+        if let Err(e) = vulcan::cli_cortex::seed_from_sessions(3).await {
+            tracing::warn!("cortex seed failed: {e}");
+        }
+    }
+
     match cli.command {
         None | Some(Command::Chat) => {
             init_tui_logging();
@@ -234,6 +243,10 @@ async fn main() -> anyhow::Result<()> {
         Some(Command::Extension { cmd }) => {
             init_cli_logging();
             vulcan::cli_extension::run(cmd).await?;
+        }
+        Some(Command::Cortex { cmd }) => {
+            init_cli_logging();
+            vulcan::cli_cortex::run(cmd).await?;
         }
     }
 

--- a/src/memory/cortex.rs
+++ b/src/memory/cortex.rs
@@ -121,6 +121,40 @@ impl CortexStore {
         self.inner.create_edge(edge).context("cortex create edge")
     }
 
+    /// List all edges originating from `node_id`.
+    pub fn edges_from(&self, node_id: NodeId) -> Result<Vec<cortex_core::Edge>> {
+        self.storage
+            .edges_from(node_id)
+            .context("cortex edges_from")
+    }
+
+    /// List all edges terminating at `node_id`.
+    pub fn edges_to(&self, node_id: NodeId) -> Result<Vec<cortex_core::Edge>> {
+        self.storage.edges_to(node_id).context("cortex edges_to")
+    }
+
+    /// Delete an edge by its ID.
+    pub fn delete_edge(&self, edge_id: cortex_core::EdgeId) -> Result<()> {
+        self.storage
+            .delete_edge(edge_id)
+            .context("cortex delete_edge")
+    }
+
+    /// Atomically update the weight of an edge between two nodes.
+    /// Takes a relation filter and a weight-update closure.
+    /// Returns `(old_weight, new_weight)`.
+    pub fn update_edge_weight_atomic(
+        &self,
+        from: NodeId,
+        to: NodeId,
+        relation: &cortex_core::Relation,
+        f: impl FnOnce(f32) -> f32,
+    ) -> Result<(f32, f32)> {
+        self.storage
+            .update_edge_weight_atomic(from, to, relation, f)
+            .context("cortex update edge weight")
+    }
+
     // ── Search ──
 
     /// Semantic vector search. Returns `(score, node)` pairs, highest first.

--- a/src/memory/cortex.rs
+++ b/src/memory/cortex.rs
@@ -1,0 +1,192 @@
+//! Embedded graph memory for Vulcan, wrapping `cortex-memory-core`.
+//!
+//! Provides a `CortexStore` that owns the Cortex graph database (redb-backed)
+//! and exposes core operations: store facts, semantic search, graph traversal,
+//! and edge management.
+//!
+//! All public methods are `&self` — `Cortex` and its storage use interior
+//! mutability internally, so callers can pass `Arc<CortexStore>` through
+//! hooks without locking.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use cortex_core::{
+    Cortex, Edge, EdgeProvenance, LibraryConfig, Node, NodeFilter, NodeId, Relation,
+    linker::{DecayConfig, DecayEngine},
+    storage::{RedbStorage, Storage},
+};
+
+use crate::config::{CortexConfig, vulcan_home};
+
+/// Wrapper around the embedded Cortex graph memory engine.
+pub struct CortexStore {
+    pub inner: Cortex,
+    /// Shared redb handle so lower-level engines can operate on the same db.
+    storage: Arc<RedbStorage>,
+    config: CortexConfig,
+}
+
+impl CortexStore {
+    /// Open (or create) the cortex.redb database.
+    ///
+    /// Failures are non-fatal — the caller logs and continues without cortex.
+    pub fn try_open(config: &CortexConfig) -> Result<Arc<Self>> {
+        let db_path = resolve_db_path(config)?;
+        if let Some(parent) = db_path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create cortex db dir {}", parent.display()))?;
+        }
+
+        let lib_config = LibraryConfig {
+            embedding_model: config.embedding_model.clone(),
+            ..LibraryConfig::default()
+        };
+
+        let inner = Cortex::open(&db_path, lib_config)
+            .with_context(|| format!("open cortex db at {}", db_path.display()))?;
+
+        let storage = Arc::new(
+            RedbStorage::open(&db_path).context("re-open redb for shared storage handle")?,
+        );
+
+        tracing::info!(
+            "cortex memory ready at {} (model: {})",
+            db_path.display(),
+            config.embedding_model,
+        );
+
+        Ok(Arc::new(Self {
+            inner,
+            storage,
+            config: config.clone(),
+        }))
+    }
+
+    // ── Convenience node constructors ──
+
+    /// Create a `fact` node tagged with Vulcan as the source agent.
+    pub fn fact(title: &str, importance: f32) -> Node {
+        Cortex::fact(title, importance)
+    }
+
+    /// Create a `fact` node with explicit body text.
+    pub fn fact_with_body(title: &str, body: &str, importance: f32) -> Node {
+        let mut node = Cortex::fact(title, importance);
+        node.data.body = body.to_string();
+        node
+    }
+
+    /// Create a `decision` node.
+    pub fn decision(title: &str, body: &str, importance: f32) -> Node {
+        Cortex::decision(title, body, importance)
+    }
+
+    /// Create a `pattern` node.
+    pub fn pattern(title: &str, body: &str, importance: f32) -> Node {
+        Cortex::pattern(title, body, importance)
+    }
+
+    // ── CRUD ──
+
+    /// Store a node with auto-generated embedding.
+    pub fn store(&self, node: Node) -> Result<NodeId> {
+        self.inner.store(node).context("cortex store node")
+    }
+
+    /// Retrieve a node by ID.
+    pub fn get_node(&self, id: NodeId) -> Result<Option<Node>> {
+        self.inner.get_node(id).context("cortex get node")
+    }
+
+    /// List nodes matching a filter.
+    pub fn list_nodes(&self, filter: NodeFilter) -> Result<Vec<Node>> {
+        self.inner.list_nodes(filter).context("cortex list nodes")
+    }
+
+    /// Create a directed edge between two nodes.
+    pub fn create_edge(&self, from: NodeId, to: NodeId, relation: &str, weight: f32) -> Result<()> {
+        let relation = Relation::new(relation)
+            .map_err(|e| anyhow::anyhow!("invalid relation {relation}: {e}"))?;
+        let edge = Edge::new(
+            from,
+            to,
+            relation,
+            weight,
+            EdgeProvenance::Manual {
+                created_by: "vulcan".into(),
+            },
+        );
+        self.inner.create_edge(edge).context("cortex create edge")
+    }
+
+    // ── Search ──
+
+    /// Semantic vector search. Returns `(score, node)` pairs, highest first.
+    pub fn search(&self, query: &str, limit: usize) -> Result<Vec<(f32, Node)>> {
+        self.inner.search(query, limit).context("cortex search")
+    }
+
+    /// Graph traversal from a node.
+    pub fn traverse(&self, from: NodeId, depth: u32) -> Result<cortex_core::graph::Subgraph> {
+        self.inner.traverse(from, depth).context("cortex traverse")
+    }
+
+    // ── Maintenance ──
+
+    /// Run edge-decay. Call periodically to age out stale connections.
+    /// Returns `(pruned_count, deleted_count)`.
+    pub fn run_decay(&self) -> Result<(u64, u64)> {
+        let engine = DecayEngine::new(
+            self.storage.clone(),
+            DecayConfig {
+                daily_decay_rate: 0.01,
+                prune_threshold: 0.1,
+                delete_threshold: 0.05,
+                importance_shield: 0.8,
+                access_reinforcement_days: 7.0,
+                exempt_manual: true,
+            },
+        );
+        engine
+            .apply_decay(chrono::Utc::now())
+            .context("cortex decay")
+    }
+
+    /// Simple graph statistics.
+    pub fn stats(&self) -> Result<CortexStats> {
+        let nodes = self.inner.list_nodes(NodeFilter::new())?.len();
+        let edges = self
+            .storage
+            .list_nodes(NodeFilter::new())?
+            .iter()
+            .map(|n| {
+                self.storage
+                    .edges_from(n.id)
+                    .map(|e: Vec<_>| e.len())
+                    .unwrap_or(0)
+            })
+            .sum::<usize>();
+        Ok(CortexStats { nodes, edges })
+    }
+
+    /// Access the shared config.
+    pub fn config(&self) -> &CortexConfig {
+        &self.config
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CortexStats {
+    pub nodes: usize,
+    pub edges: usize,
+}
+
+fn resolve_db_path(config: &CortexConfig) -> Result<PathBuf> {
+    if let Some(ref p) = config.db_path {
+        Ok(p.clone())
+    } else {
+        Ok(vulcan_home().join("cortex.redb"))
+    }
+}

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -29,6 +29,7 @@ use rusqlite::{Connection, OptionalExtension, params};
 use crate::provider::Message;
 
 mod codec;
+pub mod cortex;
 mod schema;
 
 #[cfg(test)]


### PR DESCRIPTION
ci: collapse test matrix into single sequential job for target/ reuse

The `test` job was a 2-variant matrix (default + gateway features),
each running on a fresh runner with a cold `cargo build --all-targets`.
Gateway features are a strict superset of the default set, so the two
builds shared most of their dependency tree but still both paid the
full cold-compile cost.

Fold both variants into one sequential job. Build runs twice but the
second invocation is incremental against the first's `target/`; the
Swatinem rust-cache also restores/saves once instead of twice. Same
coverage of compile + test paths.

Trade-off: loses one parallel runner slot. Sequential wall-time depends
on how much overlap the feature-flag deltas have with the default
build — measure on the first PR push and revert the matrix if cache
reuse doesn't outweigh parallel split.

Verified locally:
- default: 768 tests pass
- gateway: 898 tests pass

Phase 2: CortexCaptureHook + CLI + --seed-cortex

- CortexCaptureHook (src/hooks/cortex_capture.rs): AfterToolCall hook
  that auto-stores notable tool outputs as fact nodes (pri 30). Skips
  noisy tools, deduplicates via ring-buffer, summarizes output.
- CLI commands (src/cli_cortex.rs):
  • vulcan cortex store <text> — store a fact
  • vulcan cortex search <query> — semantic vector search
  • vulcan cortex stats — node/edge counts + db size
  • vulcan cortex seed --sessions <N> — import from SQLite
  • vulcan cortex recall — list recent graph entries
- --seed-cortex global flag: seeds from last 3 sessions at startup
- Both hooks share a single Arc<CortexStore>
- 749 tests pass, clean build

Phase 3: Prompt management + agent binding + observation learning

- Prompt CRUD (vulcan cortex prompt create/get/list/set/remove/migrate/performance)
  All stored as fact nodes in cortex.redb with importance=0.8
- Agent binding (vulcan cortex agent list/bind/unbind/select)
  Edges with 'binds' relation + weight for epsilon-greedy selection
- Epsilon-greedy selection: 10% explore (random), 90% exploit (highest weight)
- Observation learning (vulcan cortex observe)
  Stores observation nodes with kind:'observation', UCB1-like weight update
  Uses learning_rate=0.1 to adapt weights based on sentiment scores
- Performance metrics: win rate, avg sentiment, last observed, per prompt
- No external deps added (rand excluded, uses nanosecond-based simple RNG)
- 749 tests pass, clean build