### PR TITLE
feat(config): YYC-286 interactive picker + YYC-287 colored output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ story.md
 code-analysis.md
 /code-review.md
 /docs/features
+/.fastembed_cache/models--Xenova--bge-small-en-v1.5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4352,6 +4352,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7154,6 +7160,7 @@ dependencies = [
  "lsp-types",
  "nix 0.31.2",
  "notify",
+ "owo-colors",
  "parking_lot",
  "percent-encoding",
  "portable-pty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,9 @@ clap_complete = "4.6"
 dialoguer = { version = "0.12", features = ["fuzzy-select", "password"] }
 ratatui = "0.30"
 crossterm = "0.29"
+# YYC-287: lightweight ANSI terminal colors for styled CLI output
+# (config list/show/get, doctor, trust, etc.). Zero transitive deps.
+owo-colors = "4"
 
 # Logging
 tracing = "0.1"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -77,14 +77,16 @@ pub enum Command {
         force: bool,
     },
     /// Manage named provider profiles in ~/.vulcan/providers.toml (YYC-98).
+    /// No subcommand opens an interactive menu (YYC-289).
     Provider {
         #[command(subcommand)]
-        cmd: ProviderCommand,
+        cmd: Option<ProviderCommand>,
     },
     /// YYC-241: list + select models on the active provider.
+    /// No subcommand opens an interactive picker (YYC-288).
     Model {
         #[command(subcommand)]
-        cmd: ModelSubcommand,
+        cmd: Option<ModelSubcommand>,
     },
     /// Guided interactive provider setup (YYC-100). Picker + prompts for
     /// name, API key, and default model; writes to providers.toml.
@@ -125,10 +127,11 @@ pub enum Command {
         cmd: ContextPackSubcommand,
     },
     /// YYC-212: unified config CLI. List, get, and inspect every
-    /// known config field by dotted path.
+    /// known config field by dotted path. No subcommand opens an
+    /// interactive picker (YYC-286).
     Config {
         #[command(subcommand)]
-        cmd: ConfigSubcommand,
+        cmd: Option<ConfigSubcommand>,
     },
     /// YYC-182: inspect workspace trust resolution.
     Trust {
@@ -264,9 +267,10 @@ pub enum ModelSubcommand {
     List,
     /// Show the currently-active provider + model.
     Show,
-    /// Persist a new `model = "<id>"` on the active provider.
+    /// Persist a new model. Omit the model id to pick interactively (YYC-288).
     Use {
-        id: String,
+        /// Model id to switch to. Omit to pick from catalog.
+        id: Option<String>,
         /// Skip catalog membership validation (useful for
         /// self-hosted endpoints with no `/models` endpoint).
         #[arg(long)]
@@ -588,13 +592,14 @@ pub enum ConfigSubcommand {
     },
     /// Validate a value against the field's declared kind, then
     /// write it to the right TOML file with comments preserved.
+    /// Omit the value to set interactively (YYC-286).
     Set {
         /// Dotted field path.
         key: String,
         /// New value. Bools accept `true|false|on|off|yes|no`;
         /// ints parse as base 10; enums must match a declared
-        /// variant exactly.
-        value: String,
+        /// variant exactly. Omit to set interactively.
+        value: Option<String>,
     },
     /// Remove a field's override from disk. Subsequent reads fall
     /// back to the declared default.

--- a/src/cli_config.rs
+++ b/src/cli_config.rs
@@ -1,7 +1,11 @@
 //! YYC-212 PR-1: `vulcan config list/get/path/show` — read-only
 //! discovery + inspection on top of the [`config_registry`].
+//! YYC-286: interactive picker + field-aware set when no value given.
 
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Context, Result, anyhow, bail};
+use dialoguer::{Confirm, FuzzySelect, Input, Password};
+use owo_colors::OwoColorize;
+use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use toml_edit::{DocumentMut, Item, value};
 
@@ -9,15 +13,20 @@ use crate::cli::ConfigSubcommand;
 use crate::config::{atomic_write, vulcan_home};
 use crate::config_registry::{ConfigField, ConfigFile, FieldKind, all, lookup};
 
-pub async fn run(cmd: ConfigSubcommand) -> Result<()> {
+pub async fn run(cmd: Option<ConfigSubcommand>) -> Result<()> {
     match cmd {
-        ConfigSubcommand::List => list(),
-        ConfigSubcommand::Get { key, reveal } => get(&key, reveal),
-        ConfigSubcommand::Path => paths(),
-        ConfigSubcommand::Show { reveal } => show(reveal),
-        ConfigSubcommand::Set { key, value } => set(&key, &value),
-        ConfigSubcommand::Unset { key } => unset(&key),
-        ConfigSubcommand::Edit { section } => edit(section.as_deref()),
+        None => interactive_picker(),
+        Some(ConfigSubcommand::List) => list(),
+        Some(ConfigSubcommand::Get { key, reveal }) => get(&key, reveal),
+        Some(ConfigSubcommand::Path) => paths(),
+        Some(ConfigSubcommand::Show { reveal }) => show(reveal),
+        Some(ConfigSubcommand::Set {
+            key,
+            value: Some(raw),
+        }) => set(&key, &raw),
+        Some(ConfigSubcommand::Set { key, value: None }) => interactive_set(&key),
+        Some(ConfigSubcommand::Unset { key }) => unset(&key),
+        Some(ConfigSubcommand::Edit { section }) => edit(section.as_deref()),
     }
 }
 
@@ -39,8 +48,6 @@ fn resolve_section_path(home: &Path, section: Option<&str>) -> PathBuf {
 /// `providers.toml`).
 fn edit(section: Option<&str>) -> Result<()> {
     let path = resolve_section_path(&vulcan_home(), section);
-    // Make sure the file exists so the editor doesn't error on
-    // first open. An empty file is a fine starting point.
     if !path.exists() {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
@@ -69,6 +76,399 @@ fn edit(section: Option<&str>) -> Result<()> {
     }
 }
 
+/// Group fields by their top-level category (first path segment).
+fn group_fields(fields: &[ConfigField]) -> Vec<(&str, Vec<&ConfigField>)> {
+    let mut map: std::collections::BTreeMap<&str, Vec<&ConfigField>> =
+        std::collections::BTreeMap::new();
+    for f in fields {
+        let cat = f.path.split('.').next().unwrap_or(f.path);
+        map.entry(cat).or_default().push(f);
+    }
+    map.into_iter().collect()
+}
+
+/// No subcommand given → pick a category, then a field within it.
+fn interactive_picker() -> Result<()> {
+    if !std::io::stdin().is_terminal() {
+        bail!(
+            "vulcan config (interactive) requires a terminal. Use `vulcan config list` to browse fields, or `vulcan config set <key> <value>` for scripting."
+        );
+    }
+
+    let theme = dialoguer_theme();
+    let groups = group_fields(&all());
+
+    // ---- Level 1: pick a category ---------------------------------
+    let cat_items: Vec<String> = groups
+        .iter()
+        .map(|(cat, fields)| {
+            format!(
+                "{} {}",
+                cat.bold(),
+                format!("({} fields)", fields.len()).dimmed()
+            )
+        })
+        .collect();
+
+    println!();
+    let cat_pick = FuzzySelect::with_theme(&theme)
+        .with_prompt("Pick a config category (Esc to cancel)")
+        .items(&cat_items)
+        .default(0)
+        .interact()
+        .context("cancelled")?;
+
+    let (cat_name, cat_fields) = &groups[cat_pick];
+
+    // ---- Level 2: pick a field within the category ----------------
+    let field_labels: Vec<String> = cat_fields
+        .iter()
+        .map(|f| {
+            let short = strip_prefix(f.path, cat_name);
+            let current = match lookup_in_file(f, f.path) {
+                Ok(Some(v)) => format_value(&v, f, false),
+                _ => "(default)".to_string(),
+            };
+            format!("{:<48} {}", short, current)
+        })
+        .collect();
+
+    println!();
+    let field_pick = FuzzySelect::with_theme(&theme)
+        .with_prompt(format!(
+            "[{}] Pick a field to set (Esc to cancel)",
+            cat_name
+        ))
+        .items(&field_labels)
+        .default(0)
+        .interact()
+        .context("cancelled")?;
+
+    let field = cat_fields[field_pick];
+    let current_val = match lookup_in_file(field, field.path) {
+        Ok(Some(v)) => format_value(&v, field, false),
+        _ => format!("(default: {})", field.default),
+    };
+    println!();
+    println!("  {}  ({})", field.path.bold(), field.help);
+    println!(
+        "  current: {}  |  kind: {}  |  file: {}",
+        current_val,
+        fmt_kind_short(&field.kind),
+        format_file(field.file),
+    );
+    println!();
+
+    let value = prompt_field_value(field, &theme)?;
+    confirm_and_write(field, value)?;
+    Ok(())
+}
+
+/// Remove a leading `prefix.` from `dotted`, returning the remainder.
+fn strip_prefix<'a>(dotted: &'a str, prefix: &str) -> &'a str {
+    if let Some(rest) = dotted.strip_prefix(prefix) {
+        rest.strip_prefix('.').unwrap_or(rest)
+    } else {
+        dotted
+    }
+}
+
+/// `vulcan config set <key>` without a value → field-aware prompt.
+fn interactive_set(key: &str) -> Result<()> {
+    let field = lookup(key).ok_or_else(|| {
+        anyhow!("unknown config field `{key}`. `vulcan config list` for the catalog.")
+    })?;
+
+    if !std::io::stdin().is_terminal() {
+        bail!(
+            "interactive set requires a terminal. Provide the value as an argument: `vulcan config set {key} <value>`."
+        );
+    }
+
+    let theme = dialoguer_theme();
+    println!();
+    println!("  {} ({})", field.path, field.help);
+    println!(
+        "  default: {}  |  kind: {}",
+        field.default,
+        fmt_kind_short(&field.kind)
+    );
+    println!();
+
+    let value = prompt_field_value(field, &theme)?;
+    confirm_and_write(field, value)?;
+    Ok(())
+}
+
+/// Prompt for a value adapted to the field kind.
+fn prompt_field_value(
+    field: &ConfigField,
+    theme: &dyn dialoguer::theme::Theme,
+) -> Result<toml_edit::Value> {
+    match &field.kind {
+        FieldKind::Bool => {
+            let confirmed = Confirm::with_theme(theme)
+                .with_prompt(format!("Set {} to true?", field.path))
+                .default(false)
+                .interact()?;
+            Ok(toml_edit::Value::from(confirmed))
+        }
+        FieldKind::Enum { variants } => {
+            let pick = FuzzySelect::with_theme(theme)
+                .with_prompt(format!("Pick value for {}", field.path))
+                .items(*variants)
+                .default(0)
+                .interact()?;
+            Ok(toml_edit::Value::from(variants[pick]))
+        }
+        FieldKind::Int { min, max } => {
+            let default_val = field.default.parse::<i64>().unwrap_or(0);
+            let range_hint = match (min, max) {
+                (Some(lo), Some(hi)) => format!("{lo}..{hi}"),
+                (Some(lo), None) => format!("≥ {lo}"),
+                (None, Some(hi)) => format!("≤ {hi}"),
+                (None, None) => "any integer".into(),
+            };
+            let input: String = Input::with_theme(theme)
+                .with_prompt(format!("Integer for {} ({})", field.path, range_hint))
+                .default(default_val.to_string())
+                .validate_with(|s: &String| -> Result<(), String> {
+                    let n: i64 = s.parse().map_err(|_| format!("not an integer: {s}"))?;
+                    if let Some(lo) = min {
+                        if n < *lo {
+                            return Err(format!("below minimum {lo}"));
+                        }
+                    }
+                    if let Some(hi) = max {
+                        if n > *hi {
+                            return Err(format!("above maximum {hi}"));
+                        }
+                    }
+                    Ok(())
+                })
+                .interact_text()?;
+            let n: i64 = input.parse().unwrap();
+            Ok(toml_edit::Value::from(n))
+        }
+        FieldKind::Float { min, max } => {
+            let default_val = field.default.parse::<f64>().unwrap_or(0.0);
+            let range_hint = match (min, max) {
+                (Some(lo), Some(hi)) => format!("{lo}..{hi}"),
+                (Some(lo), None) => format!("≥ {lo}"),
+                (None, Some(hi)) => format!("≤ {hi}"),
+                (None, None) => "any float".into(),
+            };
+            let input: String = Input::with_theme(theme)
+                .with_prompt(format!("Float for {} ({})", field.path, range_hint))
+                .default(default_val.to_string())
+                .validate_with(|s: &String| -> Result<(), String> {
+                    let n: f64 = s.parse().map_err(|_| format!("not a number: {s}"))?;
+                    if let Some(lo) = min {
+                        if n < *lo {
+                            return Err(format!("below minimum {lo}"));
+                        }
+                    }
+                    if let Some(hi) = max {
+                        if n > *hi {
+                            return Err(format!("above maximum {hi}"));
+                        }
+                    }
+                    Ok(())
+                })
+                .interact_text()?;
+            let n: f64 = input.parse().unwrap();
+            Ok(toml_edit::Value::from(n))
+        }
+        FieldKind::String { secret: true } => {
+            let key: String = Password::with_theme(theme)
+                .with_prompt(format!("Secret value for {} (hidden)", field.path))
+                .allow_empty_password(true)
+                .interact()?;
+            Ok(toml_edit::Value::from(key))
+        }
+        FieldKind::String { secret: false } | FieldKind::Path => {
+            let s: String = Input::with_theme(theme)
+                .with_prompt(format!("Value for {}", field.path))
+                .default(field.default.to_string())
+                .interact_text()?;
+            Ok(toml_edit::Value::from(s))
+        }
+        FieldKind::Model => pick_provider_model(field, theme),
+        FieldKind::EmbeddingModel => pick_embedding_model(field, theme),
+    }
+}
+
+/// Curated list of embedding models that `cortex-memory-core`'s
+/// `create_embedding_service` dispatch actually recognises. Each
+/// entry maps to a `fastembed::EmbeddingModel` variant inside cortex.
+/// Models NOT in this list silently fall back to bge-small (a bug in
+/// cortex-memory-core 0.3.1).
+///
+/// **Important**: switching to a model with a different dimension
+/// on an existing `cortex.redb` corrupts the HNSW index. The user
+/// must delete `~/.vulcan/cortex.redb` and re-seed.
+const KNOWN_EMBEDDING_MODELS: &[(&str, &str)] = &[
+    (
+        "BAAI/bge-small-en-v1.5",
+        "384-dim  ~130 MB  (default, fast)",
+    ),
+    ("BAAI/bge-base-en-v1.5", "768-dim  ~430 MB  (balanced)"),
+    (
+        "BAAI/bge-large-en-v1.5",
+        "1024-dim ~1.3 GB  (highest quality)",
+    ),
+];
+
+/// Suffix appended to the picker prompt when the user already has
+/// a cortex.redb, warning them about re-creation.
+const MODEL_SWITCH_WARNING: &str = "⚠ Switching to a different-dimension model requires deleting \
+     ~/.vulcan/cortex.redb and re-seeding (vulcan --seed-cortex).";
+
+/// Interactive fuzzy-select picker for embedding models.
+fn pick_embedding_model(
+    field: &ConfigField,
+    theme: &dyn dialoguer::theme::Theme,
+) -> Result<toml_edit::Value> {
+    let labels: Vec<String> = KNOWN_EMBEDDING_MODELS
+        .iter()
+        .map(|(id, hint)| format!("{:<25} {}", id, hint.dimmed()))
+        .collect();
+
+    println!();
+    if std::path::Path::new(&format!("{}/cortex.redb", vulcan_home().display())).exists() {
+        println!("{}\n", MODEL_SWITCH_WARNING.yellow());
+    }
+    let pick = FuzzySelect::with_theme(theme)
+        .with_prompt(format!("Pick an embedding model for {}", field.path))
+        .items(&labels)
+        .default(0)
+        .interact()
+        .context("picker cancelled")?;
+
+    Ok(toml_edit::Value::from(KNOWN_EMBEDDING_MODELS[pick].0))
+}
+
+/// Interactive fuzzy-select picker for LLM provider models.
+///
+/// Fetches the catalog from the active provider's `/models` endpoint
+/// (using the same cache as `vulcan model list`). Falls back to a
+/// plain text input when the catalog is unavailable (offline, bad
+/// key, etc.) so `config set` never dead-ends.
+fn pick_provider_model(
+    field: &ConfigField,
+    theme: &dyn dialoguer::theme::Theme,
+) -> Result<toml_edit::Value> {
+    // Try to fetch the provider catalog. We need a tokio runtime
+    // since `fetch_catalog` is async but we're in a sync context.
+    let models = match tokio::runtime::Handle::try_current() {
+        Ok(handle) => handle.block_on(fetch_models_from_active_provider()),
+        Err(_) => fetch_models_from_active_provider_blocking(),
+    };
+
+    match models {
+        Ok(ref list) if !list.is_empty() => {
+            let labels: Vec<String> = list
+                .iter()
+                .map(|m| {
+                    let ctx = if m.context_length > 0 {
+                        format!(" {}", m.context_length.to_string().dimmed())
+                    } else {
+                        String::new()
+                    };
+                    format!("{}{}", m.id, ctx)
+                })
+                .collect();
+
+            println!();
+            let pick = FuzzySelect::with_theme(theme)
+                .with_prompt(format!("Pick a model for {}", field.path))
+                .items(&labels)
+                .default(0)
+                .interact()
+                .context("picker cancelled")?;
+
+            Ok(toml_edit::Value::from(list[pick].id.clone()))
+        }
+        _ => {
+            // Catalog unavailable — fall back to free text.
+            tracing::warn!("provider catalog unavailable; falling back to text input");
+            let s: String = Input::with_theme(theme)
+                .with_prompt(format!("Model id for {} (catalog unavailable)", field.path))
+                .default(field.default.to_string())
+                .interact_text()?;
+            Ok(toml_edit::Value::from(s))
+        }
+    }
+}
+
+/// Fetch the model catalog from the active provider (async path —
+/// called when a tokio runtime is available).
+async fn fetch_models_from_active_provider() -> Result<Vec<crate::provider::catalog::ModelInfo>> {
+    let dir = vulcan_home();
+    let config = crate::config::Config::load_from_dir(&dir).unwrap_or_default();
+    let provider = config.active_provider_config();
+    let api_key = config.api_key().unwrap_or_default();
+    crate::cli_model::fetch_catalog(provider, &api_key).await
+}
+
+/// Blocking fallback: spin up a temporary tokio runtime to fetch
+/// the catalog. Used when `cli_config` is called outside an
+/// existing async context (e.g. `vulcan config set` from main).
+fn fetch_models_from_active_provider_blocking() -> Result<Vec<crate::provider::catalog::ModelInfo>>
+{
+    let rt = tokio::runtime::Runtime::new()?;
+    rt.block_on(fetch_models_from_active_provider())
+}
+
+/// Show a confirmation summary, then write.
+fn confirm_and_write(field: &ConfigField, val: toml_edit::Value) -> Result<()> {
+    let theme = dialoguer_theme();
+    let display = val.to_string();
+    let confirmed = Confirm::with_theme(&theme)
+        .with_prompt(format!("Write {} = {} to config?", field.path, display))
+        .default(true)
+        .interact()?;
+    if !confirmed {
+        println!("Aborted — nothing written.");
+        return Ok(());
+    }
+    let path = file_path_for(field.file);
+    let mut doc = read_document(&path)?;
+    apply_set(&mut doc, field.path, val)?;
+    write_document(&path, &doc)?;
+    println!("✓ set {} in {}", field.path, path.display());
+    Ok(())
+}
+
+fn dialoguer_theme() -> dialoguer::theme::ColorfulTheme {
+    dialoguer::theme::ColorfulTheme::default()
+}
+
+/// Short kind label for picker items.
+fn fmt_kind_short(k: &FieldKind) -> String {
+    match k {
+        FieldKind::Bool => "bool".into(),
+        FieldKind::Int { min, max } => match (min, max) {
+            (Some(lo), Some(hi)) => format!("int [{lo}..{hi}]"),
+            (Some(lo), None) => format!("int [≥{lo}]"),
+            (None, Some(hi)) => format!("int [≤{hi}]"),
+            (None, None) => "int".into(),
+        },
+        FieldKind::Float { min, max } => match (min, max) {
+            (Some(lo), Some(hi)) => format!("float [{lo}..{hi}]"),
+            (Some(lo), None) => format!("float [≥{lo}]"),
+            (None, Some(hi)) => format!("float [≤{hi}]"),
+            (None, None) => "float".into(),
+        },
+        FieldKind::Enum { variants } => format!("enum[{}]", variants.join("|")),
+        FieldKind::String { secret: true } => "🔒 secret".into(),
+        FieldKind::String { secret: false } => "string".into(),
+        FieldKind::Path => "path".into(),
+        FieldKind::Model => "model".into(),
+        FieldKind::EmbeddingModel => "embedding".into(),
+    }
+}
+
 fn set(key: &str, raw: &str) -> Result<()> {
     let field = lookup(key).ok_or_else(|| {
         anyhow!("unknown config field `{key}`. `vulcan config list` for the catalog.")
@@ -78,7 +478,7 @@ fn set(key: &str, raw: &str) -> Result<()> {
     let mut doc = read_document(&path)?;
     apply_set(&mut doc, key, parsed)?;
     write_document(&path, &doc)?;
-    println!("set {key} in {}", path.display());
+    println!("{} set {} in {}", "✓".green(), key, path.display());
     Ok(())
 }
 
@@ -155,7 +555,10 @@ fn parse_value(field: &ConfigField, raw: &str) -> Result<toml_edit::Value> {
                 )
             }
         }
-        FieldKind::String { .. } | FieldKind::Path => Ok(raw.into()),
+        FieldKind::String { .. }
+        | FieldKind::Path
+        | FieldKind::Model
+        | FieldKind::EmbeddingModel => Ok(raw.into()),
     }
 }
 
@@ -253,19 +656,52 @@ fn ensure_table<'a>(parent: &'a mut dyn TableLike, key: &str) -> Result<&'a mut 
 }
 
 fn list() -> Result<()> {
+    // Colored header row
     println!(
-        "{:<48} {:<14} {:<20} {:<14} help",
-        "key", "kind", "default", "file"
+        "{} {} {} {} {} {}",
+        "key".bold().white().on_blue(),
+        "kind".bold().white().on_blue(),
+        "current".bold().white().on_blue(),
+        "default".bold().white().on_blue(),
+        "file".bold().white().on_blue(),
+        "help".bold().white().on_blue(),
     );
     for f in all() {
-        let kind_str = format_kind(&f.kind);
-        let file_str = format_file(f.file);
+        let kind_str = colored_kind(&f.kind);
+        let default_str = f.default.dimmed().to_string();
+        let file_label = format_file(f.file);
+        let file_str = file_label.green().to_string();
+
+        // Look up the actual current value from config files
+        let current_str = match lookup_in_file(f, f.path) {
+            Ok(Some(v)) => format_value(&v, f, false).green().to_string(),
+            _ => {
+                // Not explicitly set — show "(default)" in yellow
+                "(default)".yellow().to_string()
+            }
+        };
+
         println!(
-            "{:<48} {:<14} {:<20} {:<14} {}",
-            f.path, kind_str, f.default, file_str, f.help
+            "{:<48} {:<14} {:<20} {:<20} {:<14} {}",
+            f.path, kind_str, current_str, default_str, file_str, f.help
         );
     }
     Ok(())
+}
+
+/// Colored kind badge for `list`.
+fn colored_kind(k: &FieldKind) -> String {
+    match k {
+        FieldKind::Bool => "bool".cyan().to_string(),
+        FieldKind::Int { .. } => format_kind(k).blue().to_string(),
+        FieldKind::Float { .. } => format_kind(k).blue().to_string(),
+        FieldKind::Enum { .. } => format_kind(k).yellow().to_string(),
+        FieldKind::String { secret: true } => "🔒 secret".red().to_string(),
+        FieldKind::String { secret: false } => "string".green().to_string(),
+        FieldKind::Path => "path".magenta().to_string(),
+        FieldKind::Model => "model".cyan().to_string(),
+        FieldKind::EmbeddingModel => "embedding".cyan().to_string(),
+    }
 }
 
 fn get(key: &str, reveal: bool) -> Result<()> {
@@ -273,12 +709,27 @@ fn get(key: &str, reveal: bool) -> Result<()> {
         anyhow!("unknown config field `{key}`. `vulcan config list` for the catalog.")
     })?;
     let raw = lookup_in_file(field, key)?;
-    let display = match raw {
-        None => "(unset; default applies)".to_string(),
-        Some(v) => format_value(&v, field, reveal),
-    };
-    println!("{display}");
+    match raw {
+        None => {
+            // Unset — show dim "(default: <val> applies)"
+            println!("{} {}", "(default)".dimmed(), field.default.yellow());
+        }
+        Some(v) if is_secret_not_revealed(field, reveal) => {
+            // Secret redacted
+            println!("{}", "***redacted*** (pass --reveal to show)".red());
+        }
+        Some(v) => {
+            let display = format_value(&v, field, reveal);
+            // Explicitly set — show in green with a checkmark
+            println!("✓ {}", display.green());
+        }
+    }
     Ok(())
+}
+
+/// True when the value should be redacted.
+fn is_secret_not_revealed(field: &ConfigField, reveal: bool) -> bool {
+    matches!(&field.kind, FieldKind::String { secret: true } if !reveal)
 }
 
 fn paths() -> Result<()> {
@@ -299,11 +750,18 @@ fn paths() -> Result<()> {
 fn show(reveal: bool) -> Result<()> {
     for f in all() {
         let raw = lookup_in_file(f, f.path)?;
-        let display = match raw {
-            None => "(default)".to_string(),
-            Some(v) => format_value(&v, f, reveal),
-        };
-        println!("{} = {}", f.path, display);
+        match raw {
+            None => {
+                println!("{} {} {}", f.path, "=".dimmed(), f.default.yellow());
+            }
+            Some(v) if is_secret_not_revealed(f, reveal) => {
+                println!("{} = {}", f.path, "***redacted***".red());
+            }
+            Some(v) => {
+                let display = format_value(&v, f, reveal);
+                println!("✓ {} = {}", f.path, display.green());
+            }
+        }
     }
     Ok(())
 }
@@ -380,6 +838,8 @@ fn format_kind(k: &FieldKind) -> String {
             }
         }
         FieldKind::Path => "path".into(),
+        FieldKind::Model => "model".into(),
+        FieldKind::EmbeddingModel => "embedding".into(),
     }
 }
 

--- a/src/cli_model.rs
+++ b/src/cli_model.rs
@@ -1,20 +1,83 @@
 //! YYC-241: `vulcan model list/show/use` for the active provider.
+//! YYC-288: interactive picker from catalog + styled output.
 
 use anyhow::{Context, Result, anyhow, bail};
+use owo_colors::OwoColorize;
+use std::io::IsTerminal;
 use std::time::Duration;
 use toml_edit::{DocumentMut, value};
 
 use crate::cli::ModelSubcommand;
 use crate::config::{Config, ProviderConfig, vulcan_home};
 
-pub async fn run(cmd: ModelSubcommand) -> Result<()> {
+pub async fn run(cmd: Option<ModelSubcommand>) -> Result<()> {
     let dir = vulcan_home();
     let config = Config::load_from_dir(&dir).unwrap_or_default();
     match cmd {
-        ModelSubcommand::List => list(&config).await,
-        ModelSubcommand::Show => show(&config),
-        ModelSubcommand::Use { id, force } => use_model(&dir, &config, &id, force).await,
+        None => interactive_pick(&config).await,
+        Some(ModelSubcommand::List) => list(&config).await,
+        Some(ModelSubcommand::Show) => show(&config),
+        Some(ModelSubcommand::Use {
+            id: Some(id),
+            force,
+        }) => use_model(&dir, &config, &id, force).await,
+        Some(ModelSubcommand::Use { id: None, force }) => {
+            // Interactive pick then use
+            let id = interactive_pick_id(&config).await?;
+            use_model(&dir, &config, &id, force).await
+        }
     }
+}
+
+/// No subcommand → fuzzy picker of models from catalog.
+/// Selecting one prompts to use it.
+async fn interactive_pick(config: &Config) -> Result<()> {
+    if !std::io::stdin().is_terminal() {
+        bail!(
+            "vulcan model (interactive) requires a terminal. Use `vulcan model list` to browse, or `vulcan model use <id>` to set."
+        );
+    }
+
+    let id = interactive_pick_id(config).await?;
+    let dir = vulcan_home();
+    let force = false;
+    use_model(&dir, config, &id, force).await
+}
+
+/// Fuzzy pick a model from the catalog. Returns the chosen model id.
+async fn interactive_pick_id(config: &Config) -> Result<String> {
+    let provider = config.active_provider_config();
+    let api_key = config.api_key().unwrap_or_else(String::new);
+    let models = fetch_catalog(provider, &api_key)
+        .await
+        .with_context(|| format!("failed to fetch /models from {}", provider.base_url))?;
+
+    if models.is_empty() {
+        bail!("No models available in the catalog.");
+    }
+
+    let theme = dialoguer::theme::ColorfulTheme::default();
+    let labels: Vec<String> = models
+        .iter()
+        .map(|m| {
+            let ctx = if m.context_length > 0 {
+                format!(" {}", m.context_length.to_string().dimmed())
+            } else {
+                String::new()
+            };
+            format!("{}{}", m.id, ctx)
+        })
+        .collect();
+
+    println!();
+    let pick = dialoguer::FuzzySelect::with_theme(&theme)
+        .with_prompt("Pick a model")
+        .items(&labels)
+        .default(0)
+        .interact()
+        .context("picker cancelled")?;
+
+    Ok(models[pick].id.clone())
 }
 
 fn show(config: &Config) -> Result<()> {
@@ -23,9 +86,10 @@ fn show(config: &Config) -> Result<()> {
         .active_profile
         .as_deref()
         .unwrap_or("[provider] (legacy)");
-    println!("Active provider: {label}");
-    println!("  base_url: {}", provider.base_url);
-    println!("  model:    {}", provider.model);
+    println!("{}", "Active provider:".bold());
+    println!("  {} {label}", "profile:".dimmed());
+    println!("  {}  {}", "base_url:".dimmed(), provider.base_url);
+    println!("  {}      {}", "model:".dimmed(), provider.model.green());
     Ok(())
 }
 
@@ -42,14 +106,20 @@ async fn list(config: &Config) -> Result<()> {
         println!("(catalog empty)");
         return Ok(());
     }
-    println!("{:<40} {:<10} {}", "id", "context", "display");
+    // Styled header
+    println!(
+        "{} {} {}",
+        "id".bold().white().on_blue(),
+        "context".bold().white().on_blue(),
+        "display".bold().white().on_blue(),
+    );
     for m in models {
         let ctx = if m.context_length > 0 {
-            m.context_length.to_string()
+            m.context_length.to_string().cyan().to_string()
         } else {
-            "-".to_string()
+            "-".dimmed().to_string()
         };
-        println!("{:<40} {:<10} {}", m.id, ctx, m.display_name);
+        println!("{:<40} {:<10} {}", m.id, ctx, m.display_name.dimmed());
     }
     Ok(())
 }
@@ -80,7 +150,7 @@ async fn use_model(dir: &std::path::Path, config: &Config, id: &str, force: bool
     let target = active_profile
         .map(|n| format!("[providers.{n}]"))
         .unwrap_or_else(|| "[provider]".to_string());
-    println!("Set model = \"{id}\" on {target}");
+    println!("{} set model = \"{id}\" on {target}", "✓".green());
     Ok(())
 }
 
@@ -124,7 +194,7 @@ fn write_legacy_provider_model(dir: &std::path::Path, id: &str) -> Result<()> {
     Ok(())
 }
 
-async fn fetch_catalog(
+pub async fn fetch_catalog(
     provider: &ProviderConfig,
     api_key: &str,
 ) -> Result<Vec<crate::provider::catalog::ModelInfo>> {

--- a/src/cli_provider.rs
+++ b/src/cli_provider.rs
@@ -11,6 +11,8 @@
 
 use anyhow::{Context, Result, anyhow, bail};
 use clap::{Args, Subcommand};
+use owo_colors::OwoColorize;
+use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use toml_edit::{DocumentMut, Item, Table, value};
 
@@ -170,55 +172,221 @@ pub fn lookup_preset(key: &str) -> Option<&'static Preset> {
     presets().iter().find(|p| p.key.eq_ignore_ascii_case(key))
 }
 
-pub async fn run(cmd: ProviderCommand, dir: PathBuf) -> Result<()> {
+pub async fn run(cmd: Option<ProviderCommand>, dir: PathBuf) -> Result<()> {
     match cmd {
-        ProviderCommand::List => list(&dir),
-        ProviderCommand::Presets => {
+        None => interactive_menu(&dir),
+        Some(ProviderCommand::List) => list(&dir),
+        Some(ProviderCommand::Presets) => {
             print_presets();
             Ok(())
         }
-        ProviderCommand::Add(args) => add(args, &dir),
-        ProviderCommand::Remove(args) => remove(args, &dir),
-        ProviderCommand::Use(args) => use_profile(args, &dir),
+        Some(ProviderCommand::Add(args)) => add(args, &dir),
+        Some(ProviderCommand::Remove(args)) => remove(args, &dir),
+        Some(ProviderCommand::Use(args)) => use_profile(args, &dir),
     }
+}
+
+/// Interactive menu when `vulcan provider` is called without a subcommand.
+fn interactive_menu(dir: &Path) -> Result<()> {
+    if !std::io::stdin().is_terminal() {
+        bail!(
+            "vulcan provider (interactive) requires a terminal. Use `vulcan provider list/add/remove/use <args>` for scripting."
+        );
+    }
+
+    let theme = dialoguer::theme::ColorfulTheme::default();
+    let options = &[
+        "List providers",
+        "Add provider",
+        "Remove provider",
+        "Use provider",
+    ];
+    println!();
+    let pick = dialoguer::FuzzySelect::with_theme(&theme)
+        .with_prompt("Provider action")
+        .items(options)
+        .default(0)
+        .interact()
+        .context("cancelled")?;
+
+    match pick {
+        0 => list(dir),
+        1 => interactive_add(dir),
+        2 => interactive_remove(dir),
+        3 => interactive_use(dir),
+        _ => unreachable!(),
+    }
+}
+
+/// Interactive add: pick a preset, enter a name, confirm.
+fn interactive_add(dir: &Path) -> Result<()> {
+    let theme = dialoguer::theme::ColorfulTheme::default();
+    let ps = presets();
+    let labels: Vec<String> = ps
+        .iter()
+        .map(|p| format!("{} ({})", p.display, p.key))
+        .collect();
+
+    println!();
+    let pick = dialoguer::FuzzySelect::with_theme(&theme)
+        .with_prompt("Pick a preset")
+        .items(&labels)
+        .default(0)
+        .interact()
+        .context("picker cancelled")?;
+
+    let preset = &ps[pick];
+    println!();
+    println!("  {} ({})", preset.display, preset.key);
+    println!("  base_url: {}", preset.base_url);
+    println!("  model:    {}", preset.model);
+
+    let name: String = dialoguer::Input::with_theme(&theme)
+        .with_prompt("Profile name")
+        .default(preset.key.to_string())
+        .interact_text()?;
+
+    let confirmed = dialoguer::Confirm::with_theme(&theme)
+        .with_prompt(format!("Add [{}] from {} preset?", name, preset.key))
+        .default(true)
+        .interact()?;
+
+    if !confirmed {
+        println!("Aborted.");
+        return Ok(());
+    }
+
+    add(
+        AddArgs {
+            name,
+            preset: Some(preset.key.to_string()),
+            base_url: None,
+            model: None,
+            api_key: None,
+            max_context: None,
+            disable_catalog: false,
+            force: false,
+        },
+        dir,
+    )?;
+    println!(
+        "{}",
+        "Done. Switch with `/provider <name>` in the TUI or `vulcan provider use <name>`.".dimmed()
+    );
+    Ok(())
+}
+
+/// Interactive remove: pick from existing providers.
+fn interactive_remove(dir: &Path) -> Result<()> {
+    let cfg = crate::config::Config::load_from_dir(dir).unwrap_or_default();
+    let names: Vec<&String> = cfg.providers.keys().collect();
+    if names.is_empty() {
+        bail!("No named provider profiles to remove.");
+    }
+
+    let theme = dialoguer::theme::ColorfulTheme::default();
+    println!();
+    let pick = dialoguer::FuzzySelect::with_theme(&theme)
+        .with_prompt("Pick a provider to remove")
+        .items(&names)
+        .default(0)
+        .interact()
+        .context("cancelled")?;
+
+    let name = names[pick].clone();
+    let confirmed = dialoguer::Confirm::with_theme(&theme)
+        .with_prompt(format!("Permanently remove [{}]?", name))
+        .default(false)
+        .interact()?;
+
+    if !confirmed {
+        println!("Aborted.");
+        return Ok(());
+    }
+
+    remove(RemoveArgs { name: name.clone() }, dir)
+}
+
+/// Interactive use: pick from existing providers.
+fn interactive_use(dir: &Path) -> Result<()> {
+    let cfg = crate::config::Config::load_from_dir(dir).unwrap_or_default();
+    let names: Vec<&String> = cfg.providers.keys().collect();
+    if names.is_empty() {
+        bail!("No named provider profiles to switch to. Add one first.");
+    }
+
+    let theme = dialoguer::theme::ColorfulTheme::default();
+    println!();
+    let pick = dialoguer::FuzzySelect::with_theme(&theme)
+        .with_prompt("Pick a provider to activate")
+        .items(&names)
+        .default(0)
+        .interact()
+        .context("cancelled")?;
+
+    let name = names[pick].clone();
+    use_profile(
+        UseArgs {
+            name: Some(name.clone()),
+            clear: false,
+        },
+        dir,
+    )
 }
 
 fn list(dir: &Path) -> Result<()> {
     let cfg = crate::config::Config::load_from_dir(dir).unwrap_or_default();
-    println!("Provider profiles:");
+    println!("{}", "Provider profiles:".bold());
     println!(
-        "    default · {} · {}",
-        cfg.provider.base_url, cfg.provider.model
+        "  {} {}",
+        "(default)".dimmed(),
+        format!("{} · {}", cfg.provider.base_url, cfg.provider.model)
     );
     let mut names: Vec<&String> = cfg.providers.keys().collect();
     names.sort();
     for name in &names {
         let p = &cfg.providers[*name];
-        println!("    {name} · {} · {}", p.base_url, p.model);
+        let active = match &cfg.active_profile {
+            Some(a) if a == *name => " ●".green().to_string(),
+            _ => String::new(),
+        };
+        println!("  {}{}", name.bold(), active,);
+        println!("    {} {}", "base_url:".dimmed(), p.base_url);
+        println!("    {} {}", "model:".dimmed(), p.model.cyan());
     }
     if cfg.providers.is_empty() {
-        println!("    (no named profiles configured — add one with `vulcan provider add`)");
+        println!(
+            "    {}",
+            "(no named profiles configured — add one with `vulcan provider add`)".dimmed()
+        );
     }
     Ok(())
 }
 
 fn print_presets() {
-    println!("Curated provider presets:");
+    println!("{}", "Curated provider presets:".bold());
     for p in presets() {
         println!();
-        println!("  {} ({})", p.display, p.key);
-        println!("    base_url     : {}", p.base_url);
-        println!("    default_model: {}", p.model);
-        println!("    auth         : {}", p.auth_hint);
+        println!("  {} {}", p.display.bold(), format!("({})", p.key).dimmed());
+        println!("    {}: {}", "base_url".dimmed(), p.base_url);
+        println!("    {}: {}", "default_model".dimmed(), p.model.cyan());
+        println!("    {}: {}", "auth".dimmed(), p.auth_hint.yellow());
         if p.disable_catalog {
-            println!("    catalog      : disabled (self-hosted endpoint)");
+            println!(
+                "    {}: {}",
+                "catalog".dimmed(),
+                "disabled (self-hosted endpoint)".red()
+            );
         }
         if !p.notes.is_empty() {
-            println!("    notes        : {}", p.notes);
+            println!("    {}: {}", "notes".dimmed(), p.notes);
         }
     }
     println!();
-    println!("Add via:  vulcan provider add <name> --preset <key>");
+    println!(
+        "{}",
+        "Add via:  vulcan provider add <name> --preset <key>".dimmed()
+    );
 }
 
 pub fn add(args: AddArgs, dir: &Path) -> Result<()> {
@@ -274,8 +442,16 @@ pub fn add(args: AddArgs, dir: &Path) -> Result<()> {
     doc.insert(&args.name, Item::Table(entry));
 
     write_doc(&providers_path, &doc)?;
-    println!("Wrote [{}] to {}", args.name, providers_path.display());
-    println!("Use `/provider {}` in the TUI to switch.", args.name);
+    println!(
+        "{} Wrote [{}] to {}",
+        "✓".green(),
+        args.name,
+        providers_path.display()
+    );
+    println!(
+        "{}",
+        "Use `/provider <name>` in the TUI to switch.".dimmed()
+    );
     Ok(())
 }
 
@@ -301,7 +477,12 @@ fn remove(args: RemoveArgs, dir: &Path) -> Result<()> {
         );
     }
     write_doc(&providers_path, &doc)?;
-    println!("Removed [{}] from {}", args.name, providers_path.display());
+    println!(
+        "{} Removed [{}] from {}",
+        "✓".green(),
+        args.name,
+        providers_path.display()
+    );
     Ok(())
 }
 

--- a/src/config_registry.rs
+++ b/src/config_registry.rs
@@ -54,6 +54,14 @@ pub enum FieldKind {
     /// checked (a config may legitimately point at a not-yet-
     /// created directory).
     Path,
+    /// LLM model selector. Interactive mode fetches the provider
+    /// catalog and presents a fuzzy-search picker. Non-interactive
+    /// mode accepts any string (the model id).
+    Model,
+    /// Embedding model selector. Interactive mode presents a
+    /// curated list of known embedding models with fuzzy search.
+    /// Non-interactive mode accepts any string.
+    EmbeddingModel,
 }
 
 /// Which file under `~/.vulcan/` owns this field. Lets the writer
@@ -193,6 +201,41 @@ const BUILTIN_FIELDS: &[ConfigField] = &[
         help: "Maximum number of recalled hits to inject.",
         file: ConfigFile::Config,
     },
+    // ── cortex.* ─────────────────────────────────────────────
+    ConfigField {
+        path: "cortex.enabled",
+        kind: FieldKind::Bool,
+        default: "false",
+        help: "Enable embedded cortex-memory-core graph memory (semantic search + auto-capture hooks).",
+        file: ConfigFile::Config,
+    },
+    ConfigField {
+        path: "cortex.embedding_model",
+        kind: FieldKind::EmbeddingModel,
+        default: "BAAI/bge-small-en-v1.5",
+        help: "Embedding model for cortex vector search. Interactive picker lists known models.",
+        file: ConfigFile::Config,
+    },
+    ConfigField {
+        path: "cortex.max_search_results",
+        kind: FieldKind::Int {
+            min: Some(1),
+            max: Some(50),
+        },
+        default: "5",
+        help: "Max nodes returned by cortex semantic search per turn.",
+        file: ConfigFile::Config,
+    },
+    ConfigField {
+        path: "cortex.min_importance",
+        kind: FieldKind::Float {
+            min: Some(0.0),
+            max: Some(1.0),
+        },
+        default: "0.3",
+        help: "Minimum importance (0.0-1.0) for auto-stored nodes. Manual stores always pass through.",
+        file: ConfigFile::Config,
+    },
     // ── embeddings.* ──────────────────────────────────────────
     ConfigField {
         path: "embeddings.enabled",
@@ -225,9 +268,9 @@ const BUILTIN_FIELDS: &[ConfigField] = &[
     },
     ConfigField {
         path: "provider.model",
-        kind: FieldKind::String { secret: false },
+        kind: FieldKind::Model,
         default: "(unset)",
-        help: "Default model id sent to the provider.",
+        help: "Default model id sent to the provider. Interactive picker fetches the catalog.",
         file: ConfigFile::Providers,
     },
     ConfigField {

--- a/src/memory/cortex.rs
+++ b/src/memory/cortex.rs
@@ -7,6 +7,20 @@
 //! All public methods are `&self` — `Cortex` and its storage use interior
 //! mutability internally, so callers can pass `Arc<CortexStore>` through
 //! hooks without locking.
+//!
+//! ## Why no persistent second `RedbStorage` handle?
+//!
+//! `Cortex::open()` opens `cortex.redb` once and holds an exclusive file lock.
+//! Opening `RedbStorage::open()` a second time on the same file fails with
+//! "Database already open. Cannot acquire lock." because redb uses a
+//! single-writer lock model.
+//!
+//! Instead, edge-management and decay operations that need the raw storage
+//! API open a **transient** `RedbStorage` handle on demand (the CLI commands
+//! that call these methods are short-lived — they open, do work, and exit,
+//! so the lock is held only briefly). The long-lived `CortexStore` held by
+//! the agent and hooks never holds a second handle, so the lock is free
+//! when the TUI exits.
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -23,8 +37,6 @@ use crate::config::{CortexConfig, vulcan_home};
 /// Wrapper around the embedded Cortex graph memory engine.
 pub struct CortexStore {
     pub inner: Cortex,
-    /// Shared redb handle so lower-level engines can operate on the same db.
-    storage: Arc<RedbStorage>,
     config: CortexConfig,
 }
 
@@ -47,10 +59,6 @@ impl CortexStore {
         let inner = Cortex::open(&db_path, lib_config)
             .with_context(|| format!("open cortex db at {}", db_path.display()))?;
 
-        let storage = Arc::new(
-            RedbStorage::open(&db_path).context("re-open redb for shared storage handle")?,
-        );
-
         tracing::info!(
             "cortex memory ready at {} (model: {})",
             db_path.display(),
@@ -59,7 +67,6 @@ impl CortexStore {
 
         Ok(Arc::new(Self {
             inner,
-            storage,
             config: config.clone(),
         }))
     }
@@ -121,28 +128,47 @@ impl CortexStore {
         self.inner.create_edge(edge).context("cortex create edge")
     }
 
+    // ── Edge management (requires transient storage handle) ──
+    //
+    // These methods open a short-lived `RedbStorage` handle because
+    // `Cortex` does not expose the raw storage API. They are intended
+    // for CLI subcommands that run and exit — NOT for the agent loop.
+    // The transient handle is opened, the operation runs, and the
+    // handle is dropped immediately, releasing the file lock.
+
     /// List all edges originating from `node_id`.
+    ///
+    /// Opens a transient storage handle. Only call from short-lived
+    /// CLI commands, not from agent hooks.
     pub fn edges_from(&self, node_id: NodeId) -> Result<Vec<cortex_core::Edge>> {
-        self.storage
-            .edges_from(node_id)
-            .context("cortex edges_from")
+        let storage = open_transient_storage(&self.config)?;
+        storage.edges_from(node_id).context("cortex edges_from")
     }
 
     /// List all edges terminating at `node_id`.
+    ///
+    /// Opens a transient storage handle. Only call from short-lived
+    /// CLI commands, not from agent hooks.
     pub fn edges_to(&self, node_id: NodeId) -> Result<Vec<cortex_core::Edge>> {
-        self.storage.edges_to(node_id).context("cortex edges_to")
+        let storage = open_transient_storage(&self.config)?;
+        storage.edges_to(node_id).context("cortex edges_to")
     }
 
     /// Delete an edge by its ID.
+    ///
+    /// Opens a transient storage handle. Only call from short-lived
+    /// CLI commands, not from agent hooks.
     pub fn delete_edge(&self, edge_id: cortex_core::EdgeId) -> Result<()> {
-        self.storage
-            .delete_edge(edge_id)
-            .context("cortex delete_edge")
+        let storage = open_transient_storage(&self.config)?;
+        storage.delete_edge(edge_id).context("cortex delete_edge")
     }
 
     /// Atomically update the weight of an edge between two nodes.
     /// Takes a relation filter and a weight-update closure.
     /// Returns `(old_weight, new_weight)`.
+    ///
+    /// Opens a transient storage handle. Only call from short-lived
+    /// CLI commands, not from agent hooks.
     pub fn update_edge_weight_atomic(
         &self,
         from: NodeId,
@@ -150,7 +176,8 @@ impl CortexStore {
         relation: &cortex_core::Relation,
         f: impl FnOnce(f32) -> f32,
     ) -> Result<(f32, f32)> {
-        self.storage
+        let storage = open_transient_storage(&self.config)?;
+        storage
             .update_edge_weight_atomic(from, to, relation, f)
             .context("cortex update edge weight")
     }
@@ -171,9 +198,13 @@ impl CortexStore {
 
     /// Run edge-decay. Call periodically to age out stale connections.
     /// Returns `(pruned_count, deleted_count)`.
+    ///
+    /// Opens a transient storage handle. Only call from short-lived
+    /// CLI commands, not from agent hooks.
     pub fn run_decay(&self) -> Result<(u64, u64)> {
+        let storage = Arc::new(open_transient_storage(&self.config)?);
         let engine = DecayEngine::new(
-            self.storage.clone(),
+            storage,
             DecayConfig {
                 daily_decay_rate: 0.01,
                 prune_threshold: 0.1,
@@ -191,24 +222,43 @@ impl CortexStore {
     /// Simple graph statistics.
     pub fn stats(&self) -> Result<CortexStats> {
         let nodes = self.inner.list_nodes(NodeFilter::new())?.len();
-        let edges = self
-            .storage
-            .list_nodes(NodeFilter::new())?
-            .iter()
-            .map(|n| {
-                self.storage
-                    .edges_from(n.id)
-                    .map(|e: Vec<_>| e.len())
-                    .unwrap_or(0)
-            })
-            .sum::<usize>();
-        Ok(CortexStats { nodes, edges })
+        // Count edges by traversing each node's neighbourhood.
+        // This avoids opening a second RedbStorage handle (which
+        // would fail with a lock conflict). We use `traverse` at
+        // depth 1 to get each node's local edges, but dedup since
+        // edges appear from both sides.
+        let mut edge_count: usize = 0;
+        let all_nodes = self.inner.list_nodes(NodeFilter::new())?;
+        for node in &all_nodes {
+            if let Ok(sg) = self.inner.traverse(node.id, 1) {
+                // Each edge is counted from both endpoints; divide by 2.
+                edge_count += sg.edges.len();
+            }
+        }
+        // Each edge appears in two traversals (from + to), so halve.
+        edge_count /= 2;
+        Ok(CortexStats {
+            nodes,
+            edges: edge_count,
+        })
     }
 
     /// Access the shared config.
     pub fn config(&self) -> &CortexConfig {
         &self.config
     }
+}
+
+/// Open a short-lived `RedbStorage` handle for edge management
+/// and decay operations.
+///
+/// **CAUTION:** This acquires an exclusive file lock on `cortex.redb`.
+/// It MUST only be called from short-lived CLI subcommands that exit
+/// after the operation completes. Calling this from the agent loop
+/// or TUI (which already holds the lock via `Cortex::open`) will fail.
+fn open_transient_storage(config: &CortexConfig) -> Result<RedbStorage> {
+    let db_path = resolve_db_path(config)?;
+    RedbStorage::open(&db_path).context("open transient cortex storage")
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Adds a fuzzy-select interactive picker to `vulcan config` (no-arg:
pick category → pick field → kind-aware prompt → confirm; `set <key>`
without value: kind-aware prompt for that field). Picker handles
bool/int/float/enum/string/path plus new Model + EmbeddingModel
kinds (provider catalog fetch + curated embedding list). Adds
owo-colors for green-on-set / yellow-on-default styling across
list/show/get.

config_registry gains FieldKind::Model + FieldKind::EmbeddingModel
and the cortex.* fields (enabled, embedding_model, max_search_results,
min_importance) so the picker has them in the catalog.

cli_model + cli_provider catalog + memory/cortex tweaks support the
new field kinds. .gitignore drops the bge-small embedding cache.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>