### PR TITLE
feat(extensions): add input demo dogfood crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7176,6 +7176,7 @@ dependencies = [
  "tracing-subscriber",
  "vulcan-core",
  "vulcan-ext-auto-commit",
+ "vulcan-ext-input-demo",
 ]
 
 [[package]]
@@ -7263,6 +7264,19 @@ dependencies = [
  "tracing",
  "vulcan-core",
  "vulcan-extension-macros",
+]
+
+[[package]]
+name = "vulcan-ext-input-demo"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "inventory",
+ "parking_lot",
+ "tokio",
+ "tokio-util",
+ "vulcan-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "vulcan-frontend-api",
     "vulcan-extension-macros",
     "vulcan-ext-auto-commit",
+    "vulcan-ext-input-demo",
 ]
 resolver = "2"
 

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -494,6 +494,12 @@ impl Agent {
         // No-op when the agent runs without a pool (CLI one-shot) or
         // when no daemon extensions are registered.
         if let Some(p) = pool.as_ref() {
+            // GH issue #557: install the daemon's shared audit log on
+            // the registry before extension hook handlers register so
+            // any `on_input` outcome they emit lands on the same ring
+            // the CLI / `vulcan extension audit` reads from.
+            hooks = hooks.with_audit_log(p.extension_audit_log());
+
             let ctx = crate::extensions::api::SessionExtensionCtx {
                 cwd: cwd.clone(),
                 session_id: session_id.clone(),

--- a/src/agent/run.rs
+++ b/src/agent/run.rs
@@ -107,6 +107,18 @@ impl Agent {
         self.run_prompt_inner(input).await
     }
 
+    /// GH issue #557: invoke registered `on_input` hooks against
+    /// `raw` and surface the decision. Daemon entry points
+    /// (`prompt.run`, `prompt.stream`, gateway lane drains) call
+    /// this before slash dispatch / `run_prompt_*` so extensions can
+    /// block or rewrite raw user input. Audit log records every
+    /// non-Continue outcome via the registry's installed audit log.
+    pub async fn apply_on_input(&self, raw: &str) -> crate::hooks::InputDecision {
+        self.hooks
+            .apply_on_input(raw, self.turn_cancel.clone())
+            .await
+    }
+
     /// Slice 7: like [`Self::run_prompt_with_cancel`] but stamps the
     /// run record's `RunOrigin` so child runs land as
     /// `RunOrigin::Subagent { parent_run_id }` and `vulcan run show`

--- a/src/daemon/handlers/prompt.rs
+++ b/src/daemon/handlers/prompt.rs
@@ -122,7 +122,33 @@ pub async fn run(state: Arc<DaemonState>, id: String, session_id: String, input:
     sess.set_agent_cancel(cancel_token.clone());
     let mut agent = agent_arc.lock().await;
     install_daemon_subagent_runner(&mut agent, Arc::clone(&state), &session_id);
-    let result = agent.run_prompt_with_cancel(input, cancel_token).await;
+
+    // GH issue #557: extensions with the `InputInterceptor` capability
+    // can block or rewrite raw user input via `on_input` before slash
+    // dispatch + turn execution. Block short-circuits here with the
+    // hook's reason; Replace swaps the input on the wire path; Continue
+    // forwards as-is.
+    let effective_input: String = match agent.apply_on_input(input).await {
+        crate::hooks::InputDecision::Continue => input.to_string(),
+        crate::hooks::InputDecision::Replace(rewrite) => rewrite,
+        crate::hooks::InputDecision::Block(reason) => {
+            drop(agent);
+            *sess.in_flight.lock() = false;
+            sess.touch();
+            return Response::error(
+                id,
+                ProtocolError {
+                    code: "INPUT_BLOCKED".into(),
+                    message: format!("input blocked by extension: {reason}"),
+                    retryable: false,
+                },
+            );
+        }
+    };
+
+    let result = agent
+        .run_prompt_with_cancel(&effective_input, cancel_token)
+        .await;
     drop(agent);
     *sess.in_flight.lock() = false;
     sess.touch();
@@ -206,9 +232,34 @@ pub fn stream(
         let cancel_token = tokio_util::sync::CancellationToken::new();
         sess_for_task.set_agent_cancel(cancel_token.clone());
 
+        // GH issue #557: run `on_input` interception before spawning
+        // the streaming task. Block short-circuits with INPUT_BLOCKED;
+        // Replace swaps the input forwarded to `run_prompt_stream_with_cancel`.
+        let effective_input: String = {
+            let agent = agent_arc.lock().await;
+            match agent.apply_on_input(&input).await {
+                crate::hooks::InputDecision::Continue => input.clone(),
+                crate::hooks::InputDecision::Replace(rewrite) => rewrite,
+                crate::hooks::InputDecision::Block(reason) => {
+                    drop(agent);
+                    *sess_for_task.in_flight.lock() = false;
+                    sess_for_task.touch();
+                    let _ = done_tx.send(Response::error(
+                        rid.clone(),
+                        ProtocolError {
+                            code: "INPUT_BLOCKED".into(),
+                            message: format!("input blocked by extension: {reason}"),
+                            retryable: false,
+                        },
+                    ));
+                    return;
+                }
+            }
+        };
+
         // Clone the Arc for the prompt task so the guard lives inside it.
         let agent_arc2 = agent_arc.clone();
-        let input2 = input.clone();
+        let input2 = effective_input;
         let cancel2 = cancel_token.clone();
         let session_id_for_runner = session_id.clone();
         let prompt_task = tokio::spawn(async move {

--- a/src/extensions/audit.rs
+++ b/src/extensions/audit.rs
@@ -11,8 +11,11 @@ use std::collections::HashMap;
 
 use super::policy::{ExtensionPermission, PolicyDecision};
 
+/// Permission-keyed audit row. Original YYC-237 shape; covers
+/// filesystem / network / shell decisions emitted by the tool
+/// dispatch path.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ExtensionAuditEvent {
+pub struct PermissionAuditEvent {
     pub extension_id: String,
     pub permission: ExtensionPermission,
     pub decision: PolicyDecision,
@@ -21,6 +24,58 @@ pub struct ExtensionAuditEvent {
     /// requests may omit it.
     pub target: Option<String>,
     pub occurred_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// GH issue #557: action an `on_input` extension hook took on user
+/// input. `Block` short-circuits with the supplied reason; `Replace`
+/// substitutes the `after` text from the parent event.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum InputInterceptAction {
+    Block { reason: String },
+    Replace,
+}
+
+/// GH issue #557: input-intercept audit row. Recorded whenever an
+/// extension's `on_input` hook returns a non-Continue outcome.
+/// `before` is the raw user input; `after` is what the daemon
+/// dispatched (the rewrite, or the original on Block).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InputInterceptEvent {
+    pub extension_id: String,
+    pub before: String,
+    pub after: String,
+    pub action: InputInterceptAction,
+    pub occurred_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Polymorphic audit row recorded into [`ExtensionAuditLog`]. Each
+/// variant carries the typed payload for one event class.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum ExtensionAuditEvent {
+    Permission(PermissionAuditEvent),
+    InputIntercept(InputInterceptEvent),
+}
+
+impl ExtensionAuditEvent {
+    /// Common accessor across variants — every audit row knows which
+    /// extension produced it.
+    pub fn extension_id(&self) -> &str {
+        match self {
+            Self::Permission(p) => &p.extension_id,
+            Self::InputIntercept(i) => &i.extension_id,
+        }
+    }
+
+    /// Common accessor across variants — every audit row carries a
+    /// timestamp.
+    pub fn occurred_at(&self) -> chrono::DateTime<chrono::Utc> {
+        match self {
+            Self::Permission(p) => p.occurred_at,
+            Self::InputIntercept(i) => i.occurred_at,
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -117,13 +172,13 @@ mod tests {
     use super::*;
 
     fn fixture_event(id: &str) -> ExtensionAuditEvent {
-        ExtensionAuditEvent {
+        ExtensionAuditEvent::Permission(PermissionAuditEvent {
             extension_id: id.to_string(),
             permission: ExtensionPermission::FilesystemRead,
             decision: PolicyDecision::Allow,
             target: Some("/etc/hosts".into()),
             occurred_at: chrono::Utc::now(),
-        }
+        })
     }
 
     #[test]
@@ -133,7 +188,7 @@ mod tests {
         log.record(fixture_event("b"));
         log.record(fixture_event("c"));
         let recent = log.recent(2);
-        let ids: Vec<&str> = recent.iter().map(|e| e.extension_id.as_str()).collect();
+        let ids: Vec<&str> = recent.iter().map(|e| e.extension_id()).collect();
         assert_eq!(ids, vec!["c", "b"]);
     }
 
@@ -145,7 +200,7 @@ mod tests {
         log.record(fixture_event("c"));
         assert_eq!(log.len(), 2);
         let recent = log.recent(10);
-        let ids: Vec<&str> = recent.iter().map(|e| e.extension_id.as_str()).collect();
+        let ids: Vec<&str> = recent.iter().map(|e| e.extension_id()).collect();
         assert_eq!(ids, vec!["c", "b"]);
     }
 
@@ -174,6 +229,45 @@ mod tests {
     #[test]
     fn audit_event_round_trips_through_serde_json() {
         let evt = fixture_event("zeta");
+        let json = serde_json::to_string(&evt).unwrap();
+        let back: ExtensionAuditEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, evt);
+    }
+
+    #[test]
+    fn audit_log_records_input_intercept_event_and_returns_it() {
+        let log = ExtensionAuditLog::new(8);
+        let evt = ExtensionAuditEvent::InputIntercept(InputInterceptEvent {
+            extension_id: "input-demo".to_string(),
+            before: "hi".to_string(),
+            after: "hello".to_string(),
+            action: InputInterceptAction::Replace,
+            occurred_at: chrono::Utc::now(),
+        });
+        log.record(evt.clone());
+        let recent = log.recent(1);
+        assert_eq!(recent.len(), 1);
+        match &recent[0] {
+            ExtensionAuditEvent::InputIntercept(intercept) => {
+                assert_eq!(intercept.before, "hi");
+                assert_eq!(intercept.after, "hello");
+                assert!(matches!(intercept.action, InputInterceptAction::Replace));
+            }
+            other => panic!("expected InputIntercept, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn input_intercept_event_round_trips_through_serde_json() {
+        let evt = ExtensionAuditEvent::InputIntercept(InputInterceptEvent {
+            extension_id: "input-demo".to_string(),
+            before: "raw".to_string(),
+            after: "expanded".to_string(),
+            action: InputInterceptAction::Block {
+                reason: "policy".into(),
+            },
+            occurred_at: chrono::Utc::now(),
+        });
         let json = serde_json::to_string(&evt).unwrap();
         let back: ExtensionAuditEvent = serde_json::from_str(&json).unwrap();
         assert_eq!(back, evt);

--- a/src/extensions/draft.rs
+++ b/src/extensions/draft.rs
@@ -143,6 +143,7 @@ fn parse_capability(raw: &str) -> Option<ExtensionCapability> {
         "tool_provider" => Some(ExtensionCapability::ToolProvider),
         "memory_backend" => Some(ExtensionCapability::MemoryBackend),
         "lifecycle_observer" => Some(ExtensionCapability::LifecycleObserver),
+        "input_interceptor" => Some(ExtensionCapability::InputInterceptor),
         _ => None,
     }
 }

--- a/src/extensions/manifest.rs
+++ b/src/extensions/manifest.rs
@@ -59,6 +59,12 @@ pub struct ExtensionManifest {
     pub min_vulcan_version: Option<String>,
     #[serde(default)]
     pub description: Option<String>,
+    /// GH issue #557: when `true`, the daemon routes a `ReplaceInput`
+    /// proposal from this extension's `on_input` hook through
+    /// `AgentPause` so the user confirms the rewrite before it lands
+    /// on the wire. Defaults to `false`.
+    #[serde(default)]
+    pub requires_user_approval: bool,
 }
 
 #[derive(Debug, Error)]
@@ -256,5 +262,33 @@ kind = "builtin"
         let serialized = toml::to_string(&m).unwrap();
         let parsed_back = ExtensionManifest::from_toml_str(&serialized).unwrap();
         assert_eq!(m, parsed_back);
+    }
+
+    #[test]
+    fn requires_user_approval_defaults_to_false_and_parses_when_present() {
+        let default_raw = r#"
+id = "input-demo"
+name = "Input Demo"
+version = "0.1.0"
+capabilities = ["input_interceptor"]
+
+[entry]
+kind = "builtin"
+"#;
+        let default_m = ExtensionManifest::from_toml_str(default_raw).unwrap();
+        assert!(!default_m.requires_user_approval);
+
+        let opted_in_raw = r#"
+id = "input-demo"
+name = "Input Demo"
+version = "0.1.0"
+capabilities = ["input_interceptor"]
+requires_user_approval = true
+
+[entry]
+kind = "builtin"
+"#;
+        let opted_in_m = ExtensionManifest::from_toml_str(opted_in_raw).unwrap();
+        assert!(opted_in_m.requires_user_approval);
     }
 }

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -28,7 +28,10 @@ pub mod registry;
 pub mod store;
 pub mod verify;
 
-pub use audit::{ExtensionAuditEvent, ExtensionAuditLog, QuotaTracker};
+pub use audit::{
+    ExtensionAuditEvent, ExtensionAuditLog, InputInterceptAction, InputInterceptEvent,
+    PermissionAuditEvent, QuotaTracker,
+};
 pub use config_field::{ExtensionConfigField, ExtensionFieldKind};
 pub use draft::parse_skill_extension;
 pub use install_state::{InstallState, InstallStateStore, SqliteInstallStateStore};
@@ -96,6 +99,11 @@ pub enum ExtensionCapability {
     ToolProvider,
     MemoryBackend,
     LifecycleObserver,
+    /// GH issue #557: extension may register an `on_input` handler
+    /// that blocks or rewrites raw user input. Activation refuses
+    /// extensions that contribute an `on_input` hook without
+    /// declaring this capability.
+    InputInterceptor,
 }
 
 impl ExtensionCapability {
@@ -106,6 +114,7 @@ impl ExtensionCapability {
             ExtensionCapability::ToolProvider => "tool_provider",
             ExtensionCapability::MemoryBackend => "memory_backend",
             ExtensionCapability::LifecycleObserver => "lifecycle_observer",
+            ExtensionCapability::InputInterceptor => "input_interceptor",
         }
     }
 }

--- a/src/extensions/verify.rs
+++ b/src/extensions/verify.rs
@@ -135,6 +135,7 @@ mod tests {
             checksum: checksum.map(String::from),
             min_vulcan_version: min.map(String::from),
             description: None,
+            requires_user_approval: false,
         }
     }
 

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -84,6 +84,17 @@ pub enum ToolCallDecision {
     ReplaceArgs(Value),
 }
 
+/// Decision returned to the agent / daemon loop by `on_input`.
+/// `Block` short-circuits the prompt entirely; `Replace` swaps the raw
+/// user text before slash dispatch and turn execution; `Continue`
+/// passes the original input through unchanged.
+#[derive(Debug, Clone)]
+pub enum InputDecision {
+    Continue,
+    Block(String),
+    Replace(String),
+}
+
 /// A handler subscribes to the events it cares about by overriding the matching
 /// async methods. The default impls are no-ops, so a handler only needs to
 /// implement the ones it uses.
@@ -109,6 +120,13 @@ pub trait HookHandler: Send + Sync {
     }
 
     async fn on_turn_end(&self, _turn: u32, _cancel: CancellationToken) -> Result<HookOutcome> {
+        Ok(HookOutcome::Continue)
+    }
+
+    /// GH issue #557: intercept raw user input before slash dispatch
+    /// + turn execution. Outcomes honored: `Continue`, `BlockInput`,
+    /// `ReplaceInput`. Default `Continue`.
+    async fn on_input(&self, _raw: &str, _cancel: CancellationToken) -> Result<HookOutcome> {
         Ok(HookOutcome::Continue)
     }
 
@@ -269,12 +287,17 @@ pub struct HookRegistry {
     handlers: Vec<Arc<dyn HookHandler>>,
     handler_timeout: Duration,
     failure_metrics: HookFailureMetrics,
+    /// GH issue #557: optional audit log. When set, `apply_on_input`
+    /// records every non-Continue outcome as an `InputIntercept`
+    /// event. `None` means audit silently skips (CLI one-shot path).
+    audit_log: Option<Arc<crate::extensions::ExtensionAuditLog>>,
 }
 
 impl HookRegistry {
     pub fn new() -> Self {
         Self {
             handlers: Vec::new(),
+            audit_log: None,
             handler_timeout: Duration::from_secs(30),
             failure_metrics: HookFailureMetrics::default(),
         }
@@ -282,6 +305,15 @@ impl HookRegistry {
 
     pub fn with_timeout(mut self, timeout: Duration) -> Self {
         self.handler_timeout = timeout;
+        self
+    }
+
+    /// GH issue #557: install the daemon's `ExtensionAuditLog` so
+    /// `apply_on_input` can record `InputIntercept` rows on Block /
+    /// Replace outcomes. Optional — registries without an audit log
+    /// silently skip recording.
+    pub fn with_audit_log(mut self, log: Arc<crate::extensions::ExtensionAuditLog>) -> Self {
+        self.audit_log = Some(log);
         self
     }
 
@@ -579,6 +611,72 @@ impl HookRegistry {
                 self.run(h, h.on_session_shutdown(cancel.clone())).await,
             );
         }
+    }
+
+    /// GH issue #557: emit `on_input` to every handler. First
+    /// non-Continue outcome wins. `BlockInput` short-circuits the
+    /// prompt; `ReplaceInput` swaps the raw user text. Other outcome
+    /// variants are logged + ignored. Block / Replace outcomes are
+    /// also recorded to the registry's `ExtensionAuditLog` (when
+    /// installed via `with_audit_log`), with the handler's `name()`
+    /// as the audit `extension_id`.
+    pub async fn apply_on_input(&self, raw: &str, cancel: CancellationToken) -> InputDecision {
+        for h in &self.handlers {
+            match self.run(h, h.on_input(raw, cancel.clone())).await {
+                Some(HookOutcome::BlockInput { reason }) => {
+                    tracing::info!("hook {} blocked input: {reason}", h.name());
+                    self.record_input_intercept(
+                        h.name(),
+                        raw,
+                        raw,
+                        crate::extensions::InputInterceptAction::Block {
+                            reason: reason.clone(),
+                        },
+                    );
+                    return InputDecision::Block(reason);
+                }
+                Some(HookOutcome::ReplaceInput(rewrite)) => {
+                    tracing::info!("hook {} replaced input", h.name());
+                    self.record_input_intercept(
+                        h.name(),
+                        raw,
+                        &rewrite,
+                        crate::extensions::InputInterceptAction::Replace,
+                    );
+                    return InputDecision::Replace(rewrite);
+                }
+                Some(HookOutcome::Continue) | None => {}
+                Some(other) => {
+                    tracing::warn!(
+                        "hook {} returned {:?} for on_input (ignored)",
+                        h.name(),
+                        other
+                    );
+                }
+            }
+        }
+        InputDecision::Continue
+    }
+
+    fn record_input_intercept(
+        &self,
+        extension_id: &str,
+        before: &str,
+        after: &str,
+        action: crate::extensions::InputInterceptAction,
+    ) {
+        let Some(log) = self.audit_log.as_ref() else {
+            return;
+        };
+        log.record(crate::extensions::ExtensionAuditEvent::InputIntercept(
+            crate::extensions::InputInterceptEvent {
+                extension_id: extension_id.to_string(),
+                before: before.to_string(),
+                after: after.to_string(),
+                action,
+                occurred_at: chrono::Utc::now(),
+            },
+        ));
     }
 
     /// Emit BeforeToolCall. First non-Continue outcome wins.
@@ -1450,5 +1548,242 @@ mod tests {
                 .await
         );
         assert_eq!(later_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn apply_on_input_records_audit_event_for_replace() {
+        use crate::extensions::{ExtensionAuditEvent, ExtensionAuditLog, InputInterceptAction};
+
+        struct Rewriter;
+
+        #[async_trait::async_trait]
+        impl HookHandler for Rewriter {
+            fn name(&self) -> &str {
+                "input-demo"
+            }
+            async fn on_input(
+                &self,
+                _raw: &str,
+                _cancel: CancellationToken,
+            ) -> Result<HookOutcome> {
+                Ok(HookOutcome::ReplaceInput("rewritten".into()))
+            }
+        }
+
+        let audit = Arc::new(ExtensionAuditLog::new(8));
+        let mut reg = HookRegistry::new().with_audit_log(audit.clone());
+        reg.register(Arc::new(Rewriter));
+
+        let _ = reg.apply_on_input("raw", CancellationToken::new()).await;
+
+        let recent = audit.recent(1);
+        assert_eq!(recent.len(), 1);
+        match &recent[0] {
+            ExtensionAuditEvent::InputIntercept(e) => {
+                assert_eq!(e.extension_id, "input-demo");
+                assert_eq!(e.before, "raw");
+                assert_eq!(e.after, "rewritten");
+                assert!(matches!(e.action, InputInterceptAction::Replace));
+            }
+            other => panic!("expected InputIntercept, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn apply_on_input_records_audit_event_for_block() {
+        use crate::extensions::{ExtensionAuditEvent, ExtensionAuditLog, InputInterceptAction};
+
+        struct Blocker;
+
+        #[async_trait::async_trait]
+        impl HookHandler for Blocker {
+            fn name(&self) -> &str {
+                "input-policy"
+            }
+            async fn on_input(
+                &self,
+                _raw: &str,
+                _cancel: CancellationToken,
+            ) -> Result<HookOutcome> {
+                Ok(HookOutcome::BlockInput {
+                    reason: "denied".into(),
+                })
+            }
+        }
+
+        let audit = Arc::new(ExtensionAuditLog::new(8));
+        let mut reg = HookRegistry::new().with_audit_log(audit.clone());
+        reg.register(Arc::new(Blocker));
+
+        let _ = reg.apply_on_input("hello", CancellationToken::new()).await;
+
+        let recent = audit.recent(1);
+        match &recent[0] {
+            ExtensionAuditEvent::InputIntercept(e) => {
+                assert_eq!(e.extension_id, "input-policy");
+                assert_eq!(e.before, "hello");
+                assert_eq!(e.after, "hello");
+                match &e.action {
+                    InputInterceptAction::Block { reason } => assert_eq!(reason, "denied"),
+                    _ => panic!("expected Block action"),
+                }
+            }
+            other => panic!("expected InputIntercept, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn apply_on_input_does_not_record_audit_when_continue() {
+        use crate::extensions::ExtensionAuditLog;
+
+        struct Noop;
+
+        #[async_trait::async_trait]
+        impl HookHandler for Noop {
+            fn name(&self) -> &str {
+                "noop"
+            }
+        }
+
+        let audit = Arc::new(ExtensionAuditLog::new(8));
+        let mut reg = HookRegistry::new().with_audit_log(audit.clone());
+        reg.register(Arc::new(Noop));
+
+        let _ = reg.apply_on_input("hello", CancellationToken::new()).await;
+
+        assert_eq!(audit.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn apply_on_input_returns_replace_when_hook_returns_replace_input() {
+        struct Rewriter;
+
+        #[async_trait::async_trait]
+        impl HookHandler for Rewriter {
+            fn name(&self) -> &str {
+                "rewriter"
+            }
+            async fn on_input(
+                &self,
+                _raw: &str,
+                _cancel: CancellationToken,
+            ) -> Result<HookOutcome> {
+                Ok(HookOutcome::ReplaceInput("rewritten".into()))
+            }
+        }
+
+        let mut reg = HookRegistry::new();
+        reg.register(Arc::new(Rewriter));
+
+        let decision = reg
+            .apply_on_input("original", CancellationToken::new())
+            .await;
+
+        match decision {
+            InputDecision::Replace(text) => assert_eq!(text, "rewritten"),
+            other => panic!("expected Replace, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn apply_on_input_returns_continue_when_no_hook_intervenes() {
+        struct Noop;
+
+        #[async_trait::async_trait]
+        impl HookHandler for Noop {
+            fn name(&self) -> &str {
+                "noop"
+            }
+        }
+
+        let mut reg = HookRegistry::new();
+        reg.register(Arc::new(Noop));
+
+        let decision = reg
+            .apply_on_input("untouched", CancellationToken::new())
+            .await;
+
+        assert!(matches!(decision, InputDecision::Continue));
+    }
+
+    #[tokio::test]
+    async fn apply_on_input_first_decision_wins_short_circuits_later_handlers() {
+        struct Rewriter;
+        struct LaterCounter(Arc<AtomicUsize>);
+
+        #[async_trait::async_trait]
+        impl HookHandler for Rewriter {
+            fn name(&self) -> &str {
+                "rewriter"
+            }
+            fn priority(&self) -> i32 {
+                10
+            }
+            async fn on_input(
+                &self,
+                _raw: &str,
+                _cancel: CancellationToken,
+            ) -> Result<HookOutcome> {
+                Ok(HookOutcome::ReplaceInput("rewritten".into()))
+            }
+        }
+
+        #[async_trait::async_trait]
+        impl HookHandler for LaterCounter {
+            fn name(&self) -> &str {
+                "later"
+            }
+            fn priority(&self) -> i32 {
+                20
+            }
+            async fn on_input(
+                &self,
+                _raw: &str,
+                _cancel: CancellationToken,
+            ) -> Result<HookOutcome> {
+                self.0.fetch_add(1, Ordering::SeqCst);
+                Ok(HookOutcome::Continue)
+            }
+        }
+
+        let later = Arc::new(AtomicUsize::new(0));
+        let mut reg = HookRegistry::new();
+        reg.register(Arc::new(Rewriter));
+        reg.register(Arc::new(LaterCounter(later.clone())));
+
+        let _ = reg.apply_on_input("hello", CancellationToken::new()).await;
+
+        assert_eq!(later.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn apply_on_input_returns_block_when_hook_returns_block_input() {
+        struct BlockingInput;
+
+        #[async_trait::async_trait]
+        impl HookHandler for BlockingInput {
+            fn name(&self) -> &str {
+                "blocking-input"
+            }
+            async fn on_input(
+                &self,
+                _raw: &str,
+                _cancel: CancellationToken,
+            ) -> Result<HookOutcome> {
+                Ok(HookOutcome::BlockInput {
+                    reason: "policy".into(),
+                })
+            }
+        }
+
+        let mut reg = HookRegistry::new();
+        reg.register(Arc::new(BlockingInput));
+
+        let decision = reg.apply_on_input("hello", CancellationToken::new()).await;
+
+        match decision {
+            InputDecision::Block(reason) => assert_eq!(reason, "policy"),
+            other => panic!("expected Block, got {other:?}"),
+        }
     }
 }

--- a/src/pause.rs
+++ b/src/pause.rs
@@ -102,6 +102,16 @@ pub enum PauseKind {
         path: String,
         hunks: Vec<DiffScrubHunk>,
     },
+    /// GH issue #557: an extension's `on_input` hook proposed a
+    /// `ReplaceInput` rewrite and its manifest declared
+    /// `requires_user_approval = true`. The TUI shows the
+    /// before/after pair; user accepts (`Allow`), denies (`Deny`),
+    /// or denies with reason (`DenyWithReason`).
+    InputRewriteApproval {
+        extension_id: String,
+        before: String,
+        after: String,
+    },
 }
 
 /// The user's decision.

--- a/src/runtime_pool.rs
+++ b/src/runtime_pool.rs
@@ -23,8 +23,8 @@ use std::path::PathBuf;
 
 use crate::artifact::{ArtifactStore, InMemoryArtifactStore, SqliteArtifactStore};
 use crate::code::lsp::LspManager;
-use crate::extensions::ExtensionRegistry;
 use crate::extensions::api::wire_inventory_into_registry;
+use crate::extensions::{ExtensionAuditLog, ExtensionRegistry};
 use crate::memory::SessionStore;
 use crate::memory::cortex::CortexStore;
 use crate::orchestration::OrchestrationStore;
@@ -55,6 +55,11 @@ pub struct RuntimeResourcePool {
     /// active daemon-side extensions from this registry to wire their
     /// per-Session hook handlers, tools, commands, providers.
     extension_registry: Arc<ExtensionRegistry>,
+    /// GH issue #557: daemon-owned **`ExtensionAuditLog`**. Shared
+    /// across sessions — every per-Session `HookRegistry` records
+    /// `InputIntercept` outcomes here. `vulcan extension audit`
+    /// reads from this same handle.
+    extension_audit_log: Arc<ExtensionAuditLog>,
 }
 
 impl RuntimeResourcePool {
@@ -102,6 +107,8 @@ impl RuntimeResourcePool {
             "RuntimeResourcePool: extension registry populated from inventory"
         );
 
+        let extension_audit_log = Arc::new(ExtensionAuditLog::default());
+
         Ok(Self {
             session_store,
             run_store,
@@ -110,6 +117,7 @@ impl RuntimeResourcePool {
             lsp_manager,
             cortex_store: None,
             extension_registry,
+            extension_audit_log,
         })
     }
 
@@ -136,6 +144,7 @@ impl RuntimeResourcePool {
             lsp_manager: Arc::new(LspManager::new(cwd)),
             cortex_store: None,
             extension_registry,
+            extension_audit_log: Arc::new(ExtensionAuditLog::default()),
         }
     }
 
@@ -179,6 +188,14 @@ impl RuntimeResourcePool {
     /// per-Session daemon extensions.
     pub fn extension_registry(&self) -> Arc<ExtensionRegistry> {
         Arc::clone(&self.extension_registry)
+    }
+
+    /// GH issue #557: cloneable handle to the daemon-owned
+    /// **`ExtensionAuditLog`**. Per-Session `HookRegistry`s record
+    /// `InputIntercept` outcomes here so `vulcan extension audit`
+    /// can surface them across sessions.
+    pub fn extension_audit_log(&self) -> Arc<ExtensionAuditLog> {
+        Arc::clone(&self.extension_audit_log)
     }
 }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -801,6 +801,28 @@ pub async fn run_tui(
                         }
                         // DiffScrub handled above; arm kept for exhaustiveness.
                         (PauseKind::DiffScrub { .. }, _) => unreachable!(),
+                        // GH issue #557: extension wants to rewrite raw
+                        // user input. Show before/after to the user.
+                        (
+                            PauseKind::InputRewriteApproval {
+                                extension_id,
+                                before,
+                                after,
+                            },
+                            false,
+                        ) => format!(
+                            "Extension '{extension_id}' proposes input rewrite:\n  before: {before}\n  after:  {after}"
+                        ),
+                        (
+                            PauseKind::InputRewriteApproval {
+                                extension_id,
+                                before,
+                                after,
+                            },
+                            true,
+                        ) => format!(
+                            "Extension '{extension_id}' proposes input rewrite:\n  before: {before}\n  after:  {after}\n  [a]llow once, [d]eny"
+                        ),
                     };
                     app.messages.push(ChatMessage {
                         role: ChatRole::System,

--- a/vulcan-ext-input-demo/Cargo.toml
+++ b/vulcan-ext-input-demo/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "vulcan-ext-input-demo"
+version = "0.1.0"
+edition = "2024"
+description = "Sample input-intercept extension — expands `!!` to the previous user message"
+authors = ["Colin Hanway"]
+license = "MIT"
+repository = "https://github.com/yycholla/vulcan"
+
+[lib]
+name = "vulcan_ext_input_demo"
+path = "src/lib.rs"
+
+[dependencies]
+vulcan = { package = "vulcan-core", path = ".." }
+
+inventory = "0.3.24"
+async-trait = "0.1"
+parking_lot = "0.12"
+anyhow = "1"
+tokio-util = { version = "0.7.18", features = ["rt"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt"] }
+
+[package.metadata.vulcan]
+id = "input-demo"
+capabilities = ["input_interceptor"]
+requires_user_approval = false

--- a/vulcan-ext-input-demo/src/lib.rs
+++ b/vulcan-ext-input-demo/src/lib.rs
@@ -1,0 +1,151 @@
+//! Sample input-intercept extension. Expands `!!` to the most recent
+//! non-`!!` user input the extension has observed for the **Session**.
+//!
+//! Daemon-side cargo-crate extension under GH issue #557. Self-
+//! registers via `inventory::submit!`. Manifest declares
+//! `capabilities = ["input_interceptor"]` and
+//! `requires_user_approval = false` so rewrites land without a
+//! pause prompt; flip the manifest flag to exercise the
+//! `AgentPause::InputRewriteApproval` path.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use parking_lot::Mutex;
+use tokio_util::sync::CancellationToken;
+use vulcan::extensions::api::{
+    DaemonCodeExtension, ExtensionRegistration, SessionExtension, SessionExtensionCtx,
+};
+use vulcan::extensions::{
+    ExtensionCapability, ExtensionMetadata, ExtensionSource, ExtensionStatus,
+};
+use vulcan::hooks::{HookHandler, HookOutcome};
+
+const ID: &str = "input-demo";
+
+pub struct InputDemoExtension;
+
+impl Default for InputDemoExtension {
+    fn default() -> Self {
+        Self
+    }
+}
+
+impl DaemonCodeExtension for InputDemoExtension {
+    fn metadata(&self) -> ExtensionMetadata {
+        let mut m = ExtensionMetadata::new(
+            ID,
+            "Input Demo",
+            env!("CARGO_PKG_VERSION"),
+            ExtensionSource::Builtin,
+        );
+        m.status = ExtensionStatus::Active;
+        m.capabilities = vec![ExtensionCapability::InputInterceptor];
+        m.description = "Expands `!!` to the previous non-`!!` user message.".to_string();
+        m
+    }
+
+    fn instantiate(&self, _ctx: SessionExtensionCtx) -> Arc<dyn SessionExtension> {
+        Arc::new(InputDemoSession {
+            last_input: Arc::new(Mutex::new(None)),
+        })
+    }
+}
+
+struct InputDemoSession {
+    last_input: Arc<Mutex<Option<String>>>,
+}
+
+impl SessionExtension for InputDemoSession {
+    fn hook_handlers(&self) -> Vec<Arc<dyn HookHandler>> {
+        vec![Arc::new(InputDemoHook {
+            last_input: self.last_input.clone(),
+        })]
+    }
+}
+
+struct InputDemoHook {
+    last_input: Arc<Mutex<Option<String>>>,
+}
+
+#[async_trait]
+impl HookHandler for InputDemoHook {
+    fn name(&self) -> &str {
+        ID
+    }
+
+    async fn on_input(&self, raw: &str, _cancel: CancellationToken) -> anyhow::Result<HookOutcome> {
+        let trimmed = raw.trim();
+        if trimmed == "!!" {
+            // Replace with the previous user input when one exists;
+            // otherwise pass the literal `!!` through unchanged so the
+            // user sees no surprise rewrite on the very first turn.
+            return match self.last_input.lock().clone() {
+                Some(prev) => Ok(HookOutcome::ReplaceInput(prev)),
+                None => Ok(HookOutcome::Continue),
+            };
+        }
+        // Cache the latest non-`!!` input for the next turn.
+        *self.last_input.lock() = Some(raw.to_string());
+        Ok(HookOutcome::Continue)
+    }
+}
+
+inventory::submit! {
+    ExtensionRegistration {
+        register: || Arc::new(InputDemoExtension) as Arc<dyn DaemonCodeExtension>,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx() -> SessionExtensionCtx {
+        SessionExtensionCtx {
+            cwd: std::path::PathBuf::from("/tmp/test"),
+            session_id: "test-session".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn first_turn_passes_bang_bang_through_unchanged() {
+        let session = InputDemoExtension.instantiate(ctx());
+        let handlers = session.hook_handlers();
+        let outcome = handlers[0]
+            .on_input("!!", CancellationToken::new())
+            .await
+            .expect("on_input ok");
+        assert!(matches!(outcome, HookOutcome::Continue));
+    }
+
+    #[tokio::test]
+    async fn bang_bang_after_real_input_replaces_with_previous_message() {
+        let session = InputDemoExtension.instantiate(ctx());
+        let handlers = session.hook_handlers();
+
+        let _ = handlers[0]
+            .on_input("show me the code", CancellationToken::new())
+            .await;
+
+        let outcome = handlers[0]
+            .on_input("!!", CancellationToken::new())
+            .await
+            .expect("on_input ok");
+        match outcome {
+            HookOutcome::ReplaceInput(text) => assert_eq!(text, "show me the code"),
+            other => panic!("expected ReplaceInput, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn non_bang_bang_input_is_cached_and_passes_through() {
+        let session = InputDemoExtension.instantiate(ctx());
+        let handlers = session.hook_handlers();
+        let outcome = handlers[0]
+            .on_input("hello", CancellationToken::new())
+            .await
+            .expect("on_input ok");
+        assert!(matches!(outcome, HookOutcome::Continue));
+    }
+}

--- a/vulcan/Cargo.toml
+++ b/vulcan/Cargo.toml
@@ -28,6 +28,9 @@ vulcan = { package = "vulcan-core", path = ".." }
 # `use` the linker can drop unreferenced static items; the explicit
 # dep keeps the registration alive.
 vulcan-ext-auto-commit = { path = "../vulcan-ext-auto-commit" }
+# GH issue #557: input-intercept dogfood extension; same `extern crate`
+# anchoring rationale as auto-commit.
+vulcan-ext-input-demo = { path = "../vulcan-ext-input-demo" }
 
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }

--- a/vulcan/src/main.rs
+++ b/vulcan/src/main.rs
@@ -1,8 +1,9 @@
-// GH issue #549: pull every linked cargo-crate extension's
+// GH issue #549/#557: pull every linked cargo-crate extension's
 // `inventory::submit!` site into the daemon binary so its `register`
 // fn pointer survives dead-code elimination. Bare `extern crate`
 // suffices — no symbols need importing into source.
 extern crate vulcan_ext_auto_commit as _vulcan_ext_auto_commit;
+extern crate vulcan_ext_input_demo as _vulcan_ext_input_demo;
 
 use clap::{CommandFactory, Parser};
 use clap_complete::generate;


### PR DESCRIPTION
## Summary
- add vulcan-ext-input-demo dogfood extension crate
- include it in the workspace and extension crate metadata
- wire demo crate into the Vulcan package layout

Refs #557

## Tests
- Not run in this PR split step

Stacked on #562