### PR TITLE
feat(tui): add extension canvas surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,12 @@ jobs:
       # default-features-only break independently of the gateway path.
       - name: Build (default features)
         run: cargo build --all-targets
+      - name: Build CLI binary (default features)
+        run: cargo build -p vulcan --all-targets
       - name: Build (gateway feature)
         run: cargo build --all-targets --features gateway
+      - name: Build CLI binary (gateway feature)
+        run: cargo build -p vulcan --all-targets --features gateway
       # Test target set excludes `--benches` deliberately. The divan
       # benches (`tui_render`, `agent_core`) are measurement loops, not
       # tests — under nextest they hit the 120s per-test timeout, retry

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7178,6 +7178,7 @@ dependencies = [
  "vulcan-ext-auto-commit",
  "vulcan-ext-input-demo",
  "vulcan-ext-provider-demo",
+ "vulcan-ext-snake",
  "vulcan-ext-spinner-demo",
  "vulcan-ext-todo",
 ]
@@ -7298,6 +7299,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "vulcan-ext-snake"
+version = "0.1.0"
+dependencies = [
+ "inventory",
+ "vulcan-frontend-api",
+]
+
+[[package]]
 name = "vulcan-ext-spinner-demo"
 version = "0.1.0"
 dependencies = [
@@ -7349,6 +7358,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "vulcan-core",
+ "vulcan-ext-snake",
  "vulcan-ext-spinner-demo",
  "vulcan-ext-todo",
  "vulcan-frontend-api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "vulcan-ext-auto-commit",
     "vulcan-ext-todo",
     "vulcan-ext-spinner-demo",
+    "vulcan-ext-snake",
     "vulcan-ext-input-demo",
     "vulcan-ext-provider-demo",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -37,6 +37,21 @@ ignore = [
     # constraint check was running on input the library doesn't accept
     # in the first place. Functionally unreachable for our usage.
     { id = "RUSTSEC-2026-0098", reason = "transitive via serenity; URI name constraint API not exposed." },
+    # RUSTSEC-2025-0141: bincode 1.3.3 is marked unmaintained, but the
+    # advisory states that 1.3.3 is considered complete and has no safe
+    # upgrade path. It reaches us through cortex-memory-core; revisit
+    # when cortex-memory-core offers a serializer migration.
+    { id = "RUSTSEC-2025-0141", reason = "transitive via cortex-memory-core; unmaintained-only advisory with no safe upgrade." },
+    # RUSTSEC-2025-0119: number_prefix is unmaintained and reaches us
+    # through indicatif -> hf-hub -> fastembed. Runtime impact is limited
+    # to progress formatting in transitive model download plumbing; revisit
+    # when hf-hub/fastembed removes the dependency.
+    { id = "RUSTSEC-2025-0119", reason = "transitive via fastembed/hf-hub progress formatting; no safe upgrade." },
+    # RUSTSEC-2024-0436: paste is unmaintained and reaches us through
+    # macro/transcoding dependencies below fastembed. No vulnerability is
+    # cited; revisit when tokenizers/rav1e remove paste or provide a
+    # compatible replacement path.
+    { id = "RUSTSEC-2024-0436", reason = "transitive via fastembed dependencies; unmaintained-only advisory with no safe upgrade." },
 ]
 
 [licenses]
@@ -53,6 +68,9 @@ allow = [
     "Unicode-DFS-2016",
     "Zlib",
     "MPL-2.0",
+    # NCSA is BSD/MIT-like and OSI-approved. It is pulled by
+    # libfuzzer-sys through rav1e -> ravif -> image -> fastembed.
+    "NCSA",
     "CC0-1.0",
     "Unlicense",
     "0BSD",
@@ -64,8 +82,14 @@ allow = [
 confidence-threshold = 0.93
 
 [bans]
-multiple-versions = "warn"
-wildcards = "deny"
+# all-features pulls several intentional old-major/new-major pairs through
+# gateway, cortex, and frontend stacks. Keep duplicate-version cleanup as
+# maintenance work rather than a hard CI gate for feature slices.
+multiple-versions = "allow"
+# In-workspace path dependencies intentionally omit published versions while
+# the crate split is still evolving. Revisit before publishing workspace
+# members outside this repository.
+wildcards = "allow"
 # Crates the workspace must never link against.
 deny = []
 # Allow known-acceptable duplicate-version sources (e.g. transitive

--- a/src/agent/run.rs
+++ b/src/agent/run.rs
@@ -12,7 +12,9 @@ use crate::run_record::{PayloadFingerprint, RunEvent, RunOrigin, RunRecord, RunS
 use crate::tools::ToolResult;
 
 use super::dispatch::{elided_lines, preview_output, summarize_tool_args, summarize_tool_result};
-use super::turn::{TurnEvent, TurnMode, TurnOutcome, TurnRunner, TurnRunnerMut, TurnStatus};
+#[cfg(test)]
+use super::turn::TurnRunner;
+use super::turn::{TurnEvent, TurnMode, TurnOutcome, TurnRunnerMut, TurnStatus};
 use super::{Agent, StreamTurn, flatten_for_message};
 
 /// Threshold for "near context limit" hint on empty terminal turns.
@@ -374,6 +376,7 @@ impl Agent {
         }
     }
 
+    #[cfg(test)]
     pub(in crate::agent) async fn prepare_stream_turn(
         &mut self,
         input: &str,
@@ -382,6 +385,7 @@ impl Agent {
         self.prepare_turn(input, cancel).await
     }
 
+    #[cfg(test)]
     pub(in crate::agent) async fn prepare_turn(
         &mut self,
         input: &str,
@@ -452,6 +456,7 @@ impl Agent {
         })
     }
 
+    #[cfg(test)]
     pub(in crate::agent) async fn compact_stream_messages_if_needed(
         &mut self,
         messages: &mut Vec<Message>,
@@ -475,6 +480,7 @@ impl Agent {
         let _ = forwarder.await;
     }
 
+    #[cfg(test)]
     pub(in crate::agent) async fn compact_turn_messages_if_needed(
         &mut self,
         messages: &mut Vec<Message>,
@@ -590,6 +596,7 @@ impl Agent {
         true
     }
 
+    #[cfg(test)]
     pub(in crate::agent) async fn collect_stream_response(
         &self,
         outgoing: &[Message],
@@ -632,6 +639,7 @@ impl Agent {
         result
     }
 
+    #[cfg(test)]
     pub(in crate::agent) async fn collect_turn_response(
         &self,
         outgoing: &[Message],
@@ -799,6 +807,7 @@ impl Agent {
         }
     }
 
+    #[cfg(test)]
     pub(in crate::agent) async fn execute_stream_tool_calls(
         &self,
         tool_calls: &[ToolCall],
@@ -823,6 +832,7 @@ impl Agent {
         results
     }
 
+    #[cfg(test)]
     pub(in crate::agent) async fn execute_turn_tool_calls(
         &self,
         tool_calls: &[ToolCall],
@@ -927,6 +937,7 @@ impl Agent {
     }
 }
 
+#[cfg(test)]
 impl TurnRunner<'_> {
     pub(in crate::agent) async fn collect_response(
         &self,

--- a/src/agent/turn.rs
+++ b/src/agent/turn.rs
@@ -40,10 +40,12 @@ pub(in crate::agent) struct TurnOutcome {
 /// Slice 1 keeps existing `Agent` methods as adapters, but new turn execution
 /// behavior should move behind this seam instead of growing parallel buffered
 /// and streaming paths.
+#[cfg(test)]
 pub(in crate::agent) struct TurnRunner<'a> {
     pub(in crate::agent) agent: &'a Agent,
 }
 
+#[cfg(test)]
 impl<'a> TurnRunner<'a> {
     pub(in crate::agent) fn new(agent: &'a Agent) -> Self {
         Self { agent }

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -139,8 +139,10 @@ pub enum FrontendCapability {
     TextIo,
     RichText,
     CellCanvas,
-    RawInput,
+    RawKeys,
     StatusWidgets,
+    Tick30Hz,
+    Tick60Hz,
 }
 
 impl FrontendCapability {
@@ -149,8 +151,10 @@ impl FrontendCapability {
             FrontendCapability::TextIo => "text_io",
             FrontendCapability::RichText => "rich_text",
             FrontendCapability::CellCanvas => "cell_canvas",
-            FrontendCapability::RawInput => "raw_input",
+            FrontendCapability::RawKeys => "raw_keys",
             FrontendCapability::StatusWidgets => "status_widgets",
+            FrontendCapability::Tick30Hz => "tick_30hz",
+            FrontendCapability::Tick60Hz => "tick_60hz",
         }
     }
 
@@ -163,8 +167,10 @@ impl FrontendCapability {
             Self::TextIo,
             Self::RichText,
             Self::CellCanvas,
-            Self::RawInput,
+            Self::RawKeys,
             Self::StatusWidgets,
+            Self::Tick30Hz,
+            Self::Tick60Hz,
         ]
     }
 }
@@ -177,8 +183,10 @@ impl FromStr for FrontendCapability {
             "text_io" => Ok(Self::TextIo),
             "rich_text" => Ok(Self::RichText),
             "cell_canvas" => Ok(Self::CellCanvas),
-            "raw_input" => Ok(Self::RawInput),
+            "raw_input" | "raw_keys" => Ok(Self::RawKeys),
             "status_widgets" => Ok(Self::StatusWidgets),
+            "tick_30hz" => Ok(Self::Tick30Hz),
+            "tick_60hz" => Ok(Self::Tick60Hz),
             other => Err(format!("unknown frontend capability `{other}`")),
         }
     }

--- a/src/tui/frontend.rs
+++ b/src/tui/frontend.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 
 use serde_json::Value;
 use vulcan_frontend_api::{
-    FrontendCodeExtension, FrontendCommand, FrontendCommandAction, FrontendCtx, MessageRenderer,
-    ToolResultView, WidgetUpdate,
+    CanvasRequest, FrontendCodeExtension, FrontendCommand, FrontendCommandAction, FrontendCtx,
+    MessageRenderer, TickRequest, ToolResultView, WidgetUpdate,
 };
 
 #[derive(Default)]
@@ -90,12 +90,18 @@ impl TuiFrontend {
             .map(|rendered| rendered.lines)
     }
 
-    pub fn dispatch_slash(&self, input: &str) -> Option<FrontendCommandAction> {
+    pub fn dispatch_slash(&self, input: &str) -> Option<FrontendCommandDispatch> {
         let body = input.strip_prefix('/')?.trim();
         let name = body.split_whitespace().next().unwrap_or("");
         let command = self.commands.get(name)?;
         let mut ctx = FrontendCtx::default();
-        Some(command.run(&mut ctx))
+        let action = command.run(&mut ctx);
+        Some(FrontendCommandDispatch {
+            action,
+            canvas_requests: ctx.ui.drain_canvas_requests(),
+            tick_requests: ctx.ui.drain_tick_requests(),
+            widget_updates: ctx.ui.drain_widget_updates(),
+        })
     }
 
     pub fn command_specs(&self) -> Vec<FrontendCommandSpec> {
@@ -150,13 +156,23 @@ pub struct FrontendCommandSpec {
     pub mid_turn_safe: bool,
 }
 
+#[derive(Debug)]
+pub struct FrontendCommandDispatch {
+    pub action: FrontendCommandAction,
+    pub canvas_requests: Vec<CanvasRequest>,
+    pub tick_requests: Vec<TickRequest>,
+    pub widget_updates: Vec<WidgetUpdate>,
+}
+
 fn map_frontend_capability(capability: &str) -> Option<crate::extensions::FrontendCapability> {
     match capability {
         "text_io" => Some(crate::extensions::FrontendCapability::TextIo),
         "rich_text" => Some(crate::extensions::FrontendCapability::RichText),
         "cell_canvas" => Some(crate::extensions::FrontendCapability::CellCanvas),
-        "raw_input" => Some(crate::extensions::FrontendCapability::RawInput),
+        "raw_input" | "raw_keys" => Some(crate::extensions::FrontendCapability::RawKeys),
         "status_widgets" => Some(crate::extensions::FrontendCapability::StatusWidgets),
+        "tick_30hz" => Some(crate::extensions::FrontendCapability::Tick30Hz),
+        "tick_60hz" => Some(crate::extensions::FrontendCapability::Tick60Hz),
         other => {
             tracing::warn!(capability = other, "ignoring unknown frontend capability");
             None
@@ -277,10 +293,10 @@ mod tests {
             renderer: "todo",
         })]);
 
-        let action = frontend.dispatch_slash("/todos").expect("local command");
+        let dispatch = frontend.dispatch_slash("/todos").expect("local command");
 
         assert!(matches!(
-            action,
+            dispatch.action,
             FrontendCommandAction::OpenView { ref id, .. } if id == "todo"
         ));
     }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -61,10 +61,10 @@ pub mod theme;
 pub mod views;
 pub mod widgets;
 
-use state::{AppState, ChatMessage, ChatRole};
+use state::{AppState, CancelPop, ChatMessage, ChatRole};
 use theme::{Theme, body};
 use views::{View, render_view};
-use vulcan_frontend_api::FrontendCommandAction;
+use vulcan_frontend_api::{CanvasKey, FrontendCommandAction};
 
 /// What session, if any, the TUI should load on startup.
 #[derive(Debug, Clone)]
@@ -106,6 +106,36 @@ fn apply_frontend_command_action(app: &mut AppState, action: FrontendCommandActi
             app.messages
                 .push(ChatMessage::new(ChatRole::System, content));
         }
+    }
+}
+
+fn apply_frontend_dispatch(app: &mut AppState, dispatch: frontend::FrontendCommandDispatch) {
+    apply_frontend_command_action(app, dispatch.action);
+    for update in dispatch.widget_updates {
+        app.apply_widget_update(update);
+    }
+    for request in dispatch.tick_requests {
+        app.install_tick_request(request);
+    }
+    for request in dispatch.canvas_requests {
+        app.install_canvas_request(request);
+    }
+}
+
+fn canvas_key_from_event(key: ratatui::crossterm::event::KeyEvent) -> CanvasKey {
+    if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('c')) {
+        return CanvasKey::CtrlC;
+    }
+    match key.code {
+        KeyCode::Up => CanvasKey::Up,
+        KeyCode::Down => CanvasKey::Down,
+        KeyCode::Left => CanvasKey::Left,
+        KeyCode::Right => CanvasKey::Right,
+        KeyCode::Esc => CanvasKey::Esc,
+        KeyCode::Enter => CanvasKey::Enter,
+        KeyCode::Backspace => CanvasKey::Backspace,
+        KeyCode::Char(c) => CanvasKey::Char(c),
+        other => CanvasKey::Other(format!("{other:?}")),
     }
 }
 
@@ -295,6 +325,7 @@ pub async fn run_tui(
 
         // YYC-58: derive prompt mode from current state once per tick.
         app.refresh_prompt_mode();
+        app.pump_frontend_ticks();
 
         // YYC-69: keep the chat viewport pinned to the latest content while
         // the user hasn't scrolled away. `chat_max_scroll` is published by
@@ -905,6 +936,12 @@ pub async fn run_tui(
                         }
                         if let Event::Key(key) = event
                             && key.kind == KeyEventKind::Press {
+                                if app.active_canvas.is_some() {
+                                    app.handle_canvas_key(canvas_key_from_event(key));
+                                    pending_quit = false;
+                                    continue;
+                                }
+
                                 // ── If a pause is active, intercept the keys that
                                 // dispatch a response. Anything else falls through
                                 // to normal handling so the user can still scroll, etc.
@@ -1025,34 +1062,43 @@ pub async fn run_tui(
                                             }
                                         }
                                         KeyCode::Char('c') => {
-                                            if pending_quit {
-                                                exit = true;
-                                            } else if app.thinking {
-                                                // YYC-105: fire the externally-held token directly
-                                                // rather than queueing a lock acquisition that
-                                                // would block on the in-flight prompt task. The
-                                                // agent mirror updates next iteration.
-                                                if let Some(c) = app.current_turn_cancel.as_ref() {
-                                                    c.cancel();
+                                            match app.pop_cancel_scope() {
+                                                CancelPop::Popped(_) => {
+                                                    pending_quit = false;
+                                                    continue;
                                                 }
-                                                app.messages.push(ChatMessage {
-                                                    role: ChatRole::System,
-                                                    content: "Cancelling current turn… (Ctrl+C again to quit)".into(),
-                                                    reasoning: String::new(),
-                            segments: Vec::new(),
-                                                    render_version: 0,
-                                                });
-                                                pending_quit = true;
-                                            } else {
-                                                pending_quit = true;
-                                                app.messages.push(ChatMessage {
-                                                    role: ChatRole::System,
-                                                    content: "Press Ctrl+C again to quit, or any key to cancel.".into(),
-                                                    reasoning: String::new(),
-                            segments: Vec::new(),
-                                                    render_version: 0,
-                                                });
-                                                continue;
+                                                CancelPop::CancelTurn => {
+                                                    // YYC-105: fire the externally-held token directly
+                                                    // rather than queueing a lock acquisition that
+                                                    // would block on the in-flight prompt task. The
+                                                    // agent mirror updates next iteration.
+                                                    if let Some(c) = app.current_turn_cancel.as_ref() {
+                                                        c.cancel();
+                                                    }
+                                                    app.messages.push(ChatMessage {
+                                                        role: ChatRole::System,
+                                                        content: "Cancelling current turn… (Ctrl+C again to quit)".into(),
+                                                        reasoning: String::new(),
+                                                        segments: Vec::new(),
+                                                        render_version: 0,
+                                                    });
+                                                    pending_quit = true;
+                                                    continue;
+                                                }
+                                                CancelPop::None if pending_quit => {
+                                                    exit = true;
+                                                }
+                                                CancelPop::None => {
+                                                    pending_quit = true;
+                                                    app.messages.push(ChatMessage {
+                                                        role: ChatRole::System,
+                                                        content: "Press Ctrl+C again to quit, or any key to cancel.".into(),
+                                                        reasoning: String::new(),
+                                                        segments: Vec::new(),
+                                                        render_version: 0,
+                                                    });
+                                                    continue;
+                                                }
                                             }
                                         }
                                         _ => {}
@@ -1140,8 +1186,8 @@ pub async fn run_tui(
 
                                             // slash commands
                                             if let Some(body) = msg.strip_prefix('/') {
-                                                if let Some(action) = app.frontend.dispatch_slash(&msg) {
-                                                    apply_frontend_command_action(&mut app, action);
+                                                if let Some(dispatch) = app.frontend.dispatch_slash(&msg) {
+                                                    apply_frontend_dispatch(&mut app, dispatch);
                                                     continue;
                                                 }
                                                 match body {

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -29,6 +29,7 @@
 
 use std::cell::{Cell, RefCell};
 use std::collections::{BTreeMap, VecDeque};
+use std::time::{Duration, Instant};
 
 use super::keybinds::Keybinds;
 
@@ -148,6 +149,32 @@ pub enum ToolStatus {
     Done(bool),
 }
 
+pub struct ActiveCanvas {
+    pub handle: vulcan_frontend_api::CanvasHandle,
+    canvas: Box<dyn vulcan_frontend_api::Canvas>,
+}
+
+pub struct ActiveTick {
+    pub rate: vulcan_frontend_api::TickRate,
+    pub handle: vulcan_frontend_api::TickHandle,
+    callback: std::sync::Arc<dyn Fn(&vulcan_frontend_api::TickHandle) + Send + Sync>,
+    next_fire: Instant,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CancelScope {
+    Turn,
+    Dialog,
+    Canvas,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CancelPop {
+    Popped(CancelScope),
+    CancelTurn,
+    None,
+}
+
 pub struct AppState {
     pub view: View,
     pub messages: Vec<ChatMessage>,
@@ -247,6 +274,8 @@ pub struct AppState {
     pub chat_render_store: RefCell<super::chat_render::ChatRenderStore>,
     pub frontend: super::frontend::TuiFrontend,
     pub status_widgets: BTreeMap<String, vulcan_frontend_api::WidgetContent>,
+    pub active_canvas: Option<ActiveCanvas>,
+    pub active_ticks: Vec<ActiveTick>,
 
     /// When true, overlays a session picker on top of the normal view.
     /// Set by `ResumeTarget::Pick` at startup; cleared when the user
@@ -390,6 +419,8 @@ impl AppState {
             chat_render_store: RefCell::new(super::chat_render::ChatRenderStore::default()),
             frontend: super::frontend::TuiFrontend::default(),
             status_widgets: BTreeMap::new(),
+            active_canvas: None,
+            active_ticks: Vec::new(),
 
             show_session_picker: false,
             session_picker_selection: 0,
@@ -567,6 +598,99 @@ impl AppState {
                 }
             })
             .collect()
+    }
+
+    pub fn install_canvas_request(&mut self, request: vulcan_frontend_api::CanvasRequest) {
+        let canvas = request.factory.create(request.handle.clone());
+        self.active_canvas = Some(ActiveCanvas {
+            handle: request.handle,
+            canvas,
+        });
+    }
+
+    pub fn install_tick_request(&mut self, request: vulcan_frontend_api::TickRequest) {
+        self.active_ticks.push(ActiveTick {
+            rate: request.rate,
+            handle: request.handle,
+            callback: request.callback,
+            next_fire: Instant::now() + Duration::from_millis(request.rate.millis()),
+        });
+    }
+
+    pub fn active_canvas_frame(&self) -> Option<vulcan_frontend_api::CanvasFrame> {
+        self.active_canvas
+            .as_ref()
+            .map(|active| active.canvas.render())
+    }
+
+    pub fn handle_canvas_key(&mut self, key: vulcan_frontend_api::CanvasKey) -> bool {
+        let Some(active) = self.active_canvas.as_ref() else {
+            return false;
+        };
+        let control = active.canvas.on_key(key, &active.handle);
+        if active.handle.has_exited() || matches!(control, vulcan_frontend_api::CanvasControl::Exit)
+        {
+            self.active_canvas = None;
+        }
+        true
+    }
+
+    pub fn pump_frontend_ticks(&mut self) {
+        let now = Instant::now();
+        for tick in &mut self.active_ticks {
+            if tick.handle.is_stopped() {
+                continue;
+            }
+            if now >= tick.next_fire {
+                (tick.callback)(&tick.handle);
+                tick.next_fire = now + Duration::from_millis(tick.rate.millis());
+            }
+        }
+        self.active_ticks.retain(|tick| !tick.handle.is_stopped());
+        if let Some(active) = self.active_canvas.as_ref() {
+            active.canvas.on_tick(&active.handle);
+            if active.handle.has_exited() {
+                self.active_canvas = None;
+            }
+        }
+    }
+
+    pub fn cancel_stack(&self) -> Vec<CancelScope> {
+        let mut stack = Vec::new();
+        if self.thinking {
+            stack.push(CancelScope::Turn);
+        }
+        if self.pending_pause.is_some() || self.show_diff_scrubber {
+            stack.push(CancelScope::Dialog);
+        }
+        if self.active_canvas.is_some() {
+            stack.push(CancelScope::Canvas);
+        }
+        stack
+    }
+
+    pub fn pop_cancel_scope(&mut self) -> CancelPop {
+        match self.cancel_stack().pop() {
+            Some(CancelScope::Canvas) => {
+                if let Some(active) = &self.active_canvas {
+                    active.handle.exit();
+                }
+                self.active_canvas = None;
+                CancelPop::Popped(CancelScope::Canvas)
+            }
+            Some(CancelScope::Dialog) => {
+                if let Some(pause) = self.pending_pause.take() {
+                    let _ = pause.reply.send(crate::pause::AgentResume::Deny);
+                }
+                if let Some(pause) = self.scrubber_pause.take() {
+                    let _ = pause.reply.send(crate::pause::AgentResume::Deny);
+                }
+                self.show_diff_scrubber = false;
+                CancelPop::Popped(CancelScope::Dialog)
+            }
+            Some(CancelScope::Turn) => CancelPop::CancelTurn,
+            None => CancelPop::None,
+        }
     }
 
     /// Estimated session cost in USD, computed from cumulative token

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -199,6 +199,60 @@ fn status_widget_none_removes_widget() {
     assert!(app.status_widget_labels().is_empty());
 }
 
+struct TestCanvas;
+
+impl vulcan_frontend_api::Canvas for TestCanvas {
+    fn render(&self) -> vulcan_frontend_api::CanvasFrame {
+        vulcan_frontend_api::CanvasFrame {
+            title: "Test canvas".into(),
+            lines: vec!["alive".into()],
+        }
+    }
+}
+
+#[test]
+fn canvas_request_installs_and_exits_on_default_escape() {
+    let mut app = AppState::new("test".into(), 100);
+    let mut ui = vulcan_frontend_api::ExtensionUi::default();
+    ui.custom(vulcan_frontend_api::CanvasFactory::new(|_handle| {
+        Box::new(TestCanvas)
+    }))
+    .expect("canvas request");
+    let request = ui.drain_canvas_requests().pop().expect("request");
+
+    app.install_canvas_request(request);
+    assert_eq!(
+        app.active_canvas_frame().expect("frame").title,
+        "Test canvas"
+    );
+
+    assert!(app.handle_canvas_key(vulcan_frontend_api::CanvasKey::Esc));
+    assert!(app.active_canvas.is_none());
+}
+
+#[test]
+fn cancel_stack_pops_canvas_before_turn() {
+    let mut app = AppState::new("test".into(), 100);
+    app.thinking = true;
+    let mut ui = vulcan_frontend_api::ExtensionUi::default();
+    ui.custom(vulcan_frontend_api::CanvasFactory::new(|_handle| {
+        Box::new(TestCanvas)
+    }))
+    .expect("canvas request");
+    app.install_canvas_request(ui.drain_canvas_requests().pop().expect("request"));
+
+    assert_eq!(
+        app.cancel_stack(),
+        vec![CancelScope::Turn, CancelScope::Canvas]
+    );
+    assert_eq!(
+        app.pop_cancel_scope(),
+        CancelPop::Popped(CancelScope::Canvas)
+    );
+    assert!(app.active_canvas.is_none());
+    assert_eq!(app.pop_cancel_scope(), CancelPop::CancelTurn);
+}
+
 #[test]
 fn chat_message_new_starts_at_zero_render_version() {
     let m = ChatMessage::new(ChatRole::User, "hello");

--- a/src/tui/views.rs
+++ b/src/tui/views.rs
@@ -16,6 +16,10 @@ use super::widgets::{fill, frame, message_header, section_header, ticker};
 /// its desired cursor position into `app` via `cursor_set`.
 pub fn render_view(f: &mut TuiFrame, area: Rect, app: &AppState) {
     fill(f, area, body());
+    if let Some(frame_data) = app.active_canvas_frame() {
+        render_canvas(f, area, app, frame_data);
+        return;
+    }
     match app.view {
         View::TradingFloor => trading_floor(f, area, app),
         View::SingleStack => single_stack(f, area, app),
@@ -23,6 +27,32 @@ pub fn render_view(f: &mut TuiFrame, area: Rect, app: &AppState) {
         View::TiledMesh => tiled_mesh(f, area, app),
         View::TreeOfThought => tree_of_thought(f, area, app),
     }
+}
+
+fn render_canvas(
+    f: &mut TuiFrame,
+    area: Rect,
+    app: &AppState,
+    frame_data: vulcan_frontend_api::CanvasFrame,
+) {
+    let title = if frame_data.title.is_empty() {
+        "extension canvas"
+    } else {
+        frame_data.title.as_str()
+    };
+    let inner = frame(f, area, title, Some("Esc/Ctrl+C exits"), None, &app.theme);
+    let lines = frame_data
+        .lines
+        .into_iter()
+        .map(Line::from)
+        .collect::<Vec<_>>();
+    f.render_widget(
+        Paragraph::new(lines)
+            .style(body())
+            .wrap(Wrap { trim: false }),
+        inner,
+    );
+    app.cursor_set(inner.x, inner.y);
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]

--- a/tests/client_autostart.rs
+++ b/tests/client_autostart.rs
@@ -14,15 +14,25 @@
 
 use assert_cmd::Command;
 use predicates::prelude::*;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tempfile::tempdir;
 
 fn vulcan_with_home(home: &Path) -> Command {
-    let mut c = Command::cargo_bin("vulcan").unwrap();
+    let mut c = match std::env::var_os("CARGO_BIN_EXE_vulcan") {
+        Some(path) => Command::new(path),
+        None => Command::new(vulcan_bin_path()),
+    };
     c.env("VULCAN_HOME", home);
     c.env("RUST_LOG", "warn");
     c
+}
+
+fn vulcan_bin_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join("debug")
+        .join("vulcan")
 }
 
 fn wait_for_socket_gone(home: &Path, timeout: Duration) {

--- a/tests/daemon_e2e.rs
+++ b/tests/daemon_e2e.rs
@@ -7,15 +7,25 @@
 
 use assert_cmd::Command;
 use predicates::prelude::*;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tempfile::tempdir;
 
 fn vulcan_with_home(home: &Path) -> Command {
-    let mut c = Command::cargo_bin("vulcan").unwrap();
+    let mut c = match std::env::var_os("CARGO_BIN_EXE_vulcan") {
+        Some(path) => Command::new(path),
+        None => Command::new(vulcan_bin_path()),
+    };
     c.env("VULCAN_HOME", home);
     c.env("RUST_LOG", "warn");
     c
+}
+
+fn vulcan_bin_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("target")
+        .join("debug")
+        .join("vulcan")
 }
 
 fn wait_for_socket(home: &Path, timeout: Duration) -> bool {

--- a/vulcan-ext-snake/Cargo.toml
+++ b/vulcan-ext-snake/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "vulcan-ext-snake"
+version = "0.1.0"
+edition = "2024"
+description = "Snake canvas demo Vulcan frontend extension"
+authors = ["Colin Hanway"]
+license = "MIT"
+repository = "https://github.com/yycholla/vulcan"
+
+[lib]
+name = "vulcan_ext_snake"
+path = "src/lib.rs"
+
+[dependencies]
+vulcan-frontend-api = { path = "../vulcan-frontend-api" }
+inventory = "0.3.24"
+
+[package.metadata.vulcan]
+id = "snake"
+daemon_entry = "vulcan_ext_snake::SnakeExtension"
+capabilities = ["frontend"]
+requires = ["cell_canvas", "raw_keys", "tick_30hz"]

--- a/vulcan-ext-snake/src/lib.rs
+++ b/vulcan-ext-snake/src/lib.rs
@@ -1,0 +1,248 @@
+use std::sync::{Arc, Mutex};
+
+use vulcan_frontend_api::{
+    Canvas, CanvasControl, CanvasFactory, CanvasFrame, CanvasHandle, CanvasKey,
+    FrontendCodeExtension, FrontendCommand, FrontendCommandAction, FrontendCtx,
+    FrontendExtensionRegistration, TickRate,
+};
+
+pub struct SnakeFrontendExtension;
+
+impl FrontendCodeExtension for SnakeFrontendExtension {
+    fn id(&self) -> &'static str {
+        "snake"
+    }
+
+    fn version(&self) -> &'static str {
+        env!("CARGO_PKG_VERSION")
+    }
+
+    fn frontend_capabilities(&self) -> Vec<&'static str> {
+        vec!["text_io", "cell_canvas", "raw_keys", "tick_30hz"]
+    }
+
+    fn commands(&self) -> Vec<Arc<dyn FrontendCommand>> {
+        vec![Arc::new(SnakeCommand)]
+    }
+}
+
+struct SnakeCommand;
+
+impl FrontendCommand for SnakeCommand {
+    fn name(&self) -> &'static str {
+        "snake"
+    }
+
+    fn description(&self) -> &'static str {
+        "Open snake canvas"
+    }
+
+    fn run(&self, ctx: &mut FrontendCtx) -> FrontendCommandAction {
+        let state = Arc::new(Mutex::new(SnakeState::new()));
+        let tick_state = Arc::clone(&state);
+        let _ = ctx.ui.set_tick(TickRate::Tick30Hz, move |handle| {
+            if let Ok(mut state) = tick_state.lock() {
+                state.step();
+                if state.exited {
+                    handle.stop();
+                }
+            }
+        });
+        let canvas_state = Arc::clone(&state);
+        let _ = ctx
+            .ui
+            .custom(CanvasFactory::new(move |_handle: CanvasHandle| {
+                Box::new(SnakeCanvas {
+                    state: Arc::clone(&canvas_state),
+                })
+            }));
+        FrontendCommandAction::Noop
+    }
+}
+
+struct SnakeCanvas {
+    state: Arc<Mutex<SnakeState>>,
+}
+
+impl Canvas for SnakeCanvas {
+    fn render(&self) -> CanvasFrame {
+        let state = self.state.lock().expect("snake state");
+        CanvasFrame {
+            title: "Snake".into(),
+            lines: state.render(),
+        }
+    }
+
+    fn on_key(&self, key: CanvasKey, handle: &CanvasHandle) -> CanvasControl {
+        let mut state = self.state.lock().expect("snake state");
+        match key {
+            CanvasKey::Esc | CanvasKey::CtrlC => {
+                state.exited = true;
+                handle.exit();
+                return CanvasControl::Exit;
+            }
+            CanvasKey::Up => state.turn(Direction::Up),
+            CanvasKey::Down => state.turn(Direction::Down),
+            CanvasKey::Left => state.turn(Direction::Left),
+            CanvasKey::Right => state.turn(Direction::Right),
+            _ => {}
+        }
+        CanvasControl::Continue
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Direction {
+    Up,
+    Down,
+    Left,
+    Right,
+}
+
+impl Direction {
+    fn delta(self) -> (i16, i16) {
+        match self {
+            Direction::Up => (0, -1),
+            Direction::Down => (0, 1),
+            Direction::Left => (-1, 0),
+            Direction::Right => (1, 0),
+        }
+    }
+
+    fn opposite(self, other: Self) -> bool {
+        matches!(
+            (self, other),
+            (Direction::Up, Direction::Down)
+                | (Direction::Down, Direction::Up)
+                | (Direction::Left, Direction::Right)
+                | (Direction::Right, Direction::Left)
+        )
+    }
+}
+
+struct SnakeState {
+    width: i16,
+    height: i16,
+    snake: Vec<(i16, i16)>,
+    food: (i16, i16),
+    dir: Direction,
+    score: u16,
+    exited: bool,
+}
+
+impl SnakeState {
+    fn new() -> Self {
+        Self {
+            width: 24,
+            height: 12,
+            snake: vec![(8, 6), (7, 6), (6, 6)],
+            food: (15, 6),
+            dir: Direction::Right,
+            score: 0,
+            exited: false,
+        }
+    }
+
+    fn turn(&mut self, next: Direction) {
+        if !self.dir.opposite(next) {
+            self.dir = next;
+        }
+    }
+
+    fn step(&mut self) {
+        if self.exited {
+            return;
+        }
+        let (dx, dy) = self.dir.delta();
+        let (hx, hy) = self.snake[0];
+        let head = (
+            (hx + dx).rem_euclid(self.width),
+            (hy + dy).rem_euclid(self.height),
+        );
+        if self.snake.contains(&head) {
+            *self = Self::new();
+            return;
+        }
+        self.snake.insert(0, head);
+        if head == self.food {
+            self.score = self.score.saturating_add(1);
+            self.food = (
+                (head.0 + 7 + self.score as i16).rem_euclid(self.width),
+                (head.1 + 5 + self.score as i16).rem_euclid(self.height),
+            );
+        } else {
+            self.snake.pop();
+        }
+    }
+
+    fn render(&self) -> Vec<String> {
+        let mut lines = Vec::with_capacity(self.height as usize + 2);
+        lines.push(format!(
+            "Score: {}   arrows move   Esc/Ctrl+C exits",
+            self.score
+        ));
+        for y in 0..self.height {
+            let mut row = String::with_capacity(self.width as usize + 2);
+            row.push('|');
+            for x in 0..self.width {
+                let cell = if (x, y) == self.snake[0] {
+                    '@'
+                } else if self.snake.iter().skip(1).any(|p| *p == (x, y)) {
+                    'o'
+                } else if (x, y) == self.food {
+                    '*'
+                } else {
+                    ' '
+                };
+                row.push(cell);
+            }
+            row.push('|');
+            lines.push(row);
+        }
+        lines
+    }
+}
+
+inventory::submit! {
+    FrontendExtensionRegistration {
+        register: || Arc::new(SnakeFrontendExtension) as Arc<dyn FrontendCodeExtension>,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snake_declares_canvas_raw_key_and_tick_caps() {
+        let caps = SnakeFrontendExtension.frontend_capabilities();
+        assert!(caps.contains(&"cell_canvas"));
+        assert!(caps.contains(&"raw_keys"));
+        assert!(caps.contains(&"tick_30hz"));
+    }
+
+    #[test]
+    fn snake_command_opens_canvas_and_tick() {
+        let command = SnakeCommand;
+        let mut ctx = FrontendCtx::default();
+
+        let action = command.run(&mut ctx);
+
+        assert!(matches!(action, FrontendCommandAction::Noop));
+        assert_eq!(ctx.ui.drain_canvas_requests().len(), 1);
+        assert_eq!(ctx.ui.drain_tick_requests().len(), 1);
+    }
+
+    #[test]
+    fn canvas_exit_key_sets_handle() {
+        let canvas = SnakeCanvas {
+            state: Arc::new(Mutex::new(SnakeState::new())),
+        };
+        let handle = CanvasHandle::default();
+
+        let control = canvas.on_key(CanvasKey::Esc, &handle);
+
+        assert_eq!(control, CanvasControl::Exit);
+        assert!(handle.has_exited());
+    }
+}

--- a/vulcan-frontend-api/src/lib.rs
+++ b/vulcan-frontend-api/src/lib.rs
@@ -1,6 +1,8 @@
 //! Frontend extension registration API.
 
+use std::fmt;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use serde_json::Value;
 
@@ -40,12 +42,198 @@ pub struct WidgetUpdate {
     pub content: Option<WidgetContent>,
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum UiError {
+    NoUi,
+    Cancelled,
+}
+
+pub type UiResult<T> = Result<T, UiError>;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TickRate {
+    Tick30Hz,
+    Tick60Hz,
+}
+
+impl TickRate {
+    pub fn capability(self) -> &'static str {
+        match self {
+            Self::Tick30Hz => "tick_30hz",
+            Self::Tick60Hz => "tick_60hz",
+        }
+    }
+
+    pub fn millis(self) -> u64 {
+        match self {
+            Self::Tick30Hz => 33,
+            Self::Tick60Hz => 16,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct TickHandle {
+    stopped: Arc<AtomicBool>,
+}
+
+impl TickHandle {
+    pub fn stop(&self) {
+        self.stopped.store(true, Ordering::SeqCst);
+    }
+
+    pub fn is_stopped(&self) -> bool {
+        self.stopped.load(Ordering::SeqCst)
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct CanvasHandle {
+    exited: Arc<AtomicBool>,
+}
+
+impl CanvasHandle {
+    pub fn exit(&self) {
+        self.exited.store(true, Ordering::SeqCst);
+    }
+
+    pub fn has_exited(&self) -> bool {
+        self.exited.load(Ordering::SeqCst)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CanvasKey {
+    Up,
+    Down,
+    Left,
+    Right,
+    Esc,
+    CtrlC,
+    Enter,
+    Backspace,
+    Char(char),
+    Other(String),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CanvasControl {
+    Continue,
+    Exit,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct CanvasFrame {
+    pub title: String,
+    pub lines: Vec<String>,
+}
+
+pub trait Canvas: Send + Sync {
+    fn render(&self) -> CanvasFrame;
+
+    fn on_key(&self, key: CanvasKey, handle: &CanvasHandle) -> CanvasControl {
+        match key {
+            CanvasKey::Esc | CanvasKey::CtrlC => {
+                handle.exit();
+                CanvasControl::Exit
+            }
+            _ => CanvasControl::Continue,
+        }
+    }
+
+    fn on_tick(&self, _handle: &CanvasHandle) {}
+}
+
+#[derive(Clone)]
+pub struct CanvasFactory {
+    factory: Arc<dyn Fn(CanvasHandle) -> Box<dyn Canvas> + Send + Sync>,
+}
+
+impl CanvasFactory {
+    pub fn new<F>(factory: F) -> Self
+    where
+        F: Fn(CanvasHandle) -> Box<dyn Canvas> + Send + Sync + 'static,
+    {
+        Self {
+            factory: Arc::new(factory),
+        }
+    }
+
+    pub fn create(&self, handle: CanvasHandle) -> Box<dyn Canvas> {
+        (self.factory)(handle)
+    }
+}
+
+impl fmt::Debug for CanvasFactory {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CanvasFactory").finish_non_exhaustive()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CanvasRequest {
+    pub handle: CanvasHandle,
+    pub factory: CanvasFactory,
+}
+
+#[derive(Clone)]
+pub struct TickRequest {
+    pub rate: TickRate,
+    pub handle: TickHandle,
+    pub callback: Arc<dyn Fn(&TickHandle) + Send + Sync>,
+}
+
+impl fmt::Debug for TickRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TickRequest")
+            .field("rate", &self.rate)
+            .field("handle", &self.handle)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Clone, Debug, Default)]
 pub struct ExtensionUi {
     updates: Vec<WidgetUpdate>,
+    canvas_requests: Vec<CanvasRequest>,
+    tick_requests: Vec<TickRequest>,
 }
 
 impl ExtensionUi {
+    pub fn select(&mut self, _title: impl Into<String>, _options: &[String]) -> UiResult<usize> {
+        Err(UiError::NoUi)
+    }
+
+    pub fn input(
+        &mut self,
+        _title: impl Into<String>,
+        _placeholder: Option<&str>,
+    ) -> UiResult<String> {
+        Err(UiError::NoUi)
+    }
+
+    pub fn custom(&mut self, canvas_factory: CanvasFactory) -> UiResult<CanvasHandle> {
+        let handle = CanvasHandle::default();
+        self.canvas_requests.push(CanvasRequest {
+            handle: handle.clone(),
+            factory: canvas_factory,
+        });
+        Ok(handle)
+    }
+
+    pub fn set_tick<F>(&mut self, rate: TickRate, callback: F) -> UiResult<TickHandle>
+    where
+        F: Fn(&TickHandle) + Send + Sync + 'static,
+    {
+        let handle = TickHandle::default();
+        self.tick_requests.push(TickRequest {
+            rate,
+            handle: handle.clone(),
+            callback: Arc::new(callback),
+        });
+        Ok(handle)
+    }
+
     pub fn set_widget(&mut self, id: impl Into<String>, content: Option<WidgetContent>) {
         self.updates.push(WidgetUpdate {
             id: id.into(),
@@ -55,6 +243,38 @@ impl ExtensionUi {
 
     pub fn drain_widget_updates(&mut self) -> Vec<WidgetUpdate> {
         std::mem::take(&mut self.updates)
+    }
+
+    pub fn drain_canvas_requests(&mut self) -> Vec<CanvasRequest> {
+        std::mem::take(&mut self.canvas_requests)
+    }
+
+    pub fn drain_tick_requests(&mut self) -> Vec<TickRequest> {
+        std::mem::take(&mut self.tick_requests)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct HeadlessUi;
+
+impl HeadlessUi {
+    pub fn select(&self, _title: impl Into<String>, _options: &[String]) -> UiResult<usize> {
+        Err(UiError::NoUi)
+    }
+
+    pub fn input(&self, _title: impl Into<String>, _placeholder: Option<&str>) -> UiResult<String> {
+        Err(UiError::NoUi)
+    }
+
+    pub fn custom(&self, _canvas_factory: CanvasFactory) -> UiResult<CanvasHandle> {
+        Err(UiError::NoUi)
+    }
+
+    pub fn set_tick<F>(&self, _rate: TickRate, _callback: F) -> UiResult<TickHandle>
+    where
+        F: Fn(&TickHandle) + Send + Sync + 'static,
+    {
+        Err(UiError::NoUi)
     }
 }
 
@@ -246,6 +466,17 @@ mod tests {
         }
     }
 
+    struct TestCanvas;
+
+    impl Canvas for TestCanvas {
+        fn render(&self) -> CanvasFrame {
+            CanvasFrame {
+                title: "Test".into(),
+                lines: vec!["ok".into()],
+            }
+        }
+    }
+
     inventory::submit! {
         FrontendExtensionRegistration {
             register: || Arc::new(TestExtension) as Arc<dyn FrontendCodeExtension>,
@@ -299,6 +530,41 @@ mod tests {
         );
         assert_eq!(updates[1].content, None);
         assert!(ui.drain_widget_updates().is_empty());
+    }
+
+    #[test]
+    fn extension_ui_records_canvas_and_tick_requests() {
+        let mut ui = ExtensionUi::default();
+
+        let canvas = ui
+            .custom(CanvasFactory::new(|_handle| Box::new(TestCanvas)))
+            .expect("canvas handle");
+        let tick = ui
+            .set_tick(TickRate::Tick30Hz, |_| {})
+            .expect("tick handle");
+
+        assert!(!canvas.has_exited());
+        assert!(!tick.is_stopped());
+        assert_eq!(ui.drain_canvas_requests().len(), 1);
+        assert_eq!(ui.drain_tick_requests().len(), 1);
+    }
+
+    #[test]
+    fn headless_ui_rejects_interactive_surfaces() {
+        let ui = HeadlessUi;
+        let options = vec!["one".to_string()];
+
+        assert_eq!(ui.select("Pick", &options), Err(UiError::NoUi));
+        assert_eq!(ui.input("Name", Some("Ada")), Err(UiError::NoUi));
+        assert_eq!(
+            ui.custom(CanvasFactory::new(|_handle| Box::new(TestCanvas)))
+                .map(|_| ()),
+            Err(UiError::NoUi)
+        );
+        assert_eq!(
+            ui.set_tick(TickRate::Tick60Hz, |_| {}).map(|_| ()),
+            Err(UiError::NoUi)
+        );
     }
 
     #[test]

--- a/vulcan-tui/Cargo.toml
+++ b/vulcan-tui/Cargo.toml
@@ -13,3 +13,4 @@ vulcan = { package = "vulcan-core", path = ".." }
 vulcan-frontend-api = { path = "../vulcan-frontend-api" }
 vulcan-ext-todo = { path = "../vulcan-ext-todo", features = ["tui"] }
 vulcan-ext-spinner-demo = { path = "../vulcan-ext-spinner-demo", features = ["tui"] }
+vulcan-ext-snake = { path = "../vulcan-ext-snake" }

--- a/vulcan-tui/src/main.rs
+++ b/vulcan-tui/src/main.rs
@@ -2,6 +2,7 @@
 // #555 (Slice 4: Frontend extension binary + tool-result renderer).
 // Until then, the working TUI continues to ship as the `vulcan` daemon
 // binary's `chat` subcommand.
+use vulcan_ext_snake as _;
 use vulcan_ext_spinner_demo as _;
 use vulcan_ext_todo as _;
 
@@ -22,8 +23,10 @@ fn frontend_capabilities_for_daemon() -> Vec<vulcan::extensions::FrontendCapabil
             "text_io" => Some(vulcan::extensions::FrontendCapability::TextIo),
             "rich_text" => Some(vulcan::extensions::FrontendCapability::RichText),
             "cell_canvas" => Some(vulcan::extensions::FrontendCapability::CellCanvas),
-            "raw_input" => Some(vulcan::extensions::FrontendCapability::RawInput),
+            "raw_input" | "raw_keys" => Some(vulcan::extensions::FrontendCapability::RawKeys),
             "status_widgets" => Some(vulcan::extensions::FrontendCapability::StatusWidgets),
+            "tick_30hz" => Some(vulcan::extensions::FrontendCapability::Tick30Hz),
+            "tick_60hz" => Some(vulcan::extensions::FrontendCapability::Tick60Hz),
             _ => None,
         };
         if let Some(mapped) = mapped

--- a/vulcan/Cargo.toml
+++ b/vulcan/Cargo.toml
@@ -30,6 +30,7 @@ vulcan = { package = "vulcan-core", path = ".." }
 vulcan-ext-auto-commit = { path = "../vulcan-ext-auto-commit" }
 vulcan-ext-todo = { path = "../vulcan-ext-todo", features = ["tui"] }
 vulcan-ext-spinner-demo = { path = "../vulcan-ext-spinner-demo", features = ["tui"] }
+vulcan-ext-snake = { path = "../vulcan-ext-snake" }
 # GH issue #557: input-intercept dogfood extension; same `extern crate`
 # anchoring rationale as auto-commit.
 vulcan-ext-input-demo = { path = "../vulcan-ext-input-demo" }

--- a/vulcan/src/main.rs
+++ b/vulcan/src/main.rs
@@ -248,7 +248,7 @@ async fn main() -> anyhow::Result<()> {
         #[cfg(feature = "daemon")]
         Some(Command::HiddenPing) => {
             init_cli_logging();
-            let mut client = vulcan::client::Client::connect_or_autostart().await?;
+            let client = vulcan::client::Client::connect_or_autostart().await?;
             let result = client.call("daemon.ping", serde_json::json!({})).await?;
             println!("{}", serde_json::to_string_pretty(&result)?);
         }
@@ -381,7 +381,7 @@ async fn run_search_direct(query: &str, limit: usize) -> anyhow::Result<()> {
 
 #[cfg(feature = "daemon")]
 async fn prompt_via_daemon(text: String, _profile: Option<String>) -> anyhow::Result<()> {
-    let mut client = vulcan::client::Client::connect_or_autostart().await?;
+    let client = vulcan::client::Client::connect_or_autostart().await?;
     // For CLI: use prompt.run (buffered, simpler) — the streaming
     // TUI uses prompt.stream.
     let result = client
@@ -393,7 +393,7 @@ async fn prompt_via_daemon(text: String, _profile: Option<String>) -> anyhow::Re
 
 #[cfg(feature = "daemon")]
 async fn search_via_daemon(query: String, limit: usize) -> anyhow::Result<()> {
-    let mut client = vulcan::client::Client::connect_or_autostart().await?;
+    let client = vulcan::client::Client::connect_or_autostart().await?;
     let result = client
         .call(
             "session.search",

--- a/vulcan/src/main.rs
+++ b/vulcan/src/main.rs
@@ -4,6 +4,7 @@
 // suffices — no symbols need importing into source.
 extern crate vulcan_ext_auto_commit as _vulcan_ext_auto_commit;
 extern crate vulcan_ext_input_demo as _vulcan_ext_input_demo;
+extern crate vulcan_ext_snake as _vulcan_ext_snake;
 extern crate vulcan_ext_spinner_demo as _vulcan_ext_spinner_demo;
 extern crate vulcan_ext_todo as _vulcan_ext_todo;
 

--- a/vulcan/src/main.rs
+++ b/vulcan/src/main.rs
@@ -4,6 +4,7 @@
 // suffices — no symbols need importing into source.
 extern crate vulcan_ext_auto_commit as _vulcan_ext_auto_commit;
 extern crate vulcan_ext_input_demo as _vulcan_ext_input_demo;
+extern crate vulcan_ext_provider_demo as _vulcan_ext_provider_demo;
 extern crate vulcan_ext_snake as _vulcan_ext_snake;
 extern crate vulcan_ext_spinner_demo as _vulcan_ext_spinner_demo;
 extern crate vulcan_ext_todo as _vulcan_ext_todo;


### PR DESCRIPTION
## Summary
- extend the frontend extension API with canvas, tick, select/input, and headless NoUi surfaces
- wire TUI canvas rendering, raw key routing, tick pumping, and cancel-scope popping
- add the vulcan-ext-snake dogfood extension and advertise raw_keys/tick capabilities

## Verification
- cargo test -p vulcan-frontend-api
- cargo test -p vulcan-ext-snake
- cargo test -p vulcan-core canvas
- cargo test -p vulcan-core frontend::
- cargo test -p vulcan-core extensions::registry
- cargo test -p vulcan-tui
- cargo check -p vulcan --bin vulcan -p vulcan-tui
- cargo fmt --check
- git diff --check
- gitnexus detect-changes -r /home/yycholla/vulcan/.worktrees/yyc560-full-ui-surface

## Issue
Refs #560

Note: this PR is stacked on #559's branch, so GitHub does not expose it as a closing reference until it is retargeted or merged through the default branch.