### PR TITLE
feat(cli): add interactive run artifact pickers

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -109,13 +109,13 @@ pub enum Command {
     /// `vulcan run show <id>` prints the full timeline.
     Run {
         #[command(subcommand)]
-        cmd: RunSubcommand,
+        cmd: Option<RunSubcommand>,
     },
     /// YYC-180: inspect typed artifacts (plans, diffs, reports,
     /// subagent summaries) persisted alongside agent turns.
     Artifact {
         #[command(subcommand)]
-        cmd: ArtifactSubcommand,
+        cmd: Option<ArtifactSubcommand>,
     },
     /// YYC-194: governance + purge controls for local knowledge
     /// indexes (code graph, embeddings, sessions, run records,
@@ -449,6 +449,31 @@ pub enum AgentSubcommand {
         #[arg(long)]
         sentiment: Option<f32>,
     },
+}
+
+#[cfg(test)]
+mod parse_tests {
+    use super::*;
+
+    #[test]
+    fn run_accepts_no_subcommand_for_interactive_picker() {
+        let cli = Cli::parse_from(["vulcan", "run"]);
+
+        match cli.command {
+            Some(Command::Run { cmd }) => assert!(cmd.is_none()),
+            other => panic!("unexpected parse: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn artifact_accepts_no_subcommand_for_interactive_picker() {
+        let cli = Cli::parse_from(["vulcan", "artifact"]);
+
+        match cli.command {
+            Some(Command::Artifact { cmd }) => assert!(cmd.is_none()),
+            other => panic!("unexpected parse: {other:?}"),
+        }
+    }
 }
 
 #[cfg(all(test, feature = "gateway"))]

--- a/src/cli_artifact.rs
+++ b/src/cli_artifact.rs
@@ -3,26 +3,55 @@
 //! itself.
 
 use anyhow::{Context, Result, anyhow};
+use owo_colors::OwoColorize;
+use std::io::IsTerminal;
 use uuid::Uuid;
 
-use crate::artifact::{Artifact, ArtifactId, ArtifactStore, SqliteArtifactStore};
+use crate::artifact::{Artifact, ArtifactId, ArtifactKind, ArtifactStore, SqliteArtifactStore};
 use crate::cli::ArtifactSubcommand;
 use crate::run_record::{RunId, RunStore, SqliteRunStore};
 
-pub async fn run(cmd: ArtifactSubcommand) -> Result<()> {
+pub async fn run(cmd: Option<ArtifactSubcommand>) -> Result<()> {
     let store = SqliteArtifactStore::try_new().context("open ~/.vulcan/artifacts.db")?;
     match cmd {
-        ArtifactSubcommand::List {
+        None => interactive_select(&store),
+        Some(ArtifactSubcommand::List {
             limit,
             run,
             session,
-        } => list(&store, limit, run.as_deref(), session.as_deref()),
-        ArtifactSubcommand::Show { id } => show(&store, &id),
+        }) => list(&store, limit, run.as_deref(), session.as_deref()),
+        Some(ArtifactSubcommand::Show { id }) => show(&store, &id),
     }
 }
 
-fn list(
-    store: &SqliteArtifactStore,
+fn interactive_select(store: &SqliteArtifactStore) -> Result<()> {
+    if !std::io::stdin().is_terminal() {
+        anyhow::bail!(
+            "vulcan artifact (interactive) requires a terminal. Use `vulcan artifact list` to browse, or `vulcan artifact show <id>` to inspect an artifact."
+        );
+    }
+
+    let items = store.recent(20)?;
+    if items.is_empty() {
+        println!("No artifacts.");
+        return Ok(());
+    }
+
+    let labels: Vec<String> = items.iter().map(artifact_picker_label).collect();
+    println!();
+    let pick = dialoguer::FuzzySelect::with_theme(&dialoguer::theme::ColorfulTheme::default())
+        .with_prompt("Pick an artifact")
+        .items(&labels)
+        .default(0)
+        .interact()
+        .context("picker cancelled")?;
+
+    print!("{}", render_artifact_show(&items[pick]));
+    Ok(())
+}
+
+fn list<S: ArtifactStore + ?Sized>(
+    store: &S,
     limit: usize,
     run_filter: Option<&str>,
     session_filter: Option<&str>,
@@ -39,59 +68,100 @@ fn list(
         println!("No artifacts.");
         return Ok(());
     }
-    println!(
-        "{:<10} {:<18} {:<22} {:<28} title",
-        "id", "kind", "created", "source"
-    );
-    for art in items {
-        let id_short: String = art.id.to_string().chars().take(8).collect();
-        let created = art.created_at.format("%Y-%m-%d %H:%M:%S");
-        let source = art.source.unwrap_or_else(|| "-".into());
-        let title = art.title.unwrap_or_else(|| "-".into());
-        let kind = art.kind.as_str();
-        println!("{id_short:<10} {kind:<18} {created:<22} {source:<28} {title}");
-    }
+    print!("{}", render_artifact_list(&items));
     Ok(())
 }
 
-fn show(store: &SqliteArtifactStore, raw_id: &str) -> Result<()> {
+fn show<S: ArtifactStore + ?Sized>(store: &S, raw_id: &str) -> Result<()> {
     let id = resolve_artifact_id(store, raw_id)?;
     let art = store
         .get(id)?
         .ok_or_else(|| anyhow!("artifact {id} not found"))?;
-    println!("Artifact {id}");
-    println!("  kind:       {}", art.kind.as_str());
-    println!("  session:    {}", art.session_id.as_deref().unwrap_or("-"));
-    println!(
-        "  run:        {}",
+    print!("{}", render_artifact_show(&art));
+    Ok(())
+}
+
+fn render_artifact_list(items: &[Artifact]) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "{:<10} {:<20} {:<14} {:<10} {:<22} {:<22} {}\n",
+        "id".bold(),
+        "type".bold(),
+        "session".bold(),
+        "run".bold(),
+        "created".bold(),
+        "source".bold(),
+        "title".bold(),
+    ));
+    for art in items {
+        out.push_str(&format!(
+            "{:<10} {:<20} {:<14} {:<10} {:<22} {:<22} {}\n",
+            short_id(&art.id.to_string()),
+            kind_badge(art.kind),
+            truncate(art.session_id.as_deref().unwrap_or("-"), 14),
+            art.run_id
+                .map(|r| short_id(&r.to_string()))
+                .unwrap_or_else(|| "-".into()),
+            art.created_at.format("%Y-%m-%d %H:%M:%S"),
+            truncate(art.source.as_deref().unwrap_or("-"), 22),
+            art.title.as_deref().unwrap_or("-"),
+        ));
+    }
+    out
+}
+
+fn render_artifact_show(art: &Artifact) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("{} {}\n", "Artifact".bold(), art.id));
+    out.push_str(&format!("{}\n", "Metadata".bold().underline()));
+    out.push_str(&format!("  type:       {}\n", kind_badge(art.kind)));
+    out.push_str(&format!(
+        "  session:    {}\n",
+        art.session_id.as_deref().unwrap_or("-")
+    ));
+    out.push_str(&format!(
+        "  run:        {}\n",
         art.run_id
             .map(|r| r.to_string())
             .unwrap_or_else(|| "-".into())
-    );
-    println!(
-        "  parent:     {}",
+    ));
+    out.push_str(&format!(
+        "  parent:     {}\n",
         art.parent_artifact_id
             .map(|p| p.to_string())
             .unwrap_or_else(|| "-".into())
-    );
-    println!("  source:     {}", art.source.as_deref().unwrap_or("-"));
-    println!("  title:      {}", art.title.as_deref().unwrap_or("-"));
-    println!(
-        "  redaction:  {}",
+    ));
+    out.push_str(&format!(
+        "  source:     {}\n",
+        art.source.as_deref().unwrap_or("-")
+    ));
+    out.push_str(&format!(
+        "  title:      {}\n",
+        art.title.as_deref().unwrap_or("-")
+    ));
+    out.push_str(&format!(
+        "  redaction:  {}\n",
         art.redaction.0.as_deref().unwrap_or("-")
-    );
-    println!(
-        "  created:    {}",
+    ));
+    out.push_str(&format!(
+        "  created:    {}\n",
         art.created_at.format("%Y-%m-%d %H:%M:%S%.3f UTC")
-    );
+    ));
     if let Some(path) = &art.external_path {
-        println!("  external:   {path}");
+        out.push_str(&format!("  external:   {path}\n"));
     }
     if let Some(content) = &art.content {
-        println!("\n--- content ({} bytes) ---", content.len());
-        println!("{content}");
+        out.push_str(&format!(
+            "\n{} ({} bytes)\n",
+            "Content".bold().underline(),
+            content.len()
+        ));
+        out.push_str(content);
+        if !content.ends_with('\n') {
+            out.push('\n');
+        }
     }
-    Ok(())
+    out
 }
 
 fn resolve_artifact_id<S: ArtifactStore + ?Sized>(store: &S, raw_id: &str) -> Result<ArtifactId> {
@@ -110,6 +180,41 @@ fn resolve_artifact_id<S: ArtifactStore + ?Sized>(store: &S, raw_id: &str) -> Re
             "id prefix `{raw_id}` matched {n} artifacts — supply more characters"
         )),
     }
+}
+
+fn kind_badge(kind: ArtifactKind) -> String {
+    let label = format!("[{}]", kind.as_str());
+    match kind {
+        ArtifactKind::Plan => label.blue().bold().to_string(),
+        ArtifactKind::Diff => label.yellow().bold().to_string(),
+        ArtifactKind::Report => label.green().bold().to_string(),
+        ArtifactKind::ToolOutput => label.cyan().bold().to_string(),
+        ArtifactKind::SubagentSummary => label.magenta().bold().to_string(),
+        ArtifactKind::LogExcerpt => label.dimmed().to_string(),
+    }
+}
+
+fn artifact_picker_label(art: &Artifact) -> String {
+    format!(
+        "{}  {:<18}  {:<18}  {}",
+        short_id(&art.id.to_string()),
+        format!("[{}]", art.kind.as_str()),
+        truncate(art.source.as_deref().unwrap_or("-"), 18),
+        art.title.as_deref().unwrap_or("-")
+    )
+}
+
+fn short_id(id: &str) -> String {
+    id.chars().take(8).collect()
+}
+
+fn truncate(s: &str, max_chars: usize) -> String {
+    let mut out: String = s.chars().take(max_chars).collect();
+    if s.chars().count() > max_chars && max_chars > 1 {
+        out.pop();
+        out.push('…');
+    }
+    out
 }
 
 fn resolve_run_id(raw_id: &str) -> Result<RunId> {
@@ -161,5 +266,40 @@ mod tests {
         let store = InMemoryArtifactStore::new();
         let err = resolve_artifact_id(&store, "abcd1234").unwrap_err();
         assert!(err.to_string().contains("no artifact matches"));
+    }
+
+    #[test]
+    fn render_artifact_list_includes_badge_source_and_title() {
+        let art = Artifact::inline_text(ArtifactKind::Report, "findings")
+            .with_session_id("session-1")
+            .with_source("review")
+            .with_title("Review report");
+
+        let out = render_artifact_list(&[art]);
+
+        assert!(out.contains("id"));
+        assert!(out.contains("type"));
+        assert!(out.contains("session"));
+        assert!(out.contains("source"));
+        assert!(out.contains("[report]"));
+        assert!(out.contains("session-1"));
+        assert!(out.contains("review"));
+        assert!(out.contains("Review report"));
+    }
+
+    #[test]
+    fn render_artifact_show_includes_metadata_and_content_section() {
+        let art = Artifact::inline_text(ArtifactKind::Plan, "phase 1\nphase 2")
+            .with_source("planner")
+            .with_title("Plan");
+
+        let out = render_artifact_show(&art);
+
+        assert!(out.contains("Artifact"));
+        assert!(out.contains("Metadata"));
+        assert!(out.contains("Content"));
+        assert!(out.contains("[plan]"));
+        assert!(out.contains("planner"));
+        assert!(out.contains("phase 1"));
     }
 }

--- a/src/cli_run.rs
+++ b/src/cli_run.rs
@@ -5,68 +5,135 @@
 //! to. No mutation; this is a query-only command.
 
 use anyhow::{Context, Result, anyhow};
+use owo_colors::OwoColorize;
+use std::io::IsTerminal;
 use uuid::Uuid;
 
 use crate::cli::RunSubcommand;
-use crate::run_record::{RunEvent, RunId, RunStatus, RunStore, SqliteRunStore};
+use crate::run_record::{RunEvent, RunId, RunRecord, RunStatus, RunStore, SqliteRunStore};
 
-pub async fn run(cmd: RunSubcommand) -> Result<()> {
+pub async fn run(cmd: Option<RunSubcommand>) -> Result<()> {
     let store = SqliteRunStore::try_new().context("open ~/.vulcan/run_records.db")?;
     match cmd {
-        RunSubcommand::List { limit } => list(&store, limit),
-        RunSubcommand::Show { id } => show(&store, &id),
+        None => interactive_select(&store),
+        Some(RunSubcommand::List { limit }) => list(&store, limit),
+        Some(RunSubcommand::Show { id }) => show(&store, &id),
     }
 }
 
-fn list(store: &SqliteRunStore, limit: usize) -> Result<()> {
+fn interactive_select(store: &SqliteRunStore) -> Result<()> {
+    if !std::io::stdin().is_terminal() {
+        anyhow::bail!(
+            "vulcan run (interactive) requires a terminal. Use `vulcan run list` to browse, or `vulcan run show <id>` to inspect a run."
+        );
+    }
+
+    let recent = store.recent(20)?;
+    if recent.is_empty() {
+        println!("No run records yet.");
+        return Ok(());
+    }
+
+    let labels: Vec<String> = recent.iter().map(run_picker_label).collect();
+    println!();
+    let pick = dialoguer::FuzzySelect::with_theme(&dialoguer::theme::ColorfulTheme::default())
+        .with_prompt("Pick a run")
+        .items(&labels)
+        .default(0)
+        .interact()
+        .context("picker cancelled")?;
+
+    print!("{}", render_run_show(&recent[pick]));
+    Ok(())
+}
+
+fn list<S: RunStore + ?Sized>(store: &S, limit: usize) -> Result<()> {
     let recent = store.recent(limit)?;
     if recent.is_empty() {
         println!("No run records yet.");
         return Ok(());
     }
-    println!(
-        "{:<10} {:<12} {:<22} {:<22} model",
-        "id", "status", "started", "ended"
-    );
-    for rec in recent {
-        let id_short: String = rec.id.to_string().chars().take(8).collect();
-        let started = rec.started_at.format("%Y-%m-%d %H:%M:%S");
-        let ended = rec
-            .ended_at
-            .map(|t| t.format("%Y-%m-%d %H:%M:%S").to_string())
-            .unwrap_or_else(|| "-".into());
-        let status = format_status(rec.status);
-        let model = rec.model.unwrap_or_else(|| "-".into());
-        println!("{id_short:<10} {status:<12} {started:<22} {ended:<22} {model}");
-    }
+    print!("{}", render_run_list(&recent));
     Ok(())
 }
 
-fn show(store: &SqliteRunStore, raw_id: &str) -> Result<()> {
+fn show<S: RunStore + ?Sized>(store: &S, raw_id: &str) -> Result<()> {
     let id = resolve_run_id(store, raw_id)?;
     let rec = store
         .get(id)?
         .ok_or_else(|| anyhow!("run record {id} not found"))?;
-    println!("Run {id}");
-    println!("  status:     {}", format_status(rec.status));
-    println!("  origin:     {:?}", rec.origin);
-    println!("  session:    {}", rec.session_id.as_deref().unwrap_or("-"));
-    println!("  model:      {}", rec.model.as_deref().unwrap_or("-"));
-    println!(
-        "  started:    {}",
-        rec.started_at.format("%Y-%m-%d %H:%M:%S%.3f UTC")
-    );
-    if let Some(end) = rec.ended_at {
-        println!("  ended:      {}", end.format("%Y-%m-%d %H:%M:%S%.3f UTC"));
-    }
-    if let Some(err) = &rec.error {
-        println!("  error:      {err}");
-    }
-    println!("\n  events ({}):", rec.events.len());
-    for (i, ev) in rec.events.iter().enumerate() {
-        println!("    [{i:>3}] {}", format_event(ev));
-    }
+    print!("{}", render_run_show(&rec));
     Ok(())
+}
+
+fn render_run_list(records: &[RunRecord]) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "{:<10} {:<12} {:<14} {:<18} {:<22} {:<10} {:<7} {}\n",
+        "id".bold(),
+        "status".bold(),
+        "session".bold(),
+        "tool".bold(),
+        "timestamp".bold(),
+        "duration".bold(),
+        "turns".bold(),
+        "model".bold(),
+    ));
+    for rec in records {
+        out.push_str(&format!(
+            "{:<10} {:<12} {:<14} {:<18} {:<22} {:<10} {:<7} {}\n",
+            short_id(&rec.id.to_string()),
+            status_badge(rec.status),
+            truncate(rec.session_id.as_deref().unwrap_or("-"), 14),
+            truncate(&tool_summary(rec), 18),
+            rec.started_at.format("%Y-%m-%d %H:%M:%S"),
+            duration_summary(rec),
+            turn_count(rec),
+            rec.model.as_deref().unwrap_or("-"),
+        ));
+    }
+    out
+}
+
+fn render_run_show(rec: &RunRecord) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("{} {}\n", "Run".bold(), rec.id));
+    out.push_str(&format!("{}\n", "Metadata".bold().underline()));
+    out.push_str(&format!("  status:     {}\n", status_badge(rec.status)));
+    out.push_str(&format!("  origin:     {:?}\n", rec.origin));
+    out.push_str(&format!(
+        "  session:    {}\n",
+        rec.session_id.as_deref().unwrap_or("-")
+    ));
+    out.push_str(&format!(
+        "  model:      {}\n",
+        rec.model.as_deref().unwrap_or("-")
+    ));
+    out.push_str(&format!(
+        "  started:    {}\n",
+        rec.started_at.format("%Y-%m-%d %H:%M:%S%.3f UTC")
+    ));
+    if let Some(end) = rec.ended_at {
+        out.push_str(&format!(
+            "  ended:      {}\n",
+            end.format("%Y-%m-%d %H:%M:%S%.3f UTC")
+        ));
+    }
+    out.push_str(&format!("  duration:   {}\n", duration_summary(rec)));
+    out.push_str(&format!("  turns:      {}\n", turn_count(rec)));
+    out.push_str(&format!("  tools:      {}\n", tool_summary(rec)));
+    if let Some(err) = &rec.error {
+        out.push_str(&format!("  error:      {}\n", err.red()));
+    }
+    out.push_str(&format!(
+        "\n{} ({})\n",
+        "Timeline".bold().underline(),
+        rec.events.len()
+    ));
+    for (i, ev) in rec.events.iter().enumerate() {
+        out.push_str(&format!("  [{i:>3}] {}\n", format_event(ev)));
+    }
+    out
 }
 
 /// Accept either a full UUID or an 8-char prefix. Prefix lookup
@@ -99,6 +166,74 @@ fn format_status(s: RunStatus) -> &'static str {
         RunStatus::Failed => "failed",
         RunStatus::Cancelled => "cancelled",
     }
+}
+
+fn status_badge(s: RunStatus) -> String {
+    match s {
+        RunStatus::Created => format_status(s).dimmed().to_string(),
+        RunStatus::Running => format_status(s).blue().bold().to_string(),
+        RunStatus::Completed => format_status(s).green().bold().to_string(),
+        RunStatus::Failed => format_status(s).red().bold().to_string(),
+        RunStatus::Cancelled => format_status(s).yellow().bold().to_string(),
+    }
+}
+
+fn short_id(id: &str) -> String {
+    id.chars().take(8).collect()
+}
+
+fn duration_summary(rec: &RunRecord) -> String {
+    let Some(ended) = rec.ended_at else {
+        return "-".into();
+    };
+    let millis = (ended - rec.started_at).num_milliseconds().max(0);
+    if millis < 1_000 {
+        format!("{millis}ms")
+    } else {
+        format!("{:.2}s", millis as f64 / 1_000.0)
+    }
+}
+
+fn turn_count(rec: &RunRecord) -> usize {
+    rec.events
+        .iter()
+        .filter(|ev| matches!(ev, RunEvent::PromptReceived { .. }))
+        .count()
+}
+
+fn tool_summary(rec: &RunRecord) -> String {
+    let mut tools = rec.events.iter().filter_map(|ev| match ev {
+        RunEvent::ToolCall { name, .. } => Some(name.as_str()),
+        _ => None,
+    });
+    let Some(first) = tools.next() else {
+        return "-".into();
+    };
+    let rest = tools.count();
+    if rest == 0 {
+        first.to_string()
+    } else {
+        format!("{first} +{rest}")
+    }
+}
+
+fn run_picker_label(rec: &RunRecord) -> String {
+    format!(
+        "{}  {:<10}  {:<16}  {}",
+        short_id(&rec.id.to_string()),
+        format_status(rec.status),
+        truncate(&tool_summary(rec), 16),
+        rec.started_at.format("%Y-%m-%d %H:%M:%S")
+    )
+}
+
+fn truncate(s: &str, max_chars: usize) -> String {
+    let mut out: String = s.chars().take(max_chars).collect();
+    if s.chars().count() > max_chars && max_chars > 1 {
+        out.pop();
+        out.push('…');
+    }
+    out
 }
 
 fn format_event(ev: &RunEvent) -> String {
@@ -175,7 +310,7 @@ fn format_event(ev: &RunEvent) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::run_record::{InMemoryRunStore, RunOrigin, RunRecord};
+    use crate::run_record::{InMemoryRunStore, PayloadFingerprint, RunOrigin, RunRecord};
 
     #[test]
     fn resolve_run_id_accepts_full_uuid() {
@@ -219,5 +354,59 @@ mod tests {
         assert!(line.contains("12 chars"));
         assert!(line.contains("redacted"));
         assert!(!line.contains("super secret"));
+    }
+
+    #[test]
+    fn render_run_list_includes_issue_542_columns() {
+        let mut rec = RunRecord::new(RunOrigin::Cli);
+        rec.session_id = Some("session-abc".into());
+        rec.model = Some("gpt-5".into());
+        rec.status = RunStatus::Completed;
+        rec.ended_at = Some(rec.started_at + chrono::TimeDelta::milliseconds(1_250));
+        rec.events.push(RunEvent::PromptReceived {
+            fingerprint: PayloadFingerprint::of(b"hello"),
+            char_count: 5,
+            raw: None,
+        });
+        rec.events.push(RunEvent::ToolCall {
+            name: "read_file".into(),
+            args_fingerprint: PayloadFingerprint::of(b"{}"),
+            approval: None,
+            duration_ms: 41,
+            is_error: false,
+            error: None,
+        });
+
+        let out = render_run_list(&[rec]);
+
+        assert!(out.contains("id"));
+        assert!(out.contains("session"));
+        assert!(out.contains("tool"));
+        assert!(out.contains("duration"));
+        assert!(out.contains("turns"));
+        assert!(out.contains("session-abc"));
+        assert!(out.contains("read_file"));
+        assert!(out.contains("1.25s"));
+        assert!(out.contains("1"));
+    }
+
+    #[test]
+    fn render_run_show_sections_timeline() {
+        let mut rec = RunRecord::new(RunOrigin::Cli);
+        rec.status = RunStatus::Failed;
+        rec.error = Some("provider unavailable".into());
+        rec.events.push(RunEvent::ProviderError {
+            message: "timeout".into(),
+            retryable: true,
+        });
+
+        let out = render_run_show(&rec);
+
+        assert!(out.contains("Run"));
+        assert!(out.contains("Metadata"));
+        assert!(out.contains("Timeline"));
+        assert!(out.contains("failed"));
+        assert!(out.contains("provider unavailable"));
+        assert!(out.contains("provider error"));
     }
 }


### PR DESCRIPTION
## Summary
- add interactive no-subcommand pickers for vulcan run and vulcan artifact
- keep explicit run list/show and artifact list/show output paths styled and scriptable
- cover picker rendering and no-subcommand acceptance paths

## Verification
- cargo test render_
- cargo test accepts_no_subcommand
- cargo check -p vulcan
- cargo fmt --check
- git diff --check
- pre-commit passed on branch

Closes #542