### PR TITLE
feat(extensions): add live lifecycle controls

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -92,6 +92,7 @@ pub struct Agent {
     pub(in crate::agent) memory: Arc<SessionStore>,
     pub(in crate::agent) prompt_builder: PromptBuilder,
     pub(in crate::agent) hooks: Arc<HookRegistry>,
+    pub(in crate::agent) session_extensions: Vec<crate::extensions::api::SessionExtensionRuntime>,
     pub(in crate::agent) session_id: String,
     pub(in crate::agent) turns: u32,
     /// Per-turn cancellation token. `cancel_current_turn()` fires it; the
@@ -493,6 +494,7 @@ impl Agent {
         // `hook_handlers` registered into this Agent's `HookRegistry`.
         // No-op when the agent runs without a pool (CLI one-shot) or
         // when no daemon extensions are registered.
+        let mut session_extensions = Vec::new();
         if let Some(p) = pool.as_ref() {
             // GH issue #557: install the daemon's shared audit log on
             // the registry before extension hook handlers register so
@@ -504,12 +506,18 @@ impl Agent {
                 cwd: cwd.clone(),
                 session_id: session_id.clone(),
             };
-            let registered = p
+            session_extensions = p
                 .extension_registry()
-                .wire_daemon_extensions(ctx, &mut hooks);
-            if registered > 0 {
+                .wire_daemon_extensions_runtime(ctx, &hooks);
+            for ext in &session_extensions {
+                for tool in ext.wrapped_tools() {
+                    tools.register(tool);
+                }
+                ext.activate().await;
+            }
+            if !session_extensions.is_empty() {
                 tracing::info!(
-                    daemon_extensions = registered,
+                    daemon_extensions = session_extensions.len(),
                     "Agent: wired daemon-side cargo-crate extensions"
                 );
             }
@@ -649,6 +657,7 @@ impl Agent {
             memory,
             prompt_builder: PromptBuilder,
             hooks: Arc::new(hooks),
+            session_extensions,
             session_id,
             turns: 0,
             turn_cancel: CancellationToken::new(),
@@ -857,6 +866,7 @@ impl Agent {
             memory: Arc::new(SessionStore::in_memory()),
             prompt_builder: PromptBuilder,
             hooks: Arc::new(hooks),
+            session_extensions: Vec::new(),
             session_id: Uuid::new_v4().to_string(),
             turns: 0,
             turn_cancel: CancellationToken::new(),
@@ -905,6 +915,64 @@ impl Agent {
     /// `prompt.stream` holds for the duration of a turn.
     pub fn cancel_handle(&self) -> CancellationToken {
         self.turn_cancel.clone()
+    }
+
+    pub fn session_extension_ids(&self) -> Vec<String> {
+        self.session_extensions
+            .iter()
+            .map(|ext| ext.id().to_string())
+            .collect()
+    }
+
+    pub fn drain_session_extension(&self, id: &str) -> bool {
+        let mut changed = false;
+        for ext in &self.session_extensions {
+            if ext.id() == id {
+                ext.set_draining(true);
+                changed = true;
+            }
+        }
+        changed
+    }
+
+    pub async fn kill_session_extension(&mut self, id: &str) -> bool {
+        let mut kept = Vec::new();
+        let mut killed = false;
+        for ext in self.session_extensions.drain(..) {
+            if ext.id() == id {
+                ext.set_draining(true);
+                ext.deactivate().await;
+                killed = true;
+            } else {
+                kept.push(ext);
+            }
+        }
+        self.session_extensions = kept;
+        killed
+    }
+
+    pub async fn attach_session_extension(
+        &mut self,
+        id: &str,
+        registry: &crate::extensions::ExtensionRegistry,
+    ) -> Result<bool> {
+        if self.session_extensions.iter().any(|ext| ext.id() == id) {
+            return Ok(false);
+        }
+        let ctx = crate::extensions::api::SessionExtensionCtx {
+            cwd: self.tool_context.cwd.clone(),
+            session_id: self.session_id.clone(),
+        };
+        let Some(runtime) = registry.instantiate_daemon_extension_runtime(id, ctx, &self.hooks)
+        else {
+            return Ok(false);
+        };
+        for tool in runtime.wrapped_tools() {
+            self.tools.register(tool);
+        }
+        runtime.activate().await;
+        self.session_extensions.push(runtime);
+        Ok(true)
     }
 
     /// Borrow the shared LSP manager (YYC-46). Used by the

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -1347,7 +1347,7 @@ async fn fork_session_with_hooks_emits_before_fork_event() {
     }
 
     let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
-    let mut hooks = HookRegistry::new();
+    let hooks = HookRegistry::new();
     hooks.register(Arc::new(ForkHook(calls.clone())));
     let mut agent = Agent::for_test(
         Box::new(ProviderHandle(mock)),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -295,6 +295,12 @@ pub enum ExtensionSubcommand {
     Enable { id: String },
     /// Demote install state to `enabled = false`.
     Disable { id: String },
+    /// Force-stop a live extension and disable future activation.
+    Kill { id: String },
+    /// Trust a workspace-discovered extension for this manifest checksum.
+    Trust { id: String },
+    /// Remove the workspace trust marker for an extension.
+    Untrust { id: String },
     /// Permanently delete the install directory + state row.
     Uninstall {
         id: String,

--- a/src/cli_extension.rs
+++ b/src/cli_extension.rs
@@ -10,8 +10,11 @@ use std::path::Path;
 
 use crate::cli::ExtensionSubcommand;
 use crate::config::vulcan_home;
+use crate::daemon::protocol::{Request, Response, read_frame_bytes, write_request};
 use crate::extensions::ExtensionRegistry;
-use crate::extensions::install_state::{InstallState, InstallStateStore, SqliteInstallStateStore};
+use crate::extensions::install_state::{
+    ExtensionTrustStore, InstallState, InstallStateStore, SqliteInstallStateStore,
+};
 
 pub async fn run(cmd: ExtensionSubcommand) -> Result<()> {
     let home = vulcan_home();
@@ -19,8 +22,11 @@ pub async fn run(cmd: ExtensionSubcommand) -> Result<()> {
     match cmd {
         ExtensionSubcommand::List => list(&home, &install),
         ExtensionSubcommand::Show { id } => show(&home, &install, &id),
-        ExtensionSubcommand::Enable { id } => set_enabled(&home, &install, &id, true),
-        ExtensionSubcommand::Disable { id } => set_enabled(&home, &install, &id, false),
+        ExtensionSubcommand::Enable { id } => set_enabled(&home, &install, &id, true).await,
+        ExtensionSubcommand::Disable { id } => set_enabled(&home, &install, &id, false).await,
+        ExtensionSubcommand::Kill { id } => kill(&home, &install, &id).await,
+        ExtensionSubcommand::Trust { id } => trust_workspace(&install, &id),
+        ExtensionSubcommand::Untrust { id } => untrust_workspace(&install, &id),
         ExtensionSubcommand::Uninstall { id, yes } => uninstall(&home, &install, &id, yes),
         ExtensionSubcommand::New { name, kind } => scaffold_new(&name, &kind),
         ExtensionSubcommand::Validate { path } => validate_at(&path),
@@ -33,7 +39,8 @@ fn list(home: &Path, install: &SqliteInstallStateStore) -> Result<()> {
     // GH issue #549: surface cargo-crate extensions registered via
     // `inventory::submit!` alongside manifest-discovered ones.
     crate::extensions::api::wire_inventory_into_registry(&registry);
-    let (ok, broken) = registry.load_from_store(home, install);
+    let cwd = std::env::current_dir()?;
+    let (ok, broken) = registry.load_from_store_and_workspace(home, &cwd, install, install);
     let entries = registry.list();
     if entries.is_empty() {
         println!("(no extensions installed)");
@@ -48,6 +55,7 @@ fn list(home: &Path, install: &SqliteInstallStateStore) -> Result<()> {
         let source = match meta.source {
             crate::extensions::ExtensionSource::Builtin => "builtin",
             crate::extensions::ExtensionSource::LocalManifest => "local",
+            crate::extensions::ExtensionSource::UntrustedSource => "workspace",
             crate::extensions::ExtensionSource::SkillDraft => "skill",
         };
         let desc_preview: String = meta
@@ -73,7 +81,8 @@ fn list(home: &Path, install: &SqliteInstallStateStore) -> Result<()> {
 fn show(home: &Path, install: &SqliteInstallStateStore, id: &str) -> Result<()> {
     let registry = ExtensionRegistry::new();
     crate::extensions::api::wire_inventory_into_registry(&registry);
-    registry.load_from_store(home, install);
+    let cwd = std::env::current_dir()?;
+    registry.load_from_store_and_workspace(home, &cwd, install, install);
     let meta = registry
         .get(id)
         .ok_or_else(|| anyhow!("extension `{id}` not installed"))?;
@@ -84,6 +93,7 @@ fn show(home: &Path, install: &SqliteInstallStateStore, id: &str) -> Result<()> 
     let source = match meta.source {
         crate::extensions::ExtensionSource::Builtin => "builtin",
         crate::extensions::ExtensionSource::LocalManifest => "local-manifest",
+        crate::extensions::ExtensionSource::UntrustedSource => "workspace-untrusted",
         crate::extensions::ExtensionSource::SkillDraft => "skill-draft",
     };
     println!("  source:      {source}");
@@ -116,7 +126,7 @@ fn show(home: &Path, install: &SqliteInstallStateStore, id: &str) -> Result<()> 
     Ok(())
 }
 
-fn set_enabled(
+async fn set_enabled(
     home: &Path,
     install: &SqliteInstallStateStore,
     id: &str,
@@ -125,14 +135,24 @@ fn set_enabled(
     // Confirm the manifest exists before flipping state — flipping
     // state on an unknown id would silently rot.
     let registry = ExtensionRegistry::new();
-    registry.load_from_store(home, install);
-    if registry.get(id).is_none() {
-        return Err(anyhow!("extension `{id}` not installed"));
+    let cwd = std::env::current_dir()?;
+    registry.load_from_store_and_workspace(home, &cwd, install, install);
+    let meta = registry
+        .get(id)
+        .ok_or_else(|| anyhow!("extension `{id}` not installed"))?;
+    if meta.source == crate::extensions::ExtensionSource::UntrustedSource
+        && meta.broken_reason.as_deref() == Some("workspace extension requires trust")
+        && enabled
+    {
+        return Err(anyhow!(
+            "extension `{id}` was discovered from this workspace and must be trusted first"
+        ));
     }
     // Upsert a state row if missing so subsequent flips have
     // something to mutate.
     if install.get(id)?.is_none() {
-        let manifest_path = home.join(format!("extensions/{id}/extension.toml"));
+        let manifest_path = manifest_path_for(home, &cwd, id)
+            .ok_or_else(|| anyhow!("extension `{id}` manifest not found"))?;
         let raw = std::fs::read_to_string(&manifest_path)
             .with_context(|| format!("read {}", manifest_path.display()))?;
         let manifest = crate::extensions::ExtensionManifest::from_toml_str(&raw)?;
@@ -148,6 +168,7 @@ fn set_enabled(
             if enabled { "enabled" } else { "disabled" },
             id
         );
+        notify_daemon_lifecycle(id, enabled).await?;
         return Ok(());
     }
     let flipped = install.set_enabled(id, enabled)?;
@@ -155,7 +176,109 @@ fn set_enabled(
         return Err(anyhow!("extension `{id}` not installed"));
     }
     println!("{} {id}", if enabled { "enabled" } else { "disabled" });
+    notify_daemon_lifecycle(id, enabled).await?;
     Ok(())
+}
+
+async fn kill(home: &Path, install: &SqliteInstallStateStore, id: &str) -> Result<()> {
+    set_enabled(home, install, id, false).await?;
+    if let Some(result) = call_daemon("extension.kill", serde_json::json!({ "id": id })).await? {
+        println!("live daemon: {}", serde_json::to_string(&result)?);
+    }
+    println!("warning: kill may break in-flight tool calls for `{id}`");
+    println!("force-stopped {id}");
+    Ok(())
+}
+
+async fn notify_daemon_lifecycle(id: &str, enabled: bool) -> Result<()> {
+    let method = if enabled {
+        "extension.enable"
+    } else {
+        "extension.disable"
+    };
+    if let Some(result) = call_daemon(method, serde_json::json!({ "id": id })).await? {
+        println!("live daemon: {}", serde_json::to_string(&result)?);
+    }
+    Ok(())
+}
+
+fn trust_workspace(install: &SqliteInstallStateStore, id: &str) -> Result<()> {
+    let cwd = std::env::current_dir()?;
+    let manifest_path = cwd.join(format!(".vulcan/extensions/{id}/extension.toml"));
+    let raw = std::fs::read_to_string(&manifest_path)
+        .with_context(|| format!("read {}", manifest_path.display()))?;
+    let manifest = crate::extensions::ExtensionManifest::from_toml_str(&raw)?;
+    if manifest.id != id {
+        return Err(anyhow!(
+            "manifest id `{}` does not match requested extension `{id}`",
+            manifest.id
+        ));
+    }
+    let checksum = crate::extensions::store::manifest_checksum(&raw);
+    let workspace_hash = workspace_hash(&cwd);
+    install.trust(&workspace_hash, id, &checksum)?;
+    if install.get(id)?.is_none() {
+        install.upsert(&InstallState {
+            id: manifest.id,
+            version: manifest.version,
+            enabled: false,
+            installed_at: chrono::Utc::now(),
+            last_load_error: None,
+        })?;
+    }
+    println!("trusted {id} for workspace {}", cwd.display());
+    println!("Run `vulcan extension enable {id}` to activate.");
+    Ok(())
+}
+
+fn untrust_workspace(install: &SqliteInstallStateStore, id: &str) -> Result<()> {
+    let cwd = std::env::current_dir()?;
+    let removed = install.untrust(&workspace_hash(&cwd), id)?;
+    if removed {
+        println!("untrusted {id} for workspace {}", cwd.display());
+    } else {
+        println!("no trust marker for {id} in workspace {}", cwd.display());
+    }
+    Ok(())
+}
+
+fn manifest_path_for(home: &Path, workspace: &Path, id: &str) -> Option<std::path::PathBuf> {
+    let home_path = home.join(format!("extensions/{id}/extension.toml"));
+    if home_path.is_file() {
+        return Some(home_path);
+    }
+    let workspace_path = workspace.join(format!(".vulcan/extensions/{id}/extension.toml"));
+    workspace_path.is_file().then_some(workspace_path)
+}
+
+fn workspace_hash(workspace: &Path) -> String {
+    crate::extensions::store::manifest_checksum(&workspace.display().to_string())
+}
+
+async fn call_daemon(method: &str, params: serde_json::Value) -> Result<Option<serde_json::Value>> {
+    let sock_path = vulcan_home().join("vulcan.sock");
+    let mut stream = match tokio::net::UnixStream::connect(&sock_path).await {
+        Ok(stream) => stream,
+        Err(_) => return Ok(None),
+    };
+    let req = Request {
+        version: 1,
+        id: format!("cli-{method}"),
+        session: "main".into(),
+        method: method.into(),
+        params,
+    };
+    write_request(&mut stream, &req)
+        .await
+        .context("writing daemon lifecycle request")?;
+    let body = read_frame_bytes(&mut stream)
+        .await
+        .context("reading daemon lifecycle response")?;
+    let resp: Response = serde_json::from_slice(&body).context("decoding daemon response")?;
+    if let Some(err) = resp.error {
+        anyhow::bail!("{}: {}", err.code, err.message);
+    }
+    Ok(resp.result)
 }
 
 fn uninstall(

--- a/src/daemon/dispatch.rs
+++ b/src/daemon/dispatch.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use tokio::sync::{mpsc, oneshot};
 
-use crate::daemon::handlers::{agent, approval, cortex, daemon_ops, prompt, session};
+use crate::daemon::handlers::{agent, approval, cortex, daemon_ops, extension, prompt, session};
 use crate::daemon::protocol::{ProtocolError, Request, Response, StreamFrame};
 use crate::daemon::state::DaemonState;
 
@@ -119,6 +119,22 @@ impl Dispatcher {
             "prompt.cancel" => {
                 let session = req.session.clone();
                 DispatchResult::Response(prompt::cancel(&self.state, req.id, session).await)
+            }
+
+            // -- Extensions --
+            "extension.enable" => {
+                let extension_id = req.params.get("id").and_then(|v| v.as_str()).unwrap_or("");
+                DispatchResult::Response(extension::enable(&self.state, req.id, extension_id).await)
+            }
+            "extension.disable" => {
+                let extension_id = req.params.get("id").and_then(|v| v.as_str()).unwrap_or("");
+                DispatchResult::Response(
+                    extension::disable(&self.state, req.id, extension_id).await,
+                )
+            }
+            "extension.kill" => {
+                let extension_id = req.params.get("id").and_then(|v| v.as_str()).unwrap_or("");
+                DispatchResult::Response(extension::kill(&self.state, req.id, extension_id).await)
             }
 
             // -- Cortex --

--- a/src/daemon/handlers/extension.rs
+++ b/src/daemon/handlers/extension.rs
@@ -1,0 +1,212 @@
+//! Handlers for live daemon extension lifecycle operations.
+
+use serde_json::json;
+
+use crate::daemon::protocol::{ProtocolError, Response};
+use crate::daemon::state::DaemonState;
+use crate::extensions::ExtensionStatus;
+
+pub async fn enable(state: &DaemonState, req_id: String, extension_id: &str) -> Response {
+    let Some(pool) = state.pool() else {
+        return Response::error(req_id, no_pool_error());
+    };
+    let registry = pool.extension_registry();
+    if registry.get(extension_id).is_none() {
+        return Response::error(req_id, not_found(extension_id));
+    }
+    registry.set_status(extension_id, ExtensionStatus::Active);
+
+    let mut attached_sessions = Vec::new();
+    for session_id in state.sessions().ids() {
+        let Some(session) = state.sessions().get(&session_id) else {
+            continue;
+        };
+        let Some(agent_handle) = session.agent_arc() else {
+            continue;
+        };
+        let mut agent = agent_handle.lock().await;
+        match agent
+            .attach_session_extension(extension_id, &registry)
+            .await
+        {
+            Ok(true) => attached_sessions.push(session_id),
+            Ok(false) => {}
+            Err(err) => {
+                return Response::error(
+                    req_id,
+                    ProtocolError {
+                        code: "EXTENSION_ENABLE_FAILED".into(),
+                        message: format!("enable {extension_id} failed: {err}"),
+                        retryable: true,
+                    },
+                );
+            }
+        }
+    }
+
+    Response::ok(
+        req_id,
+        json!({
+            "ok": true,
+            "extension_id": extension_id,
+            "attached_sessions": attached_sessions,
+        }),
+    )
+}
+
+pub async fn disable(state: &DaemonState, req_id: String, extension_id: &str) -> Response {
+    let Some(pool) = state.pool() else {
+        return Response::error(req_id, no_pool_error());
+    };
+    let registry = pool.extension_registry();
+    if registry.get(extension_id).is_none() {
+        return Response::error(req_id, not_found(extension_id));
+    }
+    registry.set_status(extension_id, ExtensionStatus::Inactive);
+
+    let mut drained_sessions = Vec::new();
+    for session_id in state.sessions().ids() {
+        let Some(session) = state.sessions().get(&session_id) else {
+            continue;
+        };
+        let Some(agent_handle) = session.agent_arc() else {
+            continue;
+        };
+        let agent = agent_handle.lock().await;
+        if agent.drain_session_extension(extension_id) {
+            drained_sessions.push(session_id);
+        }
+    }
+
+    Response::ok(
+        req_id,
+        json!({
+            "ok": true,
+            "extension_id": extension_id,
+            "drained_sessions": drained_sessions,
+        }),
+    )
+}
+
+pub async fn kill(state: &DaemonState, req_id: String, extension_id: &str) -> Response {
+    let Some(pool) = state.pool() else {
+        return Response::error(req_id, no_pool_error());
+    };
+    let registry = pool.extension_registry();
+    if registry.get(extension_id).is_none() {
+        return Response::error(req_id, not_found(extension_id));
+    }
+    registry.set_status(extension_id, ExtensionStatus::Inactive);
+
+    let mut killed_sessions = Vec::new();
+    for session_id in state.sessions().ids() {
+        let Some(session) = state.sessions().get(&session_id) else {
+            continue;
+        };
+        let Some(agent_handle) = session.agent_arc() else {
+            continue;
+        };
+        let mut agent = agent_handle.lock().await;
+        if agent.kill_session_extension(extension_id).await {
+            killed_sessions.push(session_id);
+        }
+    }
+
+    Response::ok(
+        req_id,
+        json!({
+            "ok": true,
+            "extension_id": extension_id,
+            "killed_sessions": killed_sessions,
+            "warning": "may break in-flight tool calls",
+        }),
+    )
+}
+
+fn no_pool_error() -> ProtocolError {
+    ProtocolError {
+        code: "EXTENSION_POOL_UNAVAILABLE".into(),
+        message: "daemon runtime pool is not installed".into(),
+        retryable: true,
+    }
+}
+
+fn not_found(extension_id: &str) -> ProtocolError {
+    ProtocolError {
+        code: "EXTENSION_NOT_FOUND".into(),
+        message: format!("extension `{extension_id}` not installed"),
+        retryable: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    use crate::extensions::api::{DaemonCodeExtension, SessionExtension, SessionExtensionCtx};
+    use crate::extensions::{ExtensionMetadata, ExtensionSource};
+
+    struct LifecycleExt;
+
+    impl DaemonCodeExtension for LifecycleExt {
+        fn metadata(&self) -> ExtensionMetadata {
+            let mut meta = ExtensionMetadata::new(
+                "lifecycle-ext",
+                "Lifecycle Ext",
+                "0.1.0",
+                ExtensionSource::Builtin,
+            );
+            meta.status = ExtensionStatus::Active;
+            meta
+        }
+
+        fn instantiate(&self, _ctx: SessionExtensionCtx) -> Arc<dyn SessionExtension> {
+            struct Session;
+            impl SessionExtension for Session {}
+            Arc::new(Session)
+        }
+    }
+
+    fn test_agent() -> crate::agent::Agent {
+        crate::agent::Agent::for_test(
+            Box::new(crate::provider::mock::MockProvider::new(4096)),
+            crate::tools::ToolRegistry::new(),
+            crate::hooks::HookRegistry::new(),
+            Arc::new(crate::skills::SkillRegistry::empty()),
+        )
+    }
+
+    fn state_with_extension() -> DaemonState {
+        let pool = Arc::new(crate::runtime_pool::RuntimeResourcePool::for_tests());
+        pool.extension_registry()
+            .register_daemon_extension(Arc::new(LifecycleExt));
+        let state = DaemonState::for_tests_minimal().with_pool(pool);
+        let main = state.sessions().get("main").unwrap();
+        main.set_agent(test_agent());
+        state
+    }
+
+    #[tokio::test]
+    async fn enable_attaches_extension_to_live_agent() {
+        let state = state_with_extension();
+        let resp = enable(&state, "req-1".into(), "lifecycle-ext").await;
+        assert!(resp.error.is_none(), "{:?}", resp.error);
+        let main = state.sessions().get("main").unwrap();
+        let agent = main.agent_arc().unwrap();
+        let agent = agent.lock().await;
+        assert_eq!(agent.session_extension_ids(), vec!["lifecycle-ext"]);
+    }
+
+    #[tokio::test]
+    async fn kill_removes_extension_from_live_agent() {
+        let state = state_with_extension();
+        let _ = enable(&state, "req-1".into(), "lifecycle-ext").await;
+        let resp = kill(&state, "req-2".into(), "lifecycle-ext").await;
+        assert!(resp.error.is_none(), "{:?}", resp.error);
+        let main = state.sessions().get("main").unwrap();
+        let agent = main.agent_arc().unwrap();
+        let agent = agent.lock().await;
+        assert!(agent.session_extension_ids().is_empty());
+    }
+}

--- a/src/daemon/handlers/mod.rs
+++ b/src/daemon/handlers/mod.rs
@@ -6,5 +6,6 @@ pub mod agent;
 pub mod approval;
 pub mod cortex;
 pub mod daemon_ops;
+pub mod extension;
 pub mod prompt;
 pub mod session;

--- a/src/extensions/api.rs
+++ b/src/extensions/api.rs
@@ -15,12 +15,16 @@
 
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use super::ExtensionMetadata;
-use crate::hooks::HookHandler;
-use crate::provider::LLMProvider;
+use crate::hooks::{HookHandler, HookOutcome};
 use crate::provider::factory::ProviderFactory;
-use crate::tools::Tool;
+use crate::provider::{ChatResponse, LLMProvider, Message, StreamEvent, ToolCall};
+use crate::tools::{Tool, ToolProgress, ToolResult};
+use anyhow::Result;
+use serde_json::Value;
+use tokio_util::sync::CancellationToken;
 
 /// Parsed `[package.metadata.vulcan]` block for a cargo-crate
 /// extension. Produced by `vulcan_extension_macros::include_manifest!()`.
@@ -109,6 +113,294 @@ pub trait SessionExtension: Send + Sync {
 
     /// Lifecycle hook invoked when the session extension is deactivated.
     async fn on_deactivate(&self) {}
+}
+
+#[derive(Clone)]
+pub struct SessionExtensionRuntime {
+    id: String,
+    extension: Arc<dyn SessionExtension>,
+    draining: Arc<AtomicBool>,
+}
+
+impl SessionExtensionRuntime {
+    pub fn new(id: impl Into<String>, extension: Arc<dyn SessionExtension>) -> Self {
+        Self {
+            id: id.into(),
+            extension,
+            draining: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    pub fn is_draining(&self) -> bool {
+        self.draining.load(Ordering::SeqCst)
+    }
+
+    pub fn set_draining(&self, draining: bool) {
+        self.draining.store(draining, Ordering::SeqCst);
+    }
+
+    pub async fn deactivate(&self) {
+        self.extension.on_deactivate().await;
+    }
+
+    pub async fn activate(&self) {
+        self.extension.on_activate().await;
+    }
+
+    pub fn wrapped_hook_handlers(&self) -> Vec<Arc<dyn HookHandler>> {
+        self.extension
+            .hook_handlers()
+            .into_iter()
+            .map(|inner| {
+                Arc::new(DrainingHookHandler {
+                    inner,
+                    draining: Arc::clone(&self.draining),
+                }) as Arc<dyn HookHandler>
+            })
+            .collect()
+    }
+
+    pub fn wrapped_tools(&self) -> Vec<Arc<dyn Tool>> {
+        self.extension
+            .tools()
+            .into_iter()
+            .map(|inner| {
+                Arc::new(DrainingTool {
+                    inner,
+                    draining: Arc::clone(&self.draining),
+                }) as Arc<dyn Tool>
+            })
+            .collect()
+    }
+}
+
+struct DrainingHookHandler {
+    inner: Arc<dyn HookHandler>,
+    draining: Arc<AtomicBool>,
+}
+
+impl DrainingHookHandler {
+    fn should_skip_before_prompt(&self) -> bool {
+        self.draining.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait::async_trait]
+impl HookHandler for DrainingHookHandler {
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn priority(&self) -> i32 {
+        self.inner.priority()
+    }
+
+    async fn before_prompt(
+        &self,
+        messages: &[Message],
+        cancel: CancellationToken,
+    ) -> Result<HookOutcome> {
+        if self.should_skip_before_prompt() {
+            return Ok(HookOutcome::Continue);
+        }
+        self.inner.before_prompt(messages, cancel).await
+    }
+
+    async fn on_turn_start(&self, turn: u32, cancel: CancellationToken) -> Result<HookOutcome> {
+        self.inner.on_turn_start(turn, cancel).await
+    }
+
+    async fn on_turn_end(&self, turn: u32, cancel: CancellationToken) -> Result<HookOutcome> {
+        self.inner.on_turn_end(turn, cancel).await
+    }
+
+    async fn on_input(&self, raw: &str, cancel: CancellationToken) -> Result<HookOutcome> {
+        self.inner.on_input(raw, cancel).await
+    }
+
+    async fn on_message_start(
+        &self,
+        delta: &StreamEvent,
+        cancel: CancellationToken,
+    ) -> Result<HookOutcome> {
+        self.inner.on_message_start(delta, cancel).await
+    }
+
+    async fn on_message_update(
+        &self,
+        delta: &StreamEvent,
+        cancel: CancellationToken,
+    ) -> Result<HookOutcome> {
+        self.inner.on_message_update(delta, cancel).await
+    }
+
+    async fn on_message_end(
+        &self,
+        delta: &StreamEvent,
+        cancel: CancellationToken,
+    ) -> Result<HookOutcome> {
+        self.inner.on_message_end(delta, cancel).await
+    }
+
+    async fn on_tool_execution_start(
+        &self,
+        call: &ToolCall,
+        cancel: CancellationToken,
+    ) -> Result<HookOutcome> {
+        self.inner.on_tool_execution_start(call, cancel).await
+    }
+
+    async fn on_tool_execution_update(
+        &self,
+        call: &ToolCall,
+        progress: &ToolProgress,
+        cancel: CancellationToken,
+    ) -> Result<HookOutcome> {
+        self.inner
+            .on_tool_execution_update(call, progress, cancel)
+            .await
+    }
+
+    async fn on_tool_execution_end(
+        &self,
+        call: &ToolCall,
+        cancel: CancellationToken,
+    ) -> Result<HookOutcome> {
+        self.inner.on_tool_execution_end(call, cancel).await
+    }
+
+    async fn on_context(
+        &self,
+        messages: &[Message],
+        cancel: CancellationToken,
+    ) -> Result<HookOutcome> {
+        if self.should_skip_before_prompt() {
+            return Ok(HookOutcome::Continue);
+        }
+        self.inner.on_context(messages, cancel).await
+    }
+
+    async fn on_before_provider_request(
+        &self,
+        messages: &[Message],
+        cancel: CancellationToken,
+    ) -> Result<HookOutcome> {
+        self.inner
+            .on_before_provider_request(messages, cancel)
+            .await
+    }
+
+    async fn on_after_provider_response(
+        &self,
+        response: &ChatResponse,
+        cancel: CancellationToken,
+    ) -> Result<HookOutcome> {
+        self.inner
+            .on_after_provider_response(response, cancel)
+            .await
+    }
+
+    async fn on_session_before_compact(
+        &self,
+        messages: &[Message],
+        cancel: CancellationToken,
+    ) -> Result<HookOutcome> {
+        self.inner.on_session_before_compact(messages, cancel).await
+    }
+
+    async fn on_session_compact(
+        &self,
+        summary: &str,
+        cancel: CancellationToken,
+    ) -> Result<HookOutcome> {
+        self.inner.on_session_compact(summary, cancel).await
+    }
+
+    async fn on_session_before_fork(&self, cancel: CancellationToken) -> Result<HookOutcome> {
+        self.inner.on_session_before_fork(cancel).await
+    }
+
+    async fn on_session_shutdown(&self, cancel: CancellationToken) -> Result<HookOutcome> {
+        self.inner.on_session_shutdown(cancel).await
+    }
+
+    async fn before_tool_call(
+        &self,
+        tool: &str,
+        args: &Value,
+        cancel: CancellationToken,
+    ) -> Result<HookOutcome> {
+        self.inner.before_tool_call(tool, args, cancel).await
+    }
+
+    async fn after_tool_call(
+        &self,
+        tool: &str,
+        result: &ToolResult,
+        cancel: CancellationToken,
+    ) -> Result<HookOutcome> {
+        self.inner.after_tool_call(tool, result, cancel).await
+    }
+
+    async fn before_agent_end(
+        &self,
+        final_response: &str,
+        cancel: CancellationToken,
+    ) -> Result<HookOutcome> {
+        self.inner.before_agent_end(final_response, cancel).await
+    }
+
+    async fn session_start(&self, session_id: &str) {
+        self.inner.session_start(session_id).await;
+    }
+
+    async fn session_end(&self, session_id: &str, total_turns: u32) {
+        self.inner.session_end(session_id, total_turns).await;
+    }
+}
+
+struct DrainingTool {
+    inner: Arc<dyn Tool>,
+    draining: Arc<AtomicBool>,
+}
+
+#[async_trait::async_trait]
+impl Tool for DrainingTool {
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn description(&self) -> &str {
+        self.inner.description()
+    }
+
+    fn schema(&self) -> Value {
+        self.inner.schema()
+    }
+
+    async fn call(
+        &self,
+        params: Value,
+        cancel: CancellationToken,
+        progress: Option<crate::tools::ProgressSink>,
+    ) -> Result<ToolResult> {
+        if self.draining.load(Ordering::SeqCst) {
+            return Ok(ToolResult::err("extension draining"));
+        }
+        self.inner.call(params, cancel, progress).await
+    }
+
+    fn is_relevant(&self, ctx: &crate::tools::ToolContext) -> bool {
+        self.inner.is_relevant(ctx)
+    }
+
+    fn dynamic_description(&self, ctx: &crate::tools::ToolContext) -> Option<String> {
+        self.inner.dynamic_description(ctx)
+    }
 }
 
 /// Inventory-collected registration entry. Each extension crate
@@ -266,8 +558,8 @@ mod tests {
         let registry = ExtensionRegistry::new();
         registry.register_daemon_extension(Arc::new(WatcherExtension));
 
-        let mut hooks = HookRegistry::new();
-        let registered = registry.wire_daemon_extensions(test_ctx(), &mut hooks);
+        let hooks = HookRegistry::new();
+        let registered = registry.wire_daemon_extensions(test_ctx(), &hooks);
 
         assert_eq!(registered, 1);
         assert_eq!(hooks.handler_count(), 1);
@@ -356,5 +648,133 @@ mod tests {
         assert!(session.provider_factories().is_empty());
         session.on_activate().await;
         session.on_deactivate().await;
+    }
+
+    #[tokio::test]
+    async fn draining_runtime_skips_prompt_hooks_but_keeps_handler_registered() {
+        use crate::hooks::{HookOutcome, HookRegistry, InjectPosition};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct PromptSession {
+            calls: Arc<AtomicUsize>,
+        }
+
+        impl SessionExtension for PromptSession {
+            fn hook_handlers(&self) -> Vec<Arc<dyn HookHandler>> {
+                vec![Arc::new(PromptHook {
+                    calls: Arc::clone(&self.calls),
+                })]
+            }
+        }
+
+        struct PromptHook {
+            calls: Arc<AtomicUsize>,
+        }
+
+        #[async_trait::async_trait]
+        impl HookHandler for PromptHook {
+            fn name(&self) -> &str {
+                "prompt-hook"
+            }
+
+            async fn before_prompt(
+                &self,
+                _messages: &[Message],
+                _cancel: CancellationToken,
+            ) -> Result<HookOutcome> {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                Ok(HookOutcome::InjectMessages {
+                    messages: vec![Message::System {
+                        content: "injected".into(),
+                    }],
+                    position: InjectPosition::Append,
+                })
+            }
+        }
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let runtime = SessionExtensionRuntime::new(
+            "prompt-ext",
+            Arc::new(PromptSession {
+                calls: Arc::clone(&calls),
+            }),
+        );
+        let hooks = HookRegistry::new();
+        for handler in runtime.wrapped_hook_handlers() {
+            hooks.register(handler);
+        }
+        assert_eq!(hooks.handler_count(), 1);
+
+        let input = vec![Message::User {
+            content: "hi".into(),
+        }];
+        let out = hooks
+            .apply_before_prompt(&input, CancellationToken::new())
+            .await;
+        assert_eq!(out.len(), 2);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        runtime.set_draining(true);
+        let out = hooks
+            .apply_before_prompt(&input, CancellationToken::new())
+            .await;
+        assert_eq!(out.len(), 1);
+        assert!(matches!(
+            out.first(),
+            Some(Message::User { content }) if content == "hi"
+        ));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn draining_runtime_refuses_new_tool_calls() {
+        struct ToolSession;
+        impl SessionExtension for ToolSession {
+            fn tools(&self) -> Vec<Arc<dyn Tool>> {
+                vec![Arc::new(EchoTool)]
+            }
+        }
+
+        struct EchoTool;
+        #[async_trait::async_trait]
+        impl Tool for EchoTool {
+            fn name(&self) -> &str {
+                "echo_ext"
+            }
+
+            fn description(&self) -> &str {
+                "echo"
+            }
+
+            fn schema(&self) -> Value {
+                serde_json::json!({})
+            }
+
+            async fn call(
+                &self,
+                _params: Value,
+                _cancel: CancellationToken,
+                _progress: Option<crate::tools::ProgressSink>,
+            ) -> Result<ToolResult> {
+                Ok(ToolResult::ok("ran"))
+            }
+        }
+
+        let runtime = SessionExtensionRuntime::new("tool-ext", Arc::new(ToolSession));
+        let tool = runtime.wrapped_tools().remove(0);
+        let result = tool
+            .call(serde_json::json!({}), CancellationToken::new(), None)
+            .await
+            .unwrap();
+        assert_eq!(result.output, "ran");
+        assert!(!result.is_error);
+
+        runtime.set_draining(true);
+        let result = tool
+            .call(serde_json::json!({}), CancellationToken::new(), None)
+            .await
+            .unwrap();
+        assert_eq!(result.output, "extension draining");
+        assert!(result.is_error);
     }
 }

--- a/src/extensions/install_state.rs
+++ b/src/extensions/install_state.rs
@@ -21,6 +21,14 @@ pub struct InstallState {
     pub last_load_error: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrustMarker {
+    pub workspace_hash: String,
+    pub extension_id: String,
+    pub manifest_checksum: String,
+    pub trusted_at: chrono::DateTime<chrono::Utc>,
+}
+
 pub trait InstallStateStore: Send + Sync {
     fn upsert(&self, state: &InstallState) -> Result<()>;
     fn get(&self, id: &str) -> Result<Option<InstallState>>;
@@ -29,6 +37,23 @@ pub trait InstallStateStore: Send + Sync {
     fn record_load_error(&self, id: &str, error: &str) -> Result<bool>;
     fn clear_load_error(&self, id: &str) -> Result<bool>;
     fn remove(&self, id: &str) -> Result<bool>;
+}
+
+pub trait ExtensionTrustStore: Send + Sync {
+    fn trust(
+        &self,
+        workspace_hash: &str,
+        extension_id: &str,
+        manifest_checksum: &str,
+    ) -> Result<()>;
+    fn untrust(&self, workspace_hash: &str, extension_id: &str) -> Result<bool>;
+    fn is_trusted(
+        &self,
+        workspace_hash: &str,
+        extension_id: &str,
+        manifest_checksum: &str,
+    ) -> Result<bool>;
+    fn list_trusted(&self, workspace_hash: &str) -> Result<Vec<TrustMarker>>;
 }
 
 pub struct SqliteInstallStateStore {
@@ -71,6 +96,14 @@ impl SqliteInstallStateStore {
                 installed_at    TEXT NOT NULL,
                 last_load_error TEXT
             );
+
+            CREATE TABLE IF NOT EXISTS extension_trust (
+                workspace_hash    TEXT NOT NULL,
+                extension_id      TEXT NOT NULL,
+                manifest_checksum TEXT NOT NULL,
+                trusted_at        TEXT NOT NULL,
+                PRIMARY KEY (workspace_hash, extension_id)
+            );
             "#,
         )?;
         Ok(())
@@ -91,6 +124,90 @@ impl SqliteInstallStateStore {
                 .with_timezone(&chrono::Utc),
             last_load_error,
         })
+    }
+}
+
+impl ExtensionTrustStore for SqliteInstallStateStore {
+    fn trust(
+        &self,
+        workspace_hash: &str,
+        extension_id: &str,
+        manifest_checksum: &str,
+    ) -> Result<()> {
+        let conn = self.conn.lock();
+        conn.execute(
+            "INSERT INTO extension_trust
+                (workspace_hash, extension_id, manifest_checksum, trusted_at)
+             VALUES (?1, ?2, ?3, ?4)
+             ON CONFLICT(workspace_hash, extension_id) DO UPDATE SET
+                manifest_checksum = excluded.manifest_checksum,
+                trusted_at = excluded.trusted_at",
+            params![
+                workspace_hash,
+                extension_id,
+                manifest_checksum,
+                chrono::Utc::now().to_rfc3339(),
+            ],
+        )?;
+        Ok(())
+    }
+
+    fn untrust(&self, workspace_hash: &str, extension_id: &str) -> Result<bool> {
+        let conn = self.conn.lock();
+        let n = conn.execute(
+            "DELETE FROM extension_trust WHERE workspace_hash = ?1 AND extension_id = ?2",
+            params![workspace_hash, extension_id],
+        )?;
+        Ok(n > 0)
+    }
+
+    fn is_trusted(
+        &self,
+        workspace_hash: &str,
+        extension_id: &str,
+        manifest_checksum: &str,
+    ) -> Result<bool> {
+        let conn = self.conn.lock();
+        let found: Option<String> = conn
+            .query_row(
+                "SELECT manifest_checksum FROM extension_trust
+                 WHERE workspace_hash = ?1 AND extension_id = ?2",
+                params![workspace_hash, extension_id],
+                |row| row.get(0),
+            )
+            .optional()?;
+        Ok(found.as_deref() == Some(manifest_checksum))
+    }
+
+    fn list_trusted(&self, workspace_hash: &str) -> Result<Vec<TrustMarker>> {
+        let conn = self.conn.lock();
+        let mut stmt = conn.prepare(
+            "SELECT workspace_hash, extension_id, manifest_checksum, trusted_at
+             FROM extension_trust WHERE workspace_hash = ?1 ORDER BY extension_id ASC",
+        )?;
+        let rows: Vec<_> = stmt
+            .query_map(params![workspace_hash], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                ))
+            })?
+            .collect::<Result<_, _>>()?;
+        rows.into_iter()
+            .map(
+                |(workspace_hash, extension_id, manifest_checksum, trusted_at)| {
+                    Ok(TrustMarker {
+                        workspace_hash,
+                        extension_id,
+                        manifest_checksum,
+                        trusted_at: chrono::DateTime::parse_from_rfc3339(&trusted_at)?
+                            .with_timezone(&chrono::Utc),
+                    })
+                },
+            )
+            .collect()
     }
 }
 
@@ -290,5 +407,34 @@ mod tests {
         let listed = reopened.list().unwrap();
         assert_eq!(listed.len(), 1);
         assert_eq!(listed[0].id, "lint-helper");
+    }
+
+    #[test]
+    fn trust_marker_requires_current_checksum() {
+        let store = SqliteInstallStateStore::try_open_in_memory().unwrap();
+        store.trust("workspace-a", "todo", "sha256:old").unwrap();
+        assert!(
+            store
+                .is_trusted("workspace-a", "todo", "sha256:old")
+                .unwrap()
+        );
+        assert!(
+            !store
+                .is_trusted("workspace-a", "todo", "sha256:new")
+                .unwrap()
+        );
+
+        store.trust("workspace-a", "todo", "sha256:new").unwrap();
+        assert!(
+            store
+                .is_trusted("workspace-a", "todo", "sha256:new")
+                .unwrap()
+        );
+        assert!(store.untrust("workspace-a", "todo").unwrap());
+        assert!(
+            !store
+                .is_trusted("workspace-a", "todo", "sha256:new")
+                .unwrap()
+        );
     }
 }

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -83,6 +83,10 @@ pub enum ExtensionSource {
     /// today this only carries metadata; code execution arrives
     /// once dynamic loading lands.
     LocalManifest,
+    /// Read from `<workspace>/.vulcan/extensions/<id>/extension.toml`.
+    /// Workspace-local manifests stay inactive until the user trusts
+    /// the exact workspace/id/checksum tuple.
+    UntrustedSource,
     /// Imported from a markdown skill (`<skills_dir>/<id>.md`)
     /// via the YYC-165 PR-2 promotion path.
     SkillDraft,

--- a/src/extensions/registry.rs
+++ b/src/extensions/registry.rs
@@ -9,8 +9,10 @@
 use parking_lot::RwLock;
 use std::sync::Arc;
 
-use super::api::{DaemonCodeExtension, SessionExtensionCtx};
-use super::{ExtensionCapability, ExtensionConfigField, ExtensionMetadata, ExtensionStatus};
+use super::api::{DaemonCodeExtension, SessionExtensionCtx, SessionExtensionRuntime};
+use super::{
+    ExtensionCapability, ExtensionConfigField, ExtensionMetadata, ExtensionSource, ExtensionStatus,
+};
 use crate::hooks::{HookHandler, HookRegistry};
 
 /// YYC-227 (YYC-165 PR-4): trait an in-process, code-backed
@@ -226,12 +228,16 @@ impl ExtensionRegistry {
     /// the supplied `HookRegistry`. Returns the number of session
     /// extensions instantiated. Inactive / Draft / Broken extensions
     /// are skipped.
-    pub fn wire_daemon_extensions(
+    pub fn wire_daemon_extensions(&self, ctx: SessionExtensionCtx, hooks: &HookRegistry) -> usize {
+        self.wire_daemon_extensions_runtime(ctx, hooks).len()
+    }
+
+    pub fn wire_daemon_extensions_runtime(
         &self,
         ctx: SessionExtensionCtx,
-        hooks: &mut HookRegistry,
-    ) -> usize {
-        let mut count = 0usize;
+        hooks: &HookRegistry,
+    ) -> Vec<SessionExtensionRuntime> {
+        let mut runtimes = Vec::new();
         let metadata_snapshot = self.inner.read().clone();
         let daemon_snapshot = self.daemon_extensions.read().clone();
         for ext in daemon_snapshot {
@@ -245,12 +251,39 @@ impl ExtensionRegistry {
                 continue;
             }
             let session_ext = ext.instantiate(ctx.clone());
-            for handler in session_ext.hook_handlers() {
+            let runtime = SessionExtensionRuntime::new(id, session_ext);
+            for handler in runtime.wrapped_hook_handlers() {
                 hooks.register(handler);
             }
-            count += 1;
+            runtimes.push(runtime);
         }
-        count
+        runtimes
+    }
+
+    pub fn instantiate_daemon_extension_runtime(
+        &self,
+        id: &str,
+        ctx: SessionExtensionCtx,
+        hooks: &HookRegistry,
+    ) -> Option<SessionExtensionRuntime> {
+        let metadata_snapshot = self.inner.read().clone();
+        let active = metadata_snapshot
+            .iter()
+            .find(|m| m.id == id)
+            .map(|m| m.status == ExtensionStatus::Active)
+            .unwrap_or(false);
+        if !active {
+            return None;
+        }
+        let daemon_snapshot = self.daemon_extensions.read().clone();
+        let ext = daemon_snapshot
+            .into_iter()
+            .find(|e| e.metadata().id == id)?;
+        let runtime = SessionExtensionRuntime::new(id.to_string(), ext.instantiate(ctx));
+        for handler in runtime.wrapped_hook_handlers() {
+            hooks.register(handler);
+        }
+        Some(runtime)
     }
 
     /// YYC-232 (YYC-166 PR-4): discover installed extensions in
@@ -270,6 +303,22 @@ impl ExtensionRegistry {
         self.load_from_store_with_version(home, install_state, env!("CARGO_PKG_VERSION"))
     }
 
+    pub fn load_from_store_and_workspace(
+        &self,
+        home: &std::path::Path,
+        workspace: &std::path::Path,
+        install_state: &dyn super::install_state::InstallStateStore,
+        trust: &dyn super::install_state::ExtensionTrustStore,
+    ) -> (usize, usize) {
+        self.load_from_store_and_workspace_with_version(
+            home,
+            workspace,
+            install_state,
+            trust,
+            env!("CARGO_PKG_VERSION"),
+        )
+    }
+
     /// Test-friendly variant — `running_version` lets fixtures
     /// pin a value instead of inheriting `CARGO_PKG_VERSION`.
     pub fn load_from_store_with_version(
@@ -278,7 +327,42 @@ impl ExtensionRegistry {
         install_state: &dyn super::install_state::InstallStateStore,
         running_version: &str,
     ) -> (usize, usize) {
-        let discovered = super::store::discover(home);
+        self.load_discovered(
+            super::store::discover(home),
+            None,
+            install_state,
+            None,
+            running_version,
+        )
+    }
+
+    pub fn load_from_store_and_workspace_with_version(
+        &self,
+        home: &std::path::Path,
+        workspace: &std::path::Path,
+        install_state: &dyn super::install_state::InstallStateStore,
+        trust: &dyn super::install_state::ExtensionTrustStore,
+        running_version: &str,
+    ) -> (usize, usize) {
+        self.load_discovered(
+            super::store::discover_with_workspace(home, workspace),
+            Some(super::store::manifest_checksum(
+                &workspace.display().to_string(),
+            )),
+            install_state,
+            Some(trust),
+            running_version,
+        )
+    }
+
+    fn load_discovered(
+        &self,
+        discovered: Vec<super::store::DiscoveredExtension>,
+        workspace_hash: Option<String>,
+        install_state: &dyn super::install_state::InstallStateStore,
+        trust: Option<&dyn super::install_state::ExtensionTrustStore>,
+        running_version: &str,
+    ) -> (usize, usize) {
         let mut ok = 0usize;
         let mut broken = 0usize;
         for entry in discovered {
@@ -295,7 +379,7 @@ impl ExtensionRegistry {
                             manifest.id.clone(),
                             manifest.name.clone(),
                             manifest.version.clone(),
-                            crate::extensions::ExtensionSource::LocalManifest,
+                            entry.source.clone(),
                         );
                         meta.status = ExtensionStatus::Broken;
                         meta.broken_reason = Some(reason.clone());
@@ -309,7 +393,7 @@ impl ExtensionRegistry {
                         manifest.id.clone(),
                         manifest.name.clone(),
                         manifest.version.clone(),
-                        crate::extensions::ExtensionSource::LocalManifest,
+                        entry.source.clone(),
                     );
                     if let Some(desc) = manifest.description.clone() {
                         meta.description = desc;
@@ -321,17 +405,35 @@ impl ExtensionRegistry {
                     // to Inactive otherwise so freshly-dropped
                     // extensions stay quiet until the user opts
                     // in.
-                    let enabled = install_state
-                        .get(&manifest.id)
-                        .ok()
-                        .flatten()
-                        .map(|s| s.enabled)
-                        .unwrap_or(false);
+                    let trusted = if entry.source == ExtensionSource::UntrustedSource {
+                        match (
+                            workspace_hash.as_deref(),
+                            entry.manifest_checksum.as_deref(),
+                            trust,
+                        ) {
+                            (Some(hash), Some(checksum), Some(trust)) => trust
+                                .is_trusted(hash, &manifest.id, checksum)
+                                .unwrap_or(false),
+                            _ => false,
+                        }
+                    } else {
+                        true
+                    };
+                    let enabled = trusted
+                        && install_state
+                            .get(&manifest.id)
+                            .ok()
+                            .flatten()
+                            .map(|s| s.enabled)
+                            .unwrap_or(false);
                     meta.status = if enabled {
                         ExtensionStatus::Active
                     } else {
                         ExtensionStatus::Inactive
                     };
+                    if entry.source == ExtensionSource::UntrustedSource && !trusted {
+                        meta.broken_reason = Some("workspace extension requires trust".into());
+                    }
                     self.upsert(meta);
                     let _ = install_state.clear_load_error(&manifest.id);
                     ok += 1;
@@ -342,7 +444,7 @@ impl ExtensionRegistry {
                         dir_id.clone(),
                         dir_id.clone(),
                         "0.0.0",
-                        crate::extensions::ExtensionSource::LocalManifest,
+                        entry.source.clone(),
                     );
                     meta.status = ExtensionStatus::Broken;
                     meta.broken_reason = Some(reason.clone());
@@ -711,6 +813,71 @@ kind = "builtin"
         let got = reg.get("needs-future").unwrap();
         assert_eq!(got.status, ExtensionStatus::Broken);
         assert!(got.broken_reason.as_deref().unwrap().contains("Vulcan ≥"));
+    }
+
+    #[test]
+    fn workspace_extension_requires_matching_trust_marker_to_activate() {
+        let home = tempfile::tempdir().unwrap();
+        let workspace = tempfile::tempdir().unwrap();
+        let raw = r#"
+id = "workspace-tool"
+name = "Workspace Tool"
+version = "0.1.0"
+
+[entry]
+kind = "builtin"
+"#;
+        write_manifest(
+            workspace
+                .path()
+                .join(".vulcan/extensions/workspace-tool/extension.toml"),
+            raw,
+        );
+        let install =
+            crate::extensions::install_state::SqliteInstallStateStore::try_open_in_memory()
+                .unwrap();
+        crate::extensions::install_state::InstallStateStore::upsert(
+            &install,
+            &crate::extensions::install_state::InstallState {
+                id: "workspace-tool".into(),
+                version: "0.1.0".into(),
+                enabled: true,
+                installed_at: chrono::Utc::now(),
+                last_load_error: None,
+            },
+        )
+        .unwrap();
+
+        let reg = ExtensionRegistry::new();
+        reg.load_from_store_and_workspace(home.path(), workspace.path(), &install, &install);
+        let got = reg.get("workspace-tool").unwrap();
+        assert_eq!(
+            got.source,
+            crate::extensions::ExtensionSource::UntrustedSource
+        );
+        assert_eq!(got.status, ExtensionStatus::Inactive);
+        assert_eq!(
+            got.broken_reason.as_deref(),
+            Some("workspace extension requires trust")
+        );
+
+        let workspace_hash =
+            crate::extensions::store::manifest_checksum(&workspace.path().display().to_string());
+        let checksum = crate::extensions::store::manifest_checksum(raw);
+        crate::extensions::install_state::ExtensionTrustStore::trust(
+            &install,
+            &workspace_hash,
+            "workspace-tool",
+            &checksum,
+        )
+        .unwrap();
+
+        let reg = ExtensionRegistry::new();
+        reg.load_from_store_and_workspace(home.path(), workspace.path(), &install, &install);
+        assert_eq!(
+            reg.get("workspace-tool").unwrap().status,
+            ExtensionStatus::Active
+        );
     }
 
     #[test]

--- a/src/extensions/store.rs
+++ b/src/extensions/store.rs
@@ -11,7 +11,9 @@
 
 use std::path::{Path, PathBuf};
 
+use super::ExtensionSource;
 use super::manifest::{ExtensionManifest, ManifestError};
+use sha2::{Digest, Sha256};
 
 /// One entry surfaced by [`discover`]. Either the manifest
 /// parsed cleanly (`manifest = Some`) or the file parsed wrong
@@ -25,6 +27,10 @@ pub struct DiscoveredExtension {
     pub dir_id: String,
     /// Absolute path to the install directory.
     pub dir: PathBuf,
+    /// Scope this manifest came from.
+    pub source: ExtensionSource,
+    /// Stable checksum of the manifest file used for workspace trust.
+    pub manifest_checksum: Option<String>,
     /// Parsed manifest. `None` when the file is missing or
     /// invalid.
     pub manifest: Option<ExtensionManifest>,
@@ -42,8 +48,24 @@ pub struct DiscoveredExtension {
 /// `home` is the explicit Vulcan home — production code passes
 /// `crate::config::vulcan_home()`; tests pass a temp dir.
 pub fn discover(home: &Path) -> Vec<DiscoveredExtension> {
+    discover_root(home, ExtensionSource::LocalManifest)
+}
+
+/// Walk both the home extension store and `<workspace>/.vulcan/extensions`.
+pub fn discover_with_workspace(home: &Path, workspace: &Path) -> Vec<DiscoveredExtension> {
     let mut out = Vec::new();
-    let extensions_root = home.join("extensions");
+    out.extend(discover_root(home, ExtensionSource::LocalManifest));
+    out.extend(discover_root(
+        &workspace.join(".vulcan"),
+        ExtensionSource::UntrustedSource,
+    ));
+    out.sort_by(|a, b| a.dir_id.cmp(&b.dir_id).then_with(|| a.dir.cmp(&b.dir)));
+    out
+}
+
+fn discover_root(root: &Path, source: ExtensionSource) -> Vec<DiscoveredExtension> {
+    let mut out = Vec::new();
+    let extensions_root = root.join("extensions");
     if !extensions_root.is_dir() {
         return out;
     }
@@ -71,12 +93,16 @@ pub fn discover(home: &Path) -> Vec<DiscoveredExtension> {
                 Ok(manifest) => out.push(DiscoveredExtension {
                     dir_id,
                     dir,
+                    source: source.clone(),
+                    manifest_checksum: Some(manifest_checksum(&raw)),
                     manifest: Some(manifest),
                     parse_error: None,
                 }),
                 Err(err) => out.push(DiscoveredExtension {
                     dir_id,
                     dir,
+                    source: source.clone(),
+                    manifest_checksum: Some(manifest_checksum(&raw)),
                     manifest: None,
                     parse_error: Some(err),
                 }),
@@ -88,6 +114,19 @@ pub fn discover(home: &Path) -> Vec<DiscoveredExtension> {
     // OS-level readdir ordering.
     out.sort_by(|a, b| a.dir_id.cmp(&b.dir_id));
     out
+}
+
+pub fn manifest_checksum(raw: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(raw.as_bytes());
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(7 + digest.len() * 2);
+    hex.push_str("sha256:");
+    for byte in digest.iter() {
+        use std::fmt::Write as _;
+        let _ = write!(&mut hex, "{byte:02x}");
+    }
+    hex
 }
 
 #[cfg(test)]

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -12,6 +12,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use anyhow::Result;
+use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::time::timeout;
@@ -362,7 +363,7 @@ impl HookFailureMetrics {
 /// Holds the registered handlers in priority order and exposes one emit method
 /// per event.
 pub struct HookRegistry {
-    handlers: Vec<Arc<dyn HookHandler>>,
+    handlers: RwLock<Vec<Arc<dyn HookHandler>>>,
     handler_timeout: Duration,
     failure_metrics: HookFailureMetrics,
     /// GH issue #557: optional audit log. When set, `apply_on_input`
@@ -379,7 +380,7 @@ pub struct HookRegistry {
 impl HookRegistry {
     pub fn new() -> Self {
         Self {
-            handlers: Vec::new(),
+            handlers: RwLock::new(Vec::new()),
             audit_log: None,
             input_rewrite_approval_required: HashSet::new(),
             input_rewrite_pause_tx: None,
@@ -418,13 +419,18 @@ impl HookRegistry {
             .insert(extension_id.into());
     }
 
-    pub fn register(&mut self, handler: Arc<dyn HookHandler>) {
-        self.handlers.push(handler);
-        self.handlers.sort_by_key(|h| h.priority());
+    pub fn register(&self, handler: Arc<dyn HookHandler>) {
+        let mut handlers = self.handlers.write();
+        handlers.push(handler);
+        handlers.sort_by_key(|h| h.priority());
     }
 
     pub fn handler_count(&self) -> usize {
-        self.handlers.len()
+        self.handlers.read().len()
+    }
+
+    fn handlers_snapshot(&self) -> Vec<Arc<dyn HookHandler>> {
+        self.handlers.read().clone()
     }
 
     /// Snapshot of per-failure-mode counters since registry construction
@@ -460,8 +466,8 @@ impl HookRegistry {
         let mut after_system: Vec<Message> = Vec::new();
         let mut appended: Vec<Message> = Vec::new();
 
-        for h in &self.handlers {
-            match self.run(h, h.on_context(&current, cancel.clone())).await {
+        for h in self.handlers_snapshot() {
+            match self.run(&h, h.on_context(&current, cancel.clone())).await {
                 Some(HookOutcome::RewriteMessages(rewritten)) => {
                     tracing::info!("hook {} rewrote context messages", h.name());
                     current = rewritten;
@@ -482,7 +488,10 @@ impl HookRegistry {
                     );
                 }
             }
-            match self.run(h, h.before_prompt(messages, cancel.clone())).await {
+            match self
+                .run(&h, h.before_prompt(messages, cancel.clone()))
+                .await
+            {
                 Some(HookOutcome::InjectMessages {
                     messages: msgs,
                     position,
@@ -529,8 +538,8 @@ impl HookRegistry {
     }
 
     pub async fn on_turn_start(&self, turn: u32, cancel: CancellationToken) {
-        for h in &self.handlers {
-            match self.run(h, h.on_turn_start(turn, cancel.clone())).await {
+        for h in self.handlers_snapshot() {
+            match self.run(&h, h.on_turn_start(turn, cancel.clone())).await {
                 Some(HookOutcome::Continue) | None => {}
                 Some(other) => {
                     tracing::warn!(
@@ -544,8 +553,8 @@ impl HookRegistry {
     }
 
     pub async fn on_turn_end(&self, turn: u32, cancel: CancellationToken) {
-        for h in &self.handlers {
-            match self.run(h, h.on_turn_end(turn, cancel.clone())).await {
+        for h in self.handlers_snapshot() {
+            match self.run(&h, h.on_turn_end(turn, cancel.clone())).await {
                 Some(HookOutcome::Continue) | None => {}
                 Some(other) => {
                     tracing::warn!(
@@ -559,42 +568,43 @@ impl HookRegistry {
     }
 
     pub async fn on_message_start(&self, delta: &StreamEvent, cancel: CancellationToken) {
-        for h in &self.handlers {
+        for h in self.handlers_snapshot() {
             self.ignore_observe_outcome(
-                h,
+                &h,
                 "on_message_start",
-                self.run(h, h.on_message_start(delta, cancel.clone())).await,
+                self.run(&h, h.on_message_start(delta, cancel.clone()))
+                    .await,
             );
         }
     }
 
     pub async fn on_message_update(&self, delta: &StreamEvent, cancel: CancellationToken) {
-        for h in &self.handlers {
+        for h in self.handlers_snapshot() {
             self.ignore_observe_outcome(
-                h,
+                &h,
                 "on_message_update",
-                self.run(h, h.on_message_update(delta, cancel.clone()))
+                self.run(&h, h.on_message_update(delta, cancel.clone()))
                     .await,
             );
         }
     }
 
     pub async fn on_message_end(&self, delta: &StreamEvent, cancel: CancellationToken) {
-        for h in &self.handlers {
+        for h in self.handlers_snapshot() {
             self.ignore_observe_outcome(
-                h,
+                &h,
                 "on_message_end",
-                self.run(h, h.on_message_end(delta, cancel.clone())).await,
+                self.run(&h, h.on_message_end(delta, cancel.clone())).await,
             );
         }
     }
 
     pub async fn on_tool_execution_start(&self, call: &ToolCall, cancel: CancellationToken) {
-        for h in &self.handlers {
+        for h in self.handlers_snapshot() {
             self.ignore_observe_outcome(
-                h,
+                &h,
                 "on_tool_execution_start",
-                self.run(h, h.on_tool_execution_start(call, cancel.clone()))
+                self.run(&h, h.on_tool_execution_start(call, cancel.clone()))
                     .await,
             );
         }
@@ -606,12 +616,12 @@ impl HookRegistry {
         progress: &ToolProgress,
         cancel: CancellationToken,
     ) {
-        for h in &self.handlers {
+        for h in self.handlers_snapshot() {
             self.ignore_observe_outcome(
-                h,
+                &h,
                 "on_tool_execution_update",
                 self.run(
-                    h,
+                    &h,
                     h.on_tool_execution_update(call, progress, cancel.clone()),
                 )
                 .await,
@@ -620,11 +630,11 @@ impl HookRegistry {
     }
 
     pub async fn on_tool_execution_end(&self, call: &ToolCall, cancel: CancellationToken) {
-        for h in &self.handlers {
+        for h in self.handlers_snapshot() {
             self.ignore_observe_outcome(
-                h,
+                &h,
                 "on_tool_execution_end",
-                self.run(h, h.on_tool_execution_end(call, cancel.clone()))
+                self.run(&h, h.on_tool_execution_end(call, cancel.clone()))
                     .await,
             );
         }
@@ -635,11 +645,11 @@ impl HookRegistry {
         messages: &[Message],
         cancel: CancellationToken,
     ) {
-        for h in &self.handlers {
+        for h in self.handlers_snapshot() {
             self.ignore_observe_outcome(
-                h,
+                &h,
                 "on_before_provider_request",
-                self.run(h, h.on_before_provider_request(messages, cancel.clone()))
+                self.run(&h, h.on_before_provider_request(messages, cancel.clone()))
                     .await,
             );
         }
@@ -650,11 +660,11 @@ impl HookRegistry {
         response: &ChatResponse,
         cancel: CancellationToken,
     ) {
-        for h in &self.handlers {
+        for h in self.handlers_snapshot() {
             self.ignore_observe_outcome(
-                h,
+                &h,
                 "on_after_provider_response",
-                self.run(h, h.on_after_provider_response(response, cancel.clone()))
+                self.run(&h, h.on_after_provider_response(response, cancel.clone()))
                     .await,
             );
         }
@@ -665,9 +675,9 @@ impl HookRegistry {
         messages: &[Message],
         cancel: CancellationToken,
     ) -> CompactionDecision {
-        for h in &self.handlers {
+        for h in self.handlers_snapshot() {
             match self
-                .run(h, h.on_session_before_compact(messages, cancel.clone()))
+                .run(&h, h.on_session_before_compact(messages, cancel.clone()))
                 .await
             {
                 Some(HookOutcome::Block { reason }) => {
@@ -698,32 +708,32 @@ impl HookRegistry {
     }
 
     pub async fn on_session_compact(&self, summary: &str, cancel: CancellationToken) {
-        for h in &self.handlers {
+        for h in self.handlers_snapshot() {
             self.ignore_observe_outcome(
-                h,
+                &h,
                 "on_session_compact",
-                self.run(h, h.on_session_compact(summary, cancel.clone()))
+                self.run(&h, h.on_session_compact(summary, cancel.clone()))
                     .await,
             );
         }
     }
 
     pub async fn on_session_before_fork(&self, cancel: CancellationToken) {
-        for h in &self.handlers {
+        for h in self.handlers_snapshot() {
             self.ignore_observe_outcome(
-                h,
+                &h,
                 "on_session_before_fork",
-                self.run(h, h.on_session_before_fork(cancel.clone())).await,
+                self.run(&h, h.on_session_before_fork(cancel.clone())).await,
             );
         }
     }
 
     pub async fn on_session_shutdown(&self, cancel: CancellationToken) {
-        for h in &self.handlers {
+        for h in self.handlers_snapshot() {
             self.ignore_observe_outcome(
-                h,
+                &h,
                 "on_session_shutdown",
-                self.run(h, h.on_session_shutdown(cancel.clone())).await,
+                self.run(&h, h.on_session_shutdown(cancel.clone())).await,
             );
         }
     }
@@ -736,8 +746,8 @@ impl HookRegistry {
     /// installed via `with_audit_log`), with the handler's `name()`
     /// as the audit `extension_id`.
     pub async fn apply_on_input(&self, raw: &str, cancel: CancellationToken) -> InputDecision {
-        for h in &self.handlers {
-            match self.run(h, h.on_input(raw, cancel.clone())).await {
+        for h in self.handlers_snapshot() {
+            match self.run(&h, h.on_input(raw, cancel.clone())).await {
                 Some(HookOutcome::BlockInput { reason }) => {
                     tracing::info!("hook {} blocked input: {reason}", h.name());
                     self.record_input_intercept(
@@ -915,9 +925,9 @@ impl HookRegistry {
         args: &Value,
         cancel: CancellationToken,
     ) -> ToolCallDecision {
-        for h in &self.handlers {
+        for h in self.handlers_snapshot() {
             match self
-                .run(h, h.before_tool_call(tool, args, cancel.clone()))
+                .run(&h, h.before_tool_call(tool, args, cancel.clone()))
                 .await
             {
                 Some(HookOutcome::Block { reason }) => {
@@ -948,9 +958,9 @@ impl HookRegistry {
         result: &ToolResult,
         cancel: CancellationToken,
     ) -> Option<ToolResult> {
-        for h in &self.handlers {
+        for h in self.handlers_snapshot() {
             match self
-                .run(h, h.after_tool_call(tool, result, cancel.clone()))
+                .run(&h, h.after_tool_call(tool, result, cancel.clone()))
                 .await
             {
                 Some(HookOutcome::ReplaceResult(new)) => {
@@ -977,9 +987,9 @@ impl HookRegistry {
         response: &str,
         cancel: CancellationToken,
     ) -> Option<String> {
-        for h in &self.handlers {
+        for h in self.handlers_snapshot() {
             match self
-                .run(h, h.before_agent_end(response, cancel.clone()))
+                .run(&h, h.before_agent_end(response, cancel.clone()))
                 .await
             {
                 Some(HookOutcome::ForceContinue { instruction }) => {
@@ -1000,7 +1010,7 @@ impl HookRegistry {
     }
 
     pub async fn session_start(&self, session_id: &str) {
-        for h in &self.handlers {
+        for h in self.handlers_snapshot() {
             // Each handler gets its own timeout window. session_X are observe-
             // only so we don't care about return values.
             let _ = timeout(self.handler_timeout, h.session_start(session_id)).await;
@@ -1008,7 +1018,7 @@ impl HookRegistry {
     }
 
     pub async fn session_end(&self, session_id: &str, total_turns: u32) {
-        for h in &self.handlers {
+        for h in self.handlers_snapshot() {
             let _ = timeout(self.handler_timeout, h.session_end(session_id, total_turns)).await;
         }
     }
@@ -1145,7 +1155,7 @@ mod tests {
 
     #[tokio::test]
     async fn first_block_wins_and_short_circuits_subsequent_handlers() {
-        let mut reg = HookRegistry::new();
+        let reg = HookRegistry::new();
         let blocker = Arc::new(Probe::new(
             "blocker",
             10,
@@ -1173,7 +1183,7 @@ mod tests {
 
     #[tokio::test]
     async fn priority_ordering_lower_runs_first() {
-        let mut reg = HookRegistry::new();
+        let reg = HookRegistry::new();
         let probe_a = Arc::new(Probe::new(
             "a",
             1,
@@ -1207,7 +1217,7 @@ mod tests {
         // "handler too slow" and "handler crashed". Both still drop the
         // outcome (the loop is unaffected), but the counters differ so
         // metrics surfaces can branch on the failure mode.
-        let mut reg = HookRegistry::new().with_timeout(std::time::Duration::from_millis(50));
+        let reg = HookRegistry::new().with_timeout(std::time::Duration::from_millis(50));
         let slow = Arc::new(Probe::new("slow", 10, HookOutcome::Continue).slow(500));
         let crashed = Arc::new(Probe::new("crashed", 20, HookOutcome::Continue).errors());
         reg.register(slow);
@@ -1235,7 +1245,7 @@ mod tests {
 
     #[tokio::test]
     async fn handler_timeout_does_not_break_loop() {
-        let mut reg = HookRegistry::new().with_timeout(std::time::Duration::from_millis(50));
+        let reg = HookRegistry::new().with_timeout(std::time::Duration::from_millis(50));
         // First handler sleeps past the timeout window.
         let slow = Arc::new(
             Probe::new(
@@ -1290,7 +1300,7 @@ mod tests {
 
     #[tokio::test]
     async fn before_prompt_injections_accumulate_and_position() {
-        let mut reg = HookRegistry::new();
+        let reg = HookRegistry::new();
         reg.register(Arc::new(Injector {
             name: "after-system-1",
             msg: "AS1".into(),
@@ -1510,7 +1520,7 @@ mod tests {
 
     #[tokio::test]
     async fn on_context_rewrite_messages_replaces_outgoing_prompt_transiently() {
-        let mut reg = HookRegistry::new();
+        let reg = HookRegistry::new();
         reg.register(Arc::new(ContextRewriter));
         let input = vec![Message::User {
             content: "original".into(),
@@ -1553,7 +1563,7 @@ mod tests {
             }
         }
 
-        let mut reg = HookRegistry::new().with_timeout(std::time::Duration::from_millis(10));
+        let reg = HookRegistry::new().with_timeout(std::time::Duration::from_millis(10));
         reg.register(Arc::new(SlowTurnStart));
 
         reg.on_turn_start(1, CancellationToken::new()).await;
@@ -1726,7 +1736,7 @@ mod tests {
     #[tokio::test]
     async fn wide_observe_events_run_in_priority_order() {
         let events = Arc::new(Mutex::new(Vec::new()));
-        let mut reg = HookRegistry::new();
+        let reg = HookRegistry::new();
         reg.register(Arc::new(WideRecorder {
             name: "second",
             priority: 20,
@@ -1828,7 +1838,7 @@ mod tests {
         }
 
         let fast_calls = Arc::new(AtomicUsize::new(0));
-        let mut reg = HookRegistry::new().with_timeout(std::time::Duration::from_millis(10));
+        let reg = HookRegistry::new().with_timeout(std::time::Duration::from_millis(10));
         reg.register(Arc::new(SlowMessageUpdate));
         reg.register(Arc::new(FastMessageUpdate(fast_calls.clone())));
 
@@ -1886,7 +1896,7 @@ mod tests {
         }
 
         let later_calls = Arc::new(AtomicUsize::new(0));
-        let mut reg = HookRegistry::new();
+        let reg = HookRegistry::new();
         reg.register(Arc::new(BlockingCompact));
         reg.register(Arc::new(LaterCompact(later_calls.clone())));
 
@@ -1962,7 +1972,7 @@ mod tests {
         }
 
         let audit = Arc::new(ExtensionAuditLog::new(8));
-        let mut reg = HookRegistry::new().with_audit_log(audit.clone());
+        let reg = HookRegistry::new().with_audit_log(audit.clone());
         reg.register(Arc::new(Rewriter));
 
         let _ = reg.apply_on_input("raw", CancellationToken::new()).await;
@@ -2003,7 +2013,7 @@ mod tests {
         }
 
         let audit = Arc::new(ExtensionAuditLog::new(8));
-        let mut reg = HookRegistry::new().with_audit_log(audit.clone());
+        let reg = HookRegistry::new().with_audit_log(audit.clone());
         reg.register(Arc::new(Blocker));
 
         let _ = reg.apply_on_input("hello", CancellationToken::new()).await;
@@ -2037,7 +2047,7 @@ mod tests {
         }
 
         let audit = Arc::new(ExtensionAuditLog::new(8));
-        let mut reg = HookRegistry::new().with_audit_log(audit.clone());
+        let reg = HookRegistry::new().with_audit_log(audit.clone());
         reg.register(Arc::new(Noop));
 
         let _ = reg.apply_on_input("hello", CancellationToken::new()).await;
@@ -2063,7 +2073,7 @@ mod tests {
             }
         }
 
-        let mut reg = HookRegistry::new();
+        let reg = HookRegistry::new();
         reg.register(Arc::new(Rewriter));
 
         let decision = reg
@@ -2208,7 +2218,7 @@ mod tests {
             }
         }
 
-        let mut reg = HookRegistry::new();
+        let reg = HookRegistry::new();
         reg.register(Arc::new(Noop));
 
         let decision = reg
@@ -2259,7 +2269,7 @@ mod tests {
         }
 
         let later = Arc::new(AtomicUsize::new(0));
-        let mut reg = HookRegistry::new();
+        let reg = HookRegistry::new();
         reg.register(Arc::new(Rewriter));
         reg.register(Arc::new(LaterCounter(later.clone())));
 
@@ -2288,7 +2298,7 @@ mod tests {
             }
         }
 
-        let mut reg = HookRegistry::new();
+        let reg = HookRegistry::new();
         reg.register(Arc::new(BlockingInput));
 
         let decision = reg.apply_on_input("hello", CancellationToken::new()).await;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -122,7 +122,7 @@ pub async fn run_tui(
 
     // ── Hook registry: audit-log + (room for safety-gate, etc.). Built-in
     // hooks (skills) are registered by AgentBuilder.
-    let mut hook_reg = HookRegistry::new();
+    let hook_reg = HookRegistry::new();
     let (audit_hook, audit_buf) = AuditHook::new(200);
     hook_reg.register(audit_hook);
 


### PR DESCRIPTION
## Summary
- add live extension lifecycle controls and daemon handlers
- preserve extension trust/policy checks while exposing enable disable status operations
- cover extension, hook, and daemon extension handler paths

## Verification
- cargo check -p vulcan-core
- cargo test -p vulcan-core extensions:: -- --nocapture
- cargo test -p vulcan-core hooks:: -- --nocapture
- cargo test -p vulcan-core daemon::handlers::extension -- --nocapture
- cargo check -p vulcan
- cargo fmt --check
- git diff --check
- pre-commit passed on branch

Closes #556