### PR TITLE
feat(hooks): add compaction control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7267,6 +7267,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "vulcan-ext-compact-summary"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "inventory",
+ "tokio",
+ "tokio-util",
+ "vulcan-core",
+]
+
+[[package]]
 name = "vulcan-ext-input-demo"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "vulcan-frontend-api",
     "vulcan-extension-macros",
     "vulcan-ext-auto-commit",
+    "vulcan-ext-compact-summary",
     "vulcan-ext-input-demo",
 ]
 resolver = "2"

--- a/src/agent/run.rs
+++ b/src/agent/run.rs
@@ -7,6 +7,7 @@ use anyhow::Result;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
+use crate::hooks::{CompactionDecision, validate_rewrite_history};
 use crate::provider::{ChatResponse, Message, StreamEvent, ToolCall, ToolDefinition, Usage};
 use crate::run_record::{PayloadFingerprint, RunEvent, RunOrigin, RunRecord, RunStatus};
 use crate::tools::ToolResult;
@@ -488,17 +489,72 @@ impl Agent {
         if !self.context.should_compact(messages) {
             return;
         }
-        if !self
+        let cancel = self.turn_cancel.clone();
+        match self
             .hooks
-            .on_session_before_compact(self.turn_cancel.clone())
+            .on_session_before_compact(messages, cancel.clone())
             .await
         {
-            tracing::info!("agent iteration {iteration}: compaction blocked by hook");
-            return;
+            CompactionDecision::Continue => {}
+            CompactionDecision::RewriteHistory {
+                extension_id,
+                messages: proposed,
+            } => match validate_rewrite_history(messages, &proposed) {
+                Ok(()) => {
+                    let pre_count = messages.len();
+                    *messages = proposed;
+                    if let Err(e) = self.replace_history(messages) {
+                        tracing::warn!(
+                            "failed to replace persisted history after extension compaction: {e}"
+                        );
+                    }
+                    self.context
+                        .install_summary(format!("history rewritten by {extension_id}"));
+                    self.hooks
+                        .on_session_compact("extension rewrite history", cancel.clone())
+                        .await;
+                    let earlier_messages = pre_count.saturating_sub(messages.len()).max(1);
+                    let _ = turn_tx
+                        .send(TurnEvent::Compacted { earlier_messages })
+                        .await;
+                    tracing::info!(
+                        "agent iteration {iteration}: hook {extension_id} rewrote compaction history"
+                    );
+                    return;
+                }
+                Err(rejection) => {
+                    tracing::warn!(
+                        "hook {extension_id} returned invalid RewriteHistory for compaction: {rejection:?}; falling back to built-in compaction"
+                    );
+                    self.hooks
+                        .record_compaction_validation_failed(&extension_id, rejection);
+                }
+            },
+            CompactionDecision::Block {
+                extension_id,
+                reason,
+            } => {
+                if self.context.would_overflow_next_request(messages) {
+                    tracing::warn!(
+                        "agent iteration {iteration}: compaction block by hook {extension_id} overridden because context overflow is imminent: {reason}"
+                    );
+                    self.hooks.record_compaction_forced(&extension_id, &reason);
+                    let _ = turn_tx
+                        .send(TurnEvent::CompactionForced {
+                            extension_id,
+                            reason,
+                        })
+                        .await;
+                } else {
+                    tracing::info!(
+                        "agent iteration {iteration}: compaction blocked by hook {extension_id}: {reason}"
+                    );
+                    return;
+                }
+            }
         }
 
         let pre_count = messages.len();
-        let cancel = self.turn_cancel.clone();
         let compacted = self
             .compact_buffered_messages_if_possible(messages, cancel)
             .await;

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -173,6 +173,41 @@ fn agent_with_mock() -> (Agent, Arc<MockProvider>) {
     (agent, mock)
 }
 
+fn agent_with_mock_and_hooks(hooks: HookRegistry) -> (Agent, Arc<MockProvider>) {
+    let mock = Arc::new(MockProvider::new(128_000));
+    struct ProviderHandle(Arc<MockProvider>);
+    #[async_trait::async_trait]
+    impl LLMProvider for ProviderHandle {
+        async fn chat(
+            &self,
+            m: &[Message],
+            t: &[crate::provider::ToolDefinition],
+            c: CancellationToken,
+        ) -> Result<crate::provider::ChatResponse> {
+            self.0.chat(m, t, c).await
+        }
+        async fn chat_stream(
+            &self,
+            m: &[Message],
+            t: &[crate::provider::ToolDefinition],
+            tx: tokio::sync::mpsc::Sender<crate::provider::StreamEvent>,
+            c: CancellationToken,
+        ) -> Result<()> {
+            self.0.chat_stream(m, t, tx, c).await
+        }
+        fn max_context(&self) -> usize {
+            self.0.max_context()
+        }
+    }
+    let agent = Agent::for_test(
+        Box::new(ProviderHandle(mock.clone())),
+        ToolRegistry::new(),
+        hooks,
+        empty_skills(),
+    );
+    (agent, mock)
+}
+
 #[tokio::test]
 async fn builder_accepts_hooks_pause_channel_and_max_iterations() {
     let mut config = Config::default();
@@ -428,6 +463,250 @@ async fn compact_turn_messages_if_needed_emits_domain_event() {
         rx.try_recv(),
         Ok(TurnEvent::Compacted { earlier_messages }) if earlier_messages > 0
     ));
+}
+
+#[tokio::test]
+async fn rewrite_history_from_before_compact_replaces_durable_history() {
+    struct RewriteHook;
+
+    #[async_trait::async_trait]
+    impl crate::hooks::HookHandler for RewriteHook {
+        fn name(&self) -> &str {
+            "compact-summary"
+        }
+
+        async fn on_session_before_compact(
+            &self,
+            _messages: &[Message],
+            _cancel: CancellationToken,
+        ) -> Result<crate::hooks::HookOutcome> {
+            Ok(crate::hooks::HookOutcome::RewriteHistory(vec![
+                Message::System {
+                    content: "extension summary".into(),
+                },
+            ]))
+        }
+    }
+
+    let mut hooks = HookRegistry::new();
+    hooks.register(Arc::new(RewriteHook));
+    let (mut agent, mock) = agent_with_mock_and_hooks(hooks);
+    agent.context = ContextManager::new(10);
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel(crate::provider::STREAM_CHANNEL_CAPACITY);
+    let mut messages = vec![
+        Message::System {
+            content: "system".into(),
+        },
+        Message::User {
+            content: "old ".repeat(200),
+        },
+    ];
+
+    agent
+        .compact_turn_messages_if_needed(&mut messages, &tx, 0)
+        .await;
+
+    assert_eq!(messages.len(), 1);
+    assert!(matches!(&messages[0], Message::System { content } if content == "extension summary"));
+    assert!(
+        mock.captured_calls().is_empty(),
+        "valid rewrite must bypass built-in summarizer"
+    );
+    assert!(matches!(
+        rx.try_recv(),
+        Ok(TurnEvent::Compacted { earlier_messages }) if earlier_messages > 0
+    ));
+}
+
+#[tokio::test]
+async fn invalid_rewrite_history_falls_back_to_builtin_and_audits_rejection() {
+    use crate::extensions::{CompactionAuditAction, ExtensionAuditEvent, ExtensionAuditLog};
+
+    struct BadRewriteHook;
+
+    #[async_trait::async_trait]
+    impl crate::hooks::HookHandler for BadRewriteHook {
+        fn name(&self) -> &str {
+            "bad-compact"
+        }
+
+        async fn on_session_before_compact(
+            &self,
+            _messages: &[Message],
+            _cancel: CancellationToken,
+        ) -> Result<crate::hooks::HookOutcome> {
+            Ok(crate::hooks::HookOutcome::RewriteHistory(vec![
+                Message::User {
+                    content: "missing system".into(),
+                },
+            ]))
+        }
+    }
+
+    let audit = Arc::new(ExtensionAuditLog::new(8));
+    let mut hooks = HookRegistry::new().with_audit_log(audit.clone());
+    hooks.register(Arc::new(BadRewriteHook));
+    let (mut agent, mock) = agent_with_mock_and_hooks(hooks);
+    agent.context = ContextManager::new(10);
+    mock.enqueue_text("built in summary");
+
+    let (tx, _rx) = tokio::sync::mpsc::channel(crate::provider::STREAM_CHANNEL_CAPACITY);
+    let mut messages = vec![Message::System {
+        content: "system".into(),
+    }];
+    for i in 0..8 {
+        messages.push(Message::User {
+            content: format!("old {i} {}", "x ".repeat(40)),
+        });
+        messages.push(Message::Assistant {
+            content: Some(format!("answer {i}")),
+            tool_calls: None,
+            reasoning_content: None,
+        });
+    }
+    messages.push(Message::User {
+        content: "fresh".into(),
+    });
+
+    agent
+        .compact_turn_messages_if_needed(&mut messages, &tx, 0)
+        .await;
+
+    assert!(
+        messages.iter().any(
+            |m| matches!(m, Message::System { content } if content.contains("built in summary"))
+        )
+    );
+    assert!(audit.recent(8).iter().any(|event| matches!(
+        event,
+        ExtensionAuditEvent::Compaction(compaction)
+            if compaction.extension_id == "bad-compact"
+                && matches!(compaction.action, CompactionAuditAction::ValidationFailed { .. })
+    )));
+}
+
+#[tokio::test]
+async fn block_skips_compaction_until_context_overflow_is_imminent() {
+    struct BlockHook;
+
+    #[async_trait::async_trait]
+    impl crate::hooks::HookHandler for BlockHook {
+        fn name(&self) -> &str {
+            "block-compact"
+        }
+
+        async fn on_session_before_compact(
+            &self,
+            _messages: &[Message],
+            _cancel: CancellationToken,
+        ) -> Result<crate::hooks::HookOutcome> {
+            Ok(crate::hooks::HookOutcome::Block {
+                reason: "not now".into(),
+            })
+        }
+    }
+
+    let mut hooks = HookRegistry::new();
+    hooks.register(Arc::new(BlockHook));
+    let (mut agent, mock) = agent_with_mock_and_hooks(hooks);
+    agent.context = ContextManager::with_config(
+        10_000,
+        crate::config::CompactionConfig {
+            enabled: true,
+            trigger_ratio: 0.01,
+            reserved_tokens: 0,
+        },
+    );
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel(crate::provider::STREAM_CHANNEL_CAPACITY);
+    let original = vec![
+        Message::System {
+            content: "system".into(),
+        },
+        Message::User {
+            content: "old ".repeat(200),
+        },
+    ];
+    let mut messages = original.clone();
+
+    agent
+        .compact_turn_messages_if_needed(&mut messages, &tx, 0)
+        .await;
+
+    assert_eq!(messages.len(), original.len());
+    assert!(mock.captured_calls().is_empty());
+    assert!(rx.try_recv().is_err());
+}
+
+#[tokio::test]
+async fn block_is_overridden_on_context_overflow_and_audited() {
+    use crate::extensions::{CompactionAuditAction, ExtensionAuditEvent, ExtensionAuditLog};
+
+    struct BlockHook;
+
+    #[async_trait::async_trait]
+    impl crate::hooks::HookHandler for BlockHook {
+        fn name(&self) -> &str {
+            "block-compact"
+        }
+
+        async fn on_session_before_compact(
+            &self,
+            _messages: &[Message],
+            _cancel: CancellationToken,
+        ) -> Result<crate::hooks::HookOutcome> {
+            Ok(crate::hooks::HookOutcome::Block {
+                reason: "not now".into(),
+            })
+        }
+    }
+
+    let audit = Arc::new(ExtensionAuditLog::new(8));
+    let mut hooks = HookRegistry::new().with_audit_log(audit.clone());
+    hooks.register(Arc::new(BlockHook));
+    let (mut agent, mock) = agent_with_mock_and_hooks(hooks);
+    agent.context = ContextManager::new(10);
+    mock.enqueue_text("forced summary");
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel(crate::provider::STREAM_CHANNEL_CAPACITY);
+    let mut messages = vec![Message::System {
+        content: "system".into(),
+    }];
+    for i in 0..8 {
+        messages.push(Message::User {
+            content: format!("old {i} {}", "x ".repeat(40)),
+        });
+        messages.push(Message::Assistant {
+            content: Some(format!("answer {i}")),
+            tool_calls: None,
+            reasoning_content: None,
+        });
+    }
+    messages.push(Message::User {
+        content: "fresh".into(),
+    });
+
+    agent
+        .compact_turn_messages_if_needed(&mut messages, &tx, 0)
+        .await;
+
+    assert!(matches!(
+        rx.try_recv(),
+        Ok(TurnEvent::CompactionForced { extension_id, reason })
+            if extension_id == "block-compact" && reason == "not now"
+    ));
+    assert!(
+        messages.iter().any(
+            |m| matches!(m, Message::System { content } if content.contains("forced summary"))
+        )
+    );
+    assert!(audit.recent(8).iter().any(|event| matches!(
+        event,
+        ExtensionAuditEvent::Compaction(compaction)
+            if compaction.extension_id == "block-compact"
+                && matches!(compaction.action, CompactionAuditAction::Forced { .. })
+    )));
 }
 
 #[tokio::test]

--- a/src/agent/turn.rs
+++ b/src/agent/turn.rs
@@ -89,6 +89,10 @@ pub(in crate::agent) enum TurnEvent {
     Compacted {
         earlier_messages: usize,
     },
+    CompactionForced {
+        extension_id: String,
+        reason: String,
+    },
     ProviderDone {
         response: ChatResponse,
     },
@@ -167,6 +171,12 @@ impl From<TurnEvent> for StreamEvent {
             },
             TurnEvent::Compacted { earlier_messages } => Self::Text(format!(
                 "_(compacted {earlier_messages} earlier messages into a summary to fit context)_\n"
+            )),
+            TurnEvent::CompactionForced {
+                extension_id,
+                reason,
+            } => Self::Text(format!(
+                "_(compaction forced despite {extension_id} veto: {reason})_\n"
             )),
             TurnEvent::ProviderDone { response } => Self::Done(response),
             TurnEvent::Error { message } => Self::Error(message),

--- a/src/context.rs
+++ b/src/context.rs
@@ -109,6 +109,13 @@ impl ContextManager {
             || estimated_tokens + self.reserved_tokens >= self.max_context
     }
 
+    pub fn would_overflow_next_request(&self, messages: &[Message]) -> bool {
+        if !self.enabled {
+            return false;
+        }
+        self.estimate_tokens(messages) + self.reserved_tokens >= self.max_context
+    }
+
     /// Find the index where the kept-recent window starts.
     ///
     /// The returned index `i` is positioned at a `User` message, so the

--- a/src/extensions/audit.rs
+++ b/src/extensions/audit.rs
@@ -9,6 +9,8 @@ use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+use crate::hooks::RewriteRejection;
+
 use super::policy::{ExtensionPermission, PolicyDecision};
 
 /// Permission-keyed audit row. Original YYC-237 shape; covers
@@ -49,6 +51,20 @@ pub struct InputInterceptEvent {
     pub occurred_at: chrono::DateTime<chrono::Utc>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "action")]
+pub enum CompactionAuditAction {
+    ValidationFailed { rejection: RewriteRejection },
+    Forced { reason: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CompactionAuditEvent {
+    pub extension_id: String,
+    pub action: CompactionAuditAction,
+    pub occurred_at: chrono::DateTime<chrono::Utc>,
+}
+
 /// Polymorphic audit row recorded into [`ExtensionAuditLog`]. Each
 /// variant carries the typed payload for one event class.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -56,6 +72,7 @@ pub struct InputInterceptEvent {
 pub enum ExtensionAuditEvent {
     Permission(PermissionAuditEvent),
     InputIntercept(InputInterceptEvent),
+    Compaction(CompactionAuditEvent),
 }
 
 impl ExtensionAuditEvent {
@@ -65,6 +82,7 @@ impl ExtensionAuditEvent {
         match self {
             Self::Permission(p) => &p.extension_id,
             Self::InputIntercept(i) => &i.extension_id,
+            Self::Compaction(c) => &c.extension_id,
         }
     }
 
@@ -74,6 +92,7 @@ impl ExtensionAuditEvent {
         match self {
             Self::Permission(p) => p.occurred_at,
             Self::InputIntercept(i) => i.occurred_at,
+            Self::Compaction(c) => c.occurred_at,
         }
     }
 }
@@ -269,6 +288,38 @@ mod tests {
             occurred_at: chrono::Utc::now(),
         });
         let json = serde_json::to_string(&evt).unwrap();
+        let back: ExtensionAuditEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, evt);
+    }
+
+    #[test]
+    fn audit_log_records_compaction_validation_failed_event() {
+        let log = ExtensionAuditLog::new(8);
+        let evt = ExtensionAuditEvent::Compaction(CompactionAuditEvent {
+            extension_id: "compact-summary".to_string(),
+            action: CompactionAuditAction::ValidationFailed {
+                rejection: RewriteRejection::MissingSystem,
+            },
+            occurred_at: chrono::Utc::now(),
+        });
+        log.record(evt.clone());
+
+        assert_eq!(log.recent(1), vec![evt]);
+    }
+
+    #[test]
+    fn compaction_forced_event_round_trips_through_serde_json() {
+        let evt = ExtensionAuditEvent::Compaction(CompactionAuditEvent {
+            extension_id: "compact-summary".to_string(),
+            action: CompactionAuditAction::Forced {
+                reason: "overflow".to_string(),
+            },
+            occurred_at: chrono::Utc::now(),
+        });
+
+        let json = serde_json::to_string(&evt).unwrap();
+        assert!(json.contains("compaction"));
+        assert!(json.contains("forced"));
         let back: ExtensionAuditEvent = serde_json::from_str(&json).unwrap();
         assert_eq!(back, evt);
     }

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -29,8 +29,8 @@ pub mod store;
 pub mod verify;
 
 pub use audit::{
-    ExtensionAuditEvent, ExtensionAuditLog, InputInterceptAction, InputInterceptEvent,
-    PermissionAuditEvent, QuotaTracker,
+    CompactionAuditAction, CompactionAuditEvent, ExtensionAuditEvent, ExtensionAuditLog,
+    InputInterceptAction, InputInterceptEvent, PermissionAuditEvent, QuotaTracker,
 };
 pub use config_field::{ExtensionConfigField, ExtensionFieldKind};
 pub use draft::parse_skill_extension;

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -6,6 +6,7 @@
 //! loop. First non-Continue outcome wins for blocking-style events; injection
 //! events accumulate across all handlers.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
@@ -67,6 +68,9 @@ pub enum HookOutcome {
     /// Transiently replace the outgoing message payload. Intended for
     /// `on_context`; the persistent conversation history is not mutated.
     RewriteMessages(Vec<Message>),
+    /// Durably replace Session History during `on_session_before_compact`.
+    /// This is validated by the turn runner before it can replace history.
+    RewriteHistory(Vec<Message>),
     /// Force the agent to keep working; the instruction is appended as a user
     /// turn and the loop continues (BeforeAgentEnd only).
     ForceContinue { instruction: String },
@@ -93,6 +97,75 @@ pub enum InputDecision {
     Continue,
     Block(String),
     Replace(String),
+}
+
+/// Decision returned to the turn runner by `on_session_before_compact`.
+#[derive(Debug, Clone)]
+pub enum CompactionDecision {
+    Continue,
+    Block {
+        extension_id: String,
+        reason: String,
+    },
+    RewriteHistory {
+        extension_id: String,
+        messages: Vec<Message>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "reason")]
+pub enum RewriteRejection {
+    MissingSystem,
+    OrphanToolCallId {
+        tool_call_id: String,
+    },
+    NotShorter {
+        input_len: usize,
+        proposed_len: usize,
+    },
+}
+
+pub fn validate_rewrite_history(
+    input: &[Message],
+    proposed: &[Message],
+) -> Result<(), RewriteRejection> {
+    if proposed.len() >= input.len() {
+        return Err(RewriteRejection::NotShorter {
+            input_len: input.len(),
+            proposed_len: proposed.len(),
+        });
+    }
+    if !proposed
+        .iter()
+        .any(|msg| matches!(msg, Message::System { .. }))
+    {
+        return Err(RewriteRejection::MissingSystem);
+    }
+
+    let mut active_tool_call_ids: HashSet<&str> = HashSet::new();
+    for msg in proposed {
+        match msg {
+            Message::Assistant { tool_calls, .. } => {
+                active_tool_call_ids.clear();
+                if let Some(tool_calls) = tool_calls {
+                    active_tool_call_ids.extend(tool_calls.iter().map(|call| call.id.as_str()));
+                }
+            }
+            Message::Tool { tool_call_id, .. } => {
+                if !active_tool_call_ids.contains(tool_call_id.as_str()) {
+                    return Err(RewriteRejection::OrphanToolCallId {
+                        tool_call_id: tool_call_id.clone(),
+                    });
+                }
+            }
+            Message::System { .. } | Message::User { .. } => {
+                active_tool_call_ids.clear();
+            }
+        }
+    }
+
+    Ok(())
 }
 
 /// A handler subscribes to the events it cares about by overriding the matching
@@ -203,7 +276,11 @@ pub trait HookHandler: Send + Sync {
         Ok(HookOutcome::Continue)
     }
 
-    async fn on_session_before_compact(&self, _cancel: CancellationToken) -> Result<HookOutcome> {
+    async fn on_session_before_compact(
+        &self,
+        _messages: &[Message],
+        _cancel: CancellationToken,
+    ) -> Result<HookOutcome> {
         Ok(HookOutcome::Continue)
     }
 
@@ -559,15 +636,29 @@ impl HookRegistry {
         }
     }
 
-    pub async fn on_session_before_compact(&self, cancel: CancellationToken) -> bool {
+    pub async fn on_session_before_compact(
+        &self,
+        messages: &[Message],
+        cancel: CancellationToken,
+    ) -> CompactionDecision {
         for h in &self.handlers {
             match self
-                .run(h, h.on_session_before_compact(cancel.clone()))
+                .run(h, h.on_session_before_compact(messages, cancel.clone()))
                 .await
             {
                 Some(HookOutcome::Block { reason }) => {
                     tracing::info!("hook {} blocked compaction: {reason}", h.name());
-                    return false;
+                    return CompactionDecision::Block {
+                        extension_id: h.name().to_string(),
+                        reason,
+                    };
+                }
+                Some(HookOutcome::RewriteHistory(messages)) => {
+                    tracing::info!("hook {} rewrote compaction history", h.name());
+                    return CompactionDecision::RewriteHistory {
+                        extension_id: h.name().to_string(),
+                        messages,
+                    };
                 }
                 Some(HookOutcome::Continue) | None => {}
                 Some(other) => {
@@ -579,7 +670,7 @@ impl HookRegistry {
                 }
             }
         }
-        true
+        CompactionDecision::Continue
     }
 
     pub async fn on_session_compact(&self, summary: &str, cancel: CancellationToken) {
@@ -673,6 +764,43 @@ impl HookRegistry {
                 extension_id: extension_id.to_string(),
                 before: before.to_string(),
                 after: after.to_string(),
+                action,
+                occurred_at: chrono::Utc::now(),
+            },
+        ));
+    }
+
+    pub(crate) fn record_compaction_validation_failed(
+        &self,
+        extension_id: &str,
+        rejection: RewriteRejection,
+    ) {
+        self.record_compaction_event(
+            extension_id,
+            crate::extensions::CompactionAuditAction::ValidationFailed { rejection },
+        );
+    }
+
+    pub(crate) fn record_compaction_forced(&self, extension_id: &str, reason: &str) {
+        self.record_compaction_event(
+            extension_id,
+            crate::extensions::CompactionAuditAction::Forced {
+                reason: reason.to_string(),
+            },
+        );
+    }
+
+    fn record_compaction_event(
+        &self,
+        extension_id: &str,
+        action: crate::extensions::CompactionAuditAction,
+    ) {
+        let Some(log) = self.audit_log.as_ref() else {
+            return;
+        };
+        log.record(crate::extensions::ExtensionAuditEvent::Compaction(
+            crate::extensions::CompactionAuditEvent {
+                extension_id: extension_id.to_string(),
                 action,
                 occurred_at: chrono::Utc::now(),
             },
@@ -1144,6 +1272,117 @@ mod tests {
         assert!(matches!(decoded, HookOutcome::ReplaceInput(text) if text == "expanded"));
     }
 
+    fn assistant_with_tool_call(id: &str) -> Message {
+        Message::Assistant {
+            content: None,
+            tool_calls: Some(vec![ToolCall {
+                id: id.into(),
+                call_type: "function".into(),
+                function: crate::provider::ToolCallFunction {
+                    name: "noop".into(),
+                    arguments: "{}".into(),
+                },
+            }]),
+            reasoning_content: None,
+        }
+    }
+
+    fn tool_result_message(id: &str) -> Message {
+        Message::Tool {
+            tool_call_id: id.into(),
+            content: "ok".into(),
+        }
+    }
+
+    #[test]
+    fn rewrite_history_validator_rejects_missing_system() {
+        let input = vec![
+            Message::System {
+                content: "system".into(),
+            },
+            Message::User {
+                content: "old".into(),
+            },
+        ];
+        let proposed = vec![Message::User {
+            content: "summary".into(),
+        }];
+
+        assert!(matches!(
+            validate_rewrite_history(&input, &proposed),
+            Err(RewriteRejection::MissingSystem)
+        ));
+    }
+
+    #[test]
+    fn rewrite_history_validator_rejects_orphan_tool_call_id() {
+        let input = vec![
+            Message::System {
+                content: "system".into(),
+            },
+            Message::User {
+                content: "old".into(),
+            },
+            assistant_with_tool_call("call_1"),
+            tool_result_message("call_1"),
+        ];
+        let proposed = vec![
+            Message::System {
+                content: "system".into(),
+            },
+            tool_result_message("missing"),
+        ];
+
+        assert!(matches!(
+            validate_rewrite_history(&input, &proposed),
+            Err(RewriteRejection::OrphanToolCallId { tool_call_id }) if tool_call_id == "missing"
+        ));
+    }
+
+    #[test]
+    fn rewrite_history_validator_rejects_non_shrinking_history() {
+        let input = vec![
+            Message::System {
+                content: "system".into(),
+            },
+            Message::User {
+                content: "old".into(),
+            },
+        ];
+        let proposed = input.clone();
+
+        assert!(matches!(
+            validate_rewrite_history(&input, &proposed),
+            Err(RewriteRejection::NotShorter {
+                input_len: 2,
+                proposed_len: 2
+            })
+        ));
+    }
+
+    #[test]
+    fn rewrite_history_validator_accepts_valid_tool_history() {
+        let input = vec![
+            Message::System {
+                content: "system".into(),
+            },
+            Message::User {
+                content: "old".into(),
+            },
+            assistant_with_tool_call("call_1"),
+            tool_result_message("call_1"),
+        ];
+        let proposed = vec![
+            Message::System {
+                content: "system".into(),
+            },
+            assistant_with_tool_call("call_1"),
+            tool_result_message("call_1"),
+        ];
+
+        assert!(validate_rewrite_history(&input, &proposed).is_ok());
+    }
+
     struct ContextRewriter;
 
     #[async_trait::async_trait]
@@ -1356,6 +1595,7 @@ mod tests {
 
         async fn on_session_before_compact(
             &self,
+            _messages: &[Message],
             _cancel: CancellationToken,
         ) -> Result<HookOutcome> {
             self.push("session_before_compact");
@@ -1424,7 +1664,11 @@ mod tests {
             .await;
         reg.on_after_provider_response(&response, cancel.clone())
             .await;
-        assert!(reg.on_session_before_compact(cancel.clone()).await);
+        assert!(matches!(
+            reg.on_session_before_compact(&messages, cancel.clone())
+                .await,
+            CompactionDecision::Continue
+        ));
         reg.on_session_compact("summary", cancel.clone()).await;
         reg.on_session_before_fork(cancel.clone()).await;
         reg.on_session_shutdown(cancel).await;
@@ -1511,6 +1755,7 @@ mod tests {
 
             async fn on_session_before_compact(
                 &self,
+                _messages: &[Message],
                 _cancel: CancellationToken,
             ) -> Result<HookOutcome> {
                 Ok(HookOutcome::Block {
@@ -1531,6 +1776,7 @@ mod tests {
 
             async fn on_session_before_compact(
                 &self,
+                _messages: &[Message],
                 _cancel: CancellationToken,
             ) -> Result<HookOutcome> {
                 self.0.fetch_add(1, Ordering::SeqCst);
@@ -1543,11 +1789,55 @@ mod tests {
         reg.register(Arc::new(BlockingCompact));
         reg.register(Arc::new(LaterCompact(later_calls.clone())));
 
-        assert!(
-            !reg.on_session_before_compact(CancellationToken::new())
-                .await
-        );
+        assert!(matches!(
+            reg.on_session_before_compact(&[], CancellationToken::new())
+                .await,
+            CompactionDecision::Block {
+                extension_id,
+                reason
+            } if extension_id == "blocking-compact" && reason == "skip"
+        ));
         assert_eq!(later_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn session_before_compact_returns_first_rewrite_history() {
+        struct Rewriter;
+
+        #[async_trait::async_trait]
+        impl HookHandler for Rewriter {
+            fn name(&self) -> &str {
+                "compact-summary"
+            }
+
+            async fn on_session_before_compact(
+                &self,
+                messages: &[Message],
+                _cancel: CancellationToken,
+            ) -> Result<HookOutcome> {
+                Ok(HookOutcome::RewriteHistory(vec![messages[0].clone()]))
+            }
+        }
+
+        let messages = vec![
+            Message::System {
+                content: "system".into(),
+            },
+            Message::User {
+                content: "old".into(),
+            },
+        ];
+        let mut reg = HookRegistry::new();
+        reg.register(Arc::new(Rewriter));
+
+        assert!(matches!(
+            reg.on_session_before_compact(&messages, CancellationToken::new())
+                .await,
+            CompactionDecision::RewriteHistory {
+                extension_id,
+                messages
+            } if extension_id == "compact-summary" && messages.len() == 1
+        ));
     }
 
     #[tokio::test]

--- a/vulcan-ext-compact-summary/Cargo.toml
+++ b/vulcan-ext-compact-summary/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "vulcan-ext-compact-summary"
+version = "0.1.0"
+edition = "2024"
+description = "Sample compaction-control extension for Vulcan"
+authors = ["Colin Hanway"]
+license = "MIT"
+repository = "https://github.com/yycholla/vulcan"
+
+[lib]
+name = "vulcan_ext_compact_summary"
+path = "src/lib.rs"
+
+[dependencies]
+vulcan = { package = "vulcan-core", path = ".." }
+
+inventory = "0.3.24"
+async-trait = "0.1"
+anyhow = "1"
+tokio-util = { version = "0.7.18", features = ["rt"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt"] }
+
+[package.metadata.vulcan]
+id = "compact-summary"
+capabilities = ["hook_handler"]
+requires_user_approval = false

--- a/vulcan-ext-compact-summary/src/lib.rs
+++ b/vulcan-ext-compact-summary/src/lib.rs
@@ -1,0 +1,241 @@
+//! Sample compaction-control extension. It replaces built-in
+//! summarization with a deterministic "system + compact summary + last
+//! twenty turns" history rewrite.
+//!
+//! Demo modes for validation/override paths:
+//! - `VULCAN_EXT_COMPACT_SUMMARY_MODE=bad` returns an invalid rewrite.
+//! - `VULCAN_EXT_COMPACT_SUMMARY_MODE=block` vetoes compaction.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio_util::sync::CancellationToken;
+use vulcan::extensions::api::{
+    DaemonCodeExtension, ExtensionRegistration, SessionExtension, SessionExtensionCtx,
+};
+use vulcan::extensions::{
+    ExtensionCapability, ExtensionMetadata, ExtensionSource, ExtensionStatus,
+};
+use vulcan::hooks::{HookHandler, HookOutcome};
+use vulcan::provider::Message;
+
+const ID: &str = "compact-summary";
+const KEEP_TURNS: usize = 20;
+
+pub struct CompactSummaryExtension;
+
+impl Default for CompactSummaryExtension {
+    fn default() -> Self {
+        Self
+    }
+}
+
+impl DaemonCodeExtension for CompactSummaryExtension {
+    fn metadata(&self) -> ExtensionMetadata {
+        let mut m = ExtensionMetadata::new(
+            ID,
+            "Compact Summary",
+            env!("CARGO_PKG_VERSION"),
+            ExtensionSource::Builtin,
+        );
+        m.status = ExtensionStatus::Active;
+        m.capabilities = vec![ExtensionCapability::HookHandler];
+        m.description = "Rewrites compaction history with system context, a compact summary, and the last twenty turns.".to_string();
+        m
+    }
+
+    fn instantiate(&self, _ctx: SessionExtensionCtx) -> Arc<dyn SessionExtension> {
+        Arc::new(CompactSummarySession)
+    }
+}
+
+struct CompactSummarySession;
+
+impl SessionExtension for CompactSummarySession {
+    fn hook_handlers(&self) -> Vec<Arc<dyn HookHandler>> {
+        vec![Arc::new(CompactSummaryHook {
+            mode: CompactSummaryMode::from_env(),
+        })]
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CompactSummaryMode {
+    Rewrite,
+    BadRewrite,
+    Block,
+}
+
+impl CompactSummaryMode {
+    fn from_env() -> Self {
+        match std::env::var("VULCAN_EXT_COMPACT_SUMMARY_MODE")
+            .unwrap_or_default()
+            .as_str()
+        {
+            "bad" => Self::BadRewrite,
+            "block" => Self::Block,
+            _ => Self::Rewrite,
+        }
+    }
+}
+
+struct CompactSummaryHook {
+    mode: CompactSummaryMode,
+}
+
+#[async_trait]
+impl HookHandler for CompactSummaryHook {
+    fn name(&self) -> &str {
+        ID
+    }
+
+    async fn on_session_before_compact(
+        &self,
+        messages: &[Message],
+        _cancel: CancellationToken,
+    ) -> anyhow::Result<HookOutcome> {
+        match self.mode {
+            CompactSummaryMode::Rewrite => Ok(HookOutcome::RewriteHistory(rewrite(messages))),
+            CompactSummaryMode::BadRewrite => {
+                Ok(HookOutcome::RewriteHistory(vec![Message::User {
+                    content: "invalid rewrite without a system message".into(),
+                }]))
+            }
+            CompactSummaryMode::Block => Ok(HookOutcome::Block {
+                reason: "compact-summary demo block".into(),
+            }),
+        }
+    }
+}
+
+fn rewrite(messages: &[Message]) -> Vec<Message> {
+    let system_messages: Vec<Message> = messages
+        .iter()
+        .filter(|m| matches!(m, Message::System { .. }))
+        .cloned()
+        .collect();
+    let keep_start = last_turn_window_start(messages, KEEP_TURNS);
+    let omitted = messages[..keep_start].len();
+
+    let mut out = if system_messages.is_empty() {
+        vec![Message::System {
+            content: "Vulcan session".into(),
+        }]
+    } else {
+        system_messages
+    };
+    out.push(Message::System {
+        content: format!(
+            "Extension compact summary:\n- omitted {omitted} older messages\n- kept last {KEEP_TURNS} turns when available\n- tool registry summary: preserve tool call/result pairs in the kept window"
+        ),
+    });
+    out.extend(
+        messages[keep_start..]
+            .iter()
+            .filter(|m| !matches!(m, Message::System { .. }))
+            .cloned(),
+    );
+    out
+}
+
+fn last_turn_window_start(messages: &[Message], turns: usize) -> usize {
+    let mut seen_users = 0usize;
+    for (idx, msg) in messages.iter().enumerate().rev() {
+        if matches!(msg, Message::User { .. }) {
+            seen_users += 1;
+            if seen_users == turns {
+                return idx;
+            }
+        }
+    }
+    messages
+        .iter()
+        .position(|m| !matches!(m, Message::System { .. }))
+        .unwrap_or(messages.len())
+}
+
+inventory::submit! {
+    ExtensionRegistration {
+        register: || Arc::new(CompactSummaryExtension) as Arc<dyn DaemonCodeExtension>,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vulcan::hooks::{RewriteRejection, validate_rewrite_history};
+
+    fn ctx() -> SessionExtensionCtx {
+        SessionExtensionCtx {
+            cwd: std::path::PathBuf::from("/tmp/test"),
+            session_id: "test-session".to_string(),
+        }
+    }
+
+    fn long_history() -> Vec<Message> {
+        let mut messages = vec![Message::System {
+            content: "system".into(),
+        }];
+        for i in 0..30 {
+            messages.push(Message::User {
+                content: format!("user {i}"),
+            });
+            messages.push(Message::Assistant {
+                content: Some(format!("assistant {i}")),
+                tool_calls: None,
+                reasoning_content: None,
+            });
+        }
+        messages
+    }
+
+    #[tokio::test]
+    async fn rewrite_mode_returns_valid_shorter_history() {
+        let session = CompactSummaryExtension.instantiate(ctx());
+        let handlers = session.hook_handlers();
+        let input = long_history();
+
+        let outcome = handlers[0]
+            .on_session_before_compact(&input, CancellationToken::new())
+            .await
+            .expect("hook ok");
+
+        match outcome {
+            HookOutcome::RewriteHistory(messages) => {
+                assert!(validate_rewrite_history(&input, &messages).is_ok());
+                assert!(messages.iter().any(|m| matches!(
+                    m,
+                    Message::System { content } if content.contains("Extension compact summary")
+                )));
+            }
+            other => panic!("expected RewriteHistory, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn bad_mode_exercises_validator_rejection() {
+        let input = long_history();
+        let bad = vec![Message::User {
+            content: "bad".into(),
+        }];
+
+        assert!(matches!(
+            validate_rewrite_history(&input, &bad),
+            Err(RewriteRejection::MissingSystem)
+        ));
+    }
+
+    #[tokio::test]
+    async fn block_mode_vetoes_compaction_for_override_demo() {
+        let hook = CompactSummaryHook {
+            mode: CompactSummaryMode::Block,
+        };
+
+        let outcome = hook
+            .on_session_before_compact(&long_history(), CancellationToken::new())
+            .await
+            .expect("hook ok");
+
+        assert!(matches!(outcome, HookOutcome::Block { reason } if reason.contains("demo block")));
+    }
+}


### PR DESCRIPTION
## Summary
- add compaction hook events and validation for durable history replacement
- wire compaction block and override semantics into turn execution
- add compaction audit events and the sample compact-summary extension crate

## Verification
- focused compaction tests passed on branch
- cargo test -p vulcan-ext-compact-summary
- cargo fmt --check
- git diff --check
- pre-commit passed on branch

Closes #558