### PR TITLE
refactor(daemon): centralize session agent assembly

### DIFF
--- a/src/daemon/cli.rs
+++ b/src/daemon/cli.rs
@@ -113,9 +113,12 @@ async fn build_daemon_agent(
     config: &crate::config::Config,
     pool: Arc<crate::runtime_pool::RuntimeResourcePool>,
 ) -> anyhow::Result<crate::agent::Agent> {
-    crate::agent::Agent::builder(config)
-        .with_pool(pool)
-        .build()
+    let assembler = crate::daemon::session_agent::SessionAgentAssembler::new(
+        Arc::new(config.clone()),
+        Some(pool),
+    );
+    assembler
+        .assemble(crate::daemon::session_agent::SessionAgentOptions::default())
         .await
 }
 

--- a/src/daemon/handlers/agent.rs
+++ b/src/daemon/handlers/agent.rs
@@ -26,7 +26,7 @@ async fn resolve(state: &DaemonState, session_id: &str) -> Result<AgentHandle, P
         });
     };
     sess.touch();
-    sess.ensure_agent_with_pool(state.config(), state.pool().cloned())
+    sess.ensure_agent(&state.session_agent_assembler())
         .await
         .map_err(|e| ProtocolError {
             code: "AGENT_BUILD_FAILED".into(),

--- a/src/daemon/handlers/prompt.rs
+++ b/src/daemon/handlers/prompt.rs
@@ -2,11 +2,10 @@
 //!
 //! Slice 3: each request envelope carries a `session` field; the
 //! handler looks up the per-session warm Agent installed on that
-//! `SessionState`. The `"main"` session gets its Agent installed by
-//! the daemon boot path; other sessions are created without an Agent
-//! and currently surface `AGENT_NOT_AVAILABLE` until lazy-build lands
-//! in a later slice. Both buffered (`prompt.run`) and streaming
-//! (`prompt.stream`) variants are supported.
+//! `SessionState`. The `"main"` session is warmed by the daemon boot
+//! path; other sessions lazy-build their Agent on first prompt. Both
+//! buffered (`prompt.run`) and streaming (`prompt.stream`) variants are
+//! supported.
 
 use std::sync::Arc;
 
@@ -100,10 +99,7 @@ pub async fn run(state: Arc<DaemonState>, id: String, session_id: String, input:
         Ok(s) => s,
         Err(e) => return Response::error(id, e),
     };
-    let agent_arc = match sess
-        .ensure_agent_with_pool(state.config(), state.pool().cloned())
-        .await
-    {
+    let agent_arc = match sess.ensure_agent(&state.session_agent_assembler()).await {
         Ok(a) => a,
         Err(e) => {
             return Response::error(
@@ -194,21 +190,13 @@ pub fn stream(
 
     let rid = req_id.clone();
     let sess_for_task = sess.clone();
-    // Lazy-build needs `&Config`, but the spawned task can't borrow
-    // `state` so we clone the `Arc<Config>` out here.
-    let config = Arc::new(state.config().clone());
-    // Slice 3: clone the pool Arc out for the spawned task so the
-    // child Agent build reuses the daemon's shared adapters.
-    let pool_for_task = state.pool().cloned();
+    let assembler = state.session_agent_assembler();
     let state_for_runner = Arc::clone(&state);
     tokio::spawn(async move {
         // Lazy-build the per-session Agent. Failure surfaces on the
         // done channel as AGENT_BUILD_FAILED; in_flight is cleared
         // before returning so daemon.status doesn't get stuck.
-        let agent_arc = match sess_for_task
-            .ensure_agent_with_pool(&config, pool_for_task)
-            .await
-        {
+        let agent_arc = match sess_for_task.ensure_agent(&assembler).await {
             Ok(a) => a,
             Err(e) => {
                 *sess_for_task.in_flight.lock() = false;
@@ -355,9 +343,7 @@ pub async fn cancel(state: &DaemonState, id: String, session_id: String) -> Resp
             id,
             ProtocolError {
                 code: "AGENT_NOT_AVAILABLE".into(),
-                message: format!(
-                    "session '{session_id}' has no agent yet; lazy-build deferred to Task 3.X"
-                ),
+                message: format!("session '{session_id}' has no agent yet"),
                 retryable: false,
             },
         );

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -16,6 +16,7 @@ pub mod lifecycle;
 pub mod protocol;
 pub mod server;
 pub mod session;
+pub mod session_agent;
 pub mod state;
 pub mod subagent;
 

--- a/src/daemon/session.rs
+++ b/src/daemon/session.rs
@@ -17,6 +17,8 @@ use std::time::Instant;
 use parking_lot::{Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
 
+use crate::daemon::session_agent::{SessionAgentAssembler, SessionAgentOptions};
+
 /// Shared, async-locked handle to a per-session Agent. `Arc` so a
 /// single session can be locked from concurrent tasks (e.g. a
 /// streaming `prompt.stream` background task and an inbound
@@ -135,34 +137,19 @@ impl SessionState {
     /// `prompt.stream`, and `agent.*` handlers funnel through here.
     pub async fn ensure_agent(
         self: &Arc<Self>,
-        config: &crate::config::Config,
+        assembler: &SessionAgentAssembler,
     ) -> anyhow::Result<AgentHandle> {
-        self.ensure_agent_with_pool(config, None).await
-    }
-
-    /// Slice 3: assemble the lazy Agent from the daemon's
-    /// [`RuntimeResourcePool`] when one is provided. The
-    /// `pool == None` form still works for tests and any pre-Slice-3
-    /// boot path that hasn't installed the pool yet.
-    pub async fn ensure_agent_with_pool(
-        self: &Arc<Self>,
-        config: &crate::config::Config,
-        pool: Option<Arc<crate::runtime_pool::RuntimeResourcePool>>,
-    ) -> anyhow::Result<AgentHandle> {
-        self.ensure_agent_with_options(config, pool, None, None, None)
+        self.ensure_agent_with_options(assembler, SessionAgentOptions::default())
             .await
     }
 
-    /// Slice 7: daemon child sessions can carry spawn-time tool
-    /// profile, allowlist, and iteration cap before their Agent is
-    /// installed. Existing sessions ignore these options once warm.
+    /// Daemon child sessions can carry spawn-time tool profile,
+    /// allowlist, and iteration cap before their Agent is installed.
+    /// Existing sessions ignore these options once warm.
     pub async fn ensure_agent_with_options(
         self: &Arc<Self>,
-        config: &crate::config::Config,
-        pool: Option<Arc<crate::runtime_pool::RuntimeResourcePool>>,
-        max_iterations: Option<u32>,
-        tool_profile: Option<String>,
-        allowed_tools: Option<&[String]>,
+        assembler: &SessionAgentAssembler,
+        options: SessionAgentOptions,
     ) -> anyhow::Result<AgentHandle> {
         // Fast path: already installed.
         if let Some(handle) = self.agent_arc() {
@@ -178,21 +165,7 @@ impl SessionState {
             return Ok(handle);
         }
 
-        let mut builder = crate::agent::Agent::builder(config);
-        if let Some(pool) = pool {
-            builder = builder.with_pool(pool);
-        }
-        if let Some(max_iterations) = max_iterations {
-            builder = builder.with_max_iterations(max_iterations);
-        }
-        builder = builder.with_tool_profile(tool_profile.clone());
-        let agent = builder.build().await?;
-        let mut agent = agent;
-        if tool_profile.is_none() {
-            if let Some(allowed_tools) = allowed_tools {
-                agent.restrict_tools(allowed_tools);
-            }
-        }
+        let agent = assembler.assemble(options).await?;
         self.set_agent(agent);
         Ok(self.agent_arc().expect("just installed"))
     }
@@ -370,8 +343,9 @@ mod tests {
     async fn ensure_agent_returns_existing_when_set() {
         let sess = Arc::new(SessionState::new("foo".into()));
         sess.set_agent(test_agent());
-        let cfg = crate::config::Config::default();
-        let h = sess.ensure_agent(&cfg).await.unwrap();
+        let assembler =
+            SessionAgentAssembler::new(Arc::new(crate::config::Config::default()), None);
+        let h = sess.ensure_agent(&assembler).await.unwrap();
         let h2 = sess.agent_arc().unwrap();
         assert!(
             Arc::ptr_eq(&h, &h2),

--- a/src/daemon/session_agent.rs
+++ b/src/daemon/session_agent.rs
@@ -1,0 +1,138 @@
+//! Daemon Session-facing Agent assembly.
+//!
+//! `SessionState` owns lazy installation and concurrency; this module owns the
+//! construction policy for daemon-managed Agents.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+
+use crate::agent::Agent;
+use crate::config::Config;
+use crate::runtime_pool::RuntimeResourcePool;
+
+#[derive(Clone)]
+pub struct SessionAgentAssembler {
+    config: Arc<Config>,
+    pool: Option<Arc<RuntimeResourcePool>>,
+}
+
+impl SessionAgentAssembler {
+    pub fn new(config: Arc<Config>, pool: Option<Arc<RuntimeResourcePool>>) -> Self {
+        Self { config, pool }
+    }
+
+    pub async fn assemble(&self, options: SessionAgentOptions) -> Result<Agent> {
+        let mut builder = Agent::builder(&self.config);
+        if let Some(pool) = &self.pool {
+            builder = builder.with_pool(Arc::clone(pool));
+        }
+        if let Some(max_iterations) = options.max_iterations {
+            builder = builder.with_max_iterations(max_iterations);
+        }
+        builder = builder.with_tool_profile(options.tool_profile.clone());
+
+        let mut agent = builder.build().await?;
+        if options.tool_profile.is_none() {
+            if let Some(allowed_tools) = options.allowed_tools.as_deref() {
+                agent.restrict_tools(allowed_tools);
+            }
+        }
+        Ok(agent)
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SessionAgentOptions {
+    max_iterations: Option<u32>,
+    tool_profile: Option<String>,
+    allowed_tools: Option<Vec<String>>,
+}
+
+impl SessionAgentOptions {
+    pub fn subagent(
+        max_iterations: u32,
+        tool_profile: Option<String>,
+        allowed_tools: Vec<String>,
+    ) -> Self {
+        Self {
+            max_iterations: Some(max_iterations),
+            tool_profile,
+            allowed_tools: Some(allowed_tools),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::Message;
+
+    fn local_config() -> Config {
+        let mut config = Config::default();
+        config.provider.base_url = "http://127.0.0.1:11434/v1".into();
+        config.provider.disable_catalog = true;
+        config
+    }
+
+    #[tokio::test]
+    async fn pooled_assembly_uses_runtime_pool_resources() {
+        let config = Arc::new(local_config());
+        let pool = Arc::new(RuntimeResourcePool::for_tests());
+        let assembler = SessionAgentAssembler::new(Arc::clone(&config), Some(Arc::clone(&pool)));
+
+        let agent = assembler
+            .assemble(SessionAgentOptions::default())
+            .await
+            .unwrap();
+        let session_id = agent.session_id().to_string();
+        agent
+            .memory()
+            .save_messages(
+                &session_id,
+                &[Message::User {
+                    content: "pooled assembly".into(),
+                }],
+            )
+            .unwrap();
+
+        let loaded = pool.session_store().load_history(&session_id).unwrap();
+        assert!(
+            matches!(
+                loaded.as_deref().and_then(|messages| messages.first()),
+                Some(Message::User { content }) if content == "pooled assembly"
+            ),
+            "pooled assembly must share the RuntimeResourcePool SessionStore"
+        );
+        assert!(
+            agent
+                .tool_definitions()
+                .iter()
+                .any(|tool| tool.function.name == "spawn_subagent"),
+            "spawn_subagent must remain registered during pooled assembly"
+        );
+    }
+
+    #[tokio::test]
+    async fn non_pooled_assembly_applies_session_specific_allowlist() {
+        let config = Arc::new(local_config());
+        let assembler = SessionAgentAssembler::new(config, None);
+        let agent = assembler
+            .assemble(SessionAgentOptions::subagent(
+                2,
+                None,
+                vec!["read_file".into()],
+            ))
+            .await
+            .unwrap();
+        let tools: Vec<_> = agent
+            .tool_definitions()
+            .into_iter()
+            .map(|tool| tool.function.name)
+            .collect();
+
+        assert_eq!(agent.iterations(), 0);
+        assert!(tools.contains(&"read_file".to_string()));
+        assert!(!tools.contains(&"spawn_subagent".to_string()));
+    }
+}

--- a/src/daemon/state.rs
+++ b/src/daemon/state.rs
@@ -9,6 +9,7 @@ use tokio::sync::{Notify, watch};
 
 use crate::config::Config;
 use crate::daemon::session::SessionMap;
+use crate::daemon::session_agent::SessionAgentAssembler;
 use crate::memory::cortex::CortexStore;
 use crate::runtime_pool::RuntimeResourcePool;
 
@@ -60,6 +61,13 @@ impl DaemonState {
     /// Borrow the daemon-owned runtime resource pool, if installed.
     pub fn pool(&self) -> Option<&Arc<RuntimeResourcePool>> {
         self.pool.as_ref()
+    }
+
+    /// Build the Session-facing Agent assembler for lazy session
+    /// installs. Callers pass only session-specific options to
+    /// `SessionState`; config and pool wiring stay centralized here.
+    pub fn session_agent_assembler(&self) -> SessionAgentAssembler {
+        SessionAgentAssembler::new(Arc::clone(&self.config), self.pool.clone())
     }
 
     /// Test-only constructor. Returns a `DaemonState` with the default

--- a/src/daemon/subagent.rs
+++ b/src/daemon/subagent.rs
@@ -6,6 +6,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use tokio_util::sync::CancellationToken;
 
+use crate::daemon::session_agent::SessionAgentOptions;
 use crate::daemon::state::DaemonState;
 use crate::tools::spawn::{SubagentRunOutput, SubagentRunRequest, SubagentRunner};
 
@@ -44,11 +45,12 @@ impl SubagentRunner for DaemonSubagentRunner {
             .ok_or_else(|| anyhow::anyhow!("child session was not created: {child_session_id}"))?;
         let agent_arc = sess
             .ensure_agent_with_options(
-                self.state.config(),
-                self.state.pool().cloned(),
-                Some(request.max_iterations),
-                request.profile_name.clone(),
-                Some(&request.allowed_tools),
+                &self.state.session_agent_assembler(),
+                SessionAgentOptions::subagent(
+                    request.max_iterations,
+                    request.profile_name.clone(),
+                    request.allowed_tools.clone(),
+                ),
             )
             .await?;
 


### PR DESCRIPTION
## Summary
- centralize daemon Session Agent assembly behind a narrower Session-facing path
- preserve hook tool store extension cortex and spawn-tool construction behavior
- cover pooled and non-pooled Agent construction paths

## Verification
- implementation branch committed with pre-commit verification
- branch is a focused single-commit refactor on main

Closes #566