### PR TITLE
fix(extensions): gate input rewrite approval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7277,6 +7277,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "vulcan-core",
+ "vulcan-extension-macros",
 ]
 
 [[package]]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -348,10 +348,10 @@ pub struct ExtensionsConfig {
     /// forced to `Inactive` regardless of its own preference.
     #[serde(default)]
     pub disabled: Vec<String>,
-    /// Per-extension overrides. Settings beyond `enabled` are
-    /// preserved but not interpreted at this layer — PR-5 lands
-    /// `ConfigField` integration so per-extension settings flow
-    /// through `vulcan config`.
+    /// Per-extension overrides. Settings beyond process-local
+    /// activation gates are preserved but not interpreted at this
+    /// layer — PR-5 lands `ConfigField` integration so
+    /// per-extension settings flow through `vulcan config`.
     #[serde(default, flatten)]
     pub per_extension: HashMap<String, ExtensionEntryConfig>,
 }
@@ -362,6 +362,12 @@ pub struct ExtensionEntryConfig {
     /// `None` defers to the registry's prior status.
     #[serde(default)]
     pub enabled: Option<bool>,
+    /// Skip the interactive approval prompt for input rewrites from
+    /// this extension. The extension still needs to declare
+    /// `requires_user_approval = true` in its manifest so the default
+    /// posture is explicit.
+    #[serde(default)]
+    pub auto_approve_input: bool,
 }
 
 impl ExtensionsConfig {
@@ -392,6 +398,9 @@ impl ExtensionsConfig {
                     }
                 }
                 None => {}
+            }
+            if entry.auto_approve_input {
+                registry.set_requires_user_approval(id, false);
             }
         }
         flips

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -174,6 +174,22 @@ enabled = true
 }
 
 #[test]
+fn per_extension_auto_approve_input_disables_rewrite_approval() {
+    let cfg: Config = toml::from_str(
+        r#"
+[extensions.input-demo]
+auto_approve_input = true
+"#,
+    )
+    .expect("parses");
+    let reg = seed_registry(&["input-demo"]);
+    reg.set_requires_user_approval("input-demo", true);
+    let flips = cfg.extensions.apply_to_registry(&reg);
+    assert_eq!(flips, 0);
+    assert!(!reg.get("input-demo").unwrap().requires_user_approval);
+}
+
+#[test]
 fn empty_extensions_table_is_a_noop() {
     let cfg: Config = toml::from_str("").expect("parses");
     let reg = seed_registry(&["a", "b"]);

--- a/src/daemon/cli.rs
+++ b/src/daemon/cli.rs
@@ -75,6 +75,12 @@ async fn start(detach: bool) -> anyhow::Result<()> {
         pool_builder = pool_builder.with_cortex_store(Arc::clone(cortex));
     }
     let pool = Arc::new(pool_builder);
+    let disabled = config
+        .extensions
+        .apply_to_registry(&pool.extension_registry());
+    if disabled > 0 {
+        tracing::info!(disabled, "daemon: extension config disabled extensions");
+    }
     state = state.with_pool(Arc::clone(&pool));
 
     // YYC-266 Slice 2/3: boot the warm Agent and install it into the

--- a/src/extensions/api.rs
+++ b/src/extensions/api.rs
@@ -29,6 +29,7 @@ pub struct ExtensionManifest {
     pub id: String,
     pub version: String,
     pub daemon_entry: Option<String>,
+    pub requires_user_approval: bool,
 }
 
 /// Per-**Session** instantiation context handed to a

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -140,6 +140,9 @@ pub struct ExtensionMetadata {
     /// `vulcan extension show`. Caller-provided; the registry
     /// does not interpret it.
     pub permissions_summary: Option<String>,
+    /// Whether input rewrites from this extension require explicit
+    /// user approval before the rewritten text is applied.
+    pub requires_user_approval: bool,
     /// When `status == Broken`, free-form explanation. `None` for
     /// any other status.
     pub broken_reason: Option<String>,
@@ -167,6 +170,7 @@ impl ExtensionMetadata {
             status: ExtensionStatus::Inactive,
             capabilities: Vec::new(),
             permissions_summary: None,
+            requires_user_approval: false,
             broken_reason: None,
             priority: 100,
         }

--- a/src/extensions/registry.rs
+++ b/src/extensions/registry.rs
@@ -126,6 +126,19 @@ impl ExtensionRegistry {
         }
     }
 
+    /// Override the manifest approval policy for input rewrites. Used
+    /// by `extensions.<id>.auto_approve_input = true` after inventory
+    /// registration has populated the registry.
+    pub fn set_requires_user_approval(&self, id: &str, required: bool) -> bool {
+        let mut guard = self.inner.write();
+        if let Some(slot) = guard.iter_mut().find(|m| m.id == id) {
+            slot.requires_user_approval = required;
+            true
+        } else {
+            false
+        }
+    }
+
     /// Mark an extension `Broken` with a diagnostic reason.
     pub fn mark_broken(&self, id: &str, reason: impl Into<String>) -> bool {
         let mut guard = self.inner.write();

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -6,6 +6,7 @@
 //! loop. First non-Continue outcome wins for blocking-style events; injection
 //! events accumulate across all handlers.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
@@ -16,6 +17,7 @@ use serde_json::Value;
 use tokio::time::timeout;
 use tokio_util::sync::CancellationToken;
 
+use crate::pause::{AgentPause, AgentResume, OptionKind, PauseKind, PauseOption, PauseSender};
 use crate::provider::{ChatResponse, Message, StreamEvent, ToolCall};
 use crate::tools::{ToolProgress, ToolResult};
 
@@ -291,6 +293,11 @@ pub struct HookRegistry {
     /// records every non-Continue outcome as an `InputIntercept`
     /// event. `None` means audit silently skips (CLI one-shot path).
     audit_log: Option<Arc<crate::extensions::ExtensionAuditLog>>,
+    /// Extension ids whose `ReplaceInput` outcomes need explicit user
+    /// approval before the rewritten text is applied.
+    input_rewrite_approval_required: HashSet<String>,
+    /// Pause channel used to ask the active Frontend for approval.
+    input_rewrite_pause_tx: Option<PauseSender>,
 }
 
 impl HookRegistry {
@@ -298,6 +305,8 @@ impl HookRegistry {
         Self {
             handlers: Vec::new(),
             audit_log: None,
+            input_rewrite_approval_required: HashSet::new(),
+            input_rewrite_pause_tx: None,
             handler_timeout: Duration::from_secs(30),
             failure_metrics: HookFailureMetrics::default(),
         }
@@ -315,6 +324,22 @@ impl HookRegistry {
     pub fn with_audit_log(mut self, log: Arc<crate::extensions::ExtensionAuditLog>) -> Self {
         self.audit_log = Some(log);
         self
+    }
+
+    pub fn with_input_rewrite_pause_channel(mut self, pause_tx: PauseSender) -> Self {
+        self.input_rewrite_pause_tx = Some(pause_tx);
+        self
+    }
+
+    pub fn require_input_rewrite_approval(mut self, extension_id: impl Into<String>) -> Self {
+        self.input_rewrite_approval_required
+            .insert(extension_id.into());
+        self
+    }
+
+    pub fn mark_input_rewrite_approval_required(&mut self, extension_id: impl Into<String>) {
+        self.input_rewrite_approval_required
+            .insert(extension_id.into());
     }
 
     pub fn register(&mut self, handler: Arc<dyn HookHandler>) {
@@ -636,6 +661,24 @@ impl HookRegistry {
                     return InputDecision::Block(reason);
                 }
                 Some(HookOutcome::ReplaceInput(rewrite)) => {
+                    if let Err(reason) = self
+                        .approve_input_rewrite_if_required(h.name(), raw, &rewrite)
+                        .await
+                    {
+                        tracing::info!(
+                            "hook {} input rewrite blocked before approval: {reason}",
+                            h.name()
+                        );
+                        self.record_input_intercept(
+                            h.name(),
+                            raw,
+                            raw,
+                            crate::extensions::InputInterceptAction::Block {
+                                reason: reason.clone(),
+                            },
+                        );
+                        return InputDecision::Block(reason);
+                    }
                     tracing::info!("hook {} replaced input", h.name());
                     self.record_input_intercept(
                         h.name(),
@@ -656,6 +699,65 @@ impl HookRegistry {
             }
         }
         InputDecision::Continue
+    }
+
+    async fn approve_input_rewrite_if_required(
+        &self,
+        extension_id: &str,
+        before: &str,
+        after: &str,
+    ) -> std::result::Result<(), String> {
+        if !self.input_rewrite_approval_required.contains(extension_id) {
+            return Ok(());
+        }
+        let Some(tx) = &self.input_rewrite_pause_tx else {
+            return Err(format!(
+                "extension `{extension_id}` requires user approval for input rewrite but no pause channel is wired"
+            ));
+        };
+        let (reply, rx) = tokio::sync::oneshot::channel();
+        let pause = AgentPause {
+            kind: PauseKind::InputRewriteApproval {
+                extension_id: extension_id.to_string(),
+                before: before.to_string(),
+                after: after.to_string(),
+            },
+            reply,
+            options: vec![
+                PauseOption {
+                    key: 'a',
+                    label: "allow once".to_string(),
+                    kind: OptionKind::Primary,
+                    resume: AgentResume::Allow,
+                },
+                PauseOption {
+                    key: 'd',
+                    label: "deny".to_string(),
+                    kind: OptionKind::Destructive,
+                    resume: AgentResume::DenyWithReason("user denied input rewrite".to_string()),
+                },
+            ],
+        };
+        if tx.send(pause).await.is_err() {
+            return Err(format!(
+                "extension `{extension_id}` requires user approval for input rewrite but pause consumer dropped"
+            ));
+        }
+        match rx.await {
+            Ok(AgentResume::Allow | AgentResume::AllowAndRemember) => Ok(()),
+            Ok(AgentResume::Deny) => Err(format!(
+                "input rewrite denied for extension `{extension_id}`"
+            )),
+            Ok(AgentResume::DenyWithReason(reason)) => Err(format!(
+                "input rewrite denied for extension `{extension_id}`: {reason}"
+            )),
+            Ok(other) => Err(format!(
+                "input rewrite denied for extension `{extension_id}`: unsupported resume {other:?}"
+            )),
+            Err(_) => Err(format!(
+                "extension `{extension_id}` requires user approval for input rewrite but pause reply was dropped"
+            )),
+        }
     }
 
     fn record_input_intercept(
@@ -1682,6 +1784,127 @@ mod tests {
         match decision {
             InputDecision::Replace(text) => assert_eq!(text, "rewritten"),
             other => panic!("expected Replace, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn apply_on_input_allows_rewrite_when_approval_required_and_user_allows() {
+        use crate::pause::{AgentResume, PauseKind};
+
+        struct Rewriter;
+
+        #[async_trait::async_trait]
+        impl HookHandler for Rewriter {
+            fn name(&self) -> &str {
+                "approval-rewriter"
+            }
+            async fn on_input(
+                &self,
+                _raw: &str,
+                _cancel: CancellationToken,
+            ) -> Result<HookOutcome> {
+                Ok(HookOutcome::ReplaceInput("rewritten".into()))
+            }
+        }
+
+        let (pause_tx, mut pause_rx) = crate::pause::channel(4);
+        let mut reg = HookRegistry::new()
+            .with_input_rewrite_pause_channel(pause_tx)
+            .require_input_rewrite_approval("approval-rewriter");
+        reg.register(Arc::new(Rewriter));
+
+        let decision_task =
+            tokio::spawn(async move { reg.apply_on_input("raw", CancellationToken::new()).await });
+        let pause = pause_rx.recv().await.expect("approval pause should emit");
+        match &pause.kind {
+            PauseKind::InputRewriteApproval {
+                extension_id,
+                before,
+                after,
+            } => {
+                assert_eq!(extension_id, "approval-rewriter");
+                assert_eq!(before, "raw");
+                assert_eq!(after, "rewritten");
+            }
+            other => panic!("expected input rewrite approval, got {other:?}"),
+        }
+        pause.reply.send(AgentResume::Allow).unwrap();
+
+        match decision_task.await.unwrap() {
+            InputDecision::Replace(text) => assert_eq!(text, "rewritten"),
+            other => panic!("expected Replace, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn apply_on_input_blocks_rewrite_when_approval_required_and_user_denies() {
+        use crate::pause::AgentResume;
+
+        struct Rewriter;
+
+        #[async_trait::async_trait]
+        impl HookHandler for Rewriter {
+            fn name(&self) -> &str {
+                "approval-rewriter"
+            }
+            async fn on_input(
+                &self,
+                _raw: &str,
+                _cancel: CancellationToken,
+            ) -> Result<HookOutcome> {
+                Ok(HookOutcome::ReplaceInput("rewritten".into()))
+            }
+        }
+
+        let (pause_tx, mut pause_rx) = crate::pause::channel(4);
+        let mut reg = HookRegistry::new()
+            .with_input_rewrite_pause_channel(pause_tx)
+            .require_input_rewrite_approval("approval-rewriter");
+        reg.register(Arc::new(Rewriter));
+
+        let decision_task =
+            tokio::spawn(async move { reg.apply_on_input("raw", CancellationToken::new()).await });
+        let pause = pause_rx.recv().await.expect("approval pause should emit");
+        let deny = pause
+            .options
+            .iter()
+            .find(|option| option.key == 'd')
+            .expect("deny option")
+            .resume
+            .clone();
+        assert!(matches!(deny, AgentResume::DenyWithReason(_)));
+        pause.reply.send(deny).unwrap();
+
+        match decision_task.await.unwrap() {
+            InputDecision::Block(reason) => assert!(reason.contains("user denied input rewrite")),
+            other => panic!("expected Block, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn apply_on_input_blocks_rewrite_when_approval_required_without_pause_channel() {
+        struct Rewriter;
+
+        #[async_trait::async_trait]
+        impl HookHandler for Rewriter {
+            fn name(&self) -> &str {
+                "approval-rewriter"
+            }
+            async fn on_input(
+                &self,
+                _raw: &str,
+                _cancel: CancellationToken,
+            ) -> Result<HookOutcome> {
+                Ok(HookOutcome::ReplaceInput("rewritten".into()))
+            }
+        }
+
+        let mut reg = HookRegistry::new().require_input_rewrite_approval("approval-rewriter");
+        reg.register(Arc::new(Rewriter));
+
+        match reg.apply_on_input("raw", CancellationToken::new()).await {
+            InputDecision::Block(reason) => assert!(reason.contains("no pause channel")),
+            other => panic!("expected Block, got {other:?}"),
         }
     }
 

--- a/vulcan-ext-input-demo/Cargo.toml
+++ b/vulcan-ext-input-demo/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/lib.rs"
 
 [dependencies]
 vulcan = { package = "vulcan-core", path = ".." }
+vulcan-extension-macros = { path = "../vulcan-extension-macros" }
 
 inventory = "0.3.24"
 async-trait = "0.1"
@@ -26,4 +27,4 @@ tokio = { version = "1", features = ["macros", "rt"] }
 [package.metadata.vulcan]
 id = "input-demo"
 capabilities = ["input_interceptor"]
-requires_user_approval = false
+requires_user_approval = true

--- a/vulcan-ext-input-demo/src/lib.rs
+++ b/vulcan-ext-input-demo/src/lib.rs
@@ -4,9 +4,10 @@
 //! Daemon-side cargo-crate extension under GH issue #557. Self-
 //! registers via `inventory::submit!`. Manifest declares
 //! `capabilities = ["input_interceptor"]` and
-//! `requires_user_approval = false` so rewrites land without a
-//! pause prompt; flip the manifest flag to exercise the
-//! `AgentPause::InputRewriteApproval` path.
+//! `requires_user_approval = true` so rewrites exercise the
+//! `AgentPause::InputRewriteApproval` path. Set
+//! `extensions.input-demo.auto_approve_input = true` to skip the
+//! approval prompt locally.
 
 use std::sync::Arc;
 
@@ -20,6 +21,7 @@ use vulcan::extensions::{
     ExtensionCapability, ExtensionMetadata, ExtensionSource, ExtensionStatus,
 };
 use vulcan::hooks::{HookHandler, HookOutcome};
+use vulcan_extension_macros::include_manifest;
 
 const ID: &str = "input-demo";
 
@@ -33,14 +35,16 @@ impl Default for InputDemoExtension {
 
 impl DaemonCodeExtension for InputDemoExtension {
     fn metadata(&self) -> ExtensionMetadata {
+        let manifest = include_manifest!();
         let mut m = ExtensionMetadata::new(
-            ID,
+            manifest.id,
             "Input Demo",
-            env!("CARGO_PKG_VERSION"),
+            manifest.version,
             ExtensionSource::Builtin,
         );
         m.status = ExtensionStatus::Active;
         m.capabilities = vec![ExtensionCapability::InputInterceptor];
+        m.requires_user_approval = manifest.requires_user_approval;
         m.description = "Expands `!!` to the previous non-`!!` user message.".to_string();
         m
     }
@@ -106,6 +110,17 @@ mod tests {
             cwd: std::path::PathBuf::from("/tmp/test"),
             session_id: "test-session".to_string(),
         }
+    }
+
+    #[test]
+    fn metadata_reads_manifest_approval_policy() {
+        let meta = InputDemoExtension.metadata();
+        assert_eq!(meta.id, ID);
+        assert!(
+            meta.capabilities
+                .contains(&ExtensionCapability::InputInterceptor)
+        );
+        assert!(meta.requires_user_approval);
     }
 
     #[tokio::test]

--- a/vulcan-extension-macros/src/lib.rs
+++ b/vulcan-extension-macros/src/lib.rs
@@ -42,6 +42,10 @@ pub fn include_manifest(_input: TokenStream) -> TokenStream {
         .and_then(toml::Value::as_str)
         .unwrap_or(package_version);
     let daemon_entry = vulcan.get("daemon_entry").and_then(toml::Value::as_str);
+    let requires_user_approval = vulcan
+        .get("requires_user_approval")
+        .and_then(toml::Value::as_bool)
+        .unwrap_or(false);
 
     let id_lit = rust_string_literal(id);
     let version_lit = rust_string_literal(version);
@@ -51,7 +55,7 @@ pub fn include_manifest(_input: TokenStream) -> TokenStream {
     };
 
     format!(
-        "::vulcan::extensions::api::ExtensionManifest {{ id: {id_lit}.to_string(), version: {version_lit}.to_string(), daemon_entry: {daemon_entry_tokens} }}"
+        "::vulcan::extensions::api::ExtensionManifest {{ id: {id_lit}.to_string(), version: {version_lit}.to_string(), daemon_entry: {daemon_entry_tokens}, requires_user_approval: {requires_user_approval} }}"
     )
     .parse()
     .expect("include_manifest! generated invalid tokens")


### PR DESCRIPTION
## Summary
- require `AgentPause` approval before applying input rewrites from extensions that opt into approval
- carry `requires_user_approval` from extension manifests through metadata and the manifest macro
- add `extensions.<id>.auto_approve_input = true` config override for local opt-out
- update the input demo extension to exercise the approval path by default

## Verification
- cargo test -p vulcan-core apply_on_input
- cargo test -p vulcan-ext-input-demo
- cargo check -p vulcan
- cargo fmt --check
- git diff --cached --check
- gitnexus impact: LOW for HookRegistry, ExtensionRegistry, ExtensionsConfig, ExtensionMetadata, ExtensionManifest, include_manifest, and InputDemoExtension
- gitnexus detect-changes -r /home/yycholla/vulcan/.worktrees/yyc557-input-approval-clean ran after indexing; result was "No changes detected" because the worktree was indexed after this diff existed
- pre-commit passed: cargo check, cargo fmt, cargo clippy

Closes #557