### PR TITLE
fix(tui): allow terminal text selection

### DIFF
--- a/src/tui/init.rs
+++ b/src/tui/init.rs
@@ -9,6 +9,12 @@ use anyhow::Result;
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
 
+const ENABLE_MOUSE_CAPTURE_BY_DEFAULT: bool = false;
+
+fn mouse_capture_enabled_by_default() -> bool {
+    ENABLE_MOUSE_CAPTURE_BY_DEFAULT
+}
+
 pub(super) fn init_terminal() -> Result<Terminal<CrosstermBackend<std::io::Stdout>>> {
     ratatui::crossterm::terminal::enable_raw_mode()?;
     let mut stdout = std::io::stdout();
@@ -20,13 +26,13 @@ pub(super) fn init_terminal() -> Result<Terminal<CrosstermBackend<std::io::Stdou
         // of N KeyCode::Char events. Without this, multiline pastes
         // submit a prompt per line.
         ratatui::crossterm::event::EnableBracketedPaste,
-        // YYC-123: capture mouse events so the scroll wheel can drive
-        // the chat viewport directly. Without this, the terminal sends
-        // scroll-wheel motions as escape sequences that don't reach
-        // crossterm cleanly — users have to rely on Up/Down, which
-        // only steps one line per render frame.
-        ratatui::crossterm::event::EnableMouseCapture,
     )?;
+    if mouse_capture_enabled_by_default() {
+        // YYC-581: mouse capture blocks normal terminal drag-selection in
+        // common emulators. Keep it off by default so visible chat text can
+        // be highlighted and copied; keyboard scrolling remains available.
+        ratatui::crossterm::execute!(stdout, ratatui::crossterm::event::EnableMouseCapture)?;
+    }
     let backend = CrosstermBackend::new(stdout);
     let terminal = Terminal::new(backend)?;
     Ok(terminal)
@@ -38,10 +44,21 @@ pub(super) fn restore_terminal() -> Result<()> {
         std::io::stdout(),
         // Disable before leaving the alt screen so the user's primary
         // terminal isn't left in bracketed-paste / mouse-capture state
-        // if Vulcan exits.
+        // if Vulcan exits. This is intentionally defensive even though
+        // mouse capture is not enabled by default.
         ratatui::crossterm::event::DisableMouseCapture,
         ratatui::crossterm::event::DisableBracketedPaste,
         ratatui::crossterm::terminal::LeaveAlternateScreen,
     )?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mouse_capture_is_disabled_by_default_for_terminal_selection() {
+        assert!(!mouse_capture_enabled_by_default());
+    }
 }


### PR DESCRIPTION
## Summary

- Disable TUI mouse capture by default so common terminal drag-selection can highlight and copy visible chat text.
- Keep bracketed paste enabled and keep terminal restore defensive by still disabling mouse capture on exit.
- Document the tradeoff: keyboard scrolling remains available; mouse-wheel capture should come back only behind an explicit/configurable mode.

Fixes #581

## Verification

- `cargo test tui::init`
- pre-commit: `cargo check`, `cargo fmt`, `cargo clippy`
- `gitnexus detect-changes -r /home/yycholla/vulcan` reports one file, expected TUI init symbol, low risk

## Manual Check Needed

- Confirm visible TUI text can be drag-selected/copied in a common terminal emulator before marking ready for merge.