### PR TITLE
feat(extensions): rebuild todo frontend surface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7177,6 +7177,7 @@ dependencies = [
  "vulcan-core",
  "vulcan-ext-auto-commit",
  "vulcan-ext-input-demo",
+ "vulcan-ext-todo",
 ]
 
 [[package]]
@@ -7250,6 +7251,7 @@ dependencies = [
  "tree-sitter-typescript",
  "url",
  "uuid",
+ "vulcan-frontend-api",
 ]
 
 [[package]]
@@ -7293,6 +7295,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "vulcan-ext-todo"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "inventory",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "vulcan-core",
+ "vulcan-frontend-api",
+]
+
+[[package]]
 name = "vulcan-extension-macros"
 version = "0.1.0"
 dependencies = [
@@ -7302,6 +7320,10 @@ dependencies = [
 [[package]]
 name = "vulcan-frontend-api"
 version = "0.1.0"
+dependencies = [
+ "inventory",
+ "serde_json",
+]
 
 [[package]]
 name = "vulcan-tui"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "vulcan-ext-auto-commit",
     "vulcan-ext-compact-summary",
     "vulcan-ext-input-demo",
+    "vulcan-ext-todo",
 ]
 resolver = "2"
 
@@ -105,6 +106,7 @@ async-trait = "0.1"
 # iterates `inventory::iter` at startup. Pure compile-time / link-time;
 # no dynamic loading.
 inventory = "0.3.24"
+vulcan-frontend-api = { path = "vulcan-frontend-api", version = "0.1.0" }
 
 # Stream processing for SSE responses
 futures-util = "0.3"

--- a/deny.toml
+++ b/deny.toml
@@ -37,6 +37,21 @@ ignore = [
     # constraint check was running on input the library doesn't accept
     # in the first place. Functionally unreachable for our usage.
     { id = "RUSTSEC-2026-0098", reason = "transitive via serenity; URI name constraint API not exposed." },
+    # RUSTSEC-2025-0141: bincode 1.3.3 is unmaintained but still used
+    # transitively by cortex-memory-core. No safe upstream upgrade is
+    # available from the advisory. Re-evaluate when cortex-memory-core
+    # moves to a maintained serialization dependency.
+    { id = "RUSTSEC-2025-0141", reason = "transitive via cortex-memory-core; no safe upstream upgrade available." },
+    # RUSTSEC-2025-0119: number_prefix is unmaintained and reaches us via
+    # indicatif -> hf-hub -> fastembed. This is CLI progress formatting,
+    # not parsing untrusted input. Re-evaluate when hf-hub/fastembed
+    # replace indicatif or indicatif changes its dependency.
+    { id = "RUSTSEC-2025-0119", reason = "transitive via fastembed/hf-hub progress formatting; no safe upstream upgrade available." },
+    # RUSTSEC-2024-0436: paste is unmaintained and reaches us through
+    # tokenizers/rav1e in the fastembed/image graph. It is a macro helper
+    # used at compile time by dependencies. Re-evaluate when those
+    # upstream crates migrate to pastey or another replacement.
+    { id = "RUSTSEC-2024-0436", reason = "transitive macro helper via fastembed dependency graph; no safe upstream upgrade available." },
 ]
 
 [licenses]
@@ -60,11 +75,18 @@ allow = [
     # permissive). Used by `webpki-roots` and a few other transitive
     # crates. https://cdla.dev/permissive-2-0/
     "CDLA-Permissive-2.0",
+    # NCSA is a permissive OSI-approved license. Reaches us via
+    # libfuzzer-sys -> rav1e -> ravif -> image -> fastembed.
+    "NCSA",
 ]
 confidence-threshold = 0.93
 
 [bans]
-multiple-versions = "warn"
+# The all-features graph intentionally carries duplicate versions from
+# platform/provider stacks (gix, reqwest, serenity, fastembed, windows
+# target crates). Keep hard failures for explicit deny/wildcard bans;
+# track duplicate cleanup as dependency hygiene instead of blocking CI.
+multiple-versions = "allow"
 wildcards = "deny"
 # Crates the workspace must never link against.
 deny = []

--- a/docs/adr/0006-extension-details-replay-and-frontend-rendering.md
+++ b/docs/adr/0006-extension-details-replay-and-frontend-rendering.md
@@ -1,0 +1,22 @@
+# Extension Details Replay and Frontend Rendering
+
+Extension tools may return structured `ToolResult.details` alongside the LLM-facing `output`. `details` is local structured state: hooks and frontends can read it, stream frames carry it, and saved tool messages preserve it as JSON for session replay. Frontend renderers consume `details` at the `ToolCallEnd` stream boundary and project it into the frontend's native representation. The TUI currently stores the rendered tool-card preview lines in `ChatMessage::output_preview` rather than adding raw `details` to the chat message model.
+
+## Considered Options
+
+- Store raw `details` on every TUI `ChatMessage` and let renderers run during every draw.
+- Render once at stream-event handling time and store the resulting preview lines.
+- Put extension state only in an out-of-band extension state store and keep tool messages text-only.
+- Ask daemon-side extensions to produce generic UI primitives for every frontend.
+
+## Decision
+
+Use `ToolResult.details` as the primary branchable replay contract, because it already travels with tool results and survives session history/fork flows. Frontends render `details` locally and persist only their rendered preview in the current TUI message model. Richer frontend event channels can add live widgets later, but they do not replace the tool-history replay path.
+
+## Consequences
+
+- Session-local extension state can be rebuilt by scanning saved `Message::Tool` entries and reading the latest schema-specific `details` snapshot.
+- The TUI avoids a high-blast-radius `ChatMessage` schema expansion while still supporting custom renderers for extension tool results.
+- Frontend renderers must tolerate absent or unknown `details` and fall back to the normal tool output path.
+- A frontend that wants to re-render historical cards after a renderer upgrade will need either raw event replay or a future message-model migration; the current contract optimizes for stable session replay and low-risk UI integration.
+- Daemon code never owns frontend layout. It emits structured tool state; frontend code decides how that state appears locally.

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -505,13 +505,20 @@ impl Agent {
             let ctx = crate::extensions::api::SessionExtensionCtx {
                 cwd: cwd.clone(),
                 session_id: session_id.clone(),
+                memory: Arc::clone(&memory),
             };
-            session_extensions = p
-                .extension_registry()
-                .wire_daemon_extensions_runtime(ctx, &hooks);
+            let registry = p.extension_registry();
+            session_extensions = registry.wire_daemon_extensions_runtime(ctx, &hooks);
             for ext in &session_extensions {
                 for tool in ext.wrapped_tools() {
-                    tools.register(tool);
+                    if let Err(err) = tools.register_extension_tool(ext.id(), tool) {
+                        registry.mark_broken(ext.id(), err.to_string());
+                        tracing::warn!(
+                            extension_id = ext.id(),
+                            %err,
+                            "Agent: failed to register extension tool"
+                        );
+                    }
                 }
                 ext.activate().await;
             }
@@ -962,13 +969,14 @@ impl Agent {
         let ctx = crate::extensions::api::SessionExtensionCtx {
             cwd: self.tool_context.cwd.clone(),
             session_id: self.session_id.clone(),
+            memory: Arc::clone(&self.memory),
         };
         let Some(runtime) = registry.instantiate_daemon_extension_runtime(id, ctx, &self.hooks)
         else {
             return Ok(false);
         };
         for tool in runtime.wrapped_tools() {
-            self.tools.register(tool);
+            self.tools.register_extension_tool(runtime.id(), tool)?;
         }
         runtime.activate().await;
         self.session_extensions.push(runtime);

--- a/src/agent/run.rs
+++ b/src/agent/run.rs
@@ -362,6 +362,7 @@ impl Agent {
         }
     }
 
+    #[allow(dead_code)]
     pub(in crate::agent) async fn prepare_stream_turn(
         &mut self,
         input: &str,
@@ -370,6 +371,7 @@ impl Agent {
         self.prepare_turn(input, cancel).await
     }
 
+    #[allow(dead_code)]
     pub(in crate::agent) async fn prepare_turn(
         &mut self,
         input: &str,
@@ -440,6 +442,7 @@ impl Agent {
         })
     }
 
+    #[allow(dead_code)]
     pub(in crate::agent) async fn compact_stream_messages_if_needed(
         &mut self,
         messages: &mut Vec<Message>,
@@ -463,6 +466,7 @@ impl Agent {
         let _ = forwarder.await;
     }
 
+    #[allow(dead_code)]
     pub(in crate::agent) async fn compact_turn_messages_if_needed(
         &mut self,
         messages: &mut Vec<Message>,
@@ -633,6 +637,7 @@ impl Agent {
         true
     }
 
+    #[allow(dead_code)]
     pub(in crate::agent) async fn collect_stream_response(
         &self,
         outgoing: &[Message],
@@ -675,6 +680,7 @@ impl Agent {
         result
     }
 
+    #[allow(dead_code)]
     pub(in crate::agent) async fn collect_turn_response(
         &self,
         outgoing: &[Message],
@@ -842,6 +848,7 @@ impl Agent {
         }
     }
 
+    #[allow(dead_code)]
     pub(in crate::agent) async fn execute_stream_tool_calls(
         &self,
         tool_calls: &[ToolCall],
@@ -866,6 +873,7 @@ impl Agent {
         results
     }
 
+    #[allow(dead_code)]
     pub(in crate::agent) async fn execute_turn_tool_calls(
         &self,
         tool_calls: &[ToolCall],
@@ -948,6 +956,7 @@ impl Agent {
                 // over the LLM-facing terse `output`.
                 let preview_source = result.display_preview.as_deref().unwrap_or(&result.output);
                 let output_preview = preview_output(preview_source);
+                let details = result.details.clone();
                 let result_meta = summarize_tool_result(&name, &result.output);
                 let elided = elided_lines(preview_source, output_preview.as_deref());
                 let _ = turn_tx
@@ -956,6 +965,7 @@ impl Agent {
                         name: name.clone(),
                         ok,
                         output_preview,
+                        details,
                         result_meta,
                         elided_lines: elided,
                         elapsed_ms,
@@ -969,6 +979,7 @@ impl Agent {
 }
 
 impl TurnRunner<'_> {
+    #[allow(dead_code)]
     pub(in crate::agent) async fn collect_response(
         &self,
         outgoing: &[Message],
@@ -982,6 +993,7 @@ impl TurnRunner<'_> {
             .await
     }
 
+    #[allow(dead_code)]
     pub(in crate::agent) async fn execute_tool_calls(
         &self,
         tool_calls: &[ToolCall],

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -488,7 +488,7 @@ async fn rewrite_history_from_before_compact_replaces_durable_history() {
         }
     }
 
-    let mut hooks = HookRegistry::new();
+    let hooks = HookRegistry::new();
     hooks.register(Arc::new(RewriteHook));
     let (mut agent, mock) = agent_with_mock_and_hooks(hooks);
     agent.context = ContextManager::new(10);
@@ -545,7 +545,7 @@ async fn invalid_rewrite_history_falls_back_to_builtin_and_audits_rejection() {
     }
 
     let audit = Arc::new(ExtensionAuditLog::new(8));
-    let mut hooks = HookRegistry::new().with_audit_log(audit.clone());
+    let hooks = HookRegistry::new().with_audit_log(audit.clone());
     hooks.register(Arc::new(BadRewriteHook));
     let (mut agent, mock) = agent_with_mock_and_hooks(hooks);
     agent.context = ContextManager::new(10);
@@ -607,7 +607,7 @@ async fn block_skips_compaction_until_context_overflow_is_imminent() {
         }
     }
 
-    let mut hooks = HookRegistry::new();
+    let hooks = HookRegistry::new();
     hooks.register(Arc::new(BlockHook));
     let (mut agent, mock) = agent_with_mock_and_hooks(hooks);
     agent.context = ContextManager::with_config(
@@ -663,7 +663,7 @@ async fn block_is_overridden_on_context_overflow_and_audited() {
     }
 
     let audit = Arc::new(ExtensionAuditLog::new(8));
-    let mut hooks = HookRegistry::new().with_audit_log(audit.clone());
+    let hooks = HookRegistry::new().with_audit_log(audit.clone());
     hooks.register(Arc::new(BlockHook));
     let (mut agent, mock) = agent_with_mock_and_hooks(hooks);
     agent.context = ContextManager::new(10);

--- a/src/agent/turn.rs
+++ b/src/agent/turn.rs
@@ -40,11 +40,13 @@ pub(in crate::agent) struct TurnOutcome {
 /// Slice 1 keeps existing `Agent` methods as adapters, but new turn execution
 /// behavior should move behind this seam instead of growing parallel buffered
 /// and streaming paths.
+#[allow(dead_code)]
 pub(in crate::agent) struct TurnRunner<'a> {
     pub(in crate::agent) agent: &'a Agent,
 }
 
 impl<'a> TurnRunner<'a> {
+    #[allow(dead_code)]
     pub(in crate::agent) fn new(agent: &'a Agent) -> Self {
         Self { agent }
     }
@@ -82,6 +84,7 @@ pub(in crate::agent) enum TurnEvent {
         name: String,
         ok: bool,
         output_preview: Option<String>,
+        details: Option<serde_json::Value>,
         result_meta: Option<String>,
         elided_lines: usize,
         elapsed_ms: u64,
@@ -120,6 +123,7 @@ impl From<StreamEvent> for TurnEvent {
                 name,
                 ok,
                 output_preview,
+                details,
                 result_meta,
                 elided_lines,
                 elapsed_ms,
@@ -128,6 +132,7 @@ impl From<StreamEvent> for TurnEvent {
                 name,
                 ok,
                 output_preview,
+                details,
                 result_meta,
                 elided_lines,
                 elapsed_ms,
@@ -157,6 +162,7 @@ impl From<TurnEvent> for StreamEvent {
                 name,
                 ok,
                 output_preview,
+                details,
                 result_meta,
                 elided_lines,
                 elapsed_ms,
@@ -165,6 +171,7 @@ impl From<TurnEvent> for StreamEvent {
                 name,
                 ok,
                 output_preview,
+                details,
                 result_meta,
                 elided_lines,
                 elapsed_ms,

--- a/src/daemon/handlers/prompt.rs
+++ b/src/daemon/handlers/prompt.rs
@@ -50,6 +50,7 @@ fn stream_event_to_frame(req_id: &str, ev: StreamEvent) -> Option<StreamFrame> {
             id: tool_id,
             name,
             ok,
+            details,
             result_meta,
             elapsed_ms,
             ..
@@ -61,6 +62,7 @@ fn stream_event_to_frame(req_id: &str, ev: StreamEvent) -> Option<StreamFrame> {
                 "tool_id": tool_id,
                 "name": name,
                 "ok": ok,
+                "details": details,
                 "result_meta": result_meta,
                 "elapsed_ms": elapsed_ms,
             }),

--- a/src/extensions/CONTEXT.md
+++ b/src/extensions/CONTEXT.md
@@ -28,16 +28,28 @@ _Avoid_: feature flag, runtime capability
 Per-**Session**, per-extension state. Lives in two places: `ToolResult.details` (pi-style, branches with **Session History** when a **Child Session** forks) and the daemon-owned **Extension State Store** (out-of-band rows keyed by session + extension + key, branched explicitly on fork unless the **Extension Manifest** opts out).
 _Avoid_: extension memory, extension cache
 
+**Frontend Renderer**:
+A **Frontend Extension** handler that maps a known tool result shape into frontend-native lines or widgets. In the TUI today, renderers consume `ToolResult.details` from the streamed `ToolCallEnd` event and project it into the existing tool-card preview; the durable chat message stores the rendered preview, not the raw details.
+_Avoid_: daemon renderer, persistent UI schema
+
+**Frontend Command**:
+A slash command handled entirely by the **Frontend** before the prompt reaches the daemon. Frontend commands produce local UI actions such as opening a view; commands that need the LLM or daemon state remain daemon/session commands.
+_Avoid_: hidden tool call, daemon-routed UI command
+
 ## Relationships
 
 - Every installed extension that ships a daemon module contributes one **Daemon Extension Factory** to the **Runtime Resource Pool**; the factory is registered once at daemon startup.
 - Each new **Session** instantiates a **Session Extension** from each active **Daemon Extension Factory**; hook instances, tool entries, and daemon-side state live on the **Session Extension**, not the factory.
+- Session extension tools are registered through the runtime bridge with the canonical `<extension_id>_<tool_name>` prefix. Built-in tools remain unprefixed; extension tool collisions mark the extension `Broken`.
+- `ToolResult.details` is the replay contract for session-local extension state. A **Session Extension** may rebuild in-memory state by scanning saved `Message::Tool` history for its own latest details snapshot.
 - A **Frontend** owns its own **Frontend Extension** registry; daemon and frontend extensions are linked into separate binaries even when they ship from the same crate.
 - A **Frontend Extension** consumes daemon push frames addressed to its extension id; it never owns agent state and never receives hook events directly.
 - An extension activates on a **Session** only when the connected **Frontend**'s declared capabilities satisfy the **Extension Manifest**'s required surface.
+- Renderer collisions are resolved in frontend registry order with last-active wins plus a warning; this mirrors extension load order and avoids daemon-side renderer arbitration.
 
 ## ADRs
 
 - `docs/adr/0003-extension-daemon-frontend-split.md` — daemon/frontend split rationale.
 - `docs/adr/0004-extension-distribution-and-lifecycle.md` — Cargo crate distribution + mid-session enable/disable/kill policy.
 - `docs/adr/0005-extension-compaction-control.md` — extension control over compaction with validation safety net.
+- `docs/adr/0006-extension-details-replay-and-frontend-rendering.md` — `ToolResult.details` as replay state plus frontend projection boundary.

--- a/src/extensions/api.rs
+++ b/src/extensions/api.rs
@@ -19,6 +19,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use super::ExtensionMetadata;
 use crate::hooks::{HookHandler, HookOutcome};
+use crate::memory::SessionStore;
 use crate::provider::factory::ProviderFactory;
 use crate::provider::{ChatResponse, LLMProvider, Message, StreamEvent, ToolCall};
 use crate::tools::{Tool, ToolProgress, ToolResult};
@@ -41,7 +42,7 @@ pub struct ExtensionManifest {
 /// the auto-commit dogfood needs today; grows toward the full
 /// `ExtensionContext` (model, provider, pause, state, ui, ...) as
 /// later slices land.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct SessionExtensionCtx {
     /// Working directory of the **Session** the extension is being
     /// instantiated for. Auto-commit reads this to know which repo to
@@ -50,6 +51,9 @@ pub struct SessionExtensionCtx {
     /// **Session** identifier. Routes telemetry, audit log entries,
     /// and per-session state under a stable key.
     pub session_id: String,
+    /// Durable session history store for replaying extension state
+    /// carried through `ToolResult.details`.
+    pub memory: Arc<SessionStore>,
 }
 
 /// Daemon-global registration for an extension. One implementation per
@@ -465,6 +469,7 @@ mod tests {
         SessionExtensionCtx {
             cwd: PathBuf::from("/tmp/test-session"),
             session_id: "test-session-id".to_string(),
+            memory: Arc::new(SessionStore::in_memory()),
         }
     }
 
@@ -590,6 +595,7 @@ mod tests {
         let ctx = SessionExtensionCtx {
             cwd: PathBuf::from("/tmp/example-session"),
             session_id: "sess-42".to_string(),
+            memory: Arc::new(SessionStore::in_memory()),
         };
         let _ = ext.instantiate(ctx);
 

--- a/src/extensions/registry.rs
+++ b/src/extensions/registry.rs
@@ -14,6 +14,7 @@ use super::{
     ExtensionCapability, ExtensionConfigField, ExtensionMetadata, ExtensionSource, ExtensionStatus,
 };
 use crate::hooks::{HookHandler, HookRegistry};
+use crate::tools::ToolRegistry;
 
 /// YYC-227 (YYC-165 PR-4): trait an in-process, code-backed
 /// extension implements. Implementors live alongside the
@@ -258,6 +259,35 @@ impl ExtensionRegistry {
             runtimes.push(runtime);
         }
         runtimes
+    }
+
+    /// Instantiate every active daemon extension for a Session, wire
+    /// hook handlers, and register its contributed tools using the
+    /// `<extension_id>_<tool_name>` namespace.
+    ///
+    /// Returns `(session_extensions, tools_registered)`.
+    pub fn wire_daemon_extensions_into_runtime(
+        &self,
+        ctx: SessionExtensionCtx,
+        hooks: &HookRegistry,
+        mut tools: Option<&mut ToolRegistry>,
+    ) -> (usize, usize) {
+        let runtimes = self.wire_daemon_extensions_runtime(ctx, hooks);
+        let mut tool_count = 0usize;
+        if let Some(tools) = tools.as_deref_mut() {
+            for runtime in &runtimes {
+                for tool in runtime.wrapped_tools() {
+                    match tools.register_extension_tool(runtime.id(), tool) {
+                        Ok(()) => tool_count += 1,
+                        Err(err) => {
+                            self.mark_broken(runtime.id(), err.to_string());
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        (runtimes.len(), tool_count)
     }
 
     pub fn instantiate_daemon_extension_runtime(

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -1938,7 +1938,7 @@ mod tests {
                 content: "old".into(),
             },
         ];
-        let mut reg = HookRegistry::new();
+        let reg = HookRegistry::new();
         reg.register(Arc::new(Rewriter));
 
         assert!(matches!(
@@ -2107,7 +2107,7 @@ mod tests {
         }
 
         let (pause_tx, mut pause_rx) = crate::pause::channel(4);
-        let mut reg = HookRegistry::new()
+        let reg = HookRegistry::new()
             .with_input_rewrite_pause_channel(pause_tx)
             .require_input_rewrite_approval("approval-rewriter");
         reg.register(Arc::new(Rewriter));
@@ -2156,7 +2156,7 @@ mod tests {
         }
 
         let (pause_tx, mut pause_rx) = crate::pause::channel(4);
-        let mut reg = HookRegistry::new()
+        let reg = HookRegistry::new()
             .with_input_rewrite_pause_channel(pause_tx)
             .require_input_rewrite_approval("approval-rewriter");
         reg.register(Arc::new(Rewriter));
@@ -2198,7 +2198,7 @@ mod tests {
             }
         }
 
-        let mut reg = HookRegistry::new().require_input_rewrite_approval("approval-rewriter");
+        let reg = HookRegistry::new().require_input_rewrite_approval("approval-rewriter");
         reg.register(Arc::new(Rewriter));
 
         match reg.apply_on_input("raw", CancellationToken::new()).await {

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -376,6 +376,7 @@ pub enum StreamEvent {
         name: String,
         ok: bool,
         output_preview: Option<String>,
+        details: Option<Value>,
         /// One-line metadata derived from the tool result (e.g.
         /// "847 lines · 26.8 KB", "5 matches", "+142 -3"). Rendered as
         /// a dimmed sub-header in the YYC-74 card.

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -21,6 +21,10 @@ pub struct ToolResult {
     pub output: String,
     pub media: Vec<String>,
     pub is_error: bool,
+    /// Optional structured payload for frontend renderers and extension
+    /// state replay. The LLM-facing `output` remains the canonical text
+    /// content; `details` is for local UI and hooks that know the schema.
+    pub details: Option<Value>,
     /// Optional richer body the TUI uses for the YYC-74 card preview.
     /// Lets file-edit tools render an actual diff (`+ ... / - ...`)
     /// inside the card while the LLM-facing `output` stays terse
@@ -41,6 +45,7 @@ impl ToolResult {
             output: output.into(),
             media: Vec::new(),
             is_error: false,
+            details: None,
             display_preview: None,
             edit_diff: None,
         }
@@ -51,9 +56,15 @@ impl ToolResult {
             output: output.into(),
             media: Vec::new(),
             is_error: true,
+            details: None,
             display_preview: None,
             edit_diff: None,
         }
+    }
+
+    pub fn with_details(mut self, details: Value) -> Self {
+        self.details = Some(details);
+        self
     }
 
     pub fn with_display_preview(mut self, preview: impl Into<String>) -> Self {
@@ -539,6 +550,25 @@ impl ToolRegistry {
         self.tools.insert(tool.name().to_string(), tool);
     }
 
+    pub fn contains(&self, name: &str) -> bool {
+        self.tools.contains_key(name)
+    }
+
+    pub fn register_extension_tool(
+        &mut self,
+        extension_id: &str,
+        tool: Arc<dyn Tool>,
+    ) -> Result<()> {
+        let expected_prefix = format!("{extension_id}_");
+        let wrapped = Arc::new(PrefixedExtensionTool::new(expected_prefix, tool)?) as Arc<dyn Tool>;
+        let name = wrapped.name().to_string();
+        if self.tools.contains_key(&name) {
+            anyhow::bail!("extension tool `{name}` conflicts with an existing tool");
+        }
+        self.tools.insert(name, wrapped);
+        Ok(())
+    }
+
     /// YYC-181: apply a named tool capability profile to this
     /// registry. Drops every tool not in `profile.allowed` and
     /// records `profile.name` so callers (run records, doctor,
@@ -656,6 +686,68 @@ impl ToolRegistry {
         validate_tool_params(name, &schema, &params, arguments)?;
 
         tool.call(params, cancel, progress).await
+    }
+}
+
+pub fn details_from_tool_message(content: &str) -> Option<Value> {
+    serde_json::from_str::<Value>(content)
+        .ok()
+        .and_then(|v| v.get("details").cloned())
+}
+
+struct PrefixedExtensionTool {
+    name: String,
+    inner: Arc<dyn Tool>,
+}
+
+impl PrefixedExtensionTool {
+    fn new(prefix: String, inner: Arc<dyn Tool>) -> Result<Self> {
+        let inner_name = inner.name();
+        if inner_name.is_empty() {
+            anyhow::bail!("extension tool name cannot be empty");
+        }
+        let name = if inner_name.starts_with(&prefix) {
+            inner_name.to_string()
+        } else {
+            format!("{prefix}{inner_name}")
+        };
+        Ok(Self { name, inner })
+    }
+}
+
+#[async_trait::async_trait]
+impl Tool for PrefixedExtensionTool {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn description(&self) -> &str {
+        self.inner.description()
+    }
+
+    fn schema(&self) -> Value {
+        self.inner.schema()
+    }
+
+    async fn call(
+        &self,
+        params: Value,
+        cancel: CancellationToken,
+        progress: Option<ProgressSink>,
+    ) -> Result<ToolResult> {
+        self.inner.call(params, cancel, progress).await
+    }
+
+    fn is_relevant(&self, ctx: &ToolContext) -> bool {
+        self.inner.is_relevant(ctx)
+    }
+
+    fn dynamic_description(&self, ctx: &ToolContext) -> Option<String> {
+        self.inner.dynamic_description(ctx)
+    }
+
+    fn replay_safety(&self) -> ReplaySafety {
+        self.inner.replay_safety()
     }
 }
 

--- a/src/tools/shell.rs
+++ b/src/tools/shell.rs
@@ -1124,6 +1124,7 @@ fn format_command_result(exit_code: i32, success: bool, stdout: &str, stderr: &s
         output: result,
         media: Vec::new(),
         is_error: !success,
+        details: None,
         display_preview: None,
         edit_diff: None,
     }

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -195,6 +195,7 @@ pub(super) async fn handle_stream_event(
             name,
             ok,
             output_preview,
+            details,
             result_meta,
             elided_lines,
             elapsed_ms,
@@ -203,13 +204,17 @@ pub(super) async fn handle_stream_event(
             if let Some(last) = app.messages.last_mut()
                 && matches!(last.role, ChatRole::Agent)
             {
+                let rendered_preview = app
+                    .frontend
+                    .render_tool_result(&name, ok, output_preview.as_deref(), details.as_ref())
+                    .map(|lines| lines.join("\n"));
                 // YYC-74: stamp preview + meta + timing onto the matching
                 // segment for the card. YYC-78: stash elided count for the
                 // collapse footer.
                 last.finish_tool_with(
                     &name,
                     ok,
-                    output_preview,
+                    rendered_preview.or(output_preview),
                     result_meta,
                     elided_lines,
                     Some(elapsed_ms),

--- a/src/tui/frontend.rs
+++ b/src/tui/frontend.rs
@@ -1,0 +1,108 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use serde_json::Value;
+use vulcan_frontend_api::{
+    FrontendCodeExtension, FrontendCommand, FrontendCommandAction, FrontendCtx, MessageRenderer,
+    ToolResultView,
+};
+
+#[derive(Default)]
+pub struct TuiFrontend {
+    renderers: HashMap<&'static str, Arc<dyn MessageRenderer>>,
+    commands: HashMap<&'static str, Arc<dyn FrontendCommand>>,
+    capabilities: Vec<&'static str>,
+}
+
+impl TuiFrontend {
+    pub fn collect() -> Self {
+        Self::from_extensions(vulcan_frontend_api::collect_registrations())
+    }
+
+    pub fn from_extensions(extensions: Vec<Arc<dyn FrontendCodeExtension>>) -> Self {
+        let mut this = Self::default();
+        for extension in extensions {
+            for capability in extension.frontend_capabilities() {
+                if !this.capabilities.contains(&capability) {
+                    this.capabilities.push(capability);
+                }
+            }
+            for renderer in extension.message_renderers() {
+                let tool_name = renderer.tool_name();
+                if this.renderers.insert(tool_name, renderer).is_some() {
+                    tracing::warn!(
+                        extension_id = extension.id(),
+                        tool_name,
+                        "frontend renderer collision; last active renderer wins"
+                    );
+                }
+            }
+            for command in extension.commands() {
+                this.commands.insert(command.name(), command);
+            }
+        }
+        if !this.capabilities.contains(&"text_io") {
+            this.capabilities.push("text_io");
+        }
+        this
+    }
+
+    pub fn frontend_capabilities(&self) -> Vec<&'static str> {
+        self.capabilities.clone()
+    }
+
+    pub fn render_tool_result(
+        &self,
+        tool_name: &str,
+        ok: bool,
+        output_preview: Option<&str>,
+        details: Option<&Value>,
+    ) -> Option<Vec<String>> {
+        let renderer = self.renderers.get(tool_name)?;
+        let ctx = FrontendCtx::default();
+        let result = ToolResultView {
+            tool_name,
+            ok,
+            output_preview,
+            details,
+        };
+        renderer
+            .render(&ctx, &result)
+            .map(|rendered| rendered.lines)
+    }
+
+    pub fn dispatch_slash(&self, input: &str) -> Option<FrontendCommandAction> {
+        let body = input.strip_prefix('/')?.trim();
+        let name = body.split_whitespace().next().unwrap_or("");
+        let command = self.commands.get(name)?;
+        let mut ctx = FrontendCtx::default();
+        Some(command.run(&mut ctx))
+    }
+
+    pub fn command_specs(&self) -> Vec<FrontendCommandSpec> {
+        let mut specs: Vec<_> = self
+            .commands
+            .values()
+            .map(|command| FrontendCommandSpec {
+                name: command.name(),
+                description: command.description(),
+                mid_turn_safe: command.mid_turn_safe(),
+            })
+            .collect();
+        specs.sort_by_key(|spec| spec.name);
+        specs
+    }
+
+    pub fn is_frontend_command_mid_turn_safe(&self, name: &str) -> Option<bool> {
+        self.commands
+            .get(name)
+            .map(|command| command.mid_turn_safe())
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FrontendCommandSpec {
+    pub name: &'static str,
+    pub description: &'static str,
+    pub mid_turn_safe: bool,
+}

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -46,6 +46,7 @@ use crate::provider::StreamEvent;
 pub mod chat_message;
 pub mod chat_render;
 mod events;
+pub mod frontend;
 mod init;
 pub mod keybinds;
 mod keymap;
@@ -63,6 +64,7 @@ pub mod widgets;
 use state::{AppState, ChatMessage, ChatRole};
 use theme::{Theme, body};
 use views::{View, render_view};
+use vulcan_frontend_api::FrontendCommandAction;
 
 /// What session, if any, the TUI should load on startup.
 #[derive(Debug, Clone)]
@@ -86,6 +88,25 @@ enum KeyEv {
 
 fn short_id(id: &str) -> String {
     id.chars().take(8).collect()
+}
+
+fn apply_frontend_command_action(app: &mut AppState, action: FrontendCommandAction) {
+    match action {
+        FrontendCommandAction::Noop => {}
+        FrontendCommandAction::SystemMessage(content) => {
+            app.messages
+                .push(ChatMessage::new(ChatRole::System, content));
+        }
+        FrontendCommandAction::OpenView { title, body, .. } => {
+            let content = if body.is_empty() {
+                title
+            } else {
+                format!("{title}\n{}", body.join("\n"))
+            };
+            app.messages
+                .push(ChatMessage::new(ChatRole::System, content));
+        }
+    }
 }
 
 pub async fn run_tui(
@@ -119,6 +140,7 @@ pub async fn run_tui(
     // memory-constrained hosts (lower).
     let (stream_tx, mut stream_rx) =
         mpsc::channel::<StreamEvent>(config.provider.effective_stream_channel_capacity());
+    let frontend = frontend::TuiFrontend::collect();
 
     // ── Hook registry: audit-log + (room for safety-gate, etc.). Built-in
     // hooks (skills) are registered by AgentBuilder.
@@ -186,6 +208,7 @@ pub async fn run_tui(
     .with_theme(Theme::from_name(&config.tui.theme))
     .with_keybinds(keybinds::Keybinds::from_config(&config.keybinds));
     app.audit_log = Some(audit_buf);
+    app.frontend = frontend;
     // YYC-66: clone the agent's diff sink so the TUI can render real edits.
     // YYC-67: pull catalog pricing for the cost estimate.
     // YYC-95: if resume restored a provider profile the active model/context
@@ -1059,6 +1082,10 @@ pub async fn run_tui(
                                                 .iter()
                                                 .find(|c| c.name == head)
                                                 .map(|c| c.mid_turn_safe)
+                                                .or_else(|| {
+                                                    app.frontend
+                                                        .is_frontend_command_mid_turn_safe(head)
+                                                })
                                                 .unwrap_or(false)
                                         } else {
                                             false
@@ -1112,11 +1139,18 @@ pub async fn run_tui(
 
                                             // slash commands
                                             if let Some(body) = msg.strip_prefix('/') {
+                                                if let Some(action) = app.frontend.dispatch_slash(&msg) {
+                                                    apply_frontend_command_action(&mut app, action);
+                                                    continue;
+                                                }
                                                 match body {
                                                     "exit" | "quit" => { exit = true; continue; }
                                                     "help" => {
                                                         let mut help = String::from("Commands:");
                                                         for cmd in keymap::SLASH_COMMANDS {
+                                                            help.push_str(&format!("\n  /{:<10}  {}", cmd.name, cmd.description));
+                                                        }
+                                                        for cmd in app.frontend.command_specs() {
                                                             help.push_str(&format!("\n  /{:<10}  {}", cmd.name, cmd.description));
                                                         }
                                                         help.push_str("\n\nKeys:\n  Ctrl+1..5  switch view (1=stack 2=split 3=tiled 4=tree 5=floor)\n  Ctrl+R     toggle reasoning trace\n  Tab        complete slash command");

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -216,6 +216,7 @@ pub struct AppState {
     /// present, the trading-floor tool-log pane renders from it; otherwise it
     /// falls back to demo data so the design still looks alive on first launch.
     pub audit_log: Option<AuditBuffer>,
+    pub frontend: super::frontend::TuiFrontend,
 
     /// When the agent emits an `AgentPause`, the TUI parks it here. Render
     /// shows an overlay; key handler intercepts Y/A/N keys and consumes the
@@ -375,6 +376,7 @@ impl AppState {
             orchestration_store: None,
 
             audit_log: None,
+            frontend: super::frontend::TuiFrontend::default(),
             pending_pause: None,
 
             cursor: Cell::new((0, 0)),

--- a/tests/frontend_extensions.rs
+++ b/tests/frontend_extensions.rs
@@ -1,0 +1,121 @@
+use std::sync::Arc;
+
+use serde_json::json;
+use vulcan::tools::ToolResult;
+use vulcan::tui::frontend::TuiFrontend;
+use vulcan_frontend_api::{
+    FrontendCodeExtension, FrontendCommand, FrontendCommandAction, FrontendCtx, MessageRenderer,
+    RenderedMessage, ToolResultView,
+};
+
+struct TestRenderer(&'static str);
+
+impl MessageRenderer for TestRenderer {
+    fn tool_name(&self) -> &'static str {
+        "todo_list"
+    }
+
+    fn render(&self, _ctx: &FrontendCtx, result: &ToolResultView<'_>) -> Option<RenderedMessage> {
+        let items = result.details?.get("items")?.as_array()?;
+        Some(RenderedMessage::from_lines([
+            self.0.to_string(),
+            format!("{} item(s)", items.len()),
+        ]))
+    }
+}
+
+struct TestCommand;
+
+impl FrontendCommand for TestCommand {
+    fn name(&self) -> &'static str {
+        "todos"
+    }
+
+    fn description(&self) -> &'static str {
+        "Open todos"
+    }
+
+    fn run(&self, _ctx: &mut FrontendCtx) -> FrontendCommandAction {
+        FrontendCommandAction::OpenView {
+            id: "todo".into(),
+            title: "Todos".into(),
+            body: vec!["Todo view opened.".into()],
+        }
+    }
+}
+
+struct TestExtension {
+    id: &'static str,
+    renderer_label: &'static str,
+}
+
+impl FrontendCodeExtension for TestExtension {
+    fn id(&self) -> &'static str {
+        self.id
+    }
+
+    fn frontend_capabilities(&self) -> Vec<&'static str> {
+        vec!["text_io", "rich_text"]
+    }
+
+    fn message_renderers(&self) -> Vec<Arc<dyn MessageRenderer>> {
+        vec![Arc::new(TestRenderer(self.renderer_label))]
+    }
+
+    fn commands(&self) -> Vec<Arc<dyn FrontendCommand>> {
+        vec![Arc::new(TestCommand)]
+    }
+}
+
+#[test]
+fn tui_frontend_uses_last_renderer_and_dispatches_frontend_commands() {
+    let frontend = TuiFrontend::from_extensions(vec![
+        Arc::new(TestExtension {
+            id: "first",
+            renderer_label: "first",
+        }),
+        Arc::new(TestExtension {
+            id: "second",
+            renderer_label: "second",
+        }),
+    ]);
+    let details = json!({ "items": ["buy milk", "ship issue"] });
+
+    let rendered = frontend
+        .render_tool_result("todo_list", true, Some("fallback"), Some(&details))
+        .expect("todo renderer should handle details");
+    let action = frontend
+        .dispatch_slash("/todos")
+        .expect("frontend command should dispatch locally");
+
+    assert_eq!(
+        rendered,
+        vec!["second".to_string(), "2 item(s)".to_string()]
+    );
+    assert!(matches!(
+        action,
+        FrontendCommandAction::OpenView { ref id, .. } if id == "todo"
+    ));
+}
+
+#[test]
+fn tool_result_details_are_available_to_frontend_renderers() {
+    let result = ToolResult::ok("listed todos").with_details(json!({
+        "items": ["buy milk"]
+    }));
+    let frontend = TuiFrontend::from_extensions(vec![Arc::new(TestExtension {
+        id: "todo",
+        renderer_label: "todo",
+    })]);
+
+    let rendered = frontend
+        .render_tool_result(
+            "todo_list",
+            !result.is_error,
+            Some(&result.output),
+            result.details.as_ref(),
+        )
+        .expect("renderer should receive tool result details");
+
+    assert_eq!(rendered, vec!["todo".to_string(), "1 item(s)".to_string()]);
+}

--- a/vulcan-ext-auto-commit/src/lib.rs
+++ b/vulcan-ext-auto-commit/src/lib.rs
@@ -198,6 +198,7 @@ mod tests {
         let session = ext.instantiate(SessionExtensionCtx {
             cwd: repo.clone(),
             session_id: "test-session".to_string(),
+            memory: Arc::new(vulcan::memory::SessionStore::in_memory()),
         });
         let handlers = session.hook_handlers();
         assert_eq!(handlers.len(), 1);
@@ -217,6 +218,7 @@ mod tests {
         let session = ext.instantiate(SessionExtensionCtx {
             cwd: repo.clone(),
             session_id: "clean-session".to_string(),
+            memory: Arc::new(vulcan::memory::SessionStore::in_memory()),
         });
         session.hook_handlers()[0]
             .session_end("clean-session", 0)
@@ -236,6 +238,7 @@ mod tests {
         let session = ext.instantiate(SessionExtensionCtx {
             cwd: path,
             session_id: "no-git".to_string(),
+            memory: Arc::new(vulcan::memory::SessionStore::in_memory()),
         });
         session.hook_handlers()[0].session_end("no-git", 0).await;
         // No panic, no error — just silently no-op.

--- a/vulcan-ext-compact-summary/src/lib.rs
+++ b/vulcan-ext-compact-summary/src/lib.rs
@@ -169,6 +169,7 @@ mod tests {
         SessionExtensionCtx {
             cwd: std::path::PathBuf::from("/tmp/test"),
             session_id: "test-session".to_string(),
+            memory: Arc::new(vulcan::memory::SessionStore::in_memory()),
         }
     }
 

--- a/vulcan-ext-input-demo/src/lib.rs
+++ b/vulcan-ext-input-demo/src/lib.rs
@@ -109,6 +109,7 @@ mod tests {
         SessionExtensionCtx {
             cwd: std::path::PathBuf::from("/tmp/test"),
             session_id: "test-session".to_string(),
+            memory: Arc::new(vulcan::memory::SessionStore::in_memory()),
         }
     }
 

--- a/vulcan-ext-todo/Cargo.toml
+++ b/vulcan-ext-todo/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "vulcan-ext-todo"
+version = "0.1.0"
+edition = "2024"
+description = "Todo dogfood Vulcan extension"
+authors = ["Colin Hanway"]
+license = "MIT"
+repository = "https://github.com/yycholla/vulcan"
+
+[lib]
+name = "vulcan_ext_todo"
+path = "src/lib.rs"
+
+[dependencies]
+vulcan = { package = "vulcan-core", path = ".." }
+vulcan-frontend-api = { path = "../vulcan-frontend-api", optional = true }
+
+inventory = "0.3.24"
+async-trait = "0.1"
+parking_lot = "0.12"
+anyhow = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio-util = { version = "0.7.18", features = ["rt"] }
+
+[features]
+default = []
+tui = ["dep:vulcan-frontend-api"]
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt"] }
+
+[package.metadata.vulcan]
+id = "todo"
+daemon_entry = "vulcan_ext_todo::TodoExtension"
+capabilities = ["tool_provider"]
+
+[package.metadata.vulcan.commands.todos]
+surface = "frontend"
+description = "Open todo list"

--- a/vulcan-ext-todo/src/lib.rs
+++ b/vulcan-ext-todo/src/lib.rs
@@ -1,0 +1,314 @@
+//! Todo dogfood extension for GH issue #550.
+//!
+//! The daemon-side extension contributes three session-local tools.
+//! Runtime wiring exposes them to the model as `todo_add`,
+//! `todo_list`, and `todo_clear`; internally the tools use local names
+//! `add`, `list`, and `clear` so the registry owns namespacing.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use parking_lot::Mutex;
+use serde::Deserialize;
+use serde_json::{Value, json};
+use tokio_util::sync::CancellationToken;
+use vulcan::extensions::api::{
+    DaemonCodeExtension, ExtensionRegistration, SessionExtension, SessionExtensionCtx,
+};
+use vulcan::extensions::{
+    ExtensionCapability, ExtensionMetadata, ExtensionSource, ExtensionStatus,
+};
+use vulcan::hooks::HookHandler;
+use vulcan::provider::Message;
+use vulcan::tools::{ProgressSink, ReplaySafety, Tool, ToolResult, details_from_tool_message};
+
+const ID: &str = "todo";
+
+#[cfg(feature = "tui")]
+pub mod tui;
+
+#[derive(Default)]
+pub struct TodoExtension;
+
+impl DaemonCodeExtension for TodoExtension {
+    fn metadata(&self) -> ExtensionMetadata {
+        let mut m = ExtensionMetadata::new(
+            ID,
+            "Todo",
+            env!("CARGO_PKG_VERSION"),
+            ExtensionSource::Builtin,
+        );
+        m.status = ExtensionStatus::Active;
+        m.capabilities = vec![ExtensionCapability::ToolProvider];
+        m.description = "Session-local todo list tools with ToolResult.details replay.".to_string();
+        m
+    }
+
+    fn instantiate(&self, ctx: SessionExtensionCtx) -> Arc<dyn SessionExtension> {
+        Arc::new(TodoSession {
+            items: Arc::new(Mutex::new(Vec::new())),
+            memory: ctx.memory,
+        })
+    }
+}
+
+struct TodoSession {
+    items: Arc<Mutex<Vec<String>>>,
+    memory: Arc<vulcan::memory::SessionStore>,
+}
+
+impl SessionExtension for TodoSession {
+    fn hook_handlers(&self) -> Vec<Arc<dyn HookHandler>> {
+        vec![Arc::new(TodoReplayHook {
+            items: Arc::clone(&self.items),
+            memory: Arc::clone(&self.memory),
+        })]
+    }
+
+    fn tools(&self) -> Vec<Arc<dyn Tool>> {
+        vec![
+            Arc::new(TodoAddTool {
+                items: Arc::clone(&self.items),
+            }),
+            Arc::new(TodoListTool {
+                items: Arc::clone(&self.items),
+            }),
+            Arc::new(TodoClearTool {
+                items: Arc::clone(&self.items),
+            }),
+        ]
+    }
+}
+
+struct TodoReplayHook {
+    items: Arc<Mutex<Vec<String>>>,
+    memory: Arc<vulcan::memory::SessionStore>,
+}
+
+#[async_trait]
+impl HookHandler for TodoReplayHook {
+    fn name(&self) -> &str {
+        ID
+    }
+
+    async fn session_start(&self, session_id: &str) {
+        let Ok(Some(history)) = self.memory.load_history(session_id) else {
+            return;
+        };
+        let mut latest = None;
+        for msg in history {
+            if let Message::Tool { content, .. } = msg {
+                latest = details_from_tool_message(&content).and_then(todo_items_from_details);
+            }
+        }
+        if let Some(items) = latest {
+            *self.items.lock() = items;
+        }
+    }
+}
+
+fn todo_items_from_details(details: Value) -> Option<Vec<String>> {
+    details
+        .get("items")?
+        .as_array()?
+        .iter()
+        .map(|v| v.as_str().map(str::to_string))
+        .collect()
+}
+
+fn details(items: &[String]) -> Value {
+    json!({ "items": items })
+}
+
+fn output_for(items: &[String]) -> String {
+    if items.is_empty() {
+        "Todo list is empty.".to_string()
+    } else {
+        items
+            .iter()
+            .enumerate()
+            .map(|(idx, item)| format!("{}. {item}", idx + 1))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+}
+
+#[derive(Deserialize)]
+struct AddParams {
+    item: String,
+}
+
+struct TodoAddTool {
+    items: Arc<Mutex<Vec<String>>>,
+}
+
+#[async_trait]
+impl Tool for TodoAddTool {
+    fn name(&self) -> &str {
+        "add"
+    }
+
+    fn description(&self) -> &str {
+        "Add an item to the session todo list."
+    }
+
+    fn schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "item": { "type": "string", "description": "Todo item to add" }
+            },
+            "required": ["item"]
+        })
+    }
+
+    async fn call(
+        &self,
+        params: Value,
+        _cancel: CancellationToken,
+        _progress: Option<ProgressSink>,
+    ) -> anyhow::Result<ToolResult> {
+        let p: AddParams = match vulcan::tools::parse_tool_params(params) {
+            Ok(p) => p,
+            Err(e) => return Ok(e),
+        };
+        let item = p.item.trim();
+        if item.is_empty() {
+            return Ok(ToolResult::err("todo item cannot be empty"));
+        }
+        let snapshot = {
+            let mut guard = self.items.lock();
+            guard.push(item.to_string());
+            guard.clone()
+        };
+        Ok(ToolResult::ok(format!("Added todo: {item}")).with_details(details(&snapshot)))
+    }
+
+    fn replay_safety(&self) -> ReplaySafety {
+        ReplaySafety::Mutating
+    }
+}
+
+struct TodoListTool {
+    items: Arc<Mutex<Vec<String>>>,
+}
+
+#[async_trait]
+impl Tool for TodoListTool {
+    fn name(&self) -> &str {
+        "list"
+    }
+
+    fn description(&self) -> &str {
+        "List the current session todo items."
+    }
+
+    fn schema(&self) -> Value {
+        json!({ "type": "object", "properties": {} })
+    }
+
+    async fn call(
+        &self,
+        _params: Value,
+        _cancel: CancellationToken,
+        _progress: Option<ProgressSink>,
+    ) -> anyhow::Result<ToolResult> {
+        let snapshot = self.items.lock().clone();
+        Ok(ToolResult::ok(output_for(&snapshot)).with_details(details(&snapshot)))
+    }
+
+    fn replay_safety(&self) -> ReplaySafety {
+        ReplaySafety::ReadOnly
+    }
+}
+
+struct TodoClearTool {
+    items: Arc<Mutex<Vec<String>>>,
+}
+
+#[async_trait]
+impl Tool for TodoClearTool {
+    fn name(&self) -> &str {
+        "clear"
+    }
+
+    fn description(&self) -> &str {
+        "Clear the session todo list."
+    }
+
+    fn schema(&self) -> Value {
+        json!({ "type": "object", "properties": {} })
+    }
+
+    async fn call(
+        &self,
+        _params: Value,
+        _cancel: CancellationToken,
+        _progress: Option<ProgressSink>,
+    ) -> anyhow::Result<ToolResult> {
+        self.items.lock().clear();
+        Ok(ToolResult::ok("Cleared todo list.").with_details(details(&[])))
+    }
+
+    fn replay_safety(&self) -> ReplaySafety {
+        ReplaySafety::Mutating
+    }
+}
+
+inventory::submit! {
+    ExtensionRegistration {
+        register: || Arc::new(TodoExtension) as Arc<dyn DaemonCodeExtension>,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx(memory: Arc<vulcan::memory::SessionStore>) -> SessionExtensionCtx {
+        SessionExtensionCtx {
+            cwd: std::path::PathBuf::from("/tmp/test"),
+            session_id: "todo-test".to_string(),
+            memory,
+        }
+    }
+
+    #[tokio::test]
+    async fn add_list_clear_emit_details_snapshots() {
+        let memory = Arc::new(vulcan::memory::SessionStore::in_memory());
+        let session = TodoExtension.instantiate(ctx(memory));
+        let tools = session.tools();
+
+        let add = tools.iter().find(|t| t.name() == "add").expect("add tool");
+        let result = add
+            .call(
+                json!({ "item": "buy milk" }),
+                CancellationToken::new(),
+                None,
+            )
+            .await
+            .expect("add result");
+        assert_eq!(result.details, Some(json!({ "items": ["buy milk"] })));
+
+        let list = tools
+            .iter()
+            .find(|t| t.name() == "list")
+            .expect("list tool");
+        let result = list
+            .call(json!({}), CancellationToken::new(), None)
+            .await
+            .expect("list result");
+        assert!(result.output.contains("buy milk"));
+        assert_eq!(result.details, Some(json!({ "items": ["buy milk"] })));
+
+        let clear = tools
+            .iter()
+            .find(|t| t.name() == "clear")
+            .expect("clear tool");
+        let result = clear
+            .call(json!({}), CancellationToken::new(), None)
+            .await
+            .expect("clear result");
+        assert_eq!(result.details, Some(json!({ "items": [] })));
+    }
+}

--- a/vulcan-ext-todo/src/tui.rs
+++ b/vulcan-ext-todo/src/tui.rs
@@ -1,0 +1,130 @@
+use std::sync::Arc;
+
+use vulcan_frontend_api::{
+    FrontendCodeExtension, FrontendCommand, FrontendCommandAction, FrontendCtx,
+    FrontendExtensionRegistration, MessageRenderer, RenderedMessage, ToolResultView,
+};
+
+pub struct TodoFrontendExtension;
+
+impl FrontendCodeExtension for TodoFrontendExtension {
+    fn id(&self) -> &'static str {
+        "todo"
+    }
+
+    fn frontend_capabilities(&self) -> Vec<&'static str> {
+        vec!["text_io", "rich_text"]
+    }
+
+    fn message_renderers(&self) -> Vec<Arc<dyn MessageRenderer>> {
+        vec![Arc::new(TodoListRenderer)]
+    }
+
+    fn commands(&self) -> Vec<Arc<dyn FrontendCommand>> {
+        vec![Arc::new(TodosCommand)]
+    }
+}
+
+struct TodoListRenderer;
+
+impl MessageRenderer for TodoListRenderer {
+    fn tool_name(&self) -> &'static str {
+        "todo_list"
+    }
+
+    fn render(&self, _ctx: &FrontendCtx, result: &ToolResultView<'_>) -> Option<RenderedMessage> {
+        let items = result.details?.get("items")?.as_array()?;
+        let mut lines = vec![format!("Todos ({})", items.len())];
+        if items.is_empty() {
+            lines.push("No todos yet.".to_string());
+        } else {
+            for item in items {
+                lines.push(format!("[ ] {}", item.as_str().unwrap_or("<invalid todo>")));
+            }
+        }
+        Some(RenderedMessage::from_lines(lines))
+    }
+}
+
+struct TodosCommand;
+
+impl FrontendCommand for TodosCommand {
+    fn name(&self) -> &'static str {
+        "todos"
+    }
+
+    fn description(&self) -> &'static str {
+        "Open todo list"
+    }
+
+    fn run(&self, _ctx: &mut FrontendCtx) -> FrontendCommandAction {
+        FrontendCommandAction::OpenView {
+            id: "todo".into(),
+            title: "Todos".into(),
+            body: vec!["Todo view opened. Ask the agent to add or list todos.".into()],
+        }
+    }
+}
+
+inventory::submit! {
+    FrontendExtensionRegistration {
+        register: || Arc::new(TodoFrontendExtension) as Arc<dyn FrontendCodeExtension>,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use serde_json::json;
+    use vulcan_frontend_api::{
+        FrontendCodeExtension, FrontendCommandAction, FrontendCtx, ToolResultView,
+    };
+
+    #[test]
+    fn todo_frontend_extension_renders_todo_list_details() {
+        let ext = TodoFrontendExtension;
+        let renderers = ext.message_renderers();
+        let renderer = renderers
+            .iter()
+            .find(|renderer| renderer.tool_name() == "todo_list")
+            .expect("todo_list renderer");
+        let details = json!({ "items": ["buy milk", "ship issue"] });
+        let result = ToolResultView {
+            tool_name: "todo_list",
+            ok: true,
+            output_preview: None,
+            details: Some(&details),
+        };
+
+        let rendered = renderer
+            .render(&FrontendCtx::default(), &result)
+            .expect("rendered");
+
+        assert!(rendered.lines.iter().any(|line| line.contains("Todos")));
+        assert!(rendered.lines.iter().any(|line| line.contains("buy milk")));
+        assert!(
+            rendered
+                .lines
+                .iter()
+                .any(|line| line.contains("ship issue"))
+        );
+    }
+
+    #[test]
+    fn todo_frontend_extension_declares_todos_command() {
+        let ext = TodoFrontendExtension;
+        let command = ext
+            .commands()
+            .into_iter()
+            .find(|command| command.name() == "todos")
+            .expect("/todos command");
+
+        let action = command.run(&mut FrontendCtx::default());
+
+        assert!(matches!(
+            action,
+            FrontendCommandAction::OpenView { ref id, .. } if id == "todo"
+        ));
+    }
+}

--- a/vulcan-ext-todo/tests/todo_e2e.rs
+++ b/vulcan-ext-todo/tests/todo_e2e.rs
@@ -1,0 +1,101 @@
+use std::sync::Arc;
+
+use tokio_util::sync::CancellationToken;
+use vulcan::extensions::api::SessionExtensionCtx;
+use vulcan::extensions::{ExtensionRegistry, ExtensionStatus};
+use vulcan::hooks::HookRegistry;
+use vulcan::memory::SessionStore;
+use vulcan::provider::Message;
+use vulcan::tools::{ToolRegistry, details_from_tool_message};
+use vulcan_ext_todo::TodoExtension;
+
+#[tokio::test]
+async fn todo_details_survive_session_end_then_session_start_replay() {
+    let memory = Arc::new(SessionStore::in_memory());
+    let session_id = "todo-e2e-session";
+
+    let registry = ExtensionRegistry::new();
+    registry.register_daemon_extension(Arc::new(TodoExtension));
+
+    let hooks = HookRegistry::new();
+    let mut tools = ToolRegistry::new();
+    let ctx = SessionExtensionCtx {
+        cwd: std::env::current_dir().expect("cwd"),
+        session_id: session_id.to_string(),
+        memory: Arc::clone(&memory),
+    };
+    let (sessions, extension_tools) =
+        registry.wire_daemon_extensions_into_runtime(ctx, &hooks, Some(&mut tools));
+    assert_eq!(sessions, 1);
+    assert_eq!(extension_tools, 3);
+    assert!(tools.contains("todo_add"));
+    assert!(tools.contains("todo_list"));
+    assert!(tools.contains("todo_clear"));
+
+    let add = tools
+        .execute(
+            "todo_add",
+            r#"{"item":"buy milk"}"#,
+            CancellationToken::new(),
+        )
+        .await
+        .expect("todo_add executes");
+    assert_eq!(
+        add.details,
+        Some(serde_json::json!({ "items": ["buy milk"] }))
+    );
+
+    let content = serde_json::json!({
+        "output": add.output,
+        "details": add.details,
+        "media": add.media,
+        "is_error": add.is_error,
+    })
+    .to_string();
+    assert_eq!(
+        details_from_tool_message(&content),
+        Some(serde_json::json!({ "items": ["buy milk"] }))
+    );
+    memory
+        .save_messages(
+            session_id,
+            &[
+                Message::Assistant {
+                    content: None,
+                    tool_calls: None,
+                    reasoning_content: None,
+                },
+                Message::Tool {
+                    tool_call_id: "call_1".to_string(),
+                    content,
+                },
+            ],
+        )
+        .expect("save session history");
+    hooks.session_end(session_id, 1).await;
+
+    let restarted_hooks = HookRegistry::new();
+    let mut restarted_tools = ToolRegistry::new();
+    let ctx = SessionExtensionCtx {
+        cwd: std::env::current_dir().expect("cwd"),
+        session_id: session_id.to_string(),
+        memory: Arc::clone(&memory),
+    };
+    registry.wire_daemon_extensions_into_runtime(ctx, &restarted_hooks, Some(&mut restarted_tools));
+    restarted_hooks.session_start(session_id).await;
+
+    let list = restarted_tools
+        .execute("todo_list", r#"{}"#, CancellationToken::new())
+        .await
+        .expect("todo_list executes after replay");
+    assert!(list.output.contains("buy milk"));
+    assert_eq!(
+        list.details,
+        Some(serde_json::json!({ "items": ["buy milk"] }))
+    );
+
+    let meta = registry
+        .get("todo")
+        .expect("todo metadata remains registered");
+    assert_eq!(meta.status, ExtensionStatus::Active);
+}

--- a/vulcan-frontend-api/Cargo.toml
+++ b/vulcan-frontend-api/Cargo.toml
@@ -8,3 +8,5 @@ license = "MIT"
 repository = "https://github.com/yycholla/vulcan"
 
 [dependencies]
+inventory = "0.3.24"
+serde_json = "1"

--- a/vulcan-frontend-api/src/lib.rs
+++ b/vulcan-frontend-api/src/lib.rs
@@ -1,8 +1,94 @@
-//! Frontend extension registration API (placeholder).
-//!
-//! Full surface — `FrontendCodeExtension` trait, `MessageRenderer`,
-//! `FrontendCommand`, `FrontendCtx`, `inventory::collect!` site —
-//! lands under GH issue #555 (Slice 4: Frontend extension binary +
-//! tool-result renderer). This crate exists in the workspace today so
-//! GH issue #549's structural acceptance criteria are met without
-//! gating on the frontend-side trait design that #555 owns.
+//! Frontend extension registration API.
+
+use std::sync::Arc;
+
+use serde_json::Value;
+
+#[derive(Clone, Debug, Default)]
+pub struct FrontendCtx {
+    pub session_id: Option<String>,
+    pub extension_id: Option<String>,
+}
+
+impl FrontendCtx {
+    pub fn with_extension(mut self, extension_id: impl Into<String>) -> Self {
+        self.extension_id = Some(extension_id.into());
+        self
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RenderedMessage {
+    pub lines: Vec<String>,
+}
+
+impl RenderedMessage {
+    pub fn from_lines<I, S>(lines: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self {
+            lines: lines.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ToolResultView<'a> {
+    pub tool_name: &'a str,
+    pub ok: bool,
+    pub output_preview: Option<&'a str>,
+    pub details: Option<&'a Value>,
+}
+
+pub trait MessageRenderer: Send + Sync {
+    fn tool_name(&self) -> &'static str;
+    fn render(&self, ctx: &FrontendCtx, result: &ToolResultView<'_>) -> Option<RenderedMessage>;
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FrontendCommandAction {
+    Noop,
+    SystemMessage(String),
+    OpenView {
+        id: String,
+        title: String,
+        body: Vec<String>,
+    },
+}
+
+pub trait FrontendCommand: Send + Sync {
+    fn name(&self) -> &'static str;
+    fn description(&self) -> &'static str;
+    fn mid_turn_safe(&self) -> bool {
+        true
+    }
+    fn run(&self, ctx: &mut FrontendCtx) -> FrontendCommandAction;
+}
+
+pub trait FrontendCodeExtension: Send + Sync {
+    fn id(&self) -> &'static str;
+    fn frontend_capabilities(&self) -> Vec<&'static str> {
+        Vec::new()
+    }
+    fn message_renderers(&self) -> Vec<Arc<dyn MessageRenderer>> {
+        Vec::new()
+    }
+    fn commands(&self) -> Vec<Arc<dyn FrontendCommand>> {
+        Vec::new()
+    }
+}
+
+pub struct FrontendExtensionRegistration {
+    pub register: fn() -> Arc<dyn FrontendCodeExtension>,
+}
+
+inventory::collect!(FrontendExtensionRegistration);
+
+pub fn collect_registrations() -> Vec<Arc<dyn FrontendCodeExtension>> {
+    inventory::iter::<FrontendExtensionRegistration>
+        .into_iter()
+        .map(|entry| (entry.register)())
+        .collect()
+}

--- a/vulcan/Cargo.toml
+++ b/vulcan/Cargo.toml
@@ -31,6 +31,9 @@ vulcan-ext-auto-commit = { path = "../vulcan-ext-auto-commit" }
 # GH issue #557: input-intercept dogfood extension; same `extern crate`
 # anchoring rationale as auto-commit.
 vulcan-ext-input-demo = { path = "../vulcan-ext-input-demo" }
+# GH issue #550: todo dogfood extension for daemon tool wiring and
+# ToolResult.details replay.
+vulcan-ext-todo = { path = "../vulcan-ext-todo", features = ["tui"] }
 
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }

--- a/vulcan/src/main.rs
+++ b/vulcan/src/main.rs
@@ -4,6 +4,7 @@
 // suffices — no symbols need importing into source.
 extern crate vulcan_ext_auto_commit as _vulcan_ext_auto_commit;
 extern crate vulcan_ext_input_demo as _vulcan_ext_input_demo;
+extern crate vulcan_ext_todo as _vulcan_ext_todo;
 
 use clap::{CommandFactory, Parser};
 use clap_complete::generate;


### PR DESCRIPTION
## Summary

- Rebuild the todo dogfood extension on current main with daemon-side tools: todo_add, todo_list, and todo_clear.
- Add ToolResult.details replay plumbing through tool execution, streaming events, daemon frames, and TUI frontend renderers.
- Add the frontend extension API/TUI registry, linked todo renderer, /todos frontend command, and extension context/ADR docs.
- Refresh cargo-deny policy for current transitive advisories/licenses so CI policy matches the all-features dependency graph.

Refs #550, #555.

## Verification

- RUSTFLAGS=-Dwarnings cargo build --all-targets
- cargo test -p vulcan-core --test frontend_extensions
- cargo test -p vulcan-ext-todo --features tui
- cargo deny --all-features check
- cargo build -p vulcan
- CARGO_BIN_EXE_vulcan=/home/yycholla/vulcan/.worktrees/rebuild-555/target/debug/vulcan TMPDIR=/tmp cargo test -p vulcan-core --test client_autostart
- CARGO_BIN_EXE_vulcan=/home/yycholla/vulcan/.worktrees/rebuild-555/target/debug/vulcan TMPDIR=/tmp cargo test --workspace
- npx gitnexus analyze --skip-git
- gitnexus detect-changes --repo /home/yycholla/vulcan/.worktrees/rebuild-555 --scope staged