### PR TITLE
feat(extensions): add frontend event widgets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,10 @@ jobs:
         run: cargo build --all-targets
       - name: Build (gateway feature)
         run: cargo build --all-targets --features gateway
+      - name: Build vulcan CLI binary
+        run: |
+          cargo build -p vulcan --bin vulcan
+          echo "CARGO_BIN_EXE_vulcan=$PWD/target/debug/vulcan" >> "$GITHUB_ENV"
       # Test target set excludes `--benches` deliberately. The divan
       # benches (`tui_render`, `agent_core`) are measurement loops, not
       # tests — under nextest they hit the 120s per-test timeout, retry

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7177,6 +7177,7 @@ dependencies = [
  "vulcan-core",
  "vulcan-ext-auto-commit",
  "vulcan-ext-input-demo",
+ "vulcan-ext-spinner-demo",
  "vulcan-ext-todo",
 ]
 
@@ -7295,6 +7296,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "vulcan-ext-spinner-demo"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "inventory",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "vulcan-core",
+ "vulcan-frontend-api",
+]
+
+[[package]]
 name = "vulcan-ext-todo"
 version = "0.1.0"
 dependencies = [
@@ -7322,6 +7337,7 @@ name = "vulcan-frontend-api"
 version = "0.1.0"
 dependencies = [
  "inventory",
+ "serde",
  "serde_json",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "vulcan-ext-auto-commit",
     "vulcan-ext-compact-summary",
     "vulcan-ext-input-demo",
+    "vulcan-ext-spinner-demo",
     "vulcan-ext-todo",
 ]
 resolver = "2"

--- a/docs/adr/0007-extension-frontend-events-and-status-widgets.md
+++ b/docs/adr/0007-extension-frontend-events-and-status-widgets.md
@@ -1,0 +1,29 @@
+# Extension Frontend Events and Status Widgets
+
+Daemon-side extensions need a live frontend channel for progress that is not part of durable session history. Tool results remain the replay contract; live widgets are transient frontend state.
+
+## Considered Options
+
+- Persist widget state in session history.
+- Add daemon-owned widget primitives to every extension event.
+- Route daemon extension events through an extension-owned JSON payload and let frontend extensions map them locally.
+- Treat all frontend events as request-correlated stream frames.
+
+## Decision
+
+Use an out-of-band daemon push frame for frontend events:
+
+- Envelope: `{ "kind": "extension_event", "session_id": "...", "extension_id": "...", "payload": ... }`.
+- `payload` is extension-owned JSON. The daemon does not interpret widget shape.
+- The frontend demuxes by `extension_id` and invokes `FrontendCodeExtension::on_event(payload, ctx)`.
+- Frontend extensions set transient status widgets with `ctx.ui.set_widget(id, Option<WidgetContent>)`.
+
+Activation is frontend-aware. If a daemon extension declares required frontend capabilities, the session activates it only when the connected frontend provides those capabilities. If a frontend extension with the same id reports a different version, activation marks the daemon extension `Broken` with `extension version mismatch`.
+
+## Consequences
+
+- Live UI does not pollute saved chat history or `ToolResult.details` replay.
+- Daemon extensions can emit progress without owning layout.
+- Frontend extensions own presentation and can ignore unknown payloads safely.
+- Request-correlated text/tool frames and out-of-band push frames share the same protocol but keep different demux paths.
+- Non-frontend CLI sessions still work because extensions without frontend requirements activate normally; frontend-required extensions simply do not activate without the required capability.

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -213,6 +213,9 @@ pub struct AgentBuilder<'a> {
     /// non-daemon CLI/test paths still pass `None` and fall back to
     /// the legacy build-everything path.
     pool: Option<Arc<RuntimeResourcePool>>,
+    frontend_capabilities: Vec<crate::extensions::FrontendCapability>,
+    frontend_extensions: Vec<vulcan_frontend_api::FrontendExtensionDescriptor>,
+    frontend_events: crate::extensions::api::FrontendEventSink,
 }
 
 impl<'a> AgentBuilder<'a> {
@@ -247,6 +250,18 @@ impl<'a> AgentBuilder<'a> {
         self
     }
 
+    pub fn with_frontend_context(
+        mut self,
+        capabilities: Vec<crate::extensions::FrontendCapability>,
+        extensions: Vec<vulcan_frontend_api::FrontendExtensionDescriptor>,
+        events: crate::extensions::api::FrontendEventSink,
+    ) -> Self {
+        self.frontend_capabilities = capabilities;
+        self.frontend_extensions = extensions;
+        self.frontend_events = events;
+        self
+    }
+
     pub async fn build(self) -> Result<Agent> {
         Agent::build_from_parts(
             self.config,
@@ -255,6 +270,9 @@ impl<'a> AgentBuilder<'a> {
             self.max_iterations,
             self.tool_profile,
             self.pool,
+            self.frontend_capabilities,
+            self.frontend_extensions,
+            self.frontend_events,
         )
         .await
     }
@@ -269,6 +287,9 @@ impl Agent {
             max_iterations: None,
             tool_profile: None,
             pool: None,
+            frontend_capabilities: crate::extensions::FrontendCapability::text_only(),
+            frontend_extensions: Vec::new(),
+            frontend_events: crate::extensions::api::FrontendEventSink::default(),
         }
     }
 
@@ -287,6 +308,9 @@ impl Agent {
         max_iterations: Option<u32>,
         tool_profile_override: Option<String>,
         pool: Option<Arc<RuntimeResourcePool>>,
+        frontend_capabilities: Vec<crate::extensions::FrontendCapability>,
+        frontend_extensions: Vec<vulcan_frontend_api::FrontendExtensionDescriptor>,
+        frontend_events: crate::extensions::api::FrontendEventSink,
     ) -> Result<Self> {
         // YYC-239: TUI + gateway resolve their starting provider
         // through the same `active_provider_config` indirection.
@@ -502,10 +526,16 @@ impl Agent {
             // the CLI / `vulcan extension audit` reads from.
             hooks = hooks.with_audit_log(p.extension_audit_log());
 
+            let ctx = crate::extensions::api::SessionExtensionCtx::new(
+                cwd.clone(),
+                session_id.clone(),
+                Arc::clone(&memory),
+            )
+            .with_frontend_capabilities(frontend_capabilities.clone())
+            .with_frontend_extensions(frontend_extensions.clone());
             let ctx = crate::extensions::api::SessionExtensionCtx {
-                cwd: cwd.clone(),
-                session_id: session_id.clone(),
-                memory: Arc::clone(&memory),
+                frontend_events: frontend_events.clone(),
+                ..ctx
             };
             let registry = p.extension_registry();
             session_extensions = registry.wire_daemon_extensions_runtime(ctx, &hooks);
@@ -966,11 +996,11 @@ impl Agent {
         if self.session_extensions.iter().any(|ext| ext.id() == id) {
             return Ok(false);
         }
-        let ctx = crate::extensions::api::SessionExtensionCtx {
-            cwd: self.tool_context.cwd.clone(),
-            session_id: self.session_id.clone(),
-            memory: Arc::clone(&self.memory),
-        };
+        let ctx = crate::extensions::api::SessionExtensionCtx::new(
+            self.tool_context.cwd.clone(),
+            self.session_id.clone(),
+            Arc::clone(&self.memory),
+        );
         let Some(runtime) = registry.instantiate_daemon_extension_runtime(id, ctx, &self.hooks)
         else {
             return Ok(false);

--- a/src/daemon/dispatch.rs
+++ b/src/daemon/dispatch.rs
@@ -9,6 +9,7 @@ use tokio::sync::{mpsc, oneshot};
 use crate::daemon::handlers::{agent, approval, cortex, daemon_ops, extension, prompt, session};
 use crate::daemon::protocol::{ProtocolError, Request, Response, StreamFrame};
 use crate::daemon::state::DaemonState;
+use crate::extensions::FrontendCapability;
 
 /// Result of dispatching a request -- either a single response or a
 /// streaming response with incremental frames and a final result.
@@ -112,8 +113,9 @@ impl Dispatcher {
                     .and_then(|v| v.as_str())
                     .unwrap_or("")
                     .to_string();
+                let options = frontend_options_from_params(&req.params);
                 let (frames, done) =
-                    prompt::stream(Arc::clone(&self.state), req.id, session, input);
+                    prompt::stream(Arc::clone(&self.state), req.id, session, input, options);
                 DispatchResult::Stream { frames, done }
             }
             "prompt.cancel" => {
@@ -371,6 +373,36 @@ impl Dispatcher {
             )),
         }
     }
+}
+
+fn frontend_options_from_params(
+    params: &serde_json::Value,
+) -> crate::daemon::session_agent::SessionAgentOptions {
+    let capabilities = params
+        .get("frontend_capabilities")
+        .and_then(|value| value.as_array())
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(|value| value.as_str())
+                .filter_map(FrontendCapability::parse)
+                .collect::<Vec<_>>()
+        })
+        .filter(|capabilities| !capabilities.is_empty())
+        .unwrap_or_else(FrontendCapability::text_only);
+    let extensions = params
+        .get("frontend_extensions")
+        .cloned()
+        .and_then(|value| {
+            serde_json::from_value::<Vec<vulcan_frontend_api::FrontendExtensionDescriptor>>(value)
+                .ok()
+        })
+        .unwrap_or_default();
+    crate::daemon::session_agent::SessionAgentOptions::default().with_frontend_context(
+        capabilities,
+        extensions,
+        crate::extensions::api::FrontendEventSink::default(),
+    )
 }
 
 #[cfg(test)]

--- a/src/daemon/handlers/prompt.rs
+++ b/src/daemon/handlers/prompt.rs
@@ -14,7 +14,9 @@ use tokio::sync::{mpsc, oneshot};
 
 use crate::daemon::protocol::{ProtocolError, Response, StreamFrame};
 use crate::daemon::session::SessionState;
+use crate::daemon::session_agent::SessionAgentOptions;
 use crate::daemon::state::DaemonState;
+use crate::extensions::api::{FrontendEvent, FrontendEventSink};
 use crate::provider::StreamEvent;
 
 /// Map a daemon-internal `StreamEvent` to a wire `StreamFrame`.
@@ -75,6 +77,20 @@ fn stream_event_to_frame(req_id: &str, ev: StreamEvent) -> Option<StreamFrame> {
             id: Some(req_id.into()),
             stream: "error".into(),
             data: json!({ "reason": e }),
+        }),
+    }
+}
+
+fn frontend_event_to_frame(event: FrontendEvent) -> StreamFrame {
+    StreamFrame {
+        version: 1,
+        id: None,
+        stream: "extension_event".into(),
+        data: json!({
+            "kind": "extension_event",
+            "session_id": event.session_id,
+            "extension_id": event.extension_id,
+            "payload": event.payload,
         }),
     }
 }
@@ -172,6 +188,7 @@ pub fn stream(
     req_id: String,
     session_id: String,
     input: String,
+    options: SessionAgentOptions,
 ) -> (mpsc::Receiver<StreamFrame>, oneshot::Receiver<Response>) {
     let (frame_tx, frame_rx) = mpsc::channel(32);
     let (done_tx, done_rx) = oneshot::channel();
@@ -195,10 +212,21 @@ pub fn stream(
     let assembler = state.session_agent_assembler();
     let state_for_runner = Arc::clone(&state);
     tokio::spawn(async move {
+        let (frontend_tx, mut frontend_rx) = tokio::sync::broadcast::channel(32);
+        let frontend_capabilities = options.frontend_capabilities();
+        let frontend_extensions = options.frontend_extensions();
+        let options = options.with_frontend_context(
+            frontend_capabilities,
+            frontend_extensions,
+            FrontendEventSink::new(frontend_tx),
+        );
         // Lazy-build the per-session Agent. Failure surfaces on the
         // done channel as AGENT_BUILD_FAILED; in_flight is cleared
         // before returning so daemon.status doesn't get stuck.
-        let agent_arc = match sess_for_task.ensure_agent(&assembler).await {
+        let agent_arc = match sess_for_task
+            .ensure_agent_with_options(&assembler, options)
+            .await
+        {
             Ok(a) => a,
             Err(e) => {
                 *sess_for_task.in_flight.lock() = false;
@@ -261,12 +289,31 @@ pub fn stream(
         });
 
         // Forward events as StreamFrames.
-        while let Some(ev) = event_rx.recv().await {
-            if let Some(frame) = stream_event_to_frame(&rid, ev) {
-                if frame_tx.send(frame).await.is_err() {
-                    // TUI disconnected -- cancel the turn.
-                    cancel_token.cancel();
-                    break;
+        loop {
+            tokio::select! {
+                ev = event_rx.recv() => {
+                    let Some(ev) = ev else {
+                        break;
+                    };
+                    if let Some(frame) = stream_event_to_frame(&rid, ev) {
+                        if frame_tx.send(frame).await.is_err() {
+                            // TUI disconnected -- cancel the turn.
+                            cancel_token.cancel();
+                            break;
+                        }
+                    }
+                }
+                event = frontend_rx.recv() => {
+                    match event {
+                        Ok(event) => {
+                            if frame_tx.send(frontend_event_to_frame(event)).await.is_err() {
+                                cancel_token.cancel();
+                                break;
+                            }
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                    }
                 }
             }
         }
@@ -360,7 +407,24 @@ pub async fn cancel(state: &DaemonState, id: String, session_id: String) -> Resp
 mod tests {
     use super::*;
     use crate::daemon::state::DaemonState;
+    use crate::extensions::api::FrontendEvent;
     use std::sync::Arc;
+
+    #[test]
+    fn frontend_event_frame_is_out_of_band_push_envelope() {
+        let frame = frontend_event_to_frame(FrontendEvent {
+            session_id: "main".into(),
+            extension_id: "spinner-demo".into(),
+            payload: json!({ "widget_id": "long_task", "kind": "spinner" }),
+        });
+
+        assert_eq!(frame.id, None);
+        assert_eq!(frame.stream, "extension_event");
+        assert_eq!(frame.data["kind"], "extension_event");
+        assert_eq!(frame.data["session_id"], "main");
+        assert_eq!(frame.data["extension_id"], "spinner-demo");
+        assert_eq!(frame.data["payload"]["widget_id"], "long_task");
+    }
 
     #[tokio::test]
     async fn run_returns_session_not_found_for_bogus_session() {

--- a/src/daemon/session_agent.rs
+++ b/src/daemon/session_agent.rs
@@ -27,6 +27,11 @@ impl SessionAgentAssembler {
         if let Some(pool) = &self.pool {
             builder = builder.with_pool(Arc::clone(pool));
         }
+        builder = builder.with_frontend_context(
+            options.frontend_capabilities.clone(),
+            options.frontend_extensions.clone(),
+            options.frontend_events.clone(),
+        );
         if let Some(max_iterations) = options.max_iterations {
             builder = builder.with_max_iterations(max_iterations);
         }
@@ -42,11 +47,27 @@ impl SessionAgentAssembler {
     }
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct SessionAgentOptions {
     max_iterations: Option<u32>,
     tool_profile: Option<String>,
     allowed_tools: Option<Vec<String>>,
+    frontend_capabilities: Vec<crate::extensions::FrontendCapability>,
+    frontend_extensions: Vec<vulcan_frontend_api::FrontendExtensionDescriptor>,
+    frontend_events: crate::extensions::api::FrontendEventSink,
+}
+
+impl Default for SessionAgentOptions {
+    fn default() -> Self {
+        Self {
+            max_iterations: None,
+            tool_profile: None,
+            allowed_tools: None,
+            frontend_capabilities: crate::extensions::FrontendCapability::text_only(),
+            frontend_extensions: Vec::new(),
+            frontend_events: crate::extensions::api::FrontendEventSink::default(),
+        }
+    }
 }
 
 impl SessionAgentOptions {
@@ -59,7 +80,28 @@ impl SessionAgentOptions {
             max_iterations: Some(max_iterations),
             tool_profile,
             allowed_tools: Some(allowed_tools),
+            ..Self::default()
         }
+    }
+
+    pub fn with_frontend_context(
+        mut self,
+        capabilities: Vec<crate::extensions::FrontendCapability>,
+        extensions: Vec<vulcan_frontend_api::FrontendExtensionDescriptor>,
+        events: crate::extensions::api::FrontendEventSink,
+    ) -> Self {
+        self.frontend_capabilities = capabilities;
+        self.frontend_extensions = extensions;
+        self.frontend_events = events;
+        self
+    }
+
+    pub fn frontend_capabilities(&self) -> Vec<crate::extensions::FrontendCapability> {
+        self.frontend_capabilities.clone()
+    }
+
+    pub fn frontend_extensions(&self) -> Vec<vulcan_frontend_api::FrontendExtensionDescriptor> {
+        self.frontend_extensions.clone()
     }
 }
 

--- a/src/extensions/CONTEXT.md
+++ b/src/extensions/CONTEXT.md
@@ -32,6 +32,14 @@ _Avoid_: extension memory, extension cache
 A **Frontend Extension** handler that maps a known tool result shape into frontend-native lines or widgets. In the TUI today, renderers consume `ToolResult.details` from the streamed `ToolCallEnd` event and project it into the existing tool-card preview; the durable chat message stores the rendered preview, not the raw details.
 _Avoid_: daemon renderer, persistent UI schema
 
+**Frontend Event**:
+A daemon-to-frontend push frame with `kind = "extension_event"`, an `extension_id`, and an extension-owned `payload`. The daemon only wraps and routes the payload; the matching **Frontend Extension** interprets it through `on_event(payload, ctx)`.
+_Avoid_: daemon UI command, frontend hook event
+
+**Status Widget**:
+A small frontend-owned footer/status item set by a **Frontend Extension** via `ctx.ui.set_widget(id, content)`. The daemon-side extension emits frontend events; the frontend extension maps those events to `Text`, `Spinner`, or `Progress` widget updates and clears them with `None`.
+_Avoid_: daemon status row, persistent widget state
+
 **Frontend Command**:
 A slash command handled entirely by the **Frontend** before the prompt reaches the daemon. Frontend commands produce local UI actions such as opening a view; commands that need the LLM or daemon state remain daemon/session commands.
 _Avoid_: hidden tool call, daemon-routed UI command
@@ -45,6 +53,8 @@ _Avoid_: hidden tool call, daemon-routed UI command
 - A **Frontend** owns its own **Frontend Extension** registry; daemon and frontend extensions are linked into separate binaries even when they ship from the same crate.
 - A **Frontend Extension** consumes daemon push frames addressed to its extension id; it never owns agent state and never receives hook events directly.
 - An extension activates on a **Session** only when the connected **Frontend**'s declared capabilities satisfy the **Extension Manifest**'s required surface.
+- When a daemon extension and frontend extension share an id, their versions must match for that session; a mismatch marks the extension `Broken` with `extension version mismatch`.
+- Frontend event payloads are intentionally extension-owned JSON. The stable daemon contract is the envelope, not a shared widget schema.
 - Renderer collisions are resolved in frontend registry order with last-active wins plus a warning; this mirrors extension load order and avoids daemon-side renderer arbitration.
 
 ## ADRs
@@ -53,3 +63,4 @@ _Avoid_: hidden tool call, daemon-routed UI command
 - `docs/adr/0004-extension-distribution-and-lifecycle.md` — Cargo crate distribution + mid-session enable/disable/kill policy.
 - `docs/adr/0005-extension-compaction-control.md` — extension control over compaction with validation safety net.
 - `docs/adr/0006-extension-details-replay-and-frontend-rendering.md` — `ToolResult.details` as replay state plus frontend projection boundary.
+- `docs/adr/0007-extension-frontend-events-and-status-widgets.md` — daemon push events routed to frontend extensions plus local status widgets.

--- a/src/extensions/api.rs
+++ b/src/extensions/api.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use super::ExtensionMetadata;
+use super::FrontendCapability;
 use crate::hooks::{HookHandler, HookOutcome};
 use crate::memory::SessionStore;
 use crate::provider::factory::ProviderFactory;
@@ -25,6 +26,7 @@ use crate::provider::{ChatResponse, LLMProvider, Message, StreamEvent, ToolCall}
 use crate::tools::{Tool, ToolProgress, ToolResult};
 use anyhow::Result;
 use serde_json::Value;
+use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
 
 /// Parsed `[package.metadata.vulcan]` block for a cargo-crate
@@ -54,6 +56,83 @@ pub struct SessionExtensionCtx {
     /// Durable session history store for replaying extension state
     /// carried through `ToolResult.details`.
     pub memory: Arc<SessionStore>,
+    /// Capabilities declared by the current frontend.
+    pub frontend_capabilities: Vec<FrontendCapability>,
+    /// Frontend extension descriptors declared by the current frontend.
+    pub frontend_extensions: Vec<vulcan_frontend_api::FrontendExtensionDescriptor>,
+    /// Push channel for daemon extensions to emit frontend events.
+    pub frontend_events: FrontendEventSink,
+    /// The daemon extension id this context is currently scoped to.
+    pub extension_id: Option<String>,
+}
+
+impl SessionExtensionCtx {
+    pub fn new(cwd: PathBuf, session_id: String, memory: Arc<SessionStore>) -> Self {
+        Self {
+            cwd,
+            session_id,
+            memory,
+            frontend_capabilities: FrontendCapability::text_only(),
+            frontend_extensions: Vec::new(),
+            frontend_events: FrontendEventSink::default(),
+            extension_id: None,
+        }
+    }
+
+    pub fn for_extension(&self, extension_id: impl Into<String>) -> Self {
+        let mut ctx = self.clone();
+        ctx.extension_id = Some(extension_id.into());
+        ctx
+    }
+
+    pub fn with_frontend_extensions(
+        mut self,
+        frontend_extensions: Vec<vulcan_frontend_api::FrontendExtensionDescriptor>,
+    ) -> Self {
+        self.frontend_extensions = frontend_extensions;
+        self
+    }
+
+    pub fn with_frontend_capabilities(mut self, capabilities: Vec<FrontendCapability>) -> Self {
+        self.frontend_capabilities = capabilities;
+        self
+    }
+
+    pub fn emit_frontend_event(&self, payload: Value) -> Result<()> {
+        let Some(extension_id) = &self.extension_id else {
+            anyhow::bail!("frontend event emission requires extension-scoped context");
+        };
+        self.frontend_events.emit(FrontendEvent {
+            session_id: self.session_id.clone(),
+            extension_id: extension_id.clone(),
+            payload,
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct FrontendEvent {
+    pub session_id: String,
+    pub extension_id: String,
+    pub payload: Value,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct FrontendEventSink {
+    tx: Option<broadcast::Sender<FrontendEvent>>,
+}
+
+impl FrontendEventSink {
+    pub fn new(tx: broadcast::Sender<FrontendEvent>) -> Self {
+        Self { tx: Some(tx) }
+    }
+
+    pub fn emit(&self, event: FrontendEvent) -> Result<()> {
+        if let Some(tx) = &self.tx {
+            let _ = tx.send(event);
+        }
+        Ok(())
+    }
 }
 
 /// Daemon-global registration for an extension. One implementation per
@@ -442,6 +521,15 @@ pub fn wire_inventory_into_registry(registry: &super::ExtensionRegistry) -> usiz
 }
 
 #[cfg(test)]
+pub(crate) fn test_session_extension_ctx() -> SessionExtensionCtx {
+    SessionExtensionCtx::new(
+        PathBuf::from("/tmp/test-session"),
+        "test-session-id".to_string(),
+        Arc::new(SessionStore::in_memory()),
+    )
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::extensions::ExtensionSource;
@@ -466,11 +554,7 @@ mod tests {
 
     /// Test-only ctx with deterministic placeholder values.
     fn test_ctx() -> SessionExtensionCtx {
-        SessionExtensionCtx {
-            cwd: PathBuf::from("/tmp/test-session"),
-            session_id: "test-session-id".to_string(),
-            memory: Arc::new(SessionStore::in_memory()),
-        }
+        test_session_extension_ctx()
     }
 
     inventory::submit! {
@@ -592,11 +676,11 @@ mod tests {
 
         let seen = Arc::new(RwLock::new(None));
         let ext: Arc<dyn DaemonCodeExtension> = Arc::new(CapturingExtension { seen: seen.clone() });
-        let ctx = SessionExtensionCtx {
-            cwd: PathBuf::from("/tmp/example-session"),
-            session_id: "sess-42".to_string(),
-            memory: Arc::new(SessionStore::in_memory()),
-        };
+        let ctx = SessionExtensionCtx::new(
+            PathBuf::from("/tmp/example-session"),
+            "sess-42".to_string(),
+            Arc::new(SessionStore::in_memory()),
+        );
         let _ = ext.instantiate(ctx);
 
         let captured = seen.read().clone().expect("instantiate ran");

--- a/src/extensions/manifest.rs
+++ b/src/extensions/manifest.rs
@@ -45,6 +45,10 @@ pub struct ExtensionManifest {
     /// when the extension activates.
     #[serde(default)]
     pub capabilities: Vec<String>,
+    /// Frontend capability tags required before this extension can
+    /// activate for a frontend-backed session.
+    #[serde(default)]
+    pub requires_frontend: Vec<String>,
     /// Human-readable permissions summary surfaced in
     /// `vulcan extension list/show`.
     #[serde(default)]

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -123,6 +123,45 @@ impl ExtensionCapability {
     }
 }
 
+/// Frontend-side capabilities a daemon extension may require before it
+/// activates for a Session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FrontendCapability {
+    TextIo,
+    RichText,
+    CellCanvas,
+    RawInput,
+    StatusWidgets,
+}
+
+impl FrontendCapability {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            FrontendCapability::TextIo => "text_io",
+            FrontendCapability::RichText => "rich_text",
+            FrontendCapability::CellCanvas => "cell_canvas",
+            FrontendCapability::RawInput => "raw_input",
+            FrontendCapability::StatusWidgets => "status_widgets",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "text_io" => Some(Self::TextIo),
+            "rich_text" => Some(Self::RichText),
+            "cell_canvas" => Some(Self::CellCanvas),
+            "raw_input" => Some(Self::RawInput),
+            "status_widgets" => Some(Self::StatusWidgets),
+            _ => None,
+        }
+    }
+
+    pub fn text_only() -> Vec<Self> {
+        vec![Self::TextIo]
+    }
+}
+
 /// Static description of an extension. Carries everything needed
 /// to render `vulcan extension list/show` and to decide whether
 /// to activate, without touching code execution paths.
@@ -140,6 +179,10 @@ pub struct ExtensionMetadata {
     /// when active. Display-only today; PR-4 enforces against the
     /// active hook/tool wiring.
     pub capabilities: Vec<ExtensionCapability>,
+    /// Frontend capabilities required before this extension should be
+    /// activated for a frontend-backed Session.
+    #[serde(default)]
+    pub requires_frontend: Vec<FrontendCapability>,
     /// Optional human-readable permissions summary surfaced in
     /// `vulcan extension show`. Caller-provided; the registry
     /// does not interpret it.
@@ -173,6 +216,7 @@ impl ExtensionMetadata {
             source,
             status: ExtensionStatus::Inactive,
             capabilities: Vec::new(),
+            requires_frontend: Vec::new(),
             permissions_summary: None,
             requires_user_approval: false,
             broken_reason: None,

--- a/src/extensions/registry.rs
+++ b/src/extensions/registry.rs
@@ -243,15 +243,32 @@ impl ExtensionRegistry {
         let daemon_snapshot = self.daemon_extensions.read().clone();
         for ext in daemon_snapshot {
             let id = ext.metadata().id;
-            let active = metadata_snapshot
-                .iter()
-                .find(|m| m.id == id)
-                .map(|m| m.status == ExtensionStatus::Active)
-                .unwrap_or(false);
+            let Some(metadata) = metadata_snapshot.iter().find(|m| m.id == id) else {
+                continue;
+            };
+            let active = metadata.status == ExtensionStatus::Active;
             if !active {
                 continue;
             }
-            let session_ext = ext.instantiate(ctx.clone());
+            if let Some(frontend) = ctx
+                .frontend_extensions
+                .iter()
+                .find(|frontend| frontend.id == id)
+            {
+                if frontend.version != metadata.version {
+                    self.mark_broken(&id, "extension version mismatch");
+                    continue;
+                }
+            }
+            if !metadata.requires_frontend.is_empty()
+                && !metadata
+                    .requires_frontend
+                    .iter()
+                    .all(|required| ctx.frontend_capabilities.contains(required))
+            {
+                continue;
+            }
+            let session_ext = ext.instantiate(ctx.for_extension(id.clone()));
             let runtime = SessionExtensionRuntime::new(id, session_ext);
             for handler in runtime.wrapped_hook_handlers() {
                 hooks.register(handler);
@@ -309,7 +326,10 @@ impl ExtensionRegistry {
         let ext = daemon_snapshot
             .into_iter()
             .find(|e| e.metadata().id == id)?;
-        let runtime = SessionExtensionRuntime::new(id.to_string(), ext.instantiate(ctx));
+        let runtime = SessionExtensionRuntime::new(
+            id.to_string(),
+            ext.instantiate(ctx.for_extension(id.to_string())),
+        );
         for handler in runtime.wrapped_hook_handlers() {
             hooks.register(handler);
         }
@@ -428,6 +448,11 @@ impl ExtensionRegistry {
                     if let Some(desc) = manifest.description.clone() {
                         meta.description = desc;
                     }
+                    meta.requires_frontend = manifest
+                        .requires_frontend
+                        .iter()
+                        .filter_map(|capability| super::FrontendCapability::parse(capability))
+                        .collect();
                     if let Some(perm) = manifest.permissions.clone() {
                         meta.permissions_summary = Some(perm);
                     }
@@ -744,6 +769,54 @@ mod tests {
         assert_eq!(fields.len(), 1);
         assert_eq!(fields[0].0, "active-fielded");
         assert_eq!(fields[0].1.path, "enabled");
+    }
+
+    #[test]
+    fn daemon_extension_version_mismatch_marks_extension_broken() {
+        struct VersionedDaemonExtension {
+            meta: ExtensionMetadata,
+        }
+
+        impl crate::extensions::api::DaemonCodeExtension for VersionedDaemonExtension {
+            fn metadata(&self) -> ExtensionMetadata {
+                self.meta.clone()
+            }
+
+            fn instantiate(
+                &self,
+                _ctx: crate::extensions::api::SessionExtensionCtx,
+            ) -> Arc<dyn crate::extensions::api::SessionExtension> {
+                panic!("mismatched frontend version must not instantiate");
+            }
+        }
+
+        let reg = ExtensionRegistry::new();
+        let mut meta = ExtensionMetadata::new(
+            "versioned",
+            "Versioned",
+            "1.0.0",
+            crate::extensions::ExtensionSource::Builtin,
+        );
+        meta.status = ExtensionStatus::Active;
+        reg.register_daemon_extension(Arc::new(VersionedDaemonExtension { meta }));
+        let hooks = crate::hooks::HookRegistry::new();
+        let ctx =
+            crate::extensions::api::test_session_extension_ctx().with_frontend_extensions(vec![
+                vulcan_frontend_api::FrontendExtensionDescriptor {
+                    id: "versioned".into(),
+                    version: "2.0.0".into(),
+                },
+            ]);
+
+        let runtimes = reg.wire_daemon_extensions_runtime(ctx, &hooks);
+
+        assert!(runtimes.is_empty());
+        let got = reg.get("versioned").unwrap();
+        assert_eq!(got.status, ExtensionStatus::Broken);
+        assert_eq!(
+            got.broken_reason.as_deref(),
+            Some("extension version mismatch")
+        );
     }
 
     // ── YYC-232 (YYC-166 PR-4): store + install_state bridge ────────

--- a/src/extensions/verify.rs
+++ b/src/extensions/verify.rs
@@ -131,6 +131,7 @@ mod tests {
             version: "0.1.0".into(),
             entry: EntryKind::Builtin,
             capabilities: Vec::new(),
+            requires_frontend: Vec::new(),
             permissions: None,
             checksum: checksum.map(String::from),
             min_vulcan_version: min.map(String::from),

--- a/src/tui/frontend.rs
+++ b/src/tui/frontend.rs
@@ -4,11 +4,12 @@ use std::sync::Arc;
 use serde_json::Value;
 use vulcan_frontend_api::{
     FrontendCodeExtension, FrontendCommand, FrontendCommandAction, FrontendCtx, MessageRenderer,
-    ToolResultView,
+    ToolResultView, WidgetUpdate,
 };
 
 #[derive(Default)]
 pub struct TuiFrontend {
+    extensions: HashMap<&'static str, Arc<dyn FrontendCodeExtension>>,
     renderers: HashMap<&'static str, Arc<dyn MessageRenderer>>,
     commands: HashMap<&'static str, Arc<dyn FrontendCommand>>,
     capabilities: Vec<&'static str>,
@@ -22,6 +23,7 @@ impl TuiFrontend {
     pub fn from_extensions(extensions: Vec<Arc<dyn FrontendCodeExtension>>) -> Self {
         let mut this = Self::default();
         for extension in extensions {
+            let extension_id = extension.id();
             for capability in extension.frontend_capabilities() {
                 if !this.capabilities.contains(&capability) {
                     this.capabilities.push(capability);
@@ -31,7 +33,7 @@ impl TuiFrontend {
                 let tool_name = renderer.tool_name();
                 if this.renderers.insert(tool_name, renderer).is_some() {
                     tracing::warn!(
-                        extension_id = extension.id(),
+                        extension_id,
                         tool_name,
                         "frontend renderer collision; last active renderer wins"
                     );
@@ -40,6 +42,7 @@ impl TuiFrontend {
             for command in extension.commands() {
                 this.commands.insert(command.name(), command);
             }
+            this.extensions.insert(extension_id, extension);
         }
         if !this.capabilities.contains(&"text_io") {
             this.capabilities.push("text_io");
@@ -49,6 +52,33 @@ impl TuiFrontend {
 
     pub fn frontend_capabilities(&self) -> Vec<&'static str> {
         self.capabilities.clone()
+    }
+
+    pub fn extension_frontend_capabilities(&self) -> Vec<crate::extensions::FrontendCapability> {
+        let mut capabilities: Vec<_> = self
+            .capabilities
+            .iter()
+            .filter_map(|capability| crate::extensions::FrontendCapability::parse(capability))
+            .collect();
+        if !capabilities.contains(&crate::extensions::FrontendCapability::TextIo) {
+            capabilities.push(crate::extensions::FrontendCapability::TextIo);
+        }
+        capabilities
+    }
+
+    pub fn frontend_extensions(&self) -> Vec<vulcan_frontend_api::FrontendExtensionDescriptor> {
+        let mut descriptors: Vec<_> = self
+            .extensions
+            .values()
+            .map(
+                |extension| vulcan_frontend_api::FrontendExtensionDescriptor {
+                    id: extension.id().to_string(),
+                    version: extension.version().to_string(),
+                },
+            )
+            .collect();
+        descriptors.sort_by(|a, b| a.id.cmp(&b.id));
+        descriptors
     }
 
     pub fn render_tool_result(
@@ -77,6 +107,35 @@ impl TuiFrontend {
         let command = self.commands.get(name)?;
         let mut ctx = FrontendCtx::default();
         Some(command.run(&mut ctx))
+    }
+
+    pub fn handle_extension_event(&self, data: &Value) -> Vec<WidgetUpdate> {
+        if data.get("kind").and_then(Value::as_str) != Some("extension_event") {
+            tracing::warn!("frontend extension event missing extension_event kind");
+            return Vec::new();
+        }
+        let Some(extension_id) = data.get("extension_id").and_then(Value::as_str) else {
+            tracing::warn!("frontend extension event missing extension_id");
+            return Vec::new();
+        };
+        let Some(extension) = self.extensions.get(extension_id) else {
+            tracing::warn!(
+                extension_id,
+                "frontend extension event for unknown extension"
+            );
+            return Vec::new();
+        };
+
+        let mut ctx = FrontendCtx {
+            session_id: data
+                .get("session_id")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            extension_id: Some(extension_id.to_string()),
+            ..FrontendCtx::default()
+        };
+        extension.on_event(data.get("payload").unwrap_or(&Value::Null), &mut ctx);
+        ctx.ui.drain_widget_updates()
     }
 
     pub fn command_specs(&self) -> Vec<FrontendCommandSpec> {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -153,6 +153,7 @@ pub async fn run_tui(
     // overlay and routes the response back via the pause's oneshot reply.
     let (pause_tx, mut pause_rx) = pause::channel(8);
     let pause_tx_for_agent = pause_tx.clone();
+    let (frontend_event_tx, mut frontend_event_rx) = tokio::sync::broadcast::channel(32);
 
     // ── Long-lived agent: one per TUI session, shared across prompts so
     // hook handlers' state (audit log, rate limits, etc.) survives turns.
@@ -161,6 +162,11 @@ pub async fn run_tui(
             .with_hooks(hook_reg)
             .with_pause_channel(pause_tx_for_agent)
             .with_tool_profile(tool_profile)
+            .with_frontend_context(
+                frontend.extension_frontend_capabilities(),
+                frontend.frontend_extensions(),
+                crate::extensions::api::FrontendEventSink::new(frontend_event_tx),
+            )
             .build()
             .await?,
     ));
@@ -1599,6 +1605,21 @@ pub async fn run_tui(
                         app.thinking = false;
                         app.current_turn_cancel = None;
                     }
+                }
+            }
+            frontend_event = frontend_event_rx.recv() => {
+                match frontend_event {
+                    Ok(event) => {
+                        let updates = app.frontend.handle_extension_event(&serde_json::json!({
+                            "kind": "extension_event",
+                            "session_id": event.session_id,
+                            "extension_id": event.extension_id,
+                            "payload": event.payload,
+                        }));
+                        app.apply_widget_updates(updates);
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {}
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
                 }
             }
         }

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -28,7 +28,7 @@
 //! documentation below for which ones cross threads on purpose.
 
 use std::cell::{Cell, RefCell};
-use std::collections::VecDeque;
+use std::collections::{BTreeMap, VecDeque};
 
 use super::keybinds::Keybinds;
 
@@ -217,6 +217,7 @@ pub struct AppState {
     /// falls back to demo data so the design still looks alive on first launch.
     pub audit_log: Option<AuditBuffer>,
     pub frontend: super::frontend::TuiFrontend,
+    status_widgets: BTreeMap<String, vulcan_frontend_api::WidgetContent>,
 
     /// When the agent emits an `AgentPause`, the TUI parks it here. Render
     /// shows an overlay; key handler intercepts Y/A/N keys and consumes the
@@ -377,6 +378,7 @@ impl AppState {
 
             audit_log: None,
             frontend: super::frontend::TuiFrontend::default(),
+            status_widgets: BTreeMap::new(),
             pending_pause: None,
 
             cursor: Cell::new((0, 0)),
@@ -514,7 +516,7 @@ impl AppState {
         // YYC-96: when running on a named provider profile, prefix the
         // string with `{profile} · ` so the user can tell which provider
         // any given turn will hit.
-        match &self.provider_label {
+        let base = match &self.provider_label {
             Some(profile) => format!(
                 "{} · {} · {} / {}",
                 profile,
@@ -528,7 +530,47 @@ impl AppState {
                 format_thousands(self.prompt_tokens_last),
                 format_thousands(self.token_max),
             ),
+        };
+        let widget_status = self.status_widget_summary();
+        if widget_status.is_empty() {
+            base
+        } else {
+            format!("{base} · {widget_status}")
         }
+    }
+
+    pub fn apply_widget_updates(&mut self, updates: Vec<vulcan_frontend_api::WidgetUpdate>) {
+        for update in updates {
+            match update.content {
+                Some(content) => {
+                    self.status_widgets.insert(update.id, content);
+                }
+                None => {
+                    self.status_widgets.remove(&update.id);
+                }
+            }
+        }
+    }
+
+    pub fn status_widgets(&self) -> Vec<(String, vulcan_frontend_api::WidgetContent)> {
+        self.status_widgets
+            .iter()
+            .map(|(id, content)| (id.clone(), content.clone()))
+            .collect()
+    }
+
+    fn status_widget_summary(&self) -> String {
+        self.status_widgets
+            .values()
+            .map(|content| match content {
+                vulcan_frontend_api::WidgetContent::Text(text) => text.clone(),
+                vulcan_frontend_api::WidgetContent::Spinner(label) => label.clone(),
+                vulcan_frontend_api::WidgetContent::Progress { label, ratio } => {
+                    format!("{label} {:.0}%", ratio * 100.0)
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(" · ")
     }
 
     /// Estimated session cost in USD, computed from cumulative token

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::memory::SessionSummary;
+use vulcan_frontend_api::{WidgetContent, WidgetUpdate};
 
 #[test]
 fn orchestration_state_tracks_prompt_and_tool_flow() {
@@ -155,6 +156,46 @@ fn model_status_prefixes_active_provider_label() {
     app.prompt_tokens_last = 18_402;
     let status = app.model_status();
     assert_eq!(status, "local · deepseek/v4 · 18,402 / 128,000");
+}
+
+#[test]
+fn app_state_applies_status_widget_updates() {
+    let mut app = AppState::new("deepseek/v4".into(), 128_000);
+
+    app.apply_widget_updates(vec![
+        WidgetUpdate {
+            id: "job".into(),
+            content: Some(WidgetContent::Spinner("working".into())),
+        },
+        WidgetUpdate {
+            id: "progress".into(),
+            content: Some(WidgetContent::progress("sync", 0.5)),
+        },
+    ]);
+
+    assert_eq!(
+        app.status_widgets(),
+        vec![
+            ("job".to_string(), WidgetContent::Spinner("working".into())),
+            (
+                "progress".to_string(),
+                WidgetContent::Progress {
+                    label: "sync".into(),
+                    ratio: 0.5
+                }
+            ),
+        ]
+    );
+    assert!(app.model_status().contains("working"));
+    assert!(app.model_status().contains("sync 50%"));
+
+    app.apply_widget_updates(vec![WidgetUpdate {
+        id: "job".into(),
+        content: None,
+    }]);
+
+    assert_eq!(app.status_widgets().len(), 1);
+    assert!(!app.model_status().contains("working"));
 }
 
 #[test]

--- a/tests/client_autostart.rs
+++ b/tests/client_autostart.rs
@@ -12,14 +12,18 @@
 //! * concurrent invocations settle on a single live daemon (PID file is
 //!   acquired exclusively).
 
-use assert_cmd::Command;
 use predicates::prelude::*;
 use std::path::Path;
 use std::time::Duration;
 use tempfile::tempdir;
 
+mod support;
+use support::vulcan_command;
+
+use assert_cmd::Command;
+
 fn vulcan_with_home(home: &Path) -> Command {
-    let mut c = Command::cargo_bin("vulcan").unwrap();
+    let mut c = vulcan_command();
     c.env("VULCAN_HOME", home);
     c.env("RUST_LOG", "warn");
     c

--- a/tests/daemon_e2e.rs
+++ b/tests/daemon_e2e.rs
@@ -5,14 +5,18 @@
 //! against a real `vulcan` binary, with `VULCAN_HOME` redirected to a
 //! tempdir so the test can't collide with a developer's running daemon.
 
-use assert_cmd::Command;
 use predicates::prelude::*;
 use std::path::Path;
 use std::time::Duration;
 use tempfile::tempdir;
 
+mod support;
+use support::vulcan_command;
+
+use assert_cmd::Command;
+
 fn vulcan_with_home(home: &Path) -> Command {
-    let mut c = Command::cargo_bin("vulcan").unwrap();
+    let mut c = vulcan_command();
     c.env("VULCAN_HOME", home);
     c.env("RUST_LOG", "warn");
     c

--- a/tests/frontend_extensions.rs
+++ b/tests/frontend_extensions.rs
@@ -5,7 +5,7 @@ use vulcan::tools::ToolResult;
 use vulcan::tui::frontend::TuiFrontend;
 use vulcan_frontend_api::{
     FrontendCodeExtension, FrontendCommand, FrontendCommandAction, FrontendCtx, MessageRenderer,
-    RenderedMessage, ToolResultView,
+    RenderedMessage, ToolResultView, WidgetContent,
 };
 
 struct TestRenderer(&'static str);
@@ -65,6 +65,19 @@ impl FrontendCodeExtension for TestExtension {
     fn commands(&self) -> Vec<Arc<dyn FrontendCommand>> {
         vec![Arc::new(TestCommand)]
     }
+
+    fn version(&self) -> &'static str {
+        "1.2.3"
+    }
+
+    fn on_event(&self, payload: &serde_json::Value, ctx: &mut FrontendCtx) {
+        ctx.ui.set_widget(
+            "status",
+            Some(WidgetContent::Text(
+                payload["message"].as_str().unwrap_or_default().to_string(),
+            )),
+        );
+    }
 }
 
 #[test]
@@ -118,4 +131,53 @@ fn tool_result_details_are_available_to_frontend_renderers() {
         .expect("renderer should receive tool result details");
 
     assert_eq!(rendered, vec!["todo".to_string(), "1 item(s)".to_string()]);
+}
+
+#[test]
+fn frontend_event_dispatches_to_matching_extension_widget_updates() {
+    let frontend = TuiFrontend::from_extensions(vec![Arc::new(TestExtension {
+        id: "todo",
+        renderer_label: "todo",
+    })]);
+
+    let updates = frontend.handle_extension_event(&json!({
+        "kind": "extension_event",
+        "extension_id": "todo",
+        "payload": { "message": "synced" }
+    }));
+
+    assert_eq!(updates.len(), 1);
+    assert_eq!(updates[0].id, "status");
+    assert_eq!(
+        updates[0].content,
+        Some(WidgetContent::Text("synced".into()))
+    );
+}
+
+#[test]
+fn unknown_frontend_extension_event_is_dropped() {
+    let frontend = TuiFrontend::from_extensions(vec![Arc::new(TestExtension {
+        id: "todo",
+        renderer_label: "todo",
+    })]);
+
+    let updates = frontend.handle_extension_event(&json!({
+        "kind": "extension_event",
+        "extension_id": "missing",
+        "payload": { "message": "ignored" }
+    }));
+
+    assert!(updates.is_empty());
+}
+
+#[test]
+fn frontend_reports_extension_descriptors() {
+    let frontend = TuiFrontend::from_extensions(vec![Arc::new(TestExtension {
+        id: "todo",
+        renderer_label: "todo",
+    })]);
+
+    assert_eq!(frontend.frontend_extensions().len(), 1);
+    assert_eq!(frontend.frontend_extensions()[0].id, "todo");
+    assert_eq!(frontend.frontend_extensions()[0].version, "1.2.3");
 }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,0 +1,44 @@
+use assert_cmd::Command;
+use std::path::{Path, PathBuf};
+use std::process::Command as StdCommand;
+
+pub fn vulcan_command() -> Command {
+    Command::new(vulcan_binary_path())
+}
+
+fn vulcan_binary_path() -> PathBuf {
+    if let Some(path) = std::env::var_os("CARGO_BIN_EXE_vulcan") {
+        return PathBuf::from(path);
+    }
+
+    build_vulcan_binary();
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let exe = if cfg!(windows) {
+        "vulcan.exe"
+    } else {
+        "vulcan"
+    };
+    let path = std::env::var_os("CARGO_TARGET_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| manifest_dir.join("target"))
+        .join("debug")
+        .join(exe);
+    assert!(
+        path.exists(),
+        "built vulcan binary missing at {}",
+        path.display()
+    );
+    path
+}
+
+fn build_vulcan_binary() {
+    let status = StdCommand::new("cargo")
+        .args(["build", "-p", "vulcan", "--bin", "vulcan"])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .status()
+        .expect("spawn cargo build -p vulcan --bin vulcan");
+    assert!(
+        status.success(),
+        "cargo build -p vulcan --bin vulcan failed"
+    );
+}

--- a/vulcan-ext-auto-commit/src/lib.rs
+++ b/vulcan-ext-auto-commit/src/lib.rs
@@ -195,11 +195,11 @@ mod tests {
         assert_eq!(commit_count(&repo), 1, "starts with one commit");
 
         let ext = AutoCommitExtension;
-        let session = ext.instantiate(SessionExtensionCtx {
-            cwd: repo.clone(),
-            session_id: "test-session".to_string(),
-            memory: Arc::new(vulcan::memory::SessionStore::in_memory()),
-        });
+        let session = ext.instantiate(SessionExtensionCtx::new(
+            repo.clone(),
+            "test-session".to_string(),
+            Arc::new(vulcan::memory::SessionStore::in_memory()),
+        ));
         let handlers = session.hook_handlers();
         assert_eq!(handlers.len(), 1);
         handlers[0].session_end("test-session", 1).await;
@@ -215,11 +215,11 @@ mod tests {
         assert_eq!(commit_count(&repo), 1);
 
         let ext = AutoCommitExtension;
-        let session = ext.instantiate(SessionExtensionCtx {
-            cwd: repo.clone(),
-            session_id: "clean-session".to_string(),
-            memory: Arc::new(vulcan::memory::SessionStore::in_memory()),
-        });
+        let session = ext.instantiate(SessionExtensionCtx::new(
+            repo.clone(),
+            "clean-session".to_string(),
+            Arc::new(vulcan::memory::SessionStore::in_memory()),
+        ));
         session.hook_handlers()[0]
             .session_end("clean-session", 0)
             .await;
@@ -235,11 +235,11 @@ mod tests {
         // Not a git repo.
 
         let ext = AutoCommitExtension;
-        let session = ext.instantiate(SessionExtensionCtx {
-            cwd: path,
-            session_id: "no-git".to_string(),
-            memory: Arc::new(vulcan::memory::SessionStore::in_memory()),
-        });
+        let session = ext.instantiate(SessionExtensionCtx::new(
+            path,
+            "no-git".to_string(),
+            Arc::new(vulcan::memory::SessionStore::in_memory()),
+        ));
         session.hook_handlers()[0].session_end("no-git", 0).await;
         // No panic, no error — just silently no-op.
     }

--- a/vulcan-ext-compact-summary/src/lib.rs
+++ b/vulcan-ext-compact-summary/src/lib.rs
@@ -166,11 +166,11 @@ mod tests {
     use vulcan::hooks::{RewriteRejection, validate_rewrite_history};
 
     fn ctx() -> SessionExtensionCtx {
-        SessionExtensionCtx {
-            cwd: std::path::PathBuf::from("/tmp/test"),
-            session_id: "test-session".to_string(),
-            memory: Arc::new(vulcan::memory::SessionStore::in_memory()),
-        }
+        SessionExtensionCtx::new(
+            std::path::PathBuf::from("/tmp/test"),
+            "test-session".to_string(),
+            Arc::new(vulcan::memory::SessionStore::in_memory()),
+        )
     }
 
     fn long_history() -> Vec<Message> {

--- a/vulcan-ext-input-demo/src/lib.rs
+++ b/vulcan-ext-input-demo/src/lib.rs
@@ -106,11 +106,11 @@ mod tests {
     use super::*;
 
     fn ctx() -> SessionExtensionCtx {
-        SessionExtensionCtx {
-            cwd: std::path::PathBuf::from("/tmp/test"),
-            session_id: "test-session".to_string(),
-            memory: Arc::new(vulcan::memory::SessionStore::in_memory()),
-        }
+        SessionExtensionCtx::new(
+            std::path::PathBuf::from("/tmp/test"),
+            "test-session".to_string(),
+            Arc::new(vulcan::memory::SessionStore::in_memory()),
+        )
     }
 
     #[test]

--- a/vulcan-ext-spinner-demo/Cargo.toml
+++ b/vulcan-ext-spinner-demo/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "vulcan-ext-spinner-demo"
+version = "0.1.0"
+edition = "2024"
+description = "Spinner status-widget demo Vulcan extension"
+authors = ["Colin Hanway"]
+license = "MIT"
+repository = "https://github.com/yycholla/vulcan"
+
+[lib]
+name = "vulcan_ext_spinner_demo"
+path = "src/lib.rs"
+
+[dependencies]
+vulcan = { package = "vulcan-core", path = ".." }
+vulcan-frontend-api = { path = "../vulcan-frontend-api", optional = true }
+
+inventory = "0.3.24"
+async-trait = "0.1"
+anyhow = "1"
+serde_json = "1"
+tokio = { version = "1", features = ["time", "macros", "rt"] }
+tokio-util = { version = "0.7.18", features = ["rt"] }
+
+[features]
+default = []
+tui = ["dep:vulcan-frontend-api"]
+
+[package.metadata.vulcan]
+id = "spinner-demo"
+daemon_entry = "vulcan_ext_spinner_demo::SpinnerDemoExtension"
+capabilities = ["tool_provider"]
+requires_frontend = ["status_widgets"]

--- a/vulcan-ext-spinner-demo/src/lib.rs
+++ b/vulcan-ext-spinner-demo/src/lib.rs
@@ -1,0 +1,147 @@
+//! Spinner status-widget demo extension for GH issue #559.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use tokio_util::sync::CancellationToken;
+use vulcan::extensions::api::{
+    DaemonCodeExtension, ExtensionRegistration, SessionExtension, SessionExtensionCtx,
+};
+use vulcan::extensions::{
+    ExtensionCapability, ExtensionMetadata, ExtensionSource, ExtensionStatus, FrontendCapability,
+};
+use vulcan::tools::{ProgressSink, Tool, ToolResult};
+
+const ID: &str = "spinner-demo";
+const WIDGET_ID: &str = "long_task";
+
+#[cfg(feature = "tui")]
+pub mod tui;
+
+#[derive(Default)]
+pub struct SpinnerDemoExtension;
+
+impl DaemonCodeExtension for SpinnerDemoExtension {
+    fn metadata(&self) -> ExtensionMetadata {
+        let mut meta = ExtensionMetadata::new(
+            ID,
+            "Spinner Demo",
+            env!("CARGO_PKG_VERSION"),
+            ExtensionSource::Builtin,
+        );
+        meta.status = ExtensionStatus::Active;
+        meta.capabilities = vec![ExtensionCapability::ToolProvider];
+        meta.requires_frontend = vec![FrontendCapability::StatusWidgets];
+        meta.description =
+            "Demo long task that drives a frontend status widget over extension events.".into();
+        meta
+    }
+
+    fn instantiate(&self, ctx: SessionExtensionCtx) -> Arc<dyn SessionExtension> {
+        Arc::new(SpinnerDemoSession { ctx })
+    }
+}
+
+struct SpinnerDemoSession {
+    ctx: SessionExtensionCtx,
+}
+
+impl SessionExtension for SpinnerDemoSession {
+    fn tools(&self) -> Vec<Arc<dyn Tool>> {
+        vec![Arc::new(LongTaskTool {
+            ctx: self.ctx.clone(),
+        })]
+    }
+}
+
+struct LongTaskTool {
+    ctx: SessionExtensionCtx,
+}
+
+#[async_trait]
+impl Tool for LongTaskTool {
+    fn name(&self) -> &str {
+        "long_task"
+    }
+
+    fn description(&self) -> &str {
+        "Run a short demo task that shows and clears a frontend status spinner."
+    }
+
+    fn schema(&self) -> Value {
+        json!({ "type": "object", "properties": {} })
+    }
+
+    async fn call(
+        &self,
+        _params: Value,
+        cancel: CancellationToken,
+        _progress: Option<ProgressSink>,
+    ) -> anyhow::Result<ToolResult> {
+        self.ctx.emit_frontend_event(json!({
+            "widget_id": WIDGET_ID,
+            "kind": "spinner",
+            "label": "running demo task"
+        }))?;
+
+        let result = tokio::select! {
+            _ = tokio::time::sleep(Duration::from_millis(25)) => ToolResult::ok("Spinner demo task complete."),
+            _ = cancel.cancelled() => ToolResult::err("Cancelled"),
+        };
+
+        self.ctx.emit_frontend_event(json!({
+            "widget_id": WIDGET_ID,
+            "kind": "clear"
+        }))?;
+
+        Ok(result)
+    }
+}
+
+inventory::submit! {
+    ExtensionRegistration {
+        register: || Arc::new(SpinnerDemoExtension) as Arc<dyn DaemonCodeExtension>,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn long_task_emits_spinner_then_clear_events() {
+        let (tx, mut rx) = tokio::sync::broadcast::channel(8);
+        let ctx = SessionExtensionCtx::new(
+            std::path::PathBuf::from("/tmp/test"),
+            "session".into(),
+            Arc::new(vulcan::memory::SessionStore::in_memory()),
+        )
+        .for_extension(ID);
+        let ctx = SessionExtensionCtx {
+            frontend_events: vulcan::extensions::api::FrontendEventSink::new(tx),
+            ..ctx
+        };
+        let session = SpinnerDemoExtension.instantiate(ctx);
+        let tools = session.tools();
+        let tool = tools
+            .iter()
+            .find(|tool| tool.name() == "long_task")
+            .expect("long_task tool");
+
+        let result = tool
+            .call(json!({}), CancellationToken::new(), None)
+            .await
+            .expect("tool ok");
+
+        assert!(!result.is_error);
+        let first = rx.recv().await.expect("spinner event");
+        let second = rx.recv().await.expect("clear event");
+        assert_eq!(first.extension_id, ID);
+        assert_eq!(first.payload["kind"], "spinner");
+        assert_eq!(first.payload["widget_id"], WIDGET_ID);
+        assert_eq!(second.payload["kind"], "clear");
+        assert_eq!(second.payload["widget_id"], WIDGET_ID);
+    }
+}

--- a/vulcan-ext-spinner-demo/src/tui.rs
+++ b/vulcan-ext-spinner-demo/src/tui.rs
@@ -1,0 +1,101 @@
+use std::sync::Arc;
+
+use vulcan_frontend_api::{
+    FrontendCodeExtension, FrontendCtx, FrontendExtensionRegistration, WidgetContent,
+};
+
+pub struct SpinnerDemoFrontendExtension;
+
+impl FrontendCodeExtension for SpinnerDemoFrontendExtension {
+    fn id(&self) -> &'static str {
+        "spinner-demo"
+    }
+
+    fn version(&self) -> &'static str {
+        env!("CARGO_PKG_VERSION")
+    }
+
+    fn frontend_capabilities(&self) -> Vec<&'static str> {
+        vec!["text_io", "status_widgets"]
+    }
+
+    fn on_event(&self, payload: &serde_json::Value, ctx: &mut FrontendCtx) {
+        let widget_id = payload
+            .get("widget_id")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("spinner-demo");
+        match payload.get("kind").and_then(serde_json::Value::as_str) {
+            Some("spinner") => {
+                let label = payload
+                    .get("label")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("working");
+                ctx.ui
+                    .set_widget(widget_id, Some(WidgetContent::Spinner(label.into())));
+            }
+            Some("progress") => {
+                let label = payload
+                    .get("label")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or("working");
+                let ratio = payload
+                    .get("ratio")
+                    .and_then(serde_json::Value::as_f64)
+                    .unwrap_or(0.0);
+                ctx.ui
+                    .set_widget(widget_id, Some(WidgetContent::progress(label, ratio)));
+            }
+            Some("text") => {
+                let text = payload
+                    .get("text")
+                    .and_then(serde_json::Value::as_str)
+                    .unwrap_or_default();
+                ctx.ui
+                    .set_widget(widget_id, Some(WidgetContent::Text(text.into())));
+            }
+            Some("clear") => ctx.ui.set_widget(widget_id, None),
+            _ => {}
+        }
+    }
+}
+
+inventory::submit! {
+    FrontendExtensionRegistration {
+        register: || Arc::new(SpinnerDemoFrontendExtension) as Arc<dyn FrontendCodeExtension>,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spinner_frontend_sets_and_clears_widget() {
+        let ext = SpinnerDemoFrontendExtension;
+        let mut ctx = FrontendCtx::default().with_extension("spinner-demo");
+
+        ext.on_event(
+            &serde_json::json!({
+                "widget_id": "job",
+                "kind": "spinner",
+                "label": "working"
+            }),
+            &mut ctx,
+        );
+        ext.on_event(
+            &serde_json::json!({
+                "widget_id": "job",
+                "kind": "clear"
+            }),
+            &mut ctx,
+        );
+
+        let updates = ctx.ui.drain_widget_updates();
+        assert_eq!(updates.len(), 2);
+        assert_eq!(
+            updates[0].content,
+            Some(WidgetContent::Spinner("working".into()))
+        );
+        assert_eq!(updates[1].content, None);
+    }
+}

--- a/vulcan-ext-todo/src/lib.rs
+++ b/vulcan-ext-todo/src/lib.rs
@@ -266,11 +266,11 @@ mod tests {
     use super::*;
 
     fn ctx(memory: Arc<vulcan::memory::SessionStore>) -> SessionExtensionCtx {
-        SessionExtensionCtx {
-            cwd: std::path::PathBuf::from("/tmp/test"),
-            session_id: "todo-test".to_string(),
+        SessionExtensionCtx::new(
+            std::path::PathBuf::from("/tmp/test"),
+            "todo-test".to_string(),
             memory,
-        }
+        )
     }
 
     #[tokio::test]

--- a/vulcan-ext-todo/tests/todo_e2e.rs
+++ b/vulcan-ext-todo/tests/todo_e2e.rs
@@ -19,11 +19,11 @@ async fn todo_details_survive_session_end_then_session_start_replay() {
 
     let hooks = HookRegistry::new();
     let mut tools = ToolRegistry::new();
-    let ctx = SessionExtensionCtx {
-        cwd: std::env::current_dir().expect("cwd"),
-        session_id: session_id.to_string(),
-        memory: Arc::clone(&memory),
-    };
+    let ctx = SessionExtensionCtx::new(
+        std::env::current_dir().expect("cwd"),
+        session_id.to_string(),
+        Arc::clone(&memory),
+    );
     let (sessions, extension_tools) =
         registry.wire_daemon_extensions_into_runtime(ctx, &hooks, Some(&mut tools));
     assert_eq!(sessions, 1);
@@ -76,11 +76,11 @@ async fn todo_details_survive_session_end_then_session_start_replay() {
 
     let restarted_hooks = HookRegistry::new();
     let mut restarted_tools = ToolRegistry::new();
-    let ctx = SessionExtensionCtx {
-        cwd: std::env::current_dir().expect("cwd"),
-        session_id: session_id.to_string(),
-        memory: Arc::clone(&memory),
-    };
+    let ctx = SessionExtensionCtx::new(
+        std::env::current_dir().expect("cwd"),
+        session_id.to_string(),
+        Arc::clone(&memory),
+    );
     registry.wire_daemon_extensions_into_runtime(ctx, &restarted_hooks, Some(&mut restarted_tools));
     restarted_hooks.session_start(session_id).await;
 

--- a/vulcan-frontend-api/Cargo.toml
+++ b/vulcan-frontend-api/Cargo.toml
@@ -9,4 +9,5 @@ repository = "https://github.com/yycholla/vulcan"
 
 [dependencies]
 inventory = "0.3.24"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/vulcan-frontend-api/src/lib.rs
+++ b/vulcan-frontend-api/src/lib.rs
@@ -2,12 +2,14 @@
 
 use std::sync::Arc;
 
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 #[derive(Clone, Debug, Default)]
 pub struct FrontendCtx {
     pub session_id: Option<String>,
     pub extension_id: Option<String>,
+    pub ui: ExtensionUi,
 }
 
 impl FrontendCtx {
@@ -15,6 +17,47 @@ impl FrontendCtx {
         self.extension_id = Some(extension_id.into());
         self
     }
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct ExtensionUi {
+    updates: Vec<WidgetUpdate>,
+}
+
+impl ExtensionUi {
+    pub fn set_widget(&mut self, id: impl Into<String>, content: Option<WidgetContent>) {
+        self.updates.push(WidgetUpdate {
+            id: id.into(),
+            content,
+        });
+    }
+
+    pub fn drain_widget_updates(&mut self) -> Vec<WidgetUpdate> {
+        self.updates.drain(..).collect()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum WidgetContent {
+    Text(String),
+    Spinner(String),
+    Progress { label: String, ratio: f64 },
+}
+
+impl WidgetContent {
+    pub fn progress(label: impl Into<String>, ratio: f64) -> Self {
+        Self::Progress {
+            label: label.into(),
+            ratio: ratio.clamp(0.0, 1.0),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct WidgetUpdate {
+    pub id: String,
+    pub content: Option<WidgetContent>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -69,6 +112,9 @@ pub trait FrontendCommand: Send + Sync {
 
 pub trait FrontendCodeExtension: Send + Sync {
     fn id(&self) -> &'static str;
+    fn version(&self) -> &'static str {
+        "0.0.0"
+    }
     fn frontend_capabilities(&self) -> Vec<&'static str> {
         Vec::new()
     }
@@ -78,6 +124,13 @@ pub trait FrontendCodeExtension: Send + Sync {
     fn commands(&self) -> Vec<Arc<dyn FrontendCommand>> {
         Vec::new()
     }
+    fn on_event(&self, _payload: &Value, _ctx: &mut FrontendCtx) {}
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FrontendExtensionDescriptor {
+    pub id: String,
+    pub version: String,
 }
 
 pub struct FrontendExtensionRegistration {
@@ -91,4 +144,83 @@ pub fn collect_registrations() -> Vec<Arc<dyn FrontendCodeExtension>> {
         .into_iter()
         .map(|entry| (entry.register)())
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct EventExtension;
+
+    impl FrontendCodeExtension for EventExtension {
+        fn id(&self) -> &'static str {
+            "event"
+        }
+
+        fn on_event(&self, payload: &Value, ctx: &mut FrontendCtx) {
+            ctx.ui.set_widget(
+                "status",
+                Some(WidgetContent::Text(
+                    payload["message"].as_str().unwrap_or_default().to_string(),
+                )),
+            );
+        }
+    }
+
+    #[test]
+    fn extension_ui_records_set_and_clear_widget_updates() {
+        let mut ui = ExtensionUi::default();
+
+        ui.set_widget("job", Some(WidgetContent::Spinner("working".into())));
+        ui.set_widget("job", None);
+
+        assert_eq!(
+            ui.drain_widget_updates(),
+            vec![
+                WidgetUpdate {
+                    id: "job".into(),
+                    content: Some(WidgetContent::Spinner("working".into())),
+                },
+                WidgetUpdate {
+                    id: "job".into(),
+                    content: None,
+                },
+            ]
+        );
+        assert!(ui.drain_widget_updates().is_empty());
+    }
+
+    #[test]
+    fn progress_widget_ratio_is_clamped() {
+        assert_eq!(
+            WidgetContent::progress("done", 2.4),
+            WidgetContent::Progress {
+                label: "done".into(),
+                ratio: 1.0
+            }
+        );
+        assert_eq!(
+            WidgetContent::progress("start", -1.0),
+            WidgetContent::Progress {
+                label: "start".into(),
+                ratio: 0.0
+            }
+        );
+    }
+
+    #[test]
+    fn frontend_extension_event_can_emit_widget_update() {
+        let extension = EventExtension;
+        let mut ctx = FrontendCtx::default().with_extension("event");
+
+        extension.on_event(&serde_json::json!({ "message": "ready" }), &mut ctx);
+
+        assert_eq!(
+            ctx.ui.drain_widget_updates(),
+            vec![WidgetUpdate {
+                id: "status".into(),
+                content: Some(WidgetContent::Text("ready".into())),
+            }]
+        );
+    }
 }

--- a/vulcan/Cargo.toml
+++ b/vulcan/Cargo.toml
@@ -31,6 +31,8 @@ vulcan-ext-auto-commit = { path = "../vulcan-ext-auto-commit" }
 # GH issue #557: input-intercept dogfood extension; same `extern crate`
 # anchoring rationale as auto-commit.
 vulcan-ext-input-demo = { path = "../vulcan-ext-input-demo" }
+# GH issue #559: status-widget/event-channel dogfood extension.
+vulcan-ext-spinner-demo = { path = "../vulcan-ext-spinner-demo", features = ["tui"] }
 # GH issue #550: todo dogfood extension for daemon tool wiring and
 # ToolResult.details replay.
 vulcan-ext-todo = { path = "../vulcan-ext-todo", features = ["tui"] }

--- a/vulcan/src/main.rs
+++ b/vulcan/src/main.rs
@@ -4,6 +4,7 @@
 // suffices — no symbols need importing into source.
 extern crate vulcan_ext_auto_commit as _vulcan_ext_auto_commit;
 extern crate vulcan_ext_input_demo as _vulcan_ext_input_demo;
+extern crate vulcan_ext_spinner_demo as _vulcan_ext_spinner_demo;
 extern crate vulcan_ext_todo as _vulcan_ext_todo;
 
 use clap::{CommandFactory, Parser};
@@ -245,7 +246,7 @@ async fn main() -> anyhow::Result<()> {
         #[cfg(feature = "daemon")]
         Some(Command::HiddenPing) => {
             init_cli_logging();
-            let mut client = vulcan::client::Client::connect_or_autostart().await?;
+            let client = vulcan::client::Client::connect_or_autostart().await?;
             let result = client.call("daemon.ping", serde_json::json!({})).await?;
             println!("{}", serde_json::to_string_pretty(&result)?);
         }
@@ -378,7 +379,7 @@ async fn run_search_direct(query: &str, limit: usize) -> anyhow::Result<()> {
 
 #[cfg(feature = "daemon")]
 async fn prompt_via_daemon(text: String, _profile: Option<String>) -> anyhow::Result<()> {
-    let mut client = vulcan::client::Client::connect_or_autostart().await?;
+    let client = vulcan::client::Client::connect_or_autostart().await?;
     // For CLI: use prompt.run (buffered, simpler) — the streaming
     // TUI uses prompt.stream.
     let result = client
@@ -390,7 +391,7 @@ async fn prompt_via_daemon(text: String, _profile: Option<String>) -> anyhow::Re
 
 #[cfg(feature = "daemon")]
 async fn search_via_daemon(query: String, limit: usize) -> anyhow::Result<()> {
-    let mut client = vulcan::client::Client::connect_or_autostart().await?;
+    let client = vulcan::client::Client::connect_or_autostart().await?;
     let result = client
         .call(
             "session.search",


### PR DESCRIPTION
## Summary
- add frontend extension event/widget API and TUI demux/status widget handling
- pass frontend capabilities/descriptors into session extension activation with version mismatch gating
- route daemon extension events as out-of-band extension_event push frames
- add vulcan-ext-spinner-demo dogfood extension and document the event/widget boundary

## Verification
- cargo fmt --all
- cargo test --workspace --no-run
- TMPDIR=/tmp/vulcan-test-tmp CARGO_BIN_EXE_vulcan=/home/yycholla/vulcan/target/debug/vulcan cargo test --workspace
- gitnexus detect-changes --repo /home/yycholla/vulcan/.worktrees/rebuild-559 --scope all

Closes #559