### PR TITLE
feat(extensions): migrate core hooks to extensions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7175,6 +7175,8 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vulcan-core",
+ "vulcan-core-ext-safety",
+ "vulcan-core-ext-skills",
  "vulcan-ext-auto-commit",
  "vulcan-ext-input-demo",
  "vulcan-ext-snake",
@@ -7254,6 +7256,24 @@ dependencies = [
  "url",
  "uuid",
  "vulcan-frontend-api",
+]
+
+[[package]]
+name = "vulcan-core-ext-safety"
+version = "0.1.0"
+dependencies = [
+ "inventory",
+ "vulcan-core",
+ "vulcan-extension-macros",
+]
+
+[[package]]
+name = "vulcan-core-ext-skills"
+version = "0.1.0"
+dependencies = [
+ "inventory",
+ "vulcan-core",
+ "vulcan-extension-macros",
 ]
 
 [[package]]
@@ -7356,6 +7376,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "vulcan-core",
+ "vulcan-core-ext-safety",
+ "vulcan-core-ext-skills",
  "vulcan-ext-snake",
  "vulcan-ext-spinner-demo",
  "vulcan-ext-todo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ members = [
     "vulcan-tui",
     "vulcan-frontend-api",
     "vulcan-extension-macros",
+    "vulcan-core-ext-skills",
+    "vulcan-core-ext-safety",
     "vulcan-ext-auto-commit",
     "vulcan-ext-compact-summary",
     "vulcan-ext-snake",

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -6,8 +6,6 @@ use crate::hooks::HookRegistry;
 use crate::hooks::approval::ApprovalHook;
 use crate::hooks::diagnostics::DiagnosticsHook;
 use crate::hooks::recall::RecallHook;
-use crate::hooks::safety::SafetyHook;
-use crate::hooks::skills::SkillsHook;
 use crate::memory::SessionStore;
 use crate::pause::PauseSender;
 use crate::prompt_builder::PromptBuilder;
@@ -444,9 +442,6 @@ impl Agent {
             ContextManager::with_config(provider.max_context(), config.compaction.clone());
         let session_id = Uuid::new_v4().to_string();
 
-        // Built-in hook: surface available skills to the LLM via BeforePrompt.
-        hooks.register(Arc::new(SkillsHook::new(skills.clone())));
-
         // YYC-42: optionally recall relevant past-session context on the
         // first turn of a fresh session. Off by default — config
         // `[recall].enabled = true` opts in. Uses its own SessionStore
@@ -480,15 +475,6 @@ impl Agent {
         };
         hooks.register(Arc::new(approval_hook));
 
-        // Built-in hook: block dangerous shell invocations unless yolo_mode is on.
-        // Skipped entirely (not even registered as observe-only) when yolo_mode
-        // is true — keeps the no-op path zero-cost. With a pause emitter
-        // wired up, blocks become interactive prompts.
-        if !config.tools.yolo_mode {
-            let safety = SafetyHook::with_config(pause_tx.clone(), config.tools.dangerous_commands);
-            hooks.register(Arc::new(safety));
-        }
-
         // Built-in hook (YYC-87 / YYC-84): redirect bash invocations to
         // native tools when there's a clear equivalent. Skipped entirely
         // when the knob is `Off`. Sits at priority 5 — after safety
@@ -511,53 +497,63 @@ impl Agent {
         // when RTK is not installed — zero per-call overhead.
         hooks.register(Arc::new(crate::hooks::rtk::RtkHook::new()));
 
-        // GH issue #549: cargo-crate extensions registered via
-        // `inventory::submit!` and discovered into the pool's
-        // `ExtensionRegistry` at daemon startup. Each `Active`
-        // `DaemonCodeExtension` is instantiated per **Session** and its
-        // `hook_handlers` registered into this Agent's `HookRegistry`.
-        // No-op when the agent runs without a pool (CLI one-shot) or
-        // when no daemon extensions are registered.
-        let mut session_extensions = Vec::new();
-        if let Some(p) = pool.as_ref() {
+        // GH issue #549/#561: cargo-crate extensions registered via
+        // `inventory::submit!` now include core hook providers such as
+        // skills and safety. Every Agent wires active daemon extensions,
+        // using the daemon-owned registry when a pool exists and a local
+        // registry for direct CLI/TUI construction.
+        let extension_registry = if let Some(p) = pool.as_ref() {
             // GH issue #557: install the daemon's shared audit log on
             // the registry before extension hook handlers register so
             // any `on_input` outcome they emit lands on the same ring
             // the CLI / `vulcan extension audit` reads from.
             hooks = hooks.with_audit_log(p.extension_audit_log());
-
-            let ctx = crate::extensions::api::SessionExtensionCtx::new(
-                cwd.clone(),
-                session_id.clone(),
-                Arc::clone(&memory),
-            )
-            .with_frontend_capabilities(frontend_capabilities.clone())
-            .with_frontend_extensions(frontend_extensions.clone());
-            let ctx = crate::extensions::api::SessionExtensionCtx {
-                frontend_events: frontend_events.clone(),
-                ..ctx
-            };
-            let registry = p.extension_registry();
-            session_extensions = registry.wire_daemon_extensions_runtime(ctx, &hooks);
-            for ext in &session_extensions {
-                for tool in ext.wrapped_tools() {
-                    if let Err(err) = tools.register_extension_tool(ext.id(), tool) {
-                        registry.mark_broken(ext.id(), err.to_string());
-                        tracing::warn!(
-                            extension_id = ext.id(),
-                            %err,
-                            "Agent: failed to register extension tool"
-                        );
-                    }
+            p.extension_registry()
+        } else {
+            let registry = Arc::new(crate::extensions::ExtensionRegistry::new());
+            crate::extensions::api::wire_inventory_into_registry(&registry);
+            registry
+        };
+        let dangerous_commands = if config.tools.yolo_mode {
+            let mut cfg = config.tools.dangerous_commands;
+            cfg.policy = crate::config::DangerousCommandPolicy::Allow;
+            cfg
+        } else {
+            config.tools.dangerous_commands
+        };
+        let ctx = crate::extensions::api::SessionExtensionCtx::new(
+            cwd.clone(),
+            session_id.clone(),
+            Arc::clone(&memory),
+        )
+        .with_frontend_capabilities(frontend_capabilities.clone())
+        .with_frontend_extensions(frontend_extensions.clone())
+        .with_skills_dir(config.skills_dir.clone())
+        .with_pause_channel(pause_tx.clone())
+        .with_dangerous_commands(dangerous_commands);
+        let ctx = crate::extensions::api::SessionExtensionCtx {
+            frontend_events: frontend_events.clone(),
+            ..ctx
+        };
+        let session_extensions = extension_registry.wire_daemon_extensions_runtime(ctx, &hooks);
+        for ext in &session_extensions {
+            for tool in ext.wrapped_tools() {
+                if let Err(err) = tools.register_extension_tool(ext.id(), tool) {
+                    extension_registry.mark_broken(ext.id(), err.to_string());
+                    tracing::warn!(
+                        extension_id = ext.id(),
+                        %err,
+                        "Agent: failed to register extension tool"
+                    );
                 }
-                ext.activate().await;
             }
-            if !session_extensions.is_empty() {
-                tracing::info!(
-                    daemon_extensions = session_extensions.len(),
-                    "Agent: wired daemon-side cargo-crate extensions"
-                );
-            }
+            ext.activate().await;
+        }
+        if !session_extensions.is_empty() {
+            tracing::info!(
+                daemon_extensions = session_extensions.len(),
+                "Agent: wired daemon-side cargo-crate extensions"
+            );
         }
 
         // YYC-264: embedded cortex-memory-core graph memory. When enabled,

--- a/src/cli_extension.rs
+++ b/src/cli_extension.rs
@@ -48,8 +48,8 @@ fn list(home: &Path, install: &SqliteInstallStateStore) -> Result<()> {
         return Ok(());
     }
     println!(
-        "{:<24} {:<10} {:<10} {:<8} description",
-        "id", "status", "version", "source"
+        "{:<24} {:<10} {:<10} {:<8} {:<5} description",
+        "id", "status", "version", "source", "core"
     );
     for meta in entries {
         let source = match meta.source {
@@ -65,11 +65,12 @@ fn list(home: &Path, install: &SqliteInstallStateStore) -> Result<()> {
             .take(60)
             .collect();
         println!(
-            "{:<24} {:<10} {:<10} {:<8} {}",
+            "{:<24} {:<10} {:<10} {:<8} {:<5} {}",
             meta.id,
             meta.status.as_str(),
             meta.version,
             source,
+            meta.core,
             desc_preview
         );
     }
@@ -97,6 +98,7 @@ fn show(home: &Path, install: &SqliteInstallStateStore, id: &str) -> Result<()> 
         crate::extensions::ExtensionSource::SkillDraft => "skill-draft",
     };
     println!("  source:      {source}");
+    println!("  core:        {}", meta.core);
     println!("  priority:    {}", meta.priority);
     if !meta.description.is_empty() {
         println!("  description: {}", meta.description);
@@ -135,6 +137,7 @@ async fn set_enabled(
     // Confirm the manifest exists before flipping state — flipping
     // state on an unknown id would silently rot.
     let registry = ExtensionRegistry::new();
+    crate::extensions::api::wire_inventory_into_registry(&registry);
     let cwd = std::env::current_dir()?;
     registry.load_from_store_and_workspace(home, &cwd, install, install);
     let meta = registry
@@ -146,6 +149,11 @@ async fn set_enabled(
     {
         return Err(anyhow!(
             "extension `{id}` was discovered from this workspace and must be trusted first"
+        ));
+    }
+    if meta.core && !enabled {
+        return Err(anyhow!(
+            "extension `{id}` is core and cannot be disabled; use `vulcan extension kill {id}` for an emergency stop"
         ));
     }
     // Upsert a state row if missing so subsequent flips have
@@ -181,11 +189,23 @@ async fn set_enabled(
 }
 
 async fn kill(home: &Path, install: &SqliteInstallStateStore, id: &str) -> Result<()> {
-    set_enabled(home, install, id, false).await?;
+    let registry = ExtensionRegistry::new();
+    crate::extensions::api::wire_inventory_into_registry(&registry);
+    let cwd = std::env::current_dir()?;
+    registry.load_from_store_and_workspace(home, &cwd, install, install);
+    let is_core = registry.get(id).map(|meta| meta.core).unwrap_or(false);
+    if is_core {
+        println!("warning: `{id}` is a core extension; killing it may break runtime invariants");
+    } else {
+        set_enabled(home, install, id, false).await?;
+    }
     if let Some(result) = call_daemon("extension.kill", serde_json::json!({ "id": id })).await? {
         println!("live daemon: {}", serde_json::to_string(&result)?);
     }
     println!("warning: kill may break in-flight tool calls for `{id}`");
+    if is_core {
+        println!("warning: core kill may also break in-flight safety or context hooks");
+    }
     println!("force-stopped {id}");
     Ok(())
 }

--- a/src/extensions/api.rs
+++ b/src/extensions/api.rs
@@ -19,8 +19,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use super::ExtensionMetadata;
 use super::FrontendCapability;
+use crate::config::DangerousCommandsConfig;
 use crate::hooks::{HookHandler, HookOutcome};
 use crate::memory::SessionStore;
+use crate::pause::PauseSender;
 use crate::provider::factory::ProviderFactory;
 use crate::provider::{ChatResponse, LLMProvider, Message, StreamEvent, ToolCall};
 use crate::tools::{Tool, ToolProgress, ToolResult};
@@ -36,6 +38,7 @@ pub struct ExtensionManifest {
     pub id: String,
     pub version: String,
     pub daemon_entry: Option<String>,
+    pub core: bool,
     pub requires_user_approval: bool,
 }
 
@@ -56,6 +59,14 @@ pub struct SessionExtensionCtx {
     /// Durable session history store for replaying extension state
     /// carried through `ToolResult.details`.
     pub memory: Arc<SessionStore>,
+    /// Skills directory configured for this Session. Core skills uses
+    /// this to build the same catalog the previous hard-wired hook used.
+    pub skills_dir: PathBuf,
+    /// Optional interactive pause channel for Session extensions that
+    /// need HITL approval, including core safety.
+    pub pause_tx: Option<PauseSender>,
+    /// Dangerous-command policy for core safety.
+    pub dangerous_commands: DangerousCommandsConfig,
     /// Capabilities declared by the current frontend.
     pub frontend_capabilities: Vec<FrontendCapability>,
     /// Frontend extension descriptors declared by the current frontend.
@@ -72,6 +83,9 @@ impl SessionExtensionCtx {
             cwd,
             session_id,
             memory,
+            skills_dir: PathBuf::from(".agents/skills"),
+            pause_tx: None,
+            dangerous_commands: DangerousCommandsConfig::default(),
             frontend_capabilities: FrontendCapability::text_only(),
             frontend_extensions: Vec::new(),
             frontend_events: FrontendEventSink::default(),
@@ -95,6 +109,21 @@ impl SessionExtensionCtx {
 
     pub fn with_frontend_capabilities(mut self, capabilities: Vec<FrontendCapability>) -> Self {
         self.frontend_capabilities = capabilities;
+        self
+    }
+
+    pub fn with_skills_dir(mut self, skills_dir: PathBuf) -> Self {
+        self.skills_dir = skills_dir;
+        self
+    }
+
+    pub fn with_pause_channel(mut self, pause_tx: Option<PauseSender>) -> Self {
+        self.pause_tx = pause_tx;
+        self
+    }
+
+    pub fn with_dangerous_commands(mut self, dangerous_commands: DangerousCommandsConfig) -> Self {
+        self.dangerous_commands = dangerous_commands;
         self
     }
 

--- a/src/extensions/manifest.rs
+++ b/src/extensions/manifest.rs
@@ -58,6 +58,11 @@ pub struct ExtensionManifest {
     /// preserve it round-trip without enforcing.
     #[serde(default)]
     pub checksum: Option<String>,
+    /// Marks an extension as part of Vulcan's own runtime contract.
+    /// Core extensions cannot be disabled through normal lifecycle
+    /// commands and sort before non-core extensions.
+    #[serde(default)]
+    pub core: bool,
     /// Lowest Vulcan version that supports this manifest.
     #[serde(default)]
     pub min_vulcan_version: Option<String>,
@@ -294,5 +299,31 @@ kind = "builtin"
 "#;
         let opted_in_m = ExtensionManifest::from_toml_str(opted_in_raw).unwrap();
         assert!(opted_in_m.requires_user_approval);
+    }
+
+    #[test]
+    fn core_defaults_to_false_and_parses_when_present() {
+        let default_raw = r#"
+id = "input-demo"
+name = "Input Demo"
+version = "0.1.0"
+
+[entry]
+kind = "builtin"
+"#;
+        let default_m = ExtensionManifest::from_toml_str(default_raw).unwrap();
+        assert!(!default_m.core);
+
+        let core_raw = r#"
+id = "core-safety"
+name = "Core Safety"
+version = "0.1.0"
+core = true
+
+[entry]
+kind = "builtin"
+"#;
+        let core_m = ExtensionManifest::from_toml_str(core_raw).unwrap();
+        assert!(core_m.core);
     }
 }

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -205,6 +205,11 @@ pub struct ExtensionMetadata {
     /// `vulcan extension show`. Caller-provided; the registry
     /// does not interpret it.
     pub permissions_summary: Option<String>,
+    /// Core extensions are part of Vulcan's own runtime contract.
+    /// They always sort ahead of non-core extensions and cannot be
+    /// disabled through the normal lifecycle path.
+    #[serde(default)]
+    pub core: bool,
     /// Whether input rewrites from this extension require explicit
     /// user approval before the rewritten text is applied.
     pub requires_user_approval: bool,
@@ -236,6 +241,7 @@ impl ExtensionMetadata {
             capabilities: Vec::new(),
             requires_frontend: Vec::new(),
             permissions_summary: None,
+            core: false,
             requires_user_approval: false,
             broken_reason: None,
             priority: 100,

--- a/src/extensions/registry.rs
+++ b/src/extensions/registry.rs
@@ -155,7 +155,12 @@ impl ExtensionRegistry {
     }
 
     fn sort_in_place(items: &mut [ExtensionMetadata]) {
-        items.sort_by(|a, b| a.priority.cmp(&b.priority).then_with(|| a.id.cmp(&b.id)));
+        items.sort_by(|a, b| {
+            b.core
+                .cmp(&a.core)
+                .then_with(|| a.priority.cmp(&b.priority))
+                .then_with(|| a.id.cmp(&b.id))
+        });
     }
 
     /// YYC-227: register a code-backed extension. The registry
@@ -448,6 +453,7 @@ impl ExtensionRegistry {
                     if let Some(desc) = manifest.description.clone() {
                         meta.description = desc;
                     }
+                    meta.core = manifest.core;
                     meta.requires_frontend = manifest
                         .requires_frontend
                         .iter()
@@ -571,6 +577,22 @@ mod tests {
         let ids: Vec<String> = reg.list().into_iter().map(|m| m.id).collect();
         // Tied priorities sort by id; lower priority first.
         assert_eq!(ids, vec!["alpha", "bravo", "charlie", "delta"]);
+    }
+
+    #[test]
+    fn list_returns_core_extensions_before_priority_order() {
+        let reg = ExtensionRegistry::new();
+        let non_core_first = meta("non-core-first", 0);
+        let mut core_later = meta("core-later", 100);
+        core_later.core = true;
+        let mut core_first = meta("core-first", 10);
+        core_first.core = true;
+        reg.upsert(non_core_first);
+        reg.upsert(core_later);
+        reg.upsert(core_first);
+
+        let ids: Vec<String> = reg.list().into_iter().map(|m| m.id).collect();
+        assert_eq!(ids, vec!["core-first", "core-later", "non-core-first"]);
     }
 
     #[test]

--- a/src/extensions/verify.rs
+++ b/src/extensions/verify.rs
@@ -134,6 +134,7 @@ mod tests {
             requires_frontend: Vec::new(),
             permissions: None,
             checksum: checksum.map(String::from),
+            core: false,
             min_vulcan_version: min.map(String::from),
             description: None,
             requires_user_approval: false,

--- a/vulcan-core-ext-safety/Cargo.toml
+++ b/vulcan-core-ext-safety/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "vulcan-core-ext-safety"
+version = "0.1.0"
+edition = "2024"
+description = "Core Vulcan safety hook extension"
+license = "MIT"
+
+[package.metadata.vulcan]
+id = "core-safety"
+daemon_entry = "vulcan_core_ext_safety::CoreSafetyExtension"
+core = true
+requires_user_approval = true
+
+[dependencies]
+inventory = "0.3.24"
+vulcan = { package = "vulcan-core", path = ".." }
+vulcan-extension-macros = { path = "../vulcan-extension-macros" }

--- a/vulcan-core-ext-safety/src/lib.rs
+++ b/vulcan-core-ext-safety/src/lib.rs
@@ -1,0 +1,83 @@
+//! Core safety extension.
+//!
+//! This moves the dangerous-command safety gate onto the same daemon
+//! extension registration path used by other hook-providing code.
+
+use std::sync::Arc;
+
+use vulcan::config::DangerousCommandPolicy;
+use vulcan::extensions::api::{
+    DaemonCodeExtension, ExtensionRegistration, SessionExtension, SessionExtensionCtx,
+};
+use vulcan::extensions::{
+    ExtensionCapability, ExtensionMetadata, ExtensionSource, ExtensionStatus,
+};
+use vulcan::hooks::HookHandler;
+use vulcan::hooks::safety::SafetyHook;
+use vulcan_extension_macros::include_manifest;
+
+pub struct CoreSafetyExtension;
+
+impl DaemonCodeExtension for CoreSafetyExtension {
+    fn metadata(&self) -> ExtensionMetadata {
+        let manifest = include_manifest!();
+        let mut m = ExtensionMetadata::new(
+            manifest.id,
+            "Core Safety",
+            manifest.version,
+            ExtensionSource::Builtin,
+        );
+        m.status = ExtensionStatus::Active;
+        m.core = manifest.core;
+        m.priority = 0;
+        m.requires_user_approval = manifest.requires_user_approval;
+        m.capabilities = vec![ExtensionCapability::HookHandler];
+        m.description =
+            "Blocks dangerous shell and PTY commands unless policy or HITL approval allows them."
+                .to_string();
+        m
+    }
+
+    fn instantiate(&self, ctx: SessionExtensionCtx) -> Arc<dyn SessionExtension> {
+        Arc::new(CoreSafetySession { ctx })
+    }
+}
+
+struct CoreSafetySession {
+    ctx: SessionExtensionCtx,
+}
+
+impl SessionExtension for CoreSafetySession {
+    fn hook_handlers(&self) -> Vec<Arc<dyn HookHandler>> {
+        if matches!(
+            self.ctx.dangerous_commands.policy,
+            DangerousCommandPolicy::Allow
+        ) {
+            return Vec::new();
+        }
+        vec![Arc::new(SafetyHook::with_config(
+            self.ctx.pause_tx.clone(),
+            self.ctx.dangerous_commands,
+        ))]
+    }
+}
+
+inventory::submit! {
+    ExtensionRegistration {
+        register: || Arc::new(CoreSafetyExtension) as Arc<dyn DaemonCodeExtension>,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metadata_marks_extension_core_and_hitl() {
+        let meta = CoreSafetyExtension.metadata();
+        assert!(meta.core);
+        assert_eq!(meta.priority, 0);
+        assert_eq!(meta.status, ExtensionStatus::Active);
+        assert!(meta.requires_user_approval);
+    }
+}

--- a/vulcan-core-ext-skills/Cargo.toml
+++ b/vulcan-core-ext-skills/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "vulcan-core-ext-skills"
+version = "0.1.0"
+edition = "2024"
+description = "Core Vulcan skills hook extension"
+license = "MIT"
+
+[package.metadata.vulcan]
+id = "core-skills"
+daemon_entry = "vulcan_core_ext_skills::CoreSkillsExtension"
+core = true
+
+[dependencies]
+inventory = "0.3.24"
+vulcan = { package = "vulcan-core", path = ".." }
+vulcan-extension-macros = { path = "../vulcan-extension-macros" }

--- a/vulcan-core-ext-skills/src/lib.rs
+++ b/vulcan-core-ext-skills/src/lib.rs
@@ -1,0 +1,81 @@
+//! Core skills extension.
+//!
+//! This wraps the previous in-tree `SkillsHook` registration in the
+//! daemon extension surface so built-in context is wired the same way
+//! as other hook-providing extensions.
+
+use std::sync::Arc;
+
+use vulcan::extensions::api::{
+    DaemonCodeExtension, ExtensionRegistration, SessionExtension, SessionExtensionCtx,
+};
+use vulcan::extensions::{
+    ExtensionCapability, ExtensionMetadata, ExtensionSource, ExtensionStatus,
+};
+use vulcan::hooks::HookHandler;
+use vulcan::hooks::skills::SkillsHook;
+use vulcan::skills::SkillRegistry;
+use vulcan_extension_macros::include_manifest;
+
+pub struct CoreSkillsExtension;
+
+impl DaemonCodeExtension for CoreSkillsExtension {
+    fn metadata(&self) -> ExtensionMetadata {
+        let manifest = include_manifest!();
+        let mut m = ExtensionMetadata::new(
+            manifest.id,
+            "Core Skills",
+            manifest.version,
+            ExtensionSource::Builtin,
+        );
+        m.status = ExtensionStatus::Active;
+        m.core = manifest.core;
+        m.priority = 10;
+        m.capabilities = vec![
+            ExtensionCapability::HookHandler,
+            ExtensionCapability::PromptInjection,
+        ];
+        m.description =
+            "Injects the available skills catalog and lazily activated skill bodies.".to_string();
+        m
+    }
+
+    fn instantiate(&self, ctx: SessionExtensionCtx) -> Arc<dyn SessionExtension> {
+        Arc::new(CoreSkillsSession {
+            registry: Arc::new(SkillRegistry::default_for(&ctx.skills_dir, Some(&ctx.cwd))),
+        })
+    }
+}
+
+struct CoreSkillsSession {
+    registry: Arc<SkillRegistry>,
+}
+
+impl SessionExtension for CoreSkillsSession {
+    fn hook_handlers(&self) -> Vec<Arc<dyn HookHandler>> {
+        vec![Arc::new(SkillsHook::new(Arc::clone(&self.registry)))]
+    }
+}
+
+inventory::submit! {
+    ExtensionRegistration {
+        register: || Arc::new(CoreSkillsExtension) as Arc<dyn DaemonCodeExtension>,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metadata_marks_extension_core() {
+        let meta = CoreSkillsExtension.metadata();
+        assert!(meta.core);
+        assert_eq!(meta.priority, 10);
+        assert_eq!(meta.status, ExtensionStatus::Active);
+        assert!(
+            meta.capabilities
+                .contains(&ExtensionCapability::PromptInjection)
+        );
+    }
+}

--- a/vulcan-extension-macros/src/lib.rs
+++ b/vulcan-extension-macros/src/lib.rs
@@ -42,6 +42,10 @@ pub fn include_manifest(_input: TokenStream) -> TokenStream {
         .and_then(toml::Value::as_str)
         .unwrap_or(package_version);
     let daemon_entry = vulcan.get("daemon_entry").and_then(toml::Value::as_str);
+    let core = vulcan
+        .get("core")
+        .and_then(toml::Value::as_bool)
+        .unwrap_or(false);
     let requires_user_approval = vulcan
         .get("requires_user_approval")
         .and_then(toml::Value::as_bool)
@@ -55,7 +59,7 @@ pub fn include_manifest(_input: TokenStream) -> TokenStream {
     };
 
     format!(
-        "::vulcan::extensions::api::ExtensionManifest {{ id: {id_lit}.to_string(), version: {version_lit}.to_string(), daemon_entry: {daemon_entry_tokens}, requires_user_approval: {requires_user_approval} }}"
+        "::vulcan::extensions::api::ExtensionManifest {{ id: {id_lit}.to_string(), version: {version_lit}.to_string(), daemon_entry: {daemon_entry_tokens}, core: {core}, requires_user_approval: {requires_user_approval} }}"
     )
     .parse()
     .expect("include_manifest! generated invalid tokens")

--- a/vulcan-tui/Cargo.toml
+++ b/vulcan-tui/Cargo.toml
@@ -11,6 +11,8 @@ repository = "https://github.com/yycholla/vulcan"
 anyhow = "1"
 vulcan = { package = "vulcan-core", path = ".." }
 vulcan-frontend-api = { path = "../vulcan-frontend-api" }
+vulcan-core-ext-safety = { path = "../vulcan-core-ext-safety" }
+vulcan-core-ext-skills = { path = "../vulcan-core-ext-skills" }
 vulcan-ext-todo = { path = "../vulcan-ext-todo", features = ["tui"] }
 vulcan-ext-spinner-demo = { path = "../vulcan-ext-spinner-demo", features = ["tui"] }
 vulcan-ext-snake = { path = "../vulcan-ext-snake" }

--- a/vulcan-tui/src/main.rs
+++ b/vulcan-tui/src/main.rs
@@ -2,6 +2,8 @@
 // #555 (Slice 4: Frontend extension binary + tool-result renderer).
 // Until then, the working TUI continues to ship as the `vulcan` daemon
 // binary's `chat` subcommand.
+use vulcan_core_ext_safety as _;
+use vulcan_core_ext_skills as _;
 use vulcan_ext_snake as _;
 use vulcan_ext_spinner_demo as _;
 use vulcan_ext_todo as _;

--- a/vulcan/Cargo.toml
+++ b/vulcan/Cargo.toml
@@ -22,6 +22,8 @@ telegram = ["vulcan/telegram"]
 # as `vulcan-core`. The `package =` rename keeps the existing
 # `use vulcan::*` imports compiling.
 vulcan = { package = "vulcan-core", path = ".." }
+vulcan-core-ext-safety = { path = "../vulcan-core-ext-safety" }
+vulcan-core-ext-skills = { path = "../vulcan-core-ext-skills" }
 
 # GH issue #549: link the auto-commit dogfood extension so its
 # `inventory::submit!` site is visible at daemon startup. Without a

--- a/vulcan/src/main.rs
+++ b/vulcan/src/main.rs
@@ -2,6 +2,8 @@
 // `inventory::submit!` site into the daemon binary so its `register`
 // fn pointer survives dead-code elimination. Bare `extern crate`
 // suffices — no symbols need importing into source.
+extern crate vulcan_core_ext_safety as _vulcan_core_ext_safety;
+extern crate vulcan_core_ext_skills as _vulcan_core_ext_skills;
 extern crate vulcan_ext_auto_commit as _vulcan_ext_auto_commit;
 extern crate vulcan_ext_input_demo as _vulcan_ext_input_demo;
 extern crate vulcan_ext_snake as _vulcan_ext_snake;


### PR DESCRIPTION
## Summary
- adds `core = true` metadata/manifest support and sorts core extensions ahead of non-core extensions
- adds `core-skills` and `core-safety` daemon extension crates, linked through inventory, and moves Agent skills/safety hook wiring through the extension registry
- makes `vulcan extension disable` refuse core extensions while `kill` remains the explicit emergency stop path with louder warnings
- updates `~/wiki/queries/hooks-design.md` to document the unified core extension surface

Refs #561
Stacked on #605 / #560.

## Verification
- TMPDIR=/tmp/vulcan-test-tmp cargo test -p vulcan-core-ext-skills -p vulcan-core-ext-safety
- TMPDIR=/tmp/vulcan-test-tmp cargo test -p vulcan-core extensions::manifest
- TMPDIR=/tmp/vulcan-test-tmp cargo test -p vulcan-core extensions::registry
- TMPDIR=/tmp/vulcan-test-tmp cargo test -p vulcan-core hooks::skills
- TMPDIR=/tmp/vulcan-test-tmp cargo test -p vulcan-core hooks::safety
- TMPDIR=/tmp/vulcan-test-tmp cargo test -p vulcan-core agent::tests
- TMPDIR=/tmp/vulcan-test-tmp cargo check -p vulcan-core-ext-skills -p vulcan-core-ext-safety -p vulcan --bin vulcan -p vulcan-tui
- cargo fmt --all -- --check
- git diff --check
- cargo machete
- cargo deny check
- TMPDIR=/tmp/vulcan-test-tmp cargo run -p vulcan -- extension list
- TMPDIR=/tmp/vulcan-test-tmp cargo run -p vulcan -- extension disable core-safety (expected refusal)
- TMPDIR=/tmp/vulcan-test-tmp cargo test
- npx gitnexus detect-changes --repo /home/yycholla/vulcan/.worktrees/rebuild-561 --scope all
- npx gitnexus detect-changes --repo /home/yycholla/vulcan/.worktrees/rebuild-561 --scope staged

GitNexus reports CRITICAL combined diff risk because this intentionally touches Agent construction, registry ordering, and extension lifecycle flows; the broad local test suite passed before publishing.