### PR TITLE
Trace tool and provider boundaries

### DIFF
--- a/src/agent/dispatch.rs
+++ b/src/agent/dispatch.rs
@@ -5,8 +5,10 @@
 
 use serde_json::Value;
 use tokio_util::sync::CancellationToken;
+use tracing::Instrument;
 
 use crate::hooks::ToolCallDecision;
+use crate::observability;
 use crate::run_record::{PayloadFingerprint, RunEvent};
 use crate::tools::{ProgressSink, ToolResult};
 
@@ -67,7 +69,9 @@ impl Agent {
             }
         };
 
+        let tool_span = observability::tool_call_span(name);
         let raw_result: ToolResult = if let Some(reason) = blocked.clone() {
+            tool_span.record(observability::attr::OUTCOME, "blocked");
             // YYC-179: record the block before failing the tool
             // call so dashboards can group denied dispatches.
             self.record_run_event(RunEvent::HookDecision {
@@ -81,10 +85,23 @@ impl Agent {
             match self
                 .tools
                 .execute_with_progress(name, &effective_args_str, cancel.clone(), progress)
+                .instrument(tool_span.clone())
                 .await
             {
-                Ok(r) => r,
-                Err(e) => ToolResult::err(format!("Error: {e}")),
+                Ok(r) => {
+                    if r.is_error {
+                        tool_span.record(observability::attr::OUTCOME, "error");
+                        tool_span.record(observability::attr::ERROR_KIND, "tool_error");
+                    } else {
+                        tool_span.record(observability::attr::OUTCOME, "ok");
+                    }
+                    r
+                }
+                Err(e) => {
+                    tool_span.record(observability::attr::OUTCOME, "error");
+                    tool_span.record(observability::attr::ERROR_KIND, "dispatch_error");
+                    ToolResult::err(format!("Error: {e}"))
+                }
             }
         };
 
@@ -104,6 +121,12 @@ impl Agent {
             }
             None => raw_result,
         };
+        if final_result.is_error {
+            tool_span.record(observability::attr::OUTCOME, "error");
+            tool_span.record(observability::attr::ERROR_KIND, "tool_error");
+        } else if blocked.is_none() {
+            tool_span.record(observability::attr::OUTCOME, "ok");
+        }
 
         // YYC-179: emit one ToolCall event per dispatch with the
         // duration, approval surface, and structured error flag.

--- a/src/agent/run.rs
+++ b/src/agent/run.rs
@@ -6,8 +6,10 @@
 use anyhow::Result;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
+use tracing::Instrument;
 
 use crate::hooks::{CompactionDecision, validate_rewrite_history};
+use crate::observability;
 use crate::provider::{ChatResponse, Message, StreamEvent, ToolCall, ToolDefinition, Usage};
 use crate::run_record::{PayloadFingerprint, RunEvent, RunOrigin, RunRecord, RunStatus};
 use crate::tools::ToolResult;
@@ -53,6 +55,19 @@ fn empty_terminal_message(
     }
     format!("_({} — terminal turn)_", parts.join("; "))
 }
+
+fn record_provider_usage(span: &tracing::Span, usage: &Usage) {
+    span.record(
+        observability::attr::PROMPT_TOKENS,
+        usage.prompt_tokens as u64,
+    );
+    span.record(
+        observability::attr::COMPLETION_TOKENS,
+        usage.completion_tokens as u64,
+    );
+    span.record(observability::attr::TOTAL_TOKENS, usage.total_tokens as u64);
+}
+
 pub(crate) fn sanitize_orphan_tool_messages(messages: &mut Vec<Message>) -> usize {
     use std::collections::HashSet;
     let mut active_call_ids: HashSet<String> = HashSet::new();
@@ -603,9 +618,29 @@ impl Agent {
         };
 
         let request = ContextManager::summarization_request(&messages[1..split]);
-        let response = match self.provider.chat(&request, &[], cancel.clone()).await {
-            Ok(r) => r,
+        let provider_span = observability::provider_request_span(
+            &self.provider_config.r#type,
+            &self.provider_config.model,
+            false,
+            request.len(),
+            0,
+        );
+        let response = match self
+            .provider
+            .chat(&request, &[], cancel.clone())
+            .instrument(provider_span.clone())
+            .await
+        {
+            Ok(r) => {
+                provider_span.record(observability::attr::OUTCOME, "ok");
+                if let Some(usage) = &r.usage {
+                    record_provider_usage(&provider_span, usage);
+                }
+                r
+            }
             Err(e) => {
+                provider_span.record(observability::attr::OUTCOME, "error");
+                provider_span.record(observability::attr::ERROR_KIND, "provider_error");
                 tracing::warn!("compaction summarizer call failed: {e}");
                 return false;
             }
@@ -754,11 +789,21 @@ impl Agent {
             .on_before_provider_request(outgoing, cancel.clone())
             .await;
 
+        let provider_span = observability::provider_request_span(
+            &self.provider_config.r#type,
+            &self.provider_config.model,
+            true,
+            outgoing.len(),
+            tool_defs.len(),
+        );
         if let Err(e) = self
             .provider
             .chat_stream(outgoing, tool_defs, inner_tx, cancel.clone())
+            .instrument(provider_span.clone())
             .await
         {
+            provider_span.record(observability::attr::OUTCOME, "error");
+            provider_span.record(observability::attr::ERROR_KIND, "provider_error");
             // Surface provider failures to the TUI rather than dropping
             // the channel silently. ProviderError carries actionable hints
             // via its Display impl; if the error chain has one (most
@@ -791,11 +836,15 @@ impl Agent {
                 .await;
             return Err(e);
         }
+        provider_span.record(observability::attr::OUTCOME, "ok");
 
         let mut final_response: Option<ChatResponse> = None;
         while let Some(event) = priv_rx.recv().await {
             match event {
                 TurnEvent::ProviderDone { response } => {
+                    if let Some(usage) = &response.usage {
+                        record_provider_usage(&provider_span, usage);
+                    }
                     final_response = Some(response);
                     break;
                 }
@@ -1099,14 +1148,30 @@ impl TurnRunnerMut<'_> {
                         .hooks
                         .on_before_provider_request(&outgoing, cancel.clone())
                         .await;
+                    let provider_span = observability::provider_request_span(
+                        &self.agent.provider_config.r#type,
+                        &self.agent.provider_config.model,
+                        false,
+                        outgoing.len(),
+                        tool_defs.len(),
+                    );
                     let resp = match self
                         .agent
                         .provider
                         .chat(&outgoing, &tool_defs, cancel.clone())
+                        .instrument(provider_span.clone())
                         .await
                     {
-                        Ok(r) => r,
+                        Ok(r) => {
+                            provider_span.record(observability::attr::OUTCOME, "ok");
+                            if let Some(usage) = &r.usage {
+                                record_provider_usage(&provider_span, usage);
+                            }
+                            r
+                        }
                         Err(e) => {
+                            provider_span.record(observability::attr::OUTCOME, "error");
+                            provider_span.record(observability::attr::ERROR_KIND, "provider_error");
                             self.agent.record_run_event(RunEvent::ProviderError {
                                 message: e.to_string(),
                                 retryable: false,

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -17,7 +17,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::time::timeout;
 use tokio_util::sync::CancellationToken;
+use tracing::Instrument;
 
+use crate::observability;
 use crate::pause::{AgentPause, AgentResume, OptionKind, PauseKind, PauseOption, PauseSender};
 use crate::provider::{ChatResponse, Message, StreamEvent, ToolCall};
 use crate::tools::{ToolProgress, ToolResult};
@@ -467,7 +469,10 @@ impl HookRegistry {
         let mut appended: Vec<Message> = Vec::new();
 
         for h in self.handlers_snapshot() {
-            match self.run(&h, h.on_context(&current, cancel.clone())).await {
+            match self
+                .run("on_context", &h, h.on_context(&current, cancel.clone()))
+                .await
+            {
                 Some(HookOutcome::RewriteMessages(rewritten)) => {
                     tracing::info!("hook {} rewrote context messages", h.name());
                     current = rewritten;
@@ -489,7 +494,11 @@ impl HookRegistry {
                 }
             }
             match self
-                .run(&h, h.before_prompt(messages, cancel.clone()))
+                .run(
+                    "before_prompt",
+                    &h,
+                    h.before_prompt(messages, cancel.clone()),
+                )
                 .await
             {
                 Some(HookOutcome::InjectMessages {
@@ -539,7 +548,10 @@ impl HookRegistry {
 
     pub async fn on_turn_start(&self, turn: u32, cancel: CancellationToken) {
         for h in self.handlers_snapshot() {
-            match self.run(&h, h.on_turn_start(turn, cancel.clone())).await {
+            match self
+                .run("on_turn_start", &h, h.on_turn_start(turn, cancel.clone()))
+                .await
+            {
                 Some(HookOutcome::Continue) | None => {}
                 Some(other) => {
                     tracing::warn!(
@@ -554,7 +566,10 @@ impl HookRegistry {
 
     pub async fn on_turn_end(&self, turn: u32, cancel: CancellationToken) {
         for h in self.handlers_snapshot() {
-            match self.run(&h, h.on_turn_end(turn, cancel.clone())).await {
+            match self
+                .run("on_turn_end", &h, h.on_turn_end(turn, cancel.clone()))
+                .await
+            {
                 Some(HookOutcome::Continue) | None => {}
                 Some(other) => {
                     tracing::warn!(
@@ -572,8 +587,12 @@ impl HookRegistry {
             self.ignore_observe_outcome(
                 &h,
                 "on_message_start",
-                self.run(&h, h.on_message_start(delta, cancel.clone()))
-                    .await,
+                self.run(
+                    "on_message_start",
+                    &h,
+                    h.on_message_start(delta, cancel.clone()),
+                )
+                .await,
             );
         }
     }
@@ -583,8 +602,12 @@ impl HookRegistry {
             self.ignore_observe_outcome(
                 &h,
                 "on_message_update",
-                self.run(&h, h.on_message_update(delta, cancel.clone()))
-                    .await,
+                self.run(
+                    "on_message_update",
+                    &h,
+                    h.on_message_update(delta, cancel.clone()),
+                )
+                .await,
             );
         }
     }
@@ -594,7 +617,12 @@ impl HookRegistry {
             self.ignore_observe_outcome(
                 &h,
                 "on_message_end",
-                self.run(&h, h.on_message_end(delta, cancel.clone())).await,
+                self.run(
+                    "on_message_end",
+                    &h,
+                    h.on_message_end(delta, cancel.clone()),
+                )
+                .await,
             );
         }
     }
@@ -604,8 +632,12 @@ impl HookRegistry {
             self.ignore_observe_outcome(
                 &h,
                 "on_tool_execution_start",
-                self.run(&h, h.on_tool_execution_start(call, cancel.clone()))
-                    .await,
+                self.run(
+                    "on_tool_execution_start",
+                    &h,
+                    h.on_tool_execution_start(call, cancel.clone()),
+                )
+                .await,
             );
         }
     }
@@ -621,6 +653,7 @@ impl HookRegistry {
                 &h,
                 "on_tool_execution_update",
                 self.run(
+                    "on_tool_execution_update",
                     &h,
                     h.on_tool_execution_update(call, progress, cancel.clone()),
                 )
@@ -634,8 +667,12 @@ impl HookRegistry {
             self.ignore_observe_outcome(
                 &h,
                 "on_tool_execution_end",
-                self.run(&h, h.on_tool_execution_end(call, cancel.clone()))
-                    .await,
+                self.run(
+                    "on_tool_execution_end",
+                    &h,
+                    h.on_tool_execution_end(call, cancel.clone()),
+                )
+                .await,
             );
         }
     }
@@ -649,8 +686,12 @@ impl HookRegistry {
             self.ignore_observe_outcome(
                 &h,
                 "on_before_provider_request",
-                self.run(&h, h.on_before_provider_request(messages, cancel.clone()))
-                    .await,
+                self.run(
+                    "on_before_provider_request",
+                    &h,
+                    h.on_before_provider_request(messages, cancel.clone()),
+                )
+                .await,
             );
         }
     }
@@ -664,8 +705,12 @@ impl HookRegistry {
             self.ignore_observe_outcome(
                 &h,
                 "on_after_provider_response",
-                self.run(&h, h.on_after_provider_response(response, cancel.clone()))
-                    .await,
+                self.run(
+                    "on_after_provider_response",
+                    &h,
+                    h.on_after_provider_response(response, cancel.clone()),
+                )
+                .await,
             );
         }
     }
@@ -677,7 +722,11 @@ impl HookRegistry {
     ) -> CompactionDecision {
         for h in self.handlers_snapshot() {
             match self
-                .run(&h, h.on_session_before_compact(messages, cancel.clone()))
+                .run(
+                    "on_session_before_compact",
+                    &h,
+                    h.on_session_before_compact(messages, cancel.clone()),
+                )
                 .await
             {
                 Some(HookOutcome::Block { reason }) => {
@@ -712,8 +761,12 @@ impl HookRegistry {
             self.ignore_observe_outcome(
                 &h,
                 "on_session_compact",
-                self.run(&h, h.on_session_compact(summary, cancel.clone()))
-                    .await,
+                self.run(
+                    "on_session_compact",
+                    &h,
+                    h.on_session_compact(summary, cancel.clone()),
+                )
+                .await,
             );
         }
     }
@@ -723,7 +776,12 @@ impl HookRegistry {
             self.ignore_observe_outcome(
                 &h,
                 "on_session_before_fork",
-                self.run(&h, h.on_session_before_fork(cancel.clone())).await,
+                self.run(
+                    "on_session_before_fork",
+                    &h,
+                    h.on_session_before_fork(cancel.clone()),
+                )
+                .await,
             );
         }
     }
@@ -733,7 +791,12 @@ impl HookRegistry {
             self.ignore_observe_outcome(
                 &h,
                 "on_session_shutdown",
-                self.run(&h, h.on_session_shutdown(cancel.clone())).await,
+                self.run(
+                    "on_session_shutdown",
+                    &h,
+                    h.on_session_shutdown(cancel.clone()),
+                )
+                .await,
             );
         }
     }
@@ -747,7 +810,10 @@ impl HookRegistry {
     /// as the audit `extension_id`.
     pub async fn apply_on_input(&self, raw: &str, cancel: CancellationToken) -> InputDecision {
         for h in self.handlers_snapshot() {
-            match self.run(&h, h.on_input(raw, cancel.clone())).await {
+            match self
+                .run("on_input", &h, h.on_input(raw, cancel.clone()))
+                .await
+            {
                 Some(HookOutcome::BlockInput { reason }) => {
                     tracing::info!("hook {} blocked input: {reason}", h.name());
                     self.record_input_intercept(
@@ -927,7 +993,11 @@ impl HookRegistry {
     ) -> ToolCallDecision {
         for h in self.handlers_snapshot() {
             match self
-                .run(&h, h.before_tool_call(tool, args, cancel.clone()))
+                .run(
+                    "before_tool_call",
+                    &h,
+                    h.before_tool_call(tool, args, cancel.clone()),
+                )
                 .await
             {
                 Some(HookOutcome::Block { reason }) => {
@@ -960,7 +1030,11 @@ impl HookRegistry {
     ) -> Option<ToolResult> {
         for h in self.handlers_snapshot() {
             match self
-                .run(&h, h.after_tool_call(tool, result, cancel.clone()))
+                .run(
+                    "after_tool_call",
+                    &h,
+                    h.after_tool_call(tool, result, cancel.clone()),
+                )
                 .await
             {
                 Some(HookOutcome::ReplaceResult(new)) => {
@@ -989,7 +1063,11 @@ impl HookRegistry {
     ) -> Option<String> {
         for h in self.handlers_snapshot() {
             match self
-                .run(&h, h.before_agent_end(response, cancel.clone()))
+                .run(
+                    "before_agent_end",
+                    &h,
+                    h.before_agent_end(response, cancel.clone()),
+                )
                 .await
             {
                 Some(HookOutcome::ForceContinue { instruction }) => {
@@ -1013,22 +1091,42 @@ impl HookRegistry {
         for h in self.handlers_snapshot() {
             // Each handler gets its own timeout window. session_X are observe-
             // only so we don't care about return values.
-            let _ = timeout(self.handler_timeout, h.session_start(session_id)).await;
+            let span = hook_span("session_start", h.name());
+            let result = timeout(self.handler_timeout, h.session_start(session_id))
+                .instrument(span.clone())
+                .await;
+            record_unit_hook_result(&span, &result, self.handler_timeout);
         }
     }
 
     pub async fn session_end(&self, session_id: &str, total_turns: u32) {
         for h in self.handlers_snapshot() {
-            let _ = timeout(self.handler_timeout, h.session_end(session_id, total_turns)).await;
+            let span = hook_span("session_end", h.name());
+            let result = timeout(self.handler_timeout, h.session_end(session_id, total_turns))
+                .instrument(span.clone())
+                .await;
+            record_unit_hook_result(&span, &result, self.handler_timeout);
         }
     }
 
-    async fn run<F>(&self, h: &Arc<dyn HookHandler>, fut: F) -> Option<HookOutcome>
+    async fn run<F>(
+        &self,
+        event: &'static str,
+        h: &Arc<dyn HookHandler>,
+        fut: F,
+    ) -> Option<HookOutcome>
     where
         F: std::future::Future<Output = Result<HookOutcome>>,
     {
-        match timeout(self.handler_timeout, fut).await {
-            Ok(Ok(o)) => Some(o),
+        let span = hook_span(event, h.name());
+        match timeout(self.handler_timeout, fut)
+            .instrument(span.clone())
+            .await
+        {
+            Ok(Ok(o)) => {
+                span.record(observability::attr::OUTCOME, hook_outcome_name(&o));
+                Some(o)
+            }
             Ok(Err(e)) => {
                 // YYC-120: errors and timeouts both drop the handler's
                 // contribution to the event, but they're operationally
@@ -1037,8 +1135,11 @@ impl HookRegistry {
                 // metrics surfaces (and `failure_metrics()`) can branch on
                 // the failure mode rather than just "something went wrong".
                 self.failure_metrics.errors.fetch_add(1, Ordering::Relaxed);
+                span.record(observability::attr::OUTCOME, "error");
+                span.record(observability::attr::ERROR_KIND, "handler_error");
                 tracing::warn!(
                     handler = h.name(),
+                    hook_event = event,
                     failure = "error",
                     "hook {} returned error: {e}",
                     h.name()
@@ -1049,8 +1150,11 @@ impl HookRegistry {
                 self.failure_metrics
                     .timeouts
                     .fetch_add(1, Ordering::Relaxed);
+                span.record(observability::attr::OUTCOME, "timeout");
+                span.record(observability::attr::ERROR_KIND, "handler_timeout");
                 tracing::warn!(
                     handler = h.name(),
+                    hook_event = event,
                     failure = "timeout",
                     timeout_ms = self.handler_timeout.as_millis() as u64,
                     "hook {} timed out after {:?}",
@@ -1078,6 +1182,54 @@ impl HookRegistry {
                     event
                 );
             }
+        }
+    }
+}
+
+fn hook_span(event: &'static str, handler: &str) -> tracing::Span {
+    tracing::info_span!(
+        observability::span::HOOK_EVENT,
+        surface = "hooks",
+        hook_event = event,
+        hook_handler = handler,
+        outcome = tracing::field::Empty,
+        error_kind = tracing::field::Empty
+    )
+}
+
+fn hook_outcome_name(outcome: &HookOutcome) -> &'static str {
+    match outcome {
+        HookOutcome::Continue => "continue",
+        HookOutcome::Block { .. } => "block",
+        HookOutcome::ReplaceArgs(_) => "replace_args",
+        HookOutcome::ReplaceResult(_) => "replace_result",
+        HookOutcome::InjectMessages { .. } => "inject_messages",
+        HookOutcome::RewriteMessages(_) => "rewrite_messages",
+        HookOutcome::RewriteHistory(_) => "rewrite_history",
+        HookOutcome::ForceContinue { .. } => "force_continue",
+        HookOutcome::BlockInput { .. } => "block_input",
+        HookOutcome::ReplaceInput(_) => "replace_input",
+    }
+}
+
+fn record_unit_hook_result(
+    span: &tracing::Span,
+    result: &std::result::Result<(), tokio::time::error::Elapsed>,
+    timeout: Duration,
+) {
+    match result {
+        Ok(()) => {
+            span.record(observability::attr::OUTCOME, "continue");
+        }
+        Err(_) => {
+            span.record(observability::attr::OUTCOME, "timeout");
+            span.record(observability::attr::ERROR_KIND, "handler_timeout");
+            tracing::warn!(
+                failure = "timeout",
+                timeout_ms = timeout.as_millis() as u64,
+                "hook session notification timed out after {:?}",
+                timeout
+            );
         }
     }
 }
@@ -1241,6 +1393,37 @@ mod tests {
         let counts = reg.failure_metrics();
         assert_eq!(counts.timeouts, 2);
         assert_eq!(counts.errors, 2);
+    }
+
+    #[test]
+    fn hook_outcome_names_are_stable_for_observability() {
+        assert_eq!(hook_outcome_name(&HookOutcome::Continue), "continue");
+        assert_eq!(
+            hook_outcome_name(&HookOutcome::Block {
+                reason: "no".into()
+            }),
+            "block"
+        );
+        assert_eq!(
+            hook_outcome_name(&HookOutcome::ReplaceArgs(Value::Null)),
+            "replace_args"
+        );
+        assert_eq!(
+            hook_outcome_name(&HookOutcome::ForceContinue {
+                instruction: "keep going".into()
+            }),
+            "force_continue"
+        );
+        assert_eq!(
+            hook_outcome_name(&HookOutcome::BlockInput {
+                reason: "no".into()
+            }),
+            "block_input"
+        );
+        assert_eq!(
+            hook_outcome_name(&HookOutcome::ReplaceInput("rewritten".into())),
+            "replace_input"
+        );
     }
 
     #[tokio::test]

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -28,6 +28,12 @@ pub mod attr {
     pub const TOOL_NAME: &str = "tool_name";
     pub const PROVIDER: &str = "provider";
     pub const MODEL: &str = "model";
+    pub const STREAMING: &str = "streaming";
+    pub const MESSAGE_COUNT: &str = "message_count";
+    pub const TOOL_COUNT: &str = "tool_count";
+    pub const PROMPT_TOKENS: &str = "prompt_tokens";
+    pub const COMPLETION_TOKENS: &str = "completion_tokens";
+    pub const TOTAL_TOKENS: &str = "total_tokens";
     pub const HOOK_HANDLER: &str = "hook_handler";
     pub const HOOK_EVENT: &str = "hook_event";
     pub const OUTCOME: &str = "outcome";
@@ -54,6 +60,39 @@ pub mod metric {
     pub const TOKENS_INPUT: &str = "vulcan.tokens.input";
     pub const TOKENS_OUTPUT: &str = "vulcan.tokens.output";
     pub const RUNTIME_SECONDS: &str = "vulcan.runtime.seconds";
+}
+
+pub fn tool_call_span(tool_name: &str) -> tracing::Span {
+    tracing::info_span!(
+        span::TOOL_CALL,
+        surface = "tools",
+        tool_name,
+        outcome = tracing::field::Empty,
+        error_kind = tracing::field::Empty
+    )
+}
+
+pub fn provider_request_span(
+    provider: &str,
+    model: &str,
+    streaming: bool,
+    message_count: usize,
+    tool_count: usize,
+) -> tracing::Span {
+    tracing::info_span!(
+        span::PROVIDER_REQUEST,
+        surface = "provider",
+        provider,
+        model,
+        streaming,
+        message_count = message_count as u64,
+        tool_count = tool_count as u64,
+        outcome = tracing::field::Empty,
+        error_kind = tracing::field::Empty,
+        prompt_tokens = tracing::field::Empty,
+        completion_tokens = tracing::field::Empty,
+        total_tokens = tracing::field::Empty
+    )
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -288,6 +327,12 @@ mod tests {
             attr::TOOL_NAME,
             attr::PROVIDER,
             attr::MODEL,
+            attr::STREAMING,
+            attr::MESSAGE_COUNT,
+            attr::TOOL_COUNT,
+            attr::PROMPT_TOKENS,
+            attr::COMPLETION_TOKENS,
+            attr::TOTAL_TOKENS,
             attr::HOOK_HANDLER,
             attr::HOOK_EVENT,
             attr::OUTCOME,

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -29,6 +29,7 @@ pub mod attr {
     pub const PROVIDER: &str = "provider";
     pub const MODEL: &str = "model";
     pub const HOOK_HANDLER: &str = "hook_handler";
+    pub const HOOK_EVENT: &str = "hook_event";
     pub const OUTCOME: &str = "outcome";
     pub const ERROR_KIND: &str = "error_kind";
     pub const SURFACE: &str = "surface";
@@ -288,8 +289,10 @@ mod tests {
             attr::PROVIDER,
             attr::MODEL,
             attr::HOOK_HANDLER,
+            attr::HOOK_EVENT,
             attr::OUTCOME,
             attr::ERROR_KIND,
+            attr::SURFACE,
         ];
         assert!(attrs.iter().all(|name| !name.is_empty()));
         assert!(attrs.iter().all(|name| !name.contains('.')));


### PR DESCRIPTION
## Summary

- adds `vulcan.tool.call` spans around base Vulcan tool execution
- adds `vulcan.provider.request` spans for buffered, streaming, and compaction summarizer provider calls
- records stable provider/tool metadata plus provider token usage when available
- preserves existing run-record events and agent control flow

## Verification

- `TMPDIR=/home/yycholla/vulcan-test-tmp cargo test observability`
- `TMPDIR=/home/yycholla/vulcan-test-tmp cargo test agent::tests::collect_turn_response_emits_domain_events`
- `TMPDIR=/home/yycholla/vulcan-test-tmp cargo test run_record_captures_streaming_turn_with_tui_origin`
- `TMPDIR=/home/yycholla/vulcan-test-tmp cargo test dispatch_tool` (no matching tests; command completed cleanly)
- `TMPDIR=/home/yycholla/vulcan-test-tmp cargo check -p vulcan`
- `cargo fmt --check`
- `cargo clippy --all-targets` (passes with existing repo warnings)

Impact notes:

- `Agent.dispatch_tool`: GitNexus LOW risk.
- `Agent.collect_turn_response_impl`: GitNexus LOW risk.
- `run` in `src/agent/run.rs`: GitNexus HIGH risk because it is the unified agent loop. This PR only wraps existing provider calls with metadata spans and does not change loop decisions.

Closes #622
