### PR TITLE
Improve observability span explorer usability

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -113,6 +113,8 @@ enabled = false
 #   traces  -> http://localhost:4318/v1/traces
 #   metrics -> http://localhost:4318/v1/metrics
 # Start a local collector, then set enabled = true for manual E2E validation.
+# In SigNoz Explorer, add columns like operation, provider_mode, tool_name,
+# hook_event, hook_handler, outcome, error_kind, and total_tokens.
 endpoint = "http://localhost:4318"
 traces = true
 metrics = true

--- a/src/agent/run.rs
+++ b/src/agent/run.rs
@@ -621,7 +621,7 @@ impl Agent {
         let provider_span = observability::provider_request_span(
             &self.provider_config.r#type,
             &self.provider_config.model,
-            false,
+            observability::ProviderSpanMode::Compaction,
             request.len(),
             0,
         );
@@ -792,7 +792,7 @@ impl Agent {
         let provider_span = observability::provider_request_span(
             &self.provider_config.r#type,
             &self.provider_config.model,
-            true,
+            observability::ProviderSpanMode::Streaming,
             outgoing.len(),
             tool_defs.len(),
         );
@@ -1151,7 +1151,7 @@ impl TurnRunnerMut<'_> {
                     let provider_span = observability::provider_request_span(
                         &self.agent.provider_config.r#type,
                         &self.agent.provider_config.model,
-                        false,
+                        observability::ProviderSpanMode::Buffered,
                         outgoing.len(),
                         tool_defs.len(),
                     );

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -1187,14 +1187,48 @@ impl HookRegistry {
 }
 
 fn hook_span(event: &'static str, handler: &str) -> tracing::Span {
-    tracing::info_span!(
-        observability::span::HOOK_EVENT,
-        surface = "hooks",
-        hook_event = event,
-        hook_handler = handler,
-        outcome = tracing::field::Empty,
-        error_kind = tracing::field::Empty
-    )
+    let operation = format!("hook.{event}");
+    macro_rules! span {
+        ($name:expr) => {
+            tracing::info_span!(
+                $name,
+                surface = "hooks",
+                operation = operation.as_str(),
+                hook_event = event,
+                hook_handler = handler,
+                outcome = tracing::field::Empty,
+                error_kind = tracing::field::Empty
+            )
+        };
+    }
+
+    match event {
+        "after_tool_call" => span!(observability::span::HOOK_AFTER_TOOL_CALL),
+        "before_agent_end" => span!(observability::span::HOOK_BEFORE_AGENT_END),
+        "before_prompt" => span!(observability::span::HOOK_BEFORE_PROMPT),
+        "before_tool_call" => span!(observability::span::HOOK_BEFORE_TOOL_CALL),
+        "on_after_provider_response" => {
+            span!(observability::span::HOOK_ON_AFTER_PROVIDER_RESPONSE)
+        }
+        "on_before_provider_request" => span!(observability::span::HOOK_ON_BEFORE_PROVIDER_REQUEST),
+        "on_context" => span!(observability::span::HOOK_ON_CONTEXT),
+        "on_input" => span!(observability::span::HOOK_ON_INPUT),
+        "on_message_end" => span!(observability::span::HOOK_ON_MESSAGE_END),
+        "on_message_start" => span!(observability::span::HOOK_ON_MESSAGE_START),
+        "on_message_update" => span!(observability::span::HOOK_ON_MESSAGE_UPDATE),
+        "on_session_before_compact" => span!(observability::span::HOOK_ON_SESSION_BEFORE_COMPACT),
+        "on_session_before_fork" => span!(observability::span::HOOK_ON_SESSION_BEFORE_FORK),
+        "on_session_compact" => span!(observability::span::HOOK_ON_SESSION_COMPACT),
+        "on_session_shutdown" => span!(observability::span::HOOK_ON_SESSION_SHUTDOWN),
+        "on_tool_execution_end" => span!(observability::span::HOOK_ON_TOOL_EXECUTION_END),
+        "on_tool_execution_start" => span!(observability::span::HOOK_ON_TOOL_EXECUTION_START),
+        "on_tool_execution_update" => span!(observability::span::HOOK_ON_TOOL_EXECUTION_UPDATE),
+        "on_turn_end" => span!(observability::span::HOOK_ON_TURN_END),
+        "on_turn_start" => span!(observability::span::HOOK_ON_TURN_START),
+        "session_end" => span!(observability::span::HOOK_SESSION_END),
+        "session_start" => span!(observability::span::HOOK_SESSION_START),
+        _ => span!(observability::span::HOOK_EVENT),
+    }
 }
 
 fn hook_outcome_name(outcome: &HookOutcome) -> &'static str {

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -21,12 +21,14 @@ use crate::config::ObservabilityConfig;
 use crate::hooks::{HookFailureCounts, HookRegistry};
 
 pub mod attr {
+    pub const OPERATION: &str = "operation";
     pub const SESSION_ID: &str = "session_id";
     pub const RUN_ID: &str = "run_id";
     pub const TASK_ID: &str = "task_id";
     pub const TASK_IDENTIFIER: &str = "task_identifier";
     pub const TOOL_NAME: &str = "tool_name";
     pub const PROVIDER: &str = "provider";
+    pub const PROVIDER_MODE: &str = "provider_mode";
     pub const MODEL: &str = "model";
     pub const STREAMING: &str = "streaming";
     pub const MESSAGE_COUNT: &str = "message_count";
@@ -46,8 +48,33 @@ pub mod span {
     pub const AGENT_SESSION: &str = "vulcan.agent.session";
     pub const AGENT_TURN: &str = "vulcan.agent.turn";
     pub const HOOK_EVENT: &str = "vulcan.hook.event";
+    pub const HOOK_AFTER_TOOL_CALL: &str = "vulcan.hook.after_tool_call";
+    pub const HOOK_BEFORE_AGENT_END: &str = "vulcan.hook.before_agent_end";
+    pub const HOOK_BEFORE_PROMPT: &str = "vulcan.hook.before_prompt";
+    pub const HOOK_BEFORE_TOOL_CALL: &str = "vulcan.hook.before_tool_call";
+    pub const HOOK_ON_AFTER_PROVIDER_RESPONSE: &str = "vulcan.hook.on_after_provider_response";
+    pub const HOOK_ON_BEFORE_PROVIDER_REQUEST: &str = "vulcan.hook.on_before_provider_request";
+    pub const HOOK_ON_CONTEXT: &str = "vulcan.hook.on_context";
+    pub const HOOK_ON_INPUT: &str = "vulcan.hook.on_input";
+    pub const HOOK_ON_MESSAGE_END: &str = "vulcan.hook.on_message_end";
+    pub const HOOK_ON_MESSAGE_START: &str = "vulcan.hook.on_message_start";
+    pub const HOOK_ON_MESSAGE_UPDATE: &str = "vulcan.hook.on_message_update";
+    pub const HOOK_ON_SESSION_BEFORE_COMPACT: &str = "vulcan.hook.on_session_before_compact";
+    pub const HOOK_ON_SESSION_BEFORE_FORK: &str = "vulcan.hook.on_session_before_fork";
+    pub const HOOK_ON_SESSION_COMPACT: &str = "vulcan.hook.on_session_compact";
+    pub const HOOK_ON_SESSION_SHUTDOWN: &str = "vulcan.hook.on_session_shutdown";
+    pub const HOOK_ON_TOOL_EXECUTION_END: &str = "vulcan.hook.on_tool_execution_end";
+    pub const HOOK_ON_TOOL_EXECUTION_START: &str = "vulcan.hook.on_tool_execution_start";
+    pub const HOOK_ON_TOOL_EXECUTION_UPDATE: &str = "vulcan.hook.on_tool_execution_update";
+    pub const HOOK_ON_TURN_END: &str = "vulcan.hook.on_turn_end";
+    pub const HOOK_ON_TURN_START: &str = "vulcan.hook.on_turn_start";
+    pub const HOOK_SESSION_END: &str = "vulcan.hook.session_end";
+    pub const HOOK_SESSION_START: &str = "vulcan.hook.session_start";
     pub const TOOL_CALL: &str = "vulcan.tool.call";
     pub const PROVIDER_REQUEST: &str = "vulcan.provider.request";
+    pub const PROVIDER_BUFFERED: &str = "vulcan.provider.buffered";
+    pub const PROVIDER_COMPACTION: &str = "vulcan.provider.compaction";
+    pub const PROVIDER_STREAMING: &str = "vulcan.provider.streaming";
     pub const DAEMON_REQUEST: &str = "vulcan.daemon.request";
     pub const GATEWAY_MESSAGE: &str = "vulcan.gateway.message";
     pub const TASK_ORCHESTRATION: &str = "vulcan.task.orchestration";
@@ -62,10 +89,41 @@ pub mod metric {
     pub const RUNTIME_SECONDS: &str = "vulcan.runtime.seconds";
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderSpanMode {
+    Buffered,
+    Compaction,
+    Streaming,
+}
+
+impl ProviderSpanMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Buffered => "buffered",
+            Self::Compaction => "compaction",
+            Self::Streaming => "streaming",
+        }
+    }
+
+    pub fn operation(self) -> &'static str {
+        match self {
+            Self::Buffered => "provider.buffered",
+            Self::Compaction => "provider.compaction",
+            Self::Streaming => "provider.streaming",
+        }
+    }
+
+    pub fn streaming(self) -> bool {
+        matches!(self, Self::Streaming)
+    }
+}
+
 pub fn tool_call_span(tool_name: &str) -> tracing::Span {
+    let operation = format!("tool.{tool_name}");
     tracing::info_span!(
         span::TOOL_CALL,
         surface = "tools",
+        operation = operation.as_str(),
         tool_name,
         outcome = tracing::field::Empty,
         error_kind = tracing::field::Empty
@@ -75,24 +133,36 @@ pub fn tool_call_span(tool_name: &str) -> tracing::Span {
 pub fn provider_request_span(
     provider: &str,
     model: &str,
-    streaming: bool,
+    mode: ProviderSpanMode,
     message_count: usize,
     tool_count: usize,
 ) -> tracing::Span {
-    tracing::info_span!(
-        span::PROVIDER_REQUEST,
-        surface = "provider",
-        provider,
-        model,
-        streaming,
-        message_count = message_count as u64,
-        tool_count = tool_count as u64,
-        outcome = tracing::field::Empty,
-        error_kind = tracing::field::Empty,
-        prompt_tokens = tracing::field::Empty,
-        completion_tokens = tracing::field::Empty,
-        total_tokens = tracing::field::Empty
-    )
+    macro_rules! span {
+        ($name:expr) => {
+            tracing::info_span!(
+                $name,
+                surface = "provider",
+                operation = mode.operation(),
+                provider,
+                provider_mode = mode.as_str(),
+                model,
+                streaming = mode.streaming(),
+                message_count = message_count as u64,
+                tool_count = tool_count as u64,
+                outcome = tracing::field::Empty,
+                error_kind = tracing::field::Empty,
+                prompt_tokens = tracing::field::Empty,
+                completion_tokens = tracing::field::Empty,
+                total_tokens = tracing::field::Empty
+            )
+        };
+    }
+
+    match mode {
+        ProviderSpanMode::Buffered => span!(span::PROVIDER_BUFFERED),
+        ProviderSpanMode::Compaction => span!(span::PROVIDER_COMPACTION),
+        ProviderSpanMode::Streaming => span!(span::PROVIDER_STREAMING),
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -320,12 +390,14 @@ mod tests {
     #[test]
     fn stable_attribute_and_span_names_cover_runtime_surfaces() {
         let attrs = [
+            attr::OPERATION,
             attr::SESSION_ID,
             attr::RUN_ID,
             attr::TASK_ID,
             attr::TASK_IDENTIFIER,
             attr::TOOL_NAME,
             attr::PROVIDER,
+            attr::PROVIDER_MODE,
             attr::MODEL,
             attr::STREAMING,
             attr::MESSAGE_COUNT,
@@ -343,7 +415,37 @@ mod tests {
         assert!(attrs.iter().all(|name| !name.contains('.')));
         assert_eq!(span::PROCESS, "vulcan.process");
         assert_eq!(span::AGENT_SESSION, "vulcan.agent.session");
+        assert_eq!(span::HOOK_ON_CONTEXT, "vulcan.hook.on_context");
+        assert_eq!(
+            span::HOOK_ON_BEFORE_PROVIDER_REQUEST,
+            "vulcan.hook.on_before_provider_request"
+        );
+        assert_eq!(span::TOOL_CALL, "vulcan.tool.call");
+        assert_eq!(span::PROVIDER_BUFFERED, "vulcan.provider.buffered");
+        assert_eq!(span::PROVIDER_COMPACTION, "vulcan.provider.compaction");
+        assert_eq!(span::PROVIDER_STREAMING, "vulcan.provider.streaming");
         assert_eq!(span::TASK_ORCHESTRATION, "vulcan.task.orchestration");
+    }
+
+    #[test]
+    fn provider_span_modes_are_stable_for_explorer_grouping() {
+        assert_eq!(ProviderSpanMode::Buffered.as_str(), "buffered");
+        assert_eq!(ProviderSpanMode::Buffered.operation(), "provider.buffered");
+        assert!(!ProviderSpanMode::Buffered.streaming());
+
+        assert_eq!(ProviderSpanMode::Compaction.as_str(), "compaction");
+        assert_eq!(
+            ProviderSpanMode::Compaction.operation(),
+            "provider.compaction"
+        );
+        assert!(!ProviderSpanMode::Compaction.streaming());
+
+        assert_eq!(ProviderSpanMode::Streaming.as_str(), "streaming");
+        assert_eq!(
+            ProviderSpanMode::Streaming.operation(),
+            "provider.streaming"
+        );
+        assert!(ProviderSpanMode::Streaming.streaming());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add `operation` and `provider_mode` telemetry attributes for easier Explorer grouping
- split provider spans into buffered, streaming, and compaction names
- split known hook spans by hook event name while retaining hook event and handler attributes
- document useful SigNoz Explorer columns in the example config

Closes #624.

## Verification

- `TMPDIR=/home/yycholla/vulcan-test-tmp cargo test observability`
- `TMPDIR=/home/yycholla/vulcan-test-tmp cargo test hooks::tests::wide_observe_events_run_in_priority_order`
- `TMPDIR=/home/yycholla/vulcan-test-tmp cargo test run_record_captures_streaming_turn_with_tui_origin`
- `cargo fmt --check`
- `TMPDIR=/home/yycholla/vulcan-test-tmp cargo check -p vulcan`
- `TMPDIR=/home/yycholla/vulcan-test-tmp cargo clippy --all-targets`
- `npx gitnexus detect-changes --repo vulcan`

## Notes

GitNexus impact reported HIGH risk for the shared hook runner and agent loop because these spans wrap the core execution paths. This PR keeps the change to span names and attributes only.
