### PR TITLE
Trace daemon request boundaries

### DIFF
--- a/src/daemon/handlers/prompt.rs
+++ b/src/daemon/handlers/prompt.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 
 use serde_json::json;
 use tokio::sync::{mpsc, oneshot};
+use tracing::Instrument;
 
 use crate::daemon::protocol::{ProtocolError, Response, StreamFrame};
 use crate::daemon::session::SessionState;
@@ -211,139 +212,149 @@ pub fn stream(
     let sess_for_task = sess.clone();
     let assembler = state.session_agent_assembler();
     let state_for_runner = Arc::clone(&state);
-    tokio::spawn(async move {
-        let (frontend_tx, mut frontend_rx) = tokio::sync::broadcast::channel(32);
-        let frontend_capabilities = options.frontend_capabilities();
-        let frontend_extensions = options.frontend_extensions();
-        let options = options.with_frontend_context(
-            frontend_capabilities,
-            frontend_extensions,
-            FrontendEventSink::new(frontend_tx),
-        );
-        // Lazy-build the per-session Agent. Failure surfaces on the
-        // done channel as AGENT_BUILD_FAILED; in_flight is cleared
-        // before returning so daemon.status doesn't get stuck.
-        let agent_arc = match sess_for_task
-            .ensure_agent_with_options(&assembler, options)
-            .await
-        {
-            Ok(a) => a,
-            Err(e) => {
-                *sess_for_task.in_flight.lock() = false;
-                sess_for_task.touch();
-                let _ = done_tx.send(Response::error(
-                    rid.clone(),
-                    ProtocolError {
-                        code: "AGENT_BUILD_FAILED".into(),
-                        message: format!(
-                            "agent build for session '{}' failed: {e}",
-                            sess_for_task.id
-                        ),
-                        retryable: true,
-                    },
-                ));
-                return;
-            }
-        };
-
-        let (event_tx, mut event_rx) = mpsc::channel::<StreamEvent>(32);
-        let cancel_token = tokio_util::sync::CancellationToken::new();
-        sess_for_task.set_agent_cancel(cancel_token.clone());
-
-        // GH issue #557: run `on_input` interception before spawning
-        // the streaming task. Block short-circuits with INPUT_BLOCKED;
-        // Replace swaps the input forwarded to `run_prompt_stream_with_cancel`.
-        let effective_input: String = {
-            let agent = agent_arc.lock().await;
-            match agent.apply_on_input(&input).await {
-                crate::hooks::InputDecision::Continue => input.clone(),
-                crate::hooks::InputDecision::Replace(rewrite) => rewrite,
-                crate::hooks::InputDecision::Block(reason) => {
-                    drop(agent);
+    tokio::spawn(
+        async move {
+            let (frontend_tx, mut frontend_rx) = tokio::sync::broadcast::channel(32);
+            let frontend_capabilities = options.frontend_capabilities();
+            let frontend_extensions = options.frontend_extensions();
+            let options = options.with_frontend_context(
+                frontend_capabilities,
+                frontend_extensions,
+                FrontendEventSink::new(frontend_tx),
+            );
+            // Lazy-build the per-session Agent. Failure surfaces on the
+            // done channel as AGENT_BUILD_FAILED; in_flight is cleared
+            // before returning so daemon.status doesn't get stuck.
+            let agent_arc = match sess_for_task
+                .ensure_agent_with_options(&assembler, options)
+                .await
+            {
+                Ok(a) => a,
+                Err(e) => {
                     *sess_for_task.in_flight.lock() = false;
                     sess_for_task.touch();
                     let _ = done_tx.send(Response::error(
                         rid.clone(),
                         ProtocolError {
-                            code: "INPUT_BLOCKED".into(),
-                            message: format!("input blocked by extension: {reason}"),
-                            retryable: false,
+                            code: "AGENT_BUILD_FAILED".into(),
+                            message: format!(
+                                "agent build for session '{}' failed: {e}",
+                                sess_for_task.id
+                            ),
+                            retryable: true,
                         },
                     ));
                     return;
                 }
-            }
-        };
+            };
 
-        // Clone the Arc for the prompt task so the guard lives inside it.
-        let agent_arc2 = agent_arc.clone();
-        let input2 = effective_input;
-        let cancel2 = cancel_token.clone();
-        let session_id_for_runner = session_id.clone();
-        let prompt_task = tokio::spawn(async move {
-            let mut agent = agent_arc2.lock().await;
-            install_daemon_subagent_runner(&mut agent, state_for_runner, &session_id_for_runner);
-            agent
-                .run_prompt_stream_with_cancel(&input2, event_tx, cancel2)
-                .await
-        });
+            let (event_tx, mut event_rx) = mpsc::channel::<StreamEvent>(32);
+            let cancel_token = tokio_util::sync::CancellationToken::new();
+            sess_for_task.set_agent_cancel(cancel_token.clone());
 
-        // Forward events as StreamFrames.
-        loop {
-            tokio::select! {
-                ev = event_rx.recv() => {
-                    let Some(ev) = ev else {
-                        break;
-                    };
-                    if let Some(frame) = stream_event_to_frame(&rid, ev) {
-                        if frame_tx.send(frame).await.is_err() {
-                            // TUI disconnected -- cancel the turn.
-                            cancel_token.cancel();
-                            break;
-                        }
+            // GH issue #557: run `on_input` interception before spawning
+            // the streaming task. Block short-circuits with INPUT_BLOCKED;
+            // Replace swaps the input forwarded to `run_prompt_stream_with_cancel`.
+            let effective_input: String = {
+                let agent = agent_arc.lock().await;
+                match agent.apply_on_input(&input).await {
+                    crate::hooks::InputDecision::Continue => input.clone(),
+                    crate::hooks::InputDecision::Replace(rewrite) => rewrite,
+                    crate::hooks::InputDecision::Block(reason) => {
+                        drop(agent);
+                        *sess_for_task.in_flight.lock() = false;
+                        sess_for_task.touch();
+                        let _ = done_tx.send(Response::error(
+                            rid.clone(),
+                            ProtocolError {
+                                code: "INPUT_BLOCKED".into(),
+                                message: format!("input blocked by extension: {reason}"),
+                                retryable: false,
+                            },
+                        ));
+                        return;
                     }
                 }
-                event = frontend_rx.recv() => {
-                    match event {
-                        Ok(event) => {
-                            if frame_tx.send(frontend_event_to_frame(event)).await.is_err() {
+            };
+
+            // Clone the Arc for the prompt task so the guard lives inside it.
+            let agent_arc2 = agent_arc.clone();
+            let input2 = effective_input;
+            let cancel2 = cancel_token.clone();
+            let session_id_for_runner = session_id.clone();
+            let prompt_task = tokio::spawn(
+                async move {
+                    let mut agent = agent_arc2.lock().await;
+                    install_daemon_subagent_runner(
+                        &mut agent,
+                        state_for_runner,
+                        &session_id_for_runner,
+                    );
+                    agent
+                        .run_prompt_stream_with_cancel(&input2, event_tx, cancel2)
+                        .await
+                }
+                .instrument(tracing::Span::current()),
+            );
+
+            // Forward events as StreamFrames.
+            loop {
+                tokio::select! {
+                    ev = event_rx.recv() => {
+                        let Some(ev) = ev else {
+                            break;
+                        };
+                        if let Some(frame) = stream_event_to_frame(&rid, ev) {
+                            if frame_tx.send(frame).await.is_err() {
+                                // TUI disconnected -- cancel the turn.
                                 cancel_token.cancel();
                                 break;
                             }
                         }
-                        Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
-                        Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                    }
+                    event = frontend_rx.recv() => {
+                        match event {
+                            Ok(event) => {
+                                if frame_tx.send(frontend_event_to_frame(event)).await.is_err() {
+                                    cancel_token.cancel();
+                                    break;
+                                }
+                            }
+                            Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                            Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                        }
                     }
                 }
             }
+
+            // Await final turn result (Result<String> — just text).
+            let final_response = match prompt_task.await {
+                Ok(Ok(final_text)) => Response::ok(rid.clone(), json!({ "text": final_text })),
+                Ok(Err(e)) => Response::error(
+                    rid.clone(),
+                    ProtocolError {
+                        code: "PROMPT_RUN_FAILED".into(),
+                        message: format!("{e}"),
+                        retryable: false,
+                    },
+                ),
+                Err(join_err) => Response::error(
+                    rid.clone(),
+                    ProtocolError {
+                        code: "JOIN_ERROR".into(),
+                        message: format!("{join_err}"),
+                        retryable: false,
+                    },
+                ),
+            };
+
+            // Clear in_flight in all 3 completion paths before signalling done.
+            *sess_for_task.in_flight.lock() = false;
+            sess_for_task.touch();
+            let _ = done_tx.send(final_response);
         }
-
-        // Await final turn result (Result<String> — just text).
-        let final_response = match prompt_task.await {
-            Ok(Ok(final_text)) => Response::ok(rid.clone(), json!({ "text": final_text })),
-            Ok(Err(e)) => Response::error(
-                rid.clone(),
-                ProtocolError {
-                    code: "PROMPT_RUN_FAILED".into(),
-                    message: format!("{e}"),
-                    retryable: false,
-                },
-            ),
-            Err(join_err) => Response::error(
-                rid.clone(),
-                ProtocolError {
-                    code: "JOIN_ERROR".into(),
-                    message: format!("{join_err}"),
-                    retryable: false,
-                },
-            ),
-        };
-
-        // Clear in_flight in all 3 completion paths before signalling done.
-        *sess_for_task.in_flight.lock() = false;
-        sess_for_task.touch();
-        let _ = done_tx.send(final_response);
-    });
+        .instrument(tracing::Span::current()),
+    );
 
     (frame_rx, done_rx)
 }

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 
 use tokio::net::UnixStream;
 use tokio::sync::mpsc;
+use tracing::Instrument;
 
 use crate::daemon::dispatch::{DispatchResult, Dispatcher};
 use crate::daemon::lifecycle::SocketBinder;
@@ -17,6 +18,7 @@ use crate::daemon::protocol::{
     Response, parse_request_strict, read_frame_bytes, write_frame_bytes,
 };
 use crate::daemon::state::DaemonState;
+use crate::observability;
 
 /// Long-lived daemon server. Holds the bound socket and per-process
 /// state for the lifetime of a single `vulcan daemon` process.
@@ -96,48 +98,73 @@ async fn handle_connection(stream: UnixStream, dispatcher: Arc<Dispatcher>) {
             }
         };
 
-        let response = match parse_request_strict(&body) {
+        match parse_request_strict(&body) {
             Ok(req) => {
                 let dispatcher = Arc::clone(&dispatcher);
                 let write_tx = write_tx.clone();
-                tokio::spawn(async move {
-                    let response = dispatcher.dispatch(req).await;
-                    write_dispatch_result(write_tx, response).await;
-                });
-                continue;
+                let span = observability::daemon_request_span(&req.method, &req.session, &req.id);
+                let record_span = span.clone();
+                tokio::spawn(
+                    async move {
+                        let response = dispatcher.dispatch(req).await;
+                        write_dispatch_result(write_tx, response, &record_span).await;
+                    }
+                    .instrument(span),
+                );
             }
             Err(proto_err) => {
-                DispatchResult::Response(Response::error("unknown".into(), proto_err))
+                let span =
+                    observability::daemon_request_span("parse_request", "unknown", "unknown");
+                let response =
+                    DispatchResult::Response(Response::error("unknown".into(), proto_err));
+                write_dispatch_result(write_tx.clone(), response, &span).await;
             }
-        };
-
-        write_dispatch_result(write_tx.clone(), response).await;
+        }
     }
 
     drop(write_tx);
     writer.abort();
 }
 
-async fn write_dispatch_result(write_tx: mpsc::Sender<Vec<u8>>, response: DispatchResult) {
+async fn write_dispatch_result(
+    write_tx: mpsc::Sender<Vec<u8>>,
+    response: DispatchResult,
+    span: &tracing::Span,
+) {
     match response {
         DispatchResult::Response(resp) => {
+            record_response_outcome(span, &resp);
             send_body(&write_tx, &resp, "response").await;
         }
         DispatchResult::Stream { mut frames, done } => {
             while let Some(frame) = frames.recv().await {
                 if !send_body(&write_tx, &frame, "stream frame").await {
+                    span.record(observability::attr::OUTCOME, "error");
+                    span.record(observability::attr::ERROR_KIND, "client_disconnected");
                     return;
                 }
             }
             match done.await {
                 Ok(resp) => {
+                    record_response_outcome(span, &resp);
                     send_body(&write_tx, &resp, "final response").await;
                 }
                 Err(_) => {
+                    span.record(observability::attr::OUTCOME, "error");
+                    span.record(observability::attr::ERROR_KIND, "stream_done_dropped");
                     tracing::warn!("daemon: stream completion sender dropped without result");
                 }
             }
         }
+    }
+}
+
+fn record_response_outcome(span: &tracing::Span, response: &Response) {
+    if let Some(error) = &response.error {
+        span.record(observability::attr::OUTCOME, "error");
+        span.record(observability::attr::ERROR_KIND, error.code.as_str());
+    } else {
+        span.record(observability::attr::OUTCOME, "ok");
     }
 }
 

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -22,6 +22,7 @@ use crate::hooks::{HookFailureCounts, HookRegistry};
 
 pub mod attr {
     pub const OPERATION: &str = "operation";
+    pub const REQUEST_ID: &str = "request_id";
     pub const SESSION_ID: &str = "session_id";
     pub const RUN_ID: &str = "run_id";
     pub const TASK_ID: &str = "task_id";
@@ -29,6 +30,7 @@ pub mod attr {
     pub const TOOL_NAME: &str = "tool_name";
     pub const PROVIDER: &str = "provider";
     pub const PROVIDER_MODE: &str = "provider_mode";
+    pub const RPC_METHOD: &str = "rpc_method";
     pub const MODEL: &str = "model";
     pub const STREAMING: &str = "streaming";
     pub const MESSAGE_COUNT: &str = "message_count";
@@ -116,6 +118,24 @@ impl ProviderSpanMode {
     pub fn streaming(self) -> bool {
         matches!(self, Self::Streaming)
     }
+}
+
+pub fn daemon_request_operation(method: &str) -> String {
+    format!("request.{method}")
+}
+
+pub fn daemon_request_span(method: &str, session_id: &str, request_id: &str) -> tracing::Span {
+    let operation = daemon_request_operation(method);
+    tracing::info_span!(
+        span::DAEMON_REQUEST,
+        surface = "daemon",
+        operation = operation.as_str(),
+        rpc_method = method,
+        session_id,
+        request_id,
+        outcome = tracing::field::Empty,
+        error_kind = tracing::field::Empty
+    )
 }
 
 pub fn tool_call_span(tool_name: &str) -> tracing::Span {
@@ -391,6 +411,7 @@ mod tests {
     fn stable_attribute_and_span_names_cover_runtime_surfaces() {
         let attrs = [
             attr::OPERATION,
+            attr::REQUEST_ID,
             attr::SESSION_ID,
             attr::RUN_ID,
             attr::TASK_ID,
@@ -398,6 +419,7 @@ mod tests {
             attr::TOOL_NAME,
             attr::PROVIDER,
             attr::PROVIDER_MODE,
+            attr::RPC_METHOD,
             attr::MODEL,
             attr::STREAMING,
             attr::MESSAGE_COUNT,
@@ -421,6 +443,7 @@ mod tests {
             "vulcan.hook.on_before_provider_request"
         );
         assert_eq!(span::TOOL_CALL, "vulcan.tool.call");
+        assert_eq!(span::DAEMON_REQUEST, "vulcan.daemon.request");
         assert_eq!(span::PROVIDER_BUFFERED, "vulcan.provider.buffered");
         assert_eq!(span::PROVIDER_COMPACTION, "vulcan.provider.compaction");
         assert_eq!(span::PROVIDER_STREAMING, "vulcan.provider.streaming");
@@ -446,6 +469,18 @@ mod tests {
             "provider.streaming"
         );
         assert!(ProviderSpanMode::Streaming.streaming());
+    }
+
+    #[test]
+    fn daemon_request_operations_are_stable_for_explorer_grouping() {
+        assert_eq!(
+            daemon_request_operation("prompt.stream"),
+            "request.prompt.stream"
+        );
+        assert_eq!(
+            daemon_request_operation("daemon.status"),
+            "request.daemon.status"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- adds `vulcan.daemon.request` spans around daemon request dispatch/writeback
- records request attributes: `operation`, `rpc_method`, `request_id`, `session_id`, `surface`, `outcome`, and `error_kind`
- propagates the request span into streaming prompt tasks so daemon-driven agent/provider/tool spans share the trace

Closes #628.

## Verification

- `TMPDIR=/home/yycholla/vulcan-test-tmp cargo test observability`
- `TMPDIR=/home/yycholla/vulcan-test-tmp cargo test daemon::server::tests::server_responds_to_ping`
- `TMPDIR=/home/yycholla/vulcan-test-tmp cargo test daemon::server::tests`
- `TMPDIR=/home/yycholla/vulcan-test-tmp cargo check -p vulcan`
- `cargo fmt --check`
- `TMPDIR=/home/yycholla/vulcan-test-tmp cargo clippy --all-targets`
- `npx gitnexus detect-changes --repo vulcan`

## Impact

GitNexus impact:
- `src/daemon/server.rs:handle_connection`: LOW
- `src/daemon/dispatch.rs:Dispatcher.dispatch`: MEDIUM
- `src/daemon/handlers/prompt.rs:stream`: LOW

The change is limited to span creation/outcome recording plus tracing span propagation across spawned streaming tasks.
