### PR TITLE
Add runtime metric vocabulary

### DIFF
--- a/docs/plans/2026-05-03-observability-runtime-metrics.md
+++ b/docs/plans/2026-05-03-observability-runtime-metrics.md
@@ -1,0 +1,146 @@
+# Observability Runtime Metrics Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add first-class OpenTelemetry metrics for Vulcan runtime performance, including backend request/tool/provider/hook timing and TUI frame health.
+
+**Architecture:** Keep traces for correlation and add low-cardinality metrics for dashboards and alerting. Split the work into independent PRs: shared metric helpers, backend/runtime metrics, TUI frame metrics, and process resource metrics.
+
+**Tech Stack:** Rust, `opentelemetry`, `opentelemetry_sdk`, `tracing_opentelemetry`, Ratatui/TUI loop, optional `sysinfo` for process sampling.
+
+---
+
+### Task 1: Shared Metrics Vocabulary and Helpers
+
+**Files:**
+- Modify: `src/observability.rs`
+
+**Step 1: Write the failing test**
+
+Add an observability unit test that asserts stable metric names for runtime histograms/counters:
+- `vulcan.daemon.request.duration_ms`
+- `vulcan.provider.request.duration_ms`
+- `vulcan.tool.call.duration_ms`
+- `vulcan.hook.event.duration_ms`
+- `vulcan.tokens.input`
+- `vulcan.tokens.output`
+- `vulcan.errors.total`
+- `vulcan.tui.frame.draw_ms`
+- `vulcan.tui.frame.interval_ms`
+- `vulcan.tui.frames.total`
+- `vulcan.tui.fps`
+- `vulcan.tui.surface.count`
+- `vulcan.process.memory.rss_bytes`
+- `vulcan.process.cpu.percent`
+
+**Step 2: Run test to verify it fails**
+
+Run: `TMPDIR=/home/yycholla/vulcan-test-tmp cargo test observability::tests::stable_metric_names_cover_runtime_performance`
+
+**Step 3: Implement minimal helper surface**
+
+Add metric constants and small helper functions that emit tracing metric events with stable field names. Keep labels low-cardinality: `surface`, `operation`, `outcome`, `error_kind`, `rpc_method`, `provider`, `provider_mode`, `tool_name`, `hook_event`, `hook_handler`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `TMPDIR=/home/yycholla/vulcan-test-tmp cargo test observability`
+
+**Step 5: Commit**
+
+Commit: `feat(observability): add runtime metric vocabulary`
+
+### Task 2: Backend Runtime Metrics
+
+**Files:**
+- Modify: `src/daemon/server.rs`
+- Modify: `src/agent/run.rs`
+- Modify: `src/agent/dispatch.rs`
+- Modify: `src/hooks/mod.rs`
+
+**Step 1: Write focused tests**
+
+Add/extend tests around stable outcome mapping where pure helpers exist. Prefer pure helper tests over trying to assert exporter output.
+
+**Step 2: Instrument existing boundaries**
+
+Record duration histograms and error/token counters at existing span boundaries:
+- daemon request writeback
+- provider request completion
+- tool dispatch completion
+- hook dispatch completion
+
+**Step 3: Verify**
+
+Run:
+- `TMPDIR=/home/yycholla/vulcan-test-tmp cargo test observability`
+- `TMPDIR=/home/yycholla/vulcan-test-tmp cargo test daemon::server::tests`
+- `TMPDIR=/home/yycholla/vulcan-test-tmp cargo test run_record_captures_streaming_turn_with_tui_origin`
+- `TMPDIR=/home/yycholla/vulcan-test-tmp cargo check -p vulcan`
+
+**Step 4: Commit**
+
+Commit: `feat(observability): record backend runtime metrics`
+
+### Task 3: TUI Frame Performance Metrics
+
+**Files:**
+- Modify: `src/tui/mod.rs`
+- Modify: `src/tui/state/mod.rs`
+- Modify: `src/observability.rs`
+
+**Step 1: Write focused tests**
+
+Add a pure test for frame metric snapshot/FPS calculation if new state helpers are introduced.
+
+**Step 2: Instrument the draw loop**
+
+Record:
+- draw duration per frame
+- interval between frames
+- frames total
+- rolling FPS
+- active frontend surface count
+
+Do not create per-frame spans.
+
+**Step 3: Verify**
+
+Run:
+- `TMPDIR=/home/yycholla/vulcan-test-tmp cargo test tui::`
+- `TMPDIR=/home/yycholla/vulcan-test-tmp cargo check -p vulcan`
+- `cargo fmt --check`
+
+**Step 4: Commit**
+
+Commit: `feat(observability): record tui frame metrics`
+
+### Task 4: Process Resource Metrics
+
+**Files:**
+- Modify: `Cargo.toml`
+- Modify: `src/observability.rs`
+- Modify: daemon/TUI startup path that initializes observability
+
+**Step 1: Select dependency**
+
+Use `sysinfo` only if it is not already available transitively in a usable way. Keep sampling periodic and cheap.
+
+**Step 2: Add process sampler**
+
+Emit:
+- RSS memory bytes
+- CPU percent
+- thread count if available
+
+Sample at the observability export interval or a bounded minimum such as 5 seconds.
+
+**Step 3: Verify**
+
+Run:
+- `TMPDIR=/home/yycholla/vulcan-test-tmp cargo test observability`
+- `TMPDIR=/home/yycholla/vulcan-test-tmp cargo check -p vulcan`
+- `TMPDIR=/home/yycholla/vulcan-test-tmp cargo clippy --all-targets`
+
+**Step 4: Commit**
+
+Commit: `feat(observability): sample process resource metrics`

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -83,12 +83,45 @@ pub mod span {
 }
 
 pub mod metric {
+    pub const DAEMON_REQUEST_DURATION_MS: &str = "vulcan.daemon.request.duration_ms";
+    pub const PROVIDER_REQUEST_DURATION_MS: &str = "vulcan.provider.request.duration_ms";
+    pub const TOOL_CALL_DURATION_MS: &str = "vulcan.tool.call.duration_ms";
+    pub const HOOK_EVENT_DURATION_MS: &str = "vulcan.hook.event.duration_ms";
     pub const HOOK_ERRORS: &str = "vulcan.hooks.errors";
     pub const HOOK_TIMEOUTS: &str = "vulcan.hooks.timeouts";
     pub const HOOK_HANDLERS: &str = "vulcan.hooks.handlers";
     pub const TOKENS_INPUT: &str = "vulcan.tokens.input";
     pub const TOKENS_OUTPUT: &str = "vulcan.tokens.output";
+    pub const TOKENS_TOTAL: &str = "vulcan.tokens.total";
+    pub const ERRORS_TOTAL: &str = "vulcan.errors.total";
+    pub const TUI_FRAME_DRAW_MS: &str = "vulcan.tui.frame.draw_ms";
+    pub const TUI_FRAME_INTERVAL_MS: &str = "vulcan.tui.frame.interval_ms";
+    pub const TUI_FRAMES_TOTAL: &str = "vulcan.tui.frames.total";
+    pub const TUI_FPS: &str = "vulcan.tui.fps";
+    pub const TUI_SURFACE_COUNT: &str = "vulcan.tui.surface.count";
+    pub const PROCESS_MEMORY_RSS_BYTES: &str = "vulcan.process.memory.rss_bytes";
+    pub const PROCESS_CPU_PERCENT: &str = "vulcan.process.cpu.percent";
+    pub const PROCESS_THREADS: &str = "vulcan.process.threads";
     pub const RUNTIME_SECONDS: &str = "vulcan.runtime.seconds";
+
+    pub const RUNTIME_PERFORMANCE: &[&str] = &[
+        DAEMON_REQUEST_DURATION_MS,
+        PROVIDER_REQUEST_DURATION_MS,
+        TOOL_CALL_DURATION_MS,
+        HOOK_EVENT_DURATION_MS,
+        TOKENS_INPUT,
+        TOKENS_OUTPUT,
+        TOKENS_TOTAL,
+        ERRORS_TOTAL,
+        TUI_FRAME_DRAW_MS,
+        TUI_FRAME_INTERVAL_MS,
+        TUI_FRAMES_TOTAL,
+        TUI_FPS,
+        TUI_SURFACE_COUNT,
+        PROCESS_MEMORY_RSS_BYTES,
+        PROCESS_CPU_PERCENT,
+        PROCESS_THREADS,
+    ];
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -448,6 +481,29 @@ mod tests {
         assert_eq!(span::PROVIDER_COMPACTION, "vulcan.provider.compaction");
         assert_eq!(span::PROVIDER_STREAMING, "vulcan.provider.streaming");
         assert_eq!(span::TASK_ORCHESTRATION, "vulcan.task.orchestration");
+    }
+
+    #[test]
+    fn stable_metric_names_cover_runtime_performance() {
+        assert!(
+            metric::RUNTIME_PERFORMANCE
+                .iter()
+                .all(|name| name.starts_with("vulcan."))
+        );
+        assert!(
+            metric::RUNTIME_PERFORMANCE
+                .iter()
+                .all(|name| !name.is_empty())
+        );
+        assert_eq!(
+            metric::DAEMON_REQUEST_DURATION_MS,
+            "vulcan.daemon.request.duration_ms"
+        );
+        assert_eq!(metric::TUI_FRAME_DRAW_MS, "vulcan.tui.frame.draw_ms");
+        assert_eq!(
+            metric::PROCESS_MEMORY_RSS_BYTES,
+            "vulcan.process.memory.rss_bytes"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add stable Vulcan metric names for daemon, provider, tool, hook, TUI, process, token, and error telemetry
- add an aggregate runtime performance metric list for exporter/UI discovery
- add the split implementation plan for backend, TUI, and process metric slices

Closes #632.

## Verification
- TMPDIR=/home/yycholla/vulcan-test-tmp cargo test observability::tests::stable_metric_names_cover_runtime_performance
- TMPDIR=/home/yycholla/vulcan-test-tmp cargo test observability
- cargo fmt --check
- npx gitnexus detect-changes --repo vulcan
- pre-commit cargo check/fmt/clippy passed with existing warnings

## Impact
GitNexus did not have exact symbols for the newer observability helpers, so exact impact lookup returned UNKNOWN. This slice only adds metric constants, one pure unit test, and a plan document; no runtime behavior changes.