### PR TITLE
Emit backend runtime metrics

### DIFF
--- a/src/agent/dispatch.rs
+++ b/src/agent/dispatch.rs
@@ -70,6 +70,7 @@ impl Agent {
         };
 
         let tool_span = observability::tool_call_span(name);
+        let mut metric_error_kind: Option<&'static str> = None;
         let raw_result: ToolResult = if let Some(reason) = blocked.clone() {
             tool_span.record(observability::attr::OUTCOME, "blocked");
             // YYC-179: record the block before failing the tool
@@ -90,6 +91,7 @@ impl Agent {
             {
                 Ok(r) => {
                     if r.is_error {
+                        metric_error_kind = Some("tool_error");
                         tool_span.record(observability::attr::OUTCOME, "error");
                         tool_span.record(observability::attr::ERROR_KIND, "tool_error");
                     } else {
@@ -98,6 +100,7 @@ impl Agent {
                     r
                 }
                 Err(e) => {
+                    metric_error_kind = Some("dispatch_error");
                     tool_span.record(observability::attr::OUTCOME, "error");
                     tool_span.record(observability::attr::ERROR_KIND, "dispatch_error");
                     ToolResult::err(format!("Error: {e}"))
@@ -122,8 +125,11 @@ impl Agent {
             None => raw_result,
         };
         if final_result.is_error {
-            tool_span.record(observability::attr::OUTCOME, "error");
-            tool_span.record(observability::attr::ERROR_KIND, "tool_error");
+            if blocked.is_none() {
+                metric_error_kind.get_or_insert("tool_error");
+                tool_span.record(observability::attr::OUTCOME, "error");
+                tool_span.record(observability::attr::ERROR_KIND, "tool_error");
+            }
         } else if blocked.is_none() {
             tool_span.record(observability::attr::OUTCOME, "ok");
         }
@@ -131,6 +137,19 @@ impl Agent {
         // YYC-179: emit one ToolCall event per dispatch with the
         // duration, approval surface, and structured error flag.
         let duration_ms = started.elapsed().as_millis().min(u64::MAX as u128) as u64;
+        let metric_outcome = if blocked.is_some() {
+            "blocked"
+        } else if final_result.is_error {
+            "error"
+        } else {
+            "ok"
+        };
+        observability::record_tool_call_metrics(
+            name,
+            started.elapsed(),
+            metric_outcome,
+            metric_error_kind,
+        );
         let approval = if blocked.is_some() {
             Some("blocked".to_string())
         } else {

--- a/src/agent/run.rs
+++ b/src/agent/run.rs
@@ -625,6 +625,7 @@ impl Agent {
             request.len(),
             0,
         );
+        let provider_started = std::time::Instant::now();
         let response = match self
             .provider
             .chat(&request, &[], cancel.clone())
@@ -633,14 +634,38 @@ impl Agent {
         {
             Ok(r) => {
                 provider_span.record(observability::attr::OUTCOME, "ok");
+                observability::record_provider_request_metrics(
+                    &self.provider_config.r#type,
+                    &self.provider_config.model,
+                    observability::ProviderSpanMode::Compaction,
+                    provider_started.elapsed(),
+                    "ok",
+                    None,
+                );
                 if let Some(usage) = &r.usage {
                     record_provider_usage(&provider_span, usage);
+                    observability::record_provider_token_metrics(
+                        &self.provider_config.r#type,
+                        &self.provider_config.model,
+                        observability::ProviderSpanMode::Compaction,
+                        usage.prompt_tokens,
+                        usage.completion_tokens,
+                        usage.total_tokens,
+                    );
                 }
                 r
             }
             Err(e) => {
                 provider_span.record(observability::attr::OUTCOME, "error");
                 provider_span.record(observability::attr::ERROR_KIND, "provider_error");
+                observability::record_provider_request_metrics(
+                    &self.provider_config.r#type,
+                    &self.provider_config.model,
+                    observability::ProviderSpanMode::Compaction,
+                    provider_started.elapsed(),
+                    "error",
+                    Some("provider_error"),
+                );
                 tracing::warn!("compaction summarizer call failed: {e}");
                 return false;
             }
@@ -796,6 +821,7 @@ impl Agent {
             outgoing.len(),
             tool_defs.len(),
         );
+        let provider_started = std::time::Instant::now();
         if let Err(e) = self
             .provider
             .chat_stream(outgoing, tool_defs, inner_tx, cancel.clone())
@@ -804,6 +830,14 @@ impl Agent {
         {
             provider_span.record(observability::attr::OUTCOME, "error");
             provider_span.record(observability::attr::ERROR_KIND, "provider_error");
+            observability::record_provider_request_metrics(
+                &self.provider_config.r#type,
+                &self.provider_config.model,
+                observability::ProviderSpanMode::Streaming,
+                provider_started.elapsed(),
+                "error",
+                Some("provider_error"),
+            );
             // Surface provider failures to the TUI rather than dropping
             // the channel silently. ProviderError carries actionable hints
             // via its Display impl; if the error chain has one (most
@@ -837,6 +871,14 @@ impl Agent {
             return Err(e);
         }
         provider_span.record(observability::attr::OUTCOME, "ok");
+        observability::record_provider_request_metrics(
+            &self.provider_config.r#type,
+            &self.provider_config.model,
+            observability::ProviderSpanMode::Streaming,
+            provider_started.elapsed(),
+            "ok",
+            None,
+        );
 
         let mut final_response: Option<ChatResponse> = None;
         while let Some(event) = priv_rx.recv().await {
@@ -844,6 +886,14 @@ impl Agent {
                 TurnEvent::ProviderDone { response } => {
                     if let Some(usage) = &response.usage {
                         record_provider_usage(&provider_span, usage);
+                        observability::record_provider_token_metrics(
+                            &self.provider_config.r#type,
+                            &self.provider_config.model,
+                            observability::ProviderSpanMode::Streaming,
+                            usage.prompt_tokens,
+                            usage.completion_tokens,
+                            usage.total_tokens,
+                        );
                     }
                     final_response = Some(response);
                     break;
@@ -1155,6 +1205,7 @@ impl TurnRunnerMut<'_> {
                         outgoing.len(),
                         tool_defs.len(),
                     );
+                    let provider_started = std::time::Instant::now();
                     let resp = match self
                         .agent
                         .provider
@@ -1164,14 +1215,38 @@ impl TurnRunnerMut<'_> {
                     {
                         Ok(r) => {
                             provider_span.record(observability::attr::OUTCOME, "ok");
+                            observability::record_provider_request_metrics(
+                                &self.agent.provider_config.r#type,
+                                &self.agent.provider_config.model,
+                                observability::ProviderSpanMode::Buffered,
+                                provider_started.elapsed(),
+                                "ok",
+                                None,
+                            );
                             if let Some(usage) = &r.usage {
                                 record_provider_usage(&provider_span, usage);
+                                observability::record_provider_token_metrics(
+                                    &self.agent.provider_config.r#type,
+                                    &self.agent.provider_config.model,
+                                    observability::ProviderSpanMode::Buffered,
+                                    usage.prompt_tokens,
+                                    usage.completion_tokens,
+                                    usage.total_tokens,
+                                );
                             }
                             r
                         }
                         Err(e) => {
                             provider_span.record(observability::attr::OUTCOME, "error");
                             provider_span.record(observability::attr::ERROR_KIND, "provider_error");
+                            observability::record_provider_request_metrics(
+                                &self.agent.provider_config.r#type,
+                                &self.agent.provider_config.model,
+                                observability::ProviderSpanMode::Buffered,
+                                provider_started.elapsed(),
+                                "error",
+                                Some("provider_error"),
+                            );
                             self.agent.record_run_event(RunEvent::ProviderError {
                                 message: e.to_string(),
                                 retryable: false,

--- a/src/daemon/server.rs
+++ b/src/daemon/server.rs
@@ -98,16 +98,25 @@ async fn handle_connection(stream: UnixStream, dispatcher: Arc<Dispatcher>) {
             }
         };
 
+        let request_started = std::time::Instant::now();
         match parse_request_strict(&body) {
             Ok(req) => {
                 let dispatcher = Arc::clone(&dispatcher);
                 let write_tx = write_tx.clone();
                 let span = observability::daemon_request_span(&req.method, &req.session, &req.id);
                 let record_span = span.clone();
+                let method = req.method.clone();
                 tokio::spawn(
                     async move {
                         let response = dispatcher.dispatch(req).await;
-                        write_dispatch_result(write_tx, response, &record_span).await;
+                        write_dispatch_result(
+                            write_tx,
+                            response,
+                            &record_span,
+                            &method,
+                            request_started,
+                        )
+                        .await;
                     }
                     .instrument(span),
                 );
@@ -117,7 +126,14 @@ async fn handle_connection(stream: UnixStream, dispatcher: Arc<Dispatcher>) {
                     observability::daemon_request_span("parse_request", "unknown", "unknown");
                 let response =
                     DispatchResult::Response(Response::error("unknown".into(), proto_err));
-                write_dispatch_result(write_tx.clone(), response, &span).await;
+                write_dispatch_result(
+                    write_tx.clone(),
+                    response,
+                    &span,
+                    "parse_request",
+                    request_started,
+                )
+                .await;
             }
         }
     }
@@ -130,10 +146,18 @@ async fn write_dispatch_result(
     write_tx: mpsc::Sender<Vec<u8>>,
     response: DispatchResult,
     span: &tracing::Span,
+    method: &str,
+    started: std::time::Instant,
 ) {
     match response {
         DispatchResult::Response(resp) => {
-            record_response_outcome(span, &resp);
+            let (outcome, error_kind) = record_response_outcome(span, &resp);
+            observability::record_daemon_request_metrics(
+                method,
+                started.elapsed(),
+                outcome,
+                error_kind,
+            );
             send_body(&write_tx, &resp, "response").await;
         }
         DispatchResult::Stream { mut frames, done } => {
@@ -141,17 +165,35 @@ async fn write_dispatch_result(
                 if !send_body(&write_tx, &frame, "stream frame").await {
                     span.record(observability::attr::OUTCOME, "error");
                     span.record(observability::attr::ERROR_KIND, "client_disconnected");
+                    observability::record_daemon_request_metrics(
+                        method,
+                        started.elapsed(),
+                        "error",
+                        Some("client_disconnected"),
+                    );
                     return;
                 }
             }
             match done.await {
                 Ok(resp) => {
-                    record_response_outcome(span, &resp);
+                    let (outcome, error_kind) = record_response_outcome(span, &resp);
+                    observability::record_daemon_request_metrics(
+                        method,
+                        started.elapsed(),
+                        outcome,
+                        error_kind,
+                    );
                     send_body(&write_tx, &resp, "final response").await;
                 }
                 Err(_) => {
                     span.record(observability::attr::OUTCOME, "error");
                     span.record(observability::attr::ERROR_KIND, "stream_done_dropped");
+                    observability::record_daemon_request_metrics(
+                        method,
+                        started.elapsed(),
+                        "error",
+                        Some("stream_done_dropped"),
+                    );
                     tracing::warn!("daemon: stream completion sender dropped without result");
                 }
             }
@@ -159,12 +201,17 @@ async fn write_dispatch_result(
     }
 }
 
-fn record_response_outcome(span: &tracing::Span, response: &Response) {
+fn record_response_outcome<'a>(
+    span: &tracing::Span,
+    response: &'a Response,
+) -> (&'static str, Option<&'a str>) {
     if let Some(error) = &response.error {
         span.record(observability::attr::OUTCOME, "error");
         span.record(observability::attr::ERROR_KIND, error.code.as_str());
+        ("error", Some(error.code.as_str()))
     } else {
         span.record(observability::attr::OUTCOME, "ok");
+        ("ok", None)
     }
 }
 

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -1091,21 +1091,47 @@ impl HookRegistry {
         for h in self.handlers_snapshot() {
             // Each handler gets its own timeout window. session_X are observe-
             // only so we don't care about return values.
-            let span = hook_span("session_start", h.name());
+            let handler_name = h.name();
+            let span = hook_span("session_start", handler_name);
+            let started = std::time::Instant::now();
             let result = timeout(self.handler_timeout, h.session_start(session_id))
                 .instrument(span.clone())
                 .await;
             record_unit_hook_result(&span, &result, self.handler_timeout);
+            observability::record_hook_event_metrics(
+                "session_start",
+                handler_name,
+                started.elapsed(),
+                if result.is_ok() {
+                    "continue"
+                } else {
+                    "timeout"
+                },
+                result.err().map(|_| "handler_timeout"),
+            );
         }
     }
 
     pub async fn session_end(&self, session_id: &str, total_turns: u32) {
         for h in self.handlers_snapshot() {
-            let span = hook_span("session_end", h.name());
+            let handler_name = h.name();
+            let span = hook_span("session_end", handler_name);
+            let started = std::time::Instant::now();
             let result = timeout(self.handler_timeout, h.session_end(session_id, total_turns))
                 .instrument(span.clone())
                 .await;
             record_unit_hook_result(&span, &result, self.handler_timeout);
+            observability::record_hook_event_metrics(
+                "session_end",
+                handler_name,
+                started.elapsed(),
+                if result.is_ok() {
+                    "continue"
+                } else {
+                    "timeout"
+                },
+                result.err().map(|_| "handler_timeout"),
+            );
         }
     }
 
@@ -1119,12 +1145,21 @@ impl HookRegistry {
         F: std::future::Future<Output = Result<HookOutcome>>,
     {
         let span = hook_span(event, h.name());
+        let started = std::time::Instant::now();
         match timeout(self.handler_timeout, fut)
             .instrument(span.clone())
             .await
         {
             Ok(Ok(o)) => {
-                span.record(observability::attr::OUTCOME, hook_outcome_name(&o));
+                let outcome = hook_outcome_name(&o);
+                span.record(observability::attr::OUTCOME, outcome);
+                observability::record_hook_event_metrics(
+                    event,
+                    h.name(),
+                    started.elapsed(),
+                    outcome,
+                    None,
+                );
                 Some(o)
             }
             Ok(Err(e)) => {
@@ -1137,6 +1172,13 @@ impl HookRegistry {
                 self.failure_metrics.errors.fetch_add(1, Ordering::Relaxed);
                 span.record(observability::attr::OUTCOME, "error");
                 span.record(observability::attr::ERROR_KIND, "handler_error");
+                observability::record_hook_event_metrics(
+                    event,
+                    h.name(),
+                    started.elapsed(),
+                    "error",
+                    Some("handler_error"),
+                );
                 tracing::warn!(
                     handler = h.name(),
                     hook_event = event,
@@ -1152,6 +1194,13 @@ impl HookRegistry {
                     .fetch_add(1, Ordering::Relaxed);
                 span.record(observability::attr::OUTCOME, "timeout");
                 span.record(observability::attr::ERROR_KIND, "handler_timeout");
+                observability::record_hook_event_metrics(
+                    event,
+                    h.name(),
+                    started.elapsed(),
+                    "timeout",
+                    Some("handler_timeout"),
+                );
                 tracing::warn!(
                     handler = h.name(),
                     hook_event = event,

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -4,10 +4,14 @@
 //! subscriber initialization, and snapshot shapes used by daemon, CLI, TUI,
 //! gateway, hooks, tools, providers, and Symphony.
 
-use std::time::Duration;
+use std::{sync::LazyLock, time::Duration};
 
 use anyhow::{Context, Result};
-use opentelemetry::trace::TracerProvider as _;
+use opentelemetry::{
+    KeyValue, global,
+    metrics::{Counter, Histogram},
+    trace::TracerProvider as _,
+};
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::{
     Resource,
@@ -124,6 +128,72 @@ pub mod metric {
     ];
 }
 
+struct RuntimeMetricInstruments {
+    daemon_request_duration_ms: Histogram<f64>,
+    provider_request_duration_ms: Histogram<f64>,
+    tool_call_duration_ms: Histogram<f64>,
+    hook_event_duration_ms: Histogram<f64>,
+    tokens_input: Counter<u64>,
+    tokens_output: Counter<u64>,
+    tokens_total: Counter<u64>,
+    errors_total: Counter<u64>,
+    hook_errors: Counter<u64>,
+    hook_timeouts: Counter<u64>,
+}
+
+static RUNTIME_METRICS: LazyLock<RuntimeMetricInstruments> = LazyLock::new(|| {
+    let meter = global::meter("vulcan");
+    RuntimeMetricInstruments {
+        daemon_request_duration_ms: meter
+            .f64_histogram(metric::DAEMON_REQUEST_DURATION_MS)
+            .with_unit("ms")
+            .with_description("Daemon request latency.")
+            .build(),
+        provider_request_duration_ms: meter
+            .f64_histogram(metric::PROVIDER_REQUEST_DURATION_MS)
+            .with_unit("ms")
+            .with_description("Provider request latency.")
+            .build(),
+        tool_call_duration_ms: meter
+            .f64_histogram(metric::TOOL_CALL_DURATION_MS)
+            .with_unit("ms")
+            .with_description("Tool call latency.")
+            .build(),
+        hook_event_duration_ms: meter
+            .f64_histogram(metric::HOOK_EVENT_DURATION_MS)
+            .with_unit("ms")
+            .with_description("Hook handler event latency.")
+            .build(),
+        tokens_input: meter
+            .u64_counter(metric::TOKENS_INPUT)
+            .with_unit("tokens")
+            .with_description("Provider prompt tokens.")
+            .build(),
+        tokens_output: meter
+            .u64_counter(metric::TOKENS_OUTPUT)
+            .with_unit("tokens")
+            .with_description("Provider completion tokens.")
+            .build(),
+        tokens_total: meter
+            .u64_counter(metric::TOKENS_TOTAL)
+            .with_unit("tokens")
+            .with_description("Provider total tokens.")
+            .build(),
+        errors_total: meter
+            .u64_counter(metric::ERRORS_TOTAL)
+            .with_description("Runtime errors by surface and kind.")
+            .build(),
+        hook_errors: meter
+            .u64_counter(metric::HOOK_ERRORS)
+            .with_description("Hook handler errors.")
+            .build(),
+        hook_timeouts: meter
+            .u64_counter(metric::HOOK_TIMEOUTS)
+            .with_description("Hook handler timeouts.")
+            .build(),
+    }
+});
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProviderSpanMode {
     Buffered,
@@ -216,6 +286,154 @@ pub fn provider_request_span(
         ProviderSpanMode::Compaction => span!(span::PROVIDER_COMPACTION),
         ProviderSpanMode::Streaming => span!(span::PROVIDER_STREAMING),
     }
+}
+
+fn duration_millis(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1000.0
+}
+
+fn outcome_metric_attrs(
+    surface: &'static str,
+    outcome: &str,
+    error_kind: Option<&str>,
+) -> Vec<KeyValue> {
+    let mut attrs = vec![
+        KeyValue::new(attr::SURFACE, surface),
+        KeyValue::new(attr::OUTCOME, outcome.to_string()),
+    ];
+    if let Some(kind) = error_kind {
+        attrs.push(KeyValue::new(attr::ERROR_KIND, kind.to_string()));
+    }
+    attrs
+}
+
+fn push_outcome_attrs(attrs: &mut Vec<KeyValue>, outcome: &str, error_kind: Option<&str>) {
+    attrs.push(KeyValue::new(attr::OUTCOME, outcome.to_string()));
+    if let Some(kind) = error_kind {
+        attrs.push(KeyValue::new(attr::ERROR_KIND, kind.to_string()));
+    }
+}
+
+fn provider_metric_attrs(provider: &str, model: &str, mode: ProviderSpanMode) -> Vec<KeyValue> {
+    vec![
+        KeyValue::new(attr::SURFACE, "provider"),
+        KeyValue::new(attr::PROVIDER, provider.to_string()),
+        KeyValue::new(attr::MODEL, model.to_string()),
+        KeyValue::new(attr::PROVIDER_MODE, mode.as_str()),
+        KeyValue::new(attr::STREAMING, mode.streaming()),
+    ]
+}
+
+pub fn record_provider_request_metrics(
+    provider: &str,
+    model: &str,
+    mode: ProviderSpanMode,
+    duration: Duration,
+    outcome: &str,
+    error_kind: Option<&str>,
+) {
+    let mut attrs = provider_metric_attrs(provider, model, mode);
+    push_outcome_attrs(&mut attrs, outcome, error_kind);
+    RUNTIME_METRICS
+        .provider_request_duration_ms
+        .record(duration_millis(duration), &attrs);
+    if let Some(kind) = error_kind {
+        record_error_metric("provider", kind);
+    }
+}
+
+pub fn record_provider_token_metrics(
+    provider: &str,
+    model: &str,
+    mode: ProviderSpanMode,
+    prompt_tokens: usize,
+    completion_tokens: usize,
+    total_tokens: usize,
+) {
+    let attrs = provider_metric_attrs(provider, model, mode);
+    RUNTIME_METRICS
+        .tokens_input
+        .add(prompt_tokens as u64, &attrs);
+    RUNTIME_METRICS
+        .tokens_output
+        .add(completion_tokens as u64, &attrs);
+    RUNTIME_METRICS
+        .tokens_total
+        .add(total_tokens as u64, &attrs);
+}
+
+pub fn record_tool_call_metrics(
+    tool_name: &str,
+    duration: Duration,
+    outcome: &str,
+    error_kind: Option<&str>,
+) {
+    let mut attrs = vec![
+        KeyValue::new(attr::SURFACE, "tools"),
+        KeyValue::new(attr::TOOL_NAME, tool_name.to_string()),
+    ];
+    push_outcome_attrs(&mut attrs, outcome, error_kind);
+    RUNTIME_METRICS
+        .tool_call_duration_ms
+        .record(duration_millis(duration), &attrs);
+    if let Some(kind) = error_kind {
+        record_error_metric("tools", kind);
+    }
+}
+
+pub fn record_hook_event_metrics(
+    event: &'static str,
+    handler: &str,
+    duration: Duration,
+    outcome: &str,
+    error_kind: Option<&str>,
+) {
+    let mut attrs = vec![
+        KeyValue::new(attr::SURFACE, "hooks"),
+        KeyValue::new(attr::HOOK_EVENT, event),
+        KeyValue::new(attr::HOOK_HANDLER, handler.to_string()),
+    ];
+    push_outcome_attrs(&mut attrs, outcome, error_kind);
+    RUNTIME_METRICS
+        .hook_event_duration_ms
+        .record(duration_millis(duration), &attrs);
+    match error_kind {
+        Some("handler_timeout") => {
+            RUNTIME_METRICS.hook_timeouts.add(1, &attrs);
+            record_error_metric("hooks", "handler_timeout");
+        }
+        Some(kind) => {
+            RUNTIME_METRICS.hook_errors.add(1, &attrs);
+            record_error_metric("hooks", kind);
+        }
+        None => {}
+    }
+}
+
+pub fn record_daemon_request_metrics(
+    method: &str,
+    duration: Duration,
+    outcome: &str,
+    error_kind: Option<&str>,
+) {
+    let operation = daemon_request_operation(method);
+    let mut attrs = vec![
+        KeyValue::new(attr::SURFACE, "daemon"),
+        KeyValue::new(attr::RPC_METHOD, method.to_string()),
+        KeyValue::new(attr::OPERATION, operation),
+    ];
+    push_outcome_attrs(&mut attrs, outcome, error_kind);
+    RUNTIME_METRICS
+        .daemon_request_duration_ms
+        .record(duration_millis(duration), &attrs);
+    if let Some(kind) = error_kind {
+        record_error_metric("daemon", kind);
+    }
+}
+
+pub fn record_error_metric(surface: &'static str, error_kind: &str) {
+    let attrs = outcome_metric_attrs(surface, "error", Some(error_kind));
+    RUNTIME_METRICS.errors_total.add(1, &attrs);
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -340,6 +558,7 @@ where
 
     let (otel_metrics_layer, meter_provider) = if config.metrics {
         let provider = init_meter_provider(config)?;
+        global::set_meter_provider(provider.clone());
         (
             Some(tracing_opentelemetry::MetricsLayer::new(provider.clone()).boxed()),
             Some(provider),
@@ -503,6 +722,42 @@ mod tests {
         assert_eq!(
             metric::PROCESS_MEMORY_RSS_BYTES,
             "vulcan.process.memory.rss_bytes"
+        );
+    }
+
+    #[test]
+    fn provider_metric_attributes_stay_low_cardinality() {
+        let attrs = provider_metric_attrs("openai", "gpt-5.4", ProviderSpanMode::Streaming);
+        assert!(attrs.iter().any(|kv| kv.key.as_str() == attr::SURFACE));
+        assert!(attrs.iter().any(|kv| kv.key.as_str() == attr::PROVIDER));
+        assert!(
+            attrs
+                .iter()
+                .any(|kv| kv.key.as_str() == attr::PROVIDER_MODE)
+        );
+        assert!(attrs.iter().any(|kv| kv.key.as_str() == attr::STREAMING));
+        assert!(
+            attrs.iter().all(
+                |kv| kv.key.as_str() != attr::REQUEST_ID && kv.key.as_str() != attr::SESSION_ID
+            )
+        );
+    }
+
+    #[test]
+    fn outcome_metric_attributes_include_error_kind_only_for_errors() {
+        let ok_attrs = outcome_metric_attrs("tools", "ok", None);
+        assert!(ok_attrs.iter().any(|kv| kv.key.as_str() == attr::OUTCOME));
+        assert!(
+            !ok_attrs
+                .iter()
+                .any(|kv| kv.key.as_str() == attr::ERROR_KIND)
+        );
+
+        let error_attrs = outcome_metric_attrs("provider", "error", Some("provider_error"));
+        assert!(
+            error_attrs
+                .iter()
+                .any(|kv| kv.key.as_str() == attr::ERROR_KIND)
         );
     }
 


### PR DESCRIPTION
## Summary
- add shared OpenTelemetry runtime metric instruments for backend latency, token counters, hook failures, and surface errors
- emit provider request latency and token counters across buffered, streaming, and compaction calls
- emit tool, hook, and daemon request duration/error metrics at existing span boundaries

Stacked on #635.
Closes #631.

## Verification
- TMPDIR=/home/yycholla/vulcan-test-tmp cargo test observability::tests
- TMPDIR=/home/yycholla/vulcan-test-tmp cargo test hooks::
- TMPDIR=/home/yycholla/vulcan-test-tmp cargo test daemon::server
- TMPDIR=/home/yycholla/vulcan-test-tmp cargo test agent::tests
- cargo fmt --check
- TMPDIR=/home/yycholla/vulcan-test-tmp cargo check
- npx gitnexus detect-changes --repo vulcan
- pre-commit cargo check/fmt/clippy passed with existing warnings

## Impact
GitNexus impact found LOW risk for daemon write_dispatch_result. The newer agent/hook/observability symbols were not present in the index and returned UNKNOWN; focused tests cover the touched runtime boundaries.