### PR TITLE
Emit TUI frame performance metrics

### DIFF
--- a/src/observability.rs
+++ b/src/observability.rs
@@ -9,7 +9,7 @@ use std::{sync::LazyLock, time::Duration};
 use anyhow::{Context, Result};
 use opentelemetry::{
     KeyValue, global,
-    metrics::{Counter, Histogram},
+    metrics::{Counter, Gauge, Histogram},
     trace::TracerProvider as _,
 };
 use opentelemetry_otlp::WithExportConfig;
@@ -139,6 +139,11 @@ struct RuntimeMetricInstruments {
     errors_total: Counter<u64>,
     hook_errors: Counter<u64>,
     hook_timeouts: Counter<u64>,
+    tui_frame_draw_ms: Histogram<f64>,
+    tui_frame_interval_ms: Histogram<f64>,
+    tui_frames_total: Counter<u64>,
+    tui_fps: Gauge<f64>,
+    tui_surface_count: Gauge<u64>,
 }
 
 static RUNTIME_METRICS: LazyLock<RuntimeMetricInstruments> = LazyLock::new(|| {
@@ -190,6 +195,28 @@ static RUNTIME_METRICS: LazyLock<RuntimeMetricInstruments> = LazyLock::new(|| {
         hook_timeouts: meter
             .u64_counter(metric::HOOK_TIMEOUTS)
             .with_description("Hook handler timeouts.")
+            .build(),
+        tui_frame_draw_ms: meter
+            .f64_histogram(metric::TUI_FRAME_DRAW_MS)
+            .with_unit("ms")
+            .with_description("TUI frame draw duration.")
+            .build(),
+        tui_frame_interval_ms: meter
+            .f64_histogram(metric::TUI_FRAME_INTERVAL_MS)
+            .with_unit("ms")
+            .with_description("TUI interval between completed frames.")
+            .build(),
+        tui_frames_total: meter
+            .u64_counter(metric::TUI_FRAMES_TOTAL)
+            .with_description("TUI frames drawn.")
+            .build(),
+        tui_fps: meter
+            .f64_gauge(metric::TUI_FPS)
+            .with_description("TUI instantaneous frames per second.")
+            .build(),
+        tui_surface_count: meter
+            .u64_gauge(metric::TUI_SURFACE_COUNT)
+            .with_description("TUI active frontend surface count.")
             .build(),
     }
 });
@@ -434,6 +461,27 @@ pub fn record_daemon_request_metrics(
 pub fn record_error_metric(surface: &'static str, error_kind: &str) {
     let attrs = outcome_metric_attrs(surface, "error", Some(error_kind));
     RUNTIME_METRICS.errors_total.add(1, &attrs);
+}
+
+pub fn record_tui_frame_metrics(
+    draw_duration: Duration,
+    frame_interval: Duration,
+    _frame_count: u64,
+    fps: f64,
+    surface_count: usize,
+) {
+    let attrs = [KeyValue::new(attr::SURFACE, "tui")];
+    RUNTIME_METRICS
+        .tui_frame_draw_ms
+        .record(duration_millis(draw_duration), &attrs);
+    RUNTIME_METRICS
+        .tui_frame_interval_ms
+        .record(duration_millis(frame_interval), &attrs);
+    RUNTIME_METRICS.tui_frames_total.add(1, &attrs);
+    RUNTIME_METRICS.tui_fps.record(fps, &attrs);
+    RUNTIME_METRICS
+        .tui_surface_count
+        .record(surface_count as u64, &attrs);
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -353,7 +353,7 @@ pub async fn run_tui(
 
     let mut exit = false;
     let mut pending_quit = false;
-    let mut last_draw: Instant;
+    let mut last_draw = Instant::now();
     let mut last_motion_frame = Instant::now();
 
     while !exit {
@@ -425,8 +425,12 @@ pub async fn run_tui(
             rendering::draw_surface_overlays(f, area, &app);
             rendering::draw_diagnostics(f, area, &app);
         })?;
-        app.note_frame_draw(draw_started.elapsed());
-        last_draw = Instant::now();
+        let frame_finished = Instant::now();
+        app.note_frame_draw(
+            draw_started.elapsed(),
+            frame_finished.saturating_duration_since(last_draw),
+        );
+        last_draw = frame_finished;
         if app.finish_chat_clear_if_idle() {
             continue;
         }

--- a/src/tui/rendering.rs
+++ b/src/tui/rendering.rs
@@ -844,7 +844,10 @@ mod tests {
         app.show_diagnostics = true;
         app.prompt_tokens_last = 32_000;
         app.queue.push_back("queued".into());
-        app.note_frame_draw(std::time::Duration::from_micros(2_500));
+        app.note_frame_draw(
+            std::time::Duration::from_micros(2_500),
+            std::time::Duration::from_millis(20),
+        );
 
         terminal
             .draw(|f| {

--- a/src/tui/state/mod.rs
+++ b/src/tui/state/mod.rs
@@ -55,6 +55,7 @@ use throbber_widgets_tui::ThrobberState;
 
 use crate::hooks::audit::{AuditBuffer, AuditKind};
 use crate::memory::SessionSummary;
+use crate::observability;
 
 // Re-export the types pulled into sibling submodules in YYC-110 so the
 // legacy `tui::state::*` import paths used across the TUI still resolve.
@@ -180,6 +181,8 @@ enum ChatClearPhase {
 pub struct TuiDiagnostics {
     pub frame_count: u64,
     pub last_draw_ms: f64,
+    pub last_frame_interval_ms: f64,
+    pub fps: f64,
     pub surface_count: usize,
     pub active_surface: Option<String>,
 }
@@ -642,12 +645,25 @@ impl AppState {
         self.show_diagnostics = !self.show_diagnostics;
     }
 
-    pub fn note_frame_draw(&mut self, elapsed: Duration) {
+    pub fn note_frame_draw(&mut self, elapsed: Duration, frame_interval: Duration) {
         self.diagnostics.frame_count = self.diagnostics.frame_count.saturating_add(1);
         self.diagnostics.last_draw_ms = elapsed.as_secs_f64() * 1000.0;
+        self.diagnostics.last_frame_interval_ms = frame_interval.as_secs_f64() * 1000.0;
+        self.diagnostics.fps = if frame_interval.is_zero() {
+            0.0
+        } else {
+            1.0 / frame_interval.as_secs_f64()
+        };
         self.diagnostics.surface_count = self.ui_runtime.surface_count();
         self.diagnostics.active_surface =
             self.ui_runtime.active_surface_title().map(str::to_string);
+        observability::record_tui_frame_metrics(
+            elapsed,
+            frame_interval,
+            self.diagnostics.frame_count,
+            self.diagnostics.fps,
+            self.diagnostics.surface_count,
+        );
     }
 
     pub fn open_session_picker(&mut self, selection: usize) {

--- a/src/tui/state/tests.rs
+++ b/src/tui/state/tests.rs
@@ -74,6 +74,20 @@ fn hydrate_sessions_retains_lineage_and_activity_fields() {
 }
 
 #[test]
+fn note_frame_draw_tracks_interval_and_fps() {
+    let mut app = AppState::new("test-model".into(), 128_000);
+    app.note_frame_draw(
+        std::time::Duration::from_micros(2_500),
+        std::time::Duration::from_millis(20),
+    );
+
+    assert_eq!(app.diagnostics.frame_count, 1);
+    assert_eq!(app.diagnostics.last_draw_ms, 2.5);
+    assert_eq!(app.diagnostics.last_frame_interval_ms, 20.0);
+    assert_eq!(app.diagnostics.fps, 50.0);
+}
+
+#[test]
 fn segments_interleave_reasoning_tool_text_in_arrival_order() {
     // Simulates the exact YYC-71 sequence: think → tool → think → answer.
     let mut m = ChatMessage::new(ChatRole::Agent, "");


### PR DESCRIPTION
## Summary
- add TUI frame draw duration, frame interval, frame count, FPS, and surface count metric instruments
- update the main draw loop to sample frame interval and emit metrics from the existing diagnostics update path
- preserve diagnostics overlay behavior while adding interval/FPS state for performance debugging

Stacked on #636.
Closes #633.

## Verification
- TMPDIR=/home/yycholla/vulcan-test-tmp cargo test tui::state::tests::note_frame_draw_tracks_interval_and_fps
- TMPDIR=/home/yycholla/vulcan-test-tmp cargo test tui::
- TMPDIR=/home/yycholla/vulcan-test-tmp cargo test observability::tests
- cargo fmt --check
- TMPDIR=/home/yycholla/vulcan-test-tmp cargo check
- npx gitnexus detect-changes --repo vulcan
- pre-commit cargo check/fmt/clippy passed with existing warnings

## Impact
GitNexus did not have exact symbols for note_frame_draw or run_tui and returned UNKNOWN. This slice is limited to the TUI draw-loop diagnostics path and shared metric instruments; focused TUI tests cover the touched behavior.