### PR TITLE
Sample process resource metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1314,7 +1314,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4167,6 +4167,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4264,6 +4273,25 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
 
 [[package]]
 name = "object"
@@ -5651,7 +5679,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6365,6 +6393,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
 ]
 
 [[package]]
@@ -7495,6 +7537,7 @@ dependencies = [
  "sha2 0.11.0",
  "strsim",
  "subtle",
+ "sysinfo",
  "tachyonfx",
  "teloxide-core",
  "tempfile",
@@ -7985,6 +8028,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7995,6 +8059,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -8024,6 +8099,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-registry"
@@ -8121,6 +8206,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,6 +146,8 @@ opentelemetry = "0.31"
 opentelemetry_sdk = "0.31"
 opentelemetry-otlp = { version = "0.31.1", default-features = false, features = ["http-proto", "reqwest-blocking-client", "trace", "metrics"] }
 tracing-opentelemetry = "0.32.1"
+# Low-overhead process RSS/CPU/thread sampling for OpenTelemetry runtime metrics.
+sysinfo = { version = "0.38.4", default-features = false, features = ["system"] }
 
 # Error handling
 anyhow = "1"

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -144,6 +144,9 @@ struct RuntimeMetricInstruments {
     tui_frames_total: Counter<u64>,
     tui_fps: Gauge<f64>,
     tui_surface_count: Gauge<u64>,
+    process_memory_rss_bytes: Gauge<u64>,
+    process_cpu_percent: Gauge<f64>,
+    process_threads: Gauge<u64>,
 }
 
 static RUNTIME_METRICS: LazyLock<RuntimeMetricInstruments> = LazyLock::new(|| {
@@ -217,6 +220,20 @@ static RUNTIME_METRICS: LazyLock<RuntimeMetricInstruments> = LazyLock::new(|| {
         tui_surface_count: meter
             .u64_gauge(metric::TUI_SURFACE_COUNT)
             .with_description("TUI active frontend surface count.")
+            .build(),
+        process_memory_rss_bytes: meter
+            .u64_gauge(metric::PROCESS_MEMORY_RSS_BYTES)
+            .with_unit("By")
+            .with_description("Current process resident memory.")
+            .build(),
+        process_cpu_percent: meter
+            .f64_gauge(metric::PROCESS_CPU_PERCENT)
+            .with_unit("%")
+            .with_description("Current process CPU utilization.")
+            .build(),
+        process_threads: meter
+            .u64_gauge(metric::PROCESS_THREADS)
+            .with_description("Current process thread count when available.")
             .build(),
     }
 });
@@ -484,6 +501,63 @@ pub fn record_tui_frame_metrics(
         .record(surface_count as u64, &attrs);
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ProcessResourceSnapshot {
+    pub rss_bytes: u64,
+    pub cpu_percent: f64,
+    pub thread_count: Option<u64>,
+}
+
+pub fn record_process_resource_metrics(snapshot: ProcessResourceSnapshot) {
+    let attrs = [KeyValue::new(attr::SURFACE, "process")];
+    RUNTIME_METRICS
+        .process_memory_rss_bytes
+        .record(snapshot.rss_bytes, &attrs);
+    RUNTIME_METRICS
+        .process_cpu_percent
+        .record(snapshot.cpu_percent, &attrs);
+    if let Some(thread_count) = snapshot.thread_count {
+        RUNTIME_METRICS.process_threads.record(thread_count, &attrs);
+    }
+}
+
+fn process_sampler_interval(config: &ObservabilityConfig) -> Duration {
+    Duration::from_secs(config.export_interval_secs.max(1))
+}
+
+fn collect_process_resource_snapshot(
+    system: &mut sysinfo::System,
+    pid: sysinfo::Pid,
+) -> Option<ProcessResourceSnapshot> {
+    system.refresh_processes(sysinfo::ProcessesToUpdate::Some(&[pid]), true);
+    let process = system.process(pid)?;
+    Some(ProcessResourceSnapshot {
+        rss_bytes: process.memory(),
+        cpu_percent: process.cpu_usage() as f64,
+        thread_count: process.tasks().map(|tasks| tasks.len() as u64),
+    })
+}
+
+fn spawn_process_resource_sampler(
+    config: &ObservabilityConfig,
+) -> Option<tokio::task::JoinHandle<()>> {
+    let handle = tokio::runtime::Handle::try_current().ok()?;
+    let interval = process_sampler_interval(config);
+    Some(handle.spawn(async move {
+        let pid = sysinfo::Pid::from_u32(std::process::id());
+        let mut system = sysinfo::System::new();
+        let mut ticker = tokio::time::interval(interval);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+        loop {
+            ticker.tick().await;
+            if let Some(snapshot) = collect_process_resource_snapshot(&mut system, pid) {
+                record_process_resource_metrics(snapshot);
+            }
+        }
+    }))
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct HookHealthSnapshot {
     pub handler_count: usize,
@@ -509,6 +583,7 @@ impl HookHealthSnapshot {
 pub struct ObservabilityGuard {
     tracer_provider: Option<SdkTracerProvider>,
     meter_provider: Option<SdkMeterProvider>,
+    process_sampler: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl ObservabilityGuard {
@@ -516,6 +591,7 @@ impl ObservabilityGuard {
         Self {
             tracer_provider: None,
             meter_provider: None,
+            process_sampler: None,
         }
     }
 
@@ -526,6 +602,9 @@ impl ObservabilityGuard {
 
 impl Drop for ObservabilityGuard {
     fn drop(&mut self) {
+        if let Some(handle) = self.process_sampler.take() {
+            handle.abort();
+        }
         if let Some(provider) = self.tracer_provider.take()
             && let Err(err) = provider.shutdown()
         {
@@ -604,15 +683,16 @@ where
         (None, None)
     };
 
-    let (otel_metrics_layer, meter_provider) = if config.metrics {
+    let (otel_metrics_layer, meter_provider, process_sampler) = if config.metrics {
         let provider = init_meter_provider(config)?;
         global::set_meter_provider(provider.clone());
         (
             Some(tracing_opentelemetry::MetricsLayer::new(provider.clone()).boxed()),
             Some(provider),
+            spawn_process_resource_sampler(config),
         )
     } else {
-        (None, None)
+        (None, None, None)
     };
 
     tracing_subscriber::registry()
@@ -626,6 +706,7 @@ where
     Ok(ObservabilityGuard {
         tracer_provider,
         meter_provider,
+        process_sampler,
     })
 }
 
@@ -807,6 +888,21 @@ mod tests {
                 .iter()
                 .any(|kv| kv.key.as_str() == attr::ERROR_KIND)
         );
+    }
+
+    #[test]
+    fn process_sampler_interval_is_bounded_to_at_least_one_second() {
+        let config = ObservabilityConfig {
+            export_interval_secs: 0,
+            ..ObservabilityConfig::default()
+        };
+        assert_eq!(process_sampler_interval(&config), Duration::from_secs(1));
+
+        let config = ObservabilityConfig {
+            export_interval_secs: 7,
+            ..ObservabilityConfig::default()
+        };
+        assert_eq!(process_sampler_interval(&config), Duration::from_secs(7));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a bounded process resource sampler that starts when observability metrics are enabled
- emit RSS memory, CPU percent, and thread-count gauges through the shared runtime metrics vocabulary
- abort the sampler from ObservabilityGuard drop before shutting down providers

Stacked on #637.
Closes #634.

## Verification
- TMPDIR=/home/yycholla/vulcan-test-tmp cargo test observability::tests
- cargo fmt --check
- TMPDIR=/home/yycholla/vulcan-test-tmp cargo check
- npx gitnexus detect-changes --repo vulcan
- pre-commit cargo check/fmt/clippy passed with existing warnings

## Impact
GitNexus did not have exact symbols for the newer observability helpers and reported no detected graph changes. This slice is isolated to observability setup/guard lifecycle plus the sysinfo dependency.