### PR TITLE
Renderer Slice 7: LaTeX sidecar decision

### DIFF
--- a/docs/reference/renderer-latex-decision.md
+++ b/docs/reference/renderer-latex-decision.md
@@ -1,0 +1,57 @@
+# Renderer LaTeX Decision
+
+Issue: #589
+
+## Decision
+
+Defer full LaTeX document rendering from Renderer Pipeline v1.
+
+Vulcan should keep Markdown math as the default TeX-adjacent behavior and prefer
+Typst previews before introducing a full LaTeX document pipeline. If full LaTeX
+is added later, the first implementation should be a sidecar/subprocess worker
+behind explicit opt-in config and a default-off `render-latex` feature.
+
+## Comparison
+
+| Approach | Default build impact | Runtime/security profile | Fit |
+| --- | --- | --- | --- |
+| Embedded `tectonic` crate | High | Pulls TeX engine complexity into the Rust binary | Defer |
+| External `tectonic`/`latexmk` subprocess | None when feature/config disabled | Isolatable with timeout, temp dir, scrubbed env, and output caps | Best later option |
+| Defer full LaTeX | None | No new renderer attack surface | Best for v1 |
+
+## Later Implementation Contract
+
+A future LaTeX renderer should:
+
+- Be disabled by default and gated behind `render-latex`.
+- Run outside the TUI draw path in a background worker or sidecar process.
+- Use a cache under `vulcan_home()/render-cache/latex`.
+- Key cache entries by source hash, engine, executable version, output format,
+  renderer version, and relevant options.
+- Compile in a temporary working directory under the cache root.
+- Invoke executables directly without a shell.
+- Scrub environment variables and pass an explicit executable path from config.
+- Disable shell escape and restrict include roots where the chosen engine allows
+  it.
+- Enforce timeout/kill behavior and cap stdout/stderr/error payload sizes.
+- Render source text by default, and when enabled show generated artifact paths
+  or preview placeholders without assuming terminal image support.
+
+## Runtime Requirements If Enabled Later
+
+An external sidecar route should document at least:
+
+- Supported executable: `tectonic` CLI first; `latexmk` only when a TeXLive-like
+  install is intentionally supported.
+- Required config: executable path, timeout, output format, include roots, and
+  cache size/retention.
+- Failure UX: source fallback plus a concise error and generated artifact path
+  when available.
+- Security caveat: user-provided `.tex` is active document code, not passive
+  Markdown text.
+
+## v1 Outcome
+
+Renderer Pipeline v1 does not add a `render-latex` feature or LaTeX dependency.
+Default `cargo test` and default builds remain unaffected by full document TeX
+support.

--- a/docs/testing/renderer-pipeline-v1.md
+++ b/docs/testing/renderer-pipeline-v1.md
@@ -44,6 +44,13 @@ the automated renderer tests pass.
 - [ ] Failed preview generation does not block normal chat rendering.
 - [ ] Media placeholders show useful alt text or path context.
 
+## LaTeX Decision
+
+- [ ] Inline and display math stay readable without requiring a full LaTeX engine.
+- [ ] Full `.tex` document rendering is not present in the default build.
+- [ ] The LaTeX decision note documents the deferred sidecar requirements.
+- [ ] No `render-latex` feature or LaTeX runtime dependency is required for Renderer Pipeline v1.
+
 ## CLI And Non-TUI Output
 
 - [ ] CLI output paths using rendered Markdown still produce readable plain/ANSI output.


### PR DESCRIPTION
## Summary
- add the Renderer Pipeline v1 LaTeX decision note
- defer full LaTeX document rendering from v1 and recommend a later sidecar/subprocess path
- extend the manual milestone checklist with LaTeX/default-build checks

## Verification
- `rg -n "render-latex|tectonic|latexmk|render-cache/latex|LaTeX" Cargo.toml docs/reference/renderer-latex-decision.md docs/testing/renderer-pipeline-v1.md`
- `git diff --check`
- `rtk cargo test -p vulcan-core --lib -- --skip memory::cortex::tests::stats_and_decay_use_open_store_handle`
- pre-commit `cargo check`, `cargo fmt`, `cargo clippy`
- `npx gitnexus analyze`

Note: the full lib suite previously failed only on FastEmbed model retrieval in `memory::cortex::tests::stats_and_decay_use_open_store_handle`, so this docs-only verification used the same targeted skip.

Fixes #589
