### PR TITLE
Support Codex Responses provider profiles

### DIFF
--- a/src/cli_auth.rs
+++ b/src/cli_auth.rs
@@ -88,7 +88,12 @@ async fn run_preset(
         .validate_with(validate_profile_name)
         .interact_text()?;
 
-    let api_key_opt = prompt_api_key(theme, preset.base_url, preset.auth_hint)?;
+    let api_key_opt = if preset.auth_source == Some("codex") {
+        ensure_codex_login_hint();
+        None
+    } else {
+        prompt_api_key(theme, preset.base_url, preset.auth_hint)?
+    };
 
     let model = pick_or_input_model(
         theme,
@@ -221,6 +226,21 @@ fn validate_profile_name(input: &String) -> Result<(), &'static str> {
         Err("name required")
     } else {
         Ok(())
+    }
+}
+
+fn ensure_codex_login_hint() {
+    if std::env::var_os("CODEX_HOME")
+        .map(std::path::PathBuf::from)
+        .or_else(|| {
+            std::env::var_os("HOME").map(|home| std::path::PathBuf::from(home).join(".codex"))
+        })
+        .map(|home| home.join("auth.json").exists())
+        .unwrap_or(false)
+    {
+        println!("  codex auth   : found local Codex auth cache");
+    } else {
+        println!("  codex auth   : run `codex login` first; Vulcan will reuse that login cache");
     }
 }
 

--- a/src/cli_provider.rs
+++ b/src/cli_provider.rs
@@ -84,9 +84,11 @@ pub struct RemoveArgs {
 pub struct Preset {
     pub key: &'static str,
     pub display: &'static str,
+    pub provider_type: &'static str,
     pub base_url: &'static str,
     pub model: &'static str,
     pub auth_hint: &'static str,
+    pub auth_source: Option<&'static str>,
     pub disable_catalog: bool,
     pub notes: &'static str,
 }
@@ -96,72 +98,99 @@ pub fn presets() -> &'static [Preset] {
         Preset {
             key: "openrouter",
             display: "OpenRouter",
+            provider_type: "openai-compat",
             base_url: "https://openrouter.ai/api/v1",
             model: "deepseek/deepseek-v4-flash",
             auth_hint: "VULCAN_API_KEY (sk-or-...)",
+            auth_source: None,
             disable_catalog: false,
             notes: "Aggregator — most models routable through one endpoint.",
         },
         Preset {
             key: "openai",
             display: "OpenAI",
+            provider_type: "openai-compat",
             base_url: "https://api.openai.com/v1",
             model: "gpt-5",
             auth_hint: "OPENAI_API_KEY or VULCAN_API_KEY",
+            auth_source: None,
             disable_catalog: false,
             notes: "First-party endpoint; supports tools, structured output, vision.",
         },
         Preset {
+            key: "openai-codex",
+            display: "OpenAI (Codex OAuth)",
+            provider_type: "openai-responses",
+            base_url: "https://chatgpt.com/backend-api/codex",
+            model: "gpt-5.5",
+            auth_hint: "~/.codex/auth.json from `codex login`",
+            auth_source: Some("codex"),
+            disable_catalog: true,
+            notes: "Reuses Codex CLI ChatGPT login cache via the Codex backend; no token is copied into providers.toml.",
+        },
+        Preset {
             key: "anthropic",
             display: "Anthropic",
+            provider_type: "openai-compat",
             base_url: "https://api.anthropic.com/v1",
             model: "claude-opus-4-7",
             auth_hint: "ANTHROPIC_API_KEY or VULCAN_API_KEY",
+            auth_source: None,
             disable_catalog: false,
             notes: "Claude family. Native API; OpenAI-compat path may need explicit headers.",
         },
         Preset {
             key: "deepseek",
             display: "DeepSeek (direct)",
+            provider_type: "openai-compat",
             base_url: "https://api.deepseek.com/v1",
             model: "deepseek-chat",
             auth_hint: "DEEPSEEK_API_KEY or VULCAN_API_KEY",
+            auth_source: None,
             disable_catalog: false,
             notes: "Direct route — bypasses OpenRouter when you want lower latency / no markup.",
         },
         Preset {
             key: "groq",
             display: "Groq",
+            provider_type: "openai-compat",
             base_url: "https://api.groq.com/openai/v1",
             model: "llama-3.3-70b-versatile",
             auth_hint: "GROQ_API_KEY or VULCAN_API_KEY",
+            auth_source: None,
             disable_catalog: false,
             notes: "Hosted LPU inference; Llama / Mixtral / Qwen at very high tok/s.",
         },
         Preset {
             key: "together",
             display: "Together AI",
+            provider_type: "openai-compat",
             base_url: "https://api.together.xyz/v1",
             model: "meta-llama/Llama-3.3-70B-Instruct-Turbo",
             auth_hint: "TOGETHER_API_KEY or VULCAN_API_KEY",
+            auth_source: None,
             disable_catalog: false,
             notes: "Wide open-weights selection.",
         },
         Preset {
             key: "fireworks",
             display: "Fireworks AI",
+            provider_type: "openai-compat",
             base_url: "https://api.fireworks.ai/inference/v1",
             model: "accounts/fireworks/models/qwen2p5-coder-32b-instruct",
             auth_hint: "FIREWORKS_API_KEY or VULCAN_API_KEY",
+            auth_source: None,
             disable_catalog: false,
             notes: "Fast hosted inference; strong coder models.",
         },
         Preset {
             key: "ollama",
             display: "Ollama (local)",
+            provider_type: "openai-compat",
             base_url: "http://localhost:11434/v1",
             model: "qwen2.5-coder:latest",
             auth_hint: "no auth required (set api_key = \"ollama\" if your build expects it)",
+            auth_source: None,
             disable_catalog: true,
             notes: "Local self-hosted; catalog disabled because it doesn't publish an OpenAI-shape `/models`.",
         },
@@ -397,6 +426,8 @@ pub fn add(args: AddArgs, dir: &Path) -> Result<()> {
     let mut base_url = args.base_url.clone();
     let mut model = args.model.clone();
     let mut disable_catalog = args.disable_catalog;
+    let mut provider_type = "openai-compat";
+    let mut auth_source = None;
     if let Some(preset_key) = &args.preset {
         let preset = lookup_preset(preset_key).ok_or_else(|| {
             anyhow!(
@@ -405,6 +436,8 @@ pub fn add(args: AddArgs, dir: &Path) -> Result<()> {
         })?;
         base_url.get_or_insert_with(|| preset.base_url.to_string());
         model.get_or_insert_with(|| preset.model.to_string());
+        provider_type = preset.provider_type;
+        auth_source = preset.auth_source;
         if !disable_catalog {
             disable_catalog = preset.disable_catalog;
         }
@@ -427,11 +460,14 @@ pub fn add(args: AddArgs, dir: &Path) -> Result<()> {
 
     let mut entry = Table::new();
     entry.set_implicit(false);
-    entry.insert("type", value("openai-compat"));
+    entry.insert("type", value(provider_type));
     entry.insert("base_url", value(base_url));
     entry.insert("model", value(model));
     if let Some(key) = args.api_key {
         entry.insert("api_key", value(key));
+    }
+    if let Some(source) = auth_source {
+        entry.insert("auth_source", value(source));
     }
     if let Some(max_ctx) = args.max_context {
         entry.insert("max_context", value(max_ctx as i64));
@@ -570,6 +606,7 @@ mod tests {
         for must in [
             "openrouter",
             "openai",
+            "openai-codex",
             "anthropic",
             "ollama",
             "groq",
@@ -750,6 +787,40 @@ mod tests {
         let cfg = crate::config::Config::load_from_dir(dir.path()).unwrap();
         assert_eq!(cfg.providers["or"].model, "anthropic/claude-opus-4-7");
         assert_eq!(cfg.providers["or"].base_url, "https://openrouter.ai/api/v1");
+    }
+
+    #[test]
+    fn add_openai_codex_preset_writes_auth_source_not_token() {
+        let dir = tempdir().unwrap();
+        add(
+            AddArgs {
+                name: "codex".into(),
+                preset: Some("openai-codex".into()),
+                base_url: None,
+                model: None,
+                api_key: None,
+                max_context: None,
+                disable_catalog: false,
+                force: false,
+            },
+            dir.path(),
+        )
+        .unwrap();
+
+        let providers_raw = std::fs::read_to_string(dir.path().join("providers.toml")).unwrap();
+        assert!(providers_raw.contains("[codex]"));
+        assert!(providers_raw.contains("auth_source = \"codex\""));
+        assert!(!providers_raw.contains("access_token"));
+
+        let cfg = crate::config::Config::load_from_dir(dir.path()).unwrap();
+        assert_eq!(cfg.providers["codex"].r#type, "openai-responses");
+        assert_eq!(
+            cfg.providers["codex"].base_url,
+            "https://chatgpt.com/backend-api/codex"
+        );
+        assert!(cfg.providers["codex"].disable_catalog);
+        assert_eq!(cfg.providers["codex"].auth_source.as_deref(), Some("codex"));
+        assert!(cfg.providers["codex"].api_key.is_none());
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use serde::Deserialize;
+use serde_json::Value as JsonValue;
 use std::collections::HashMap;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -995,6 +996,10 @@ pub struct ProviderConfig {
     pub base_url: String,
     /// API key — can also be set via VULCAN_API_KEY env var
     pub api_key: Option<String>,
+    /// Optional auth source. "codex" reuses the local Codex CLI login
+    /// cache instead of storing a key in Vulcan config.
+    #[serde(default)]
+    pub auth_source: Option<String>,
     /// Model name (e.g. "anthropic/claude-sonnet-4", "gpt-4o")
     #[serde(default = "default_model")]
     pub model: String,
@@ -1249,6 +1254,7 @@ impl Default for ProviderConfig {
             r#type: default_provider_type(),
             base_url: default_base_url(),
             api_key: None,
+            auth_source: None,
             model: default_model(),
             max_context: default_max_context(),
             max_retries: default_max_retries(),
@@ -1634,7 +1640,7 @@ impl Config {
         Ok(report)
     }
 
-    /// Resolve the API key: env var > active provider > compile-time warning.
+    /// Resolve the API key: env var > active provider > external auth source.
     /// YYC-239: pulls the key from the active provider profile (via
     /// `active_provider_config`) instead of always the legacy
     /// `[provider]` block.
@@ -1643,13 +1649,47 @@ impl Config {
     }
 
     /// Resolve the API key for a provider profile: env var wins, then the
-    /// profile-local key. Named providers intentionally use the same global
-    /// env override so one-off shells can redirect auth without editing TOML.
+    /// profile-local key, then configured external auth. Named providers
+    /// intentionally use the same global env override so one-off shells can
+    /// redirect auth without editing TOML.
     pub fn api_key_for(&self, provider: &ProviderConfig) -> Option<String> {
         std::env::var("VULCAN_API_KEY")
             .ok()
             .or_else(|| provider.api_key.clone())
+            .or_else(|| auth_source_token(provider.auth_source.as_deref()))
     }
+}
+
+fn auth_source_token(auth_source: Option<&str>) -> Option<String> {
+    match auth_source {
+        Some(source) if source.eq_ignore_ascii_case("codex") => codex_auth_token(),
+        _ => None,
+    }
+}
+
+fn codex_auth_token() -> Option<String> {
+    let codex_home = std::env::var_os("CODEX_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|home| PathBuf::from(home).join(".codex")))?;
+    codex_auth_token_from_file(&codex_home.join("auth.json"))
+}
+
+fn codex_auth_token_from_file(path: &Path) -> Option<String> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    let value: JsonValue = serde_json::from_str(&raw).ok()?;
+    value
+        .get("OPENAI_API_KEY")
+        .and_then(JsonValue::as_str)
+        .filter(|token| !token.trim().is_empty())
+        .map(ToString::to_string)
+        .or_else(|| {
+            value
+                .get("tokens")
+                .and_then(|tokens| tokens.get("access_token"))
+                .and_then(JsonValue::as_str)
+                .filter(|token| !token.trim().is_empty())
+                .map(ToString::to_string)
+        })
 }
 
 // YYC-265: tests live in their own file so the main config module

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -50,6 +50,56 @@ model = "speedy"
 }
 
 #[test]
+fn provider_codex_auth_source_parses() {
+    let cfg: Config = toml::from_str(
+        r#"
+[provider]
+type = "openai-compat"
+base_url = "https://api.openai.com/v1"
+model = "gpt-5"
+auth_source = "codex"
+"#,
+    )
+    .expect("parses");
+
+    assert_eq!(cfg.provider.auth_source.as_deref(), Some("codex"));
+}
+
+#[test]
+fn codex_auth_token_from_file_prefers_api_key_then_access_token() {
+    let dir = tempfile::tempdir().unwrap();
+    let auth = dir.path().join("auth.json");
+    std::fs::write(
+        &auth,
+        r#"{
+          "OPENAI_API_KEY": "sk-file-key",
+          "auth_mode": "api",
+          "tokens": { "access_token": "access-token" }
+        }"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        codex_auth_token_from_file(&auth).as_deref(),
+        Some("sk-file-key")
+    );
+
+    std::fs::write(
+        &auth,
+        r#"{
+          "auth_mode": "chatgpt",
+          "tokens": { "access_token": "access-token" }
+        }"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        codex_auth_token_from_file(&auth).as_deref(),
+        Some("access-token")
+    );
+}
+
+#[test]
 fn active_profile_pointing_at_missing_falls_back_to_legacy() {
     let cfg: Config = toml::from_str(
         r#"

--- a/src/provider/codex.rs
+++ b/src/provider/codex.rs
@@ -1,0 +1,416 @@
+use crate::config::ProviderDebugMode;
+use crate::provider::{
+    ChatResponse, LLMProvider, Message, ProviderError, StreamEvent, ToolCall, ToolCallFunction,
+    ToolDefinition, Usage,
+};
+use anyhow::{Context, Result};
+use reqwest::Client;
+use serde_json::{Value, json};
+use std::time::Duration;
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+
+pub struct ResponsesProvider {
+    client: Client,
+    base_url: String,
+    token: String,
+    model: String,
+    max_context: usize,
+    max_retries: u32,
+    max_output_tokens: Option<usize>,
+    debug_mode: ProviderDebugMode,
+}
+
+impl ResponsesProvider {
+    pub fn new(
+        base_url: &str,
+        token: &str,
+        model: &str,
+        max_context: usize,
+        max_retries: u32,
+        max_output_tokens: Option<usize>,
+        debug_mode: ProviderDebugMode,
+    ) -> Result<Self> {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(300))
+            .build()
+            .context("Failed to build HTTP client")?;
+
+        Ok(Self {
+            client,
+            base_url: crate::provider::normalize_base_url(base_url),
+            token: token.to_string(),
+            model: model.to_string(),
+            max_context,
+            max_retries,
+            max_output_tokens,
+            debug_mode,
+        })
+    }
+
+    fn build_request(&self, messages: &[Message], tools: &[ToolDefinition]) -> Value {
+        let mut instructions = Vec::new();
+        let mut input = Vec::new();
+
+        for message in messages {
+            match message {
+                Message::System { content } => instructions.push(content.clone()),
+                Message::User { content } => {
+                    input.push(json!({
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": content}],
+                    }));
+                }
+                Message::Assistant {
+                    content,
+                    tool_calls,
+                    ..
+                } => {
+                    if let Some(content) = content.as_ref().filter(|content| !content.is_empty()) {
+                        input.push(json!({
+                            "role": "assistant",
+                            "content": [{"type": "output_text", "text": content}],
+                        }));
+                    }
+                    if let Some(tool_calls) = tool_calls {
+                        for call in tool_calls {
+                            input.push(json!({
+                                "type": "function_call",
+                                "call_id": call.id,
+                                "name": call.function.name,
+                                "arguments": call.function.arguments,
+                            }));
+                        }
+                    }
+                }
+                Message::Tool {
+                    tool_call_id,
+                    content,
+                } => {
+                    input.push(json!({
+                        "type": "function_call_output",
+                        "call_id": tool_call_id,
+                        "output": content,
+                    }));
+                }
+            }
+        }
+
+        let tools = tools
+            .iter()
+            .map(|tool| {
+                json!({
+                    "type": "function",
+                    "name": tool.function.name,
+                    "description": tool.function.description,
+                    "parameters": tool.function.parameters,
+                    "strict": false,
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let mut body = json!({
+            "model": self.model,
+            "input": input,
+            "stream": true,
+            "store": false,
+        });
+        if !instructions.is_empty() {
+            body["instructions"] = Value::String(instructions.join("\n\n"));
+        }
+        if !tools.is_empty() {
+            body["tools"] = Value::Array(tools);
+            body["tool_choice"] = Value::String("auto".to_string());
+            body["parallel_tool_calls"] = Value::Bool(true);
+        }
+        if let Some(max_output_tokens) = self.max_output_tokens {
+            body["max_output_tokens"] = json!(max_output_tokens);
+        }
+        body
+    }
+
+    async fn do_request(
+        &self,
+        messages: &[Message],
+        tools: &[ToolDefinition],
+        cancel: &CancellationToken,
+    ) -> std::result::Result<reqwest::Response, ProviderError> {
+        let url = format!("{}/responses", self.base_url);
+        let body = self.build_request(messages, tools);
+        if self.debug_mode.logs_wire() {
+            tracing::info!(
+                provider = "openai-responses",
+                model = %self.model,
+                url = %url,
+                request_body = %crate::provider::redact::redact_value(&body),
+                "provider wire request"
+            );
+        }
+
+        let mut last_err = None;
+        for attempt in 0..=self.max_retries {
+            if cancel.is_cancelled() {
+                return Err(ProviderError::Other {
+                    status: 0,
+                    body: "Cancelled".into(),
+                });
+            }
+            if attempt > 0 {
+                tokio::time::sleep(Duration::from_millis(250 * 2_u64.pow(attempt.min(5)))).await;
+            }
+
+            let send_result = self
+                .client
+                .post(&url)
+                .header("Authorization", format!("Bearer {}", self.token))
+                .header("Content-Type", "application/json")
+                .json(&body)
+                .send()
+                .await;
+
+            let err = match send_result {
+                Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) => {
+                    let status = response.status();
+                    let body = response.text().await.unwrap_or_default();
+                    ProviderError::from_response(status, &body, &self.model)
+                }
+                Err(e) => ProviderError::Network(e),
+            };
+
+            if err.is_retryable() && attempt < self.max_retries {
+                last_err = Some(err);
+                continue;
+            }
+            return Err(err);
+        }
+
+        Err(last_err.unwrap_or(ProviderError::Other {
+            status: 0,
+            body: "retry budget exhausted".into(),
+        }))
+    }
+}
+
+#[async_trait::async_trait]
+impl LLMProvider for ResponsesProvider {
+    async fn chat(
+        &self,
+        messages: &[Message],
+        tools: &[ToolDefinition],
+        cancel: CancellationToken,
+    ) -> Result<ChatResponse> {
+        let (tx, mut rx) = mpsc::channel(crate::provider::STREAM_CHANNEL_CAPACITY);
+        self.chat_stream(messages, tools, tx, cancel).await?;
+
+        while let Some(event) = rx.recv().await {
+            if let StreamEvent::Done(response) = event {
+                return Ok(response);
+            }
+        }
+        anyhow::bail!("Responses stream ended without final response")
+    }
+
+    async fn chat_stream(
+        &self,
+        messages: &[Message],
+        tools: &[ToolDefinition],
+        tx: mpsc::Sender<StreamEvent>,
+        cancel: CancellationToken,
+    ) -> Result<()> {
+        let response = self.do_request(messages, tools, &cancel).await?;
+        let mut stream = response.bytes_stream();
+        let mut buf = String::new();
+        let mut content = String::new();
+        let mut reasoning = String::new();
+        let mut tool_calls = Vec::new();
+        let mut finish_reason = None;
+        let mut usage = None;
+
+        use futures_util::StreamExt;
+        while let Some(chunk) = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => anyhow::bail!("Cancelled"),
+            next = stream.next() => next,
+        } {
+            let chunk = chunk.context("Failed to read stream chunk")?;
+            buf.push_str(&String::from_utf8_lossy(&chunk));
+            drain_sse_buffer(
+                &mut buf,
+                &mut content,
+                &mut reasoning,
+                &mut tool_calls,
+                &mut finish_reason,
+                &mut usage,
+                Some(&tx),
+            )
+            .await;
+        }
+        drain_sse_buffer(
+            &mut buf,
+            &mut content,
+            &mut reasoning,
+            &mut tool_calls,
+            &mut finish_reason,
+            &mut usage,
+            Some(&tx),
+        )
+        .await;
+
+        let response = ChatResponse {
+            content: Some(content).filter(|content| !content.is_empty()),
+            tool_calls: Some(tool_calls).filter(|calls| !calls.is_empty()),
+            usage,
+            finish_reason,
+            reasoning_content: Some(reasoning).filter(|reasoning| !reasoning.is_empty()),
+        };
+        let _ = tx.send(StreamEvent::Done(response)).await;
+        Ok(())
+    }
+
+    fn max_context(&self) -> usize {
+        self.max_context
+    }
+}
+
+async fn drain_sse_buffer(
+    buf: &mut String,
+    content: &mut String,
+    reasoning: &mut String,
+    tool_calls: &mut Vec<ToolCall>,
+    finish_reason: &mut Option<String>,
+    usage: &mut Option<Usage>,
+    tx: Option<&mpsc::Sender<StreamEvent>>,
+) {
+    while let Some(newline) = buf.find('\n') {
+        let line = buf[..newline].trim_end_matches('\r').to_string();
+        *buf = buf[newline + 1..].to_string();
+        let Some(data) = line.strip_prefix("data: ") else {
+            continue;
+        };
+        if data == "[DONE]" {
+            continue;
+        }
+        let Ok(value) = serde_json::from_str::<Value>(data) else {
+            continue;
+        };
+        apply_responses_event(
+            &value,
+            content,
+            reasoning,
+            tool_calls,
+            finish_reason,
+            usage,
+            tx,
+        )
+        .await;
+    }
+}
+
+async fn apply_responses_event(
+    value: &Value,
+    content: &mut String,
+    reasoning: &mut String,
+    tool_calls: &mut Vec<ToolCall>,
+    finish_reason: &mut Option<String>,
+    usage: &mut Option<Usage>,
+    tx: Option<&mpsc::Sender<StreamEvent>>,
+) {
+    match value.get("type").and_then(Value::as_str) {
+        Some("response.output_text.delta") => {
+            if let Some(delta) = value.get("delta").and_then(Value::as_str) {
+                content.push_str(delta);
+                if let Some(tx) = tx {
+                    let _ = tx.send(StreamEvent::Text(delta.to_string())).await;
+                }
+            }
+        }
+        Some("response.reasoning_summary_text.delta" | "response.reasoning_text.delta") => {
+            if let Some(delta) = value.get("delta").and_then(Value::as_str) {
+                reasoning.push_str(delta);
+                if let Some(tx) = tx {
+                    let _ = tx.send(StreamEvent::Reasoning(delta.to_string())).await;
+                }
+            }
+        }
+        Some("response.output_item.done") => {
+            if let Some(item) = value.get("item")
+                && item.get("type").and_then(Value::as_str) == Some("function_call")
+            {
+                let call_id = item
+                    .get("call_id")
+                    .and_then(Value::as_str)
+                    .or_else(|| item.get("id").and_then(Value::as_str))
+                    .unwrap_or("call");
+                let name = item.get("name").and_then(Value::as_str).unwrap_or_default();
+                let arguments = item
+                    .get("arguments")
+                    .and_then(Value::as_str)
+                    .unwrap_or("{}");
+                tool_calls.push(ToolCall {
+                    id: call_id.to_string(),
+                    call_type: "function".to_string(),
+                    function: ToolCallFunction {
+                        name: name.to_string(),
+                        arguments: arguments.to_string(),
+                    },
+                });
+            }
+        }
+        Some("response.completed") => {
+            *finish_reason = Some("stop".to_string());
+            if let Some(total) = value
+                .get("response")
+                .and_then(|response| response.get("usage"))
+                .and_then(|usage| usage.get("total_tokens"))
+                .and_then(Value::as_u64)
+            {
+                *usage = Some(Usage {
+                    prompt_tokens: 0,
+                    completion_tokens: 0,
+                    total_tokens: total as usize,
+                });
+            }
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn parses_responses_text_reasoning_and_function_call_events() {
+        let mut buf = concat!(
+            "data: {\"type\":\"response.output_text.delta\",\"delta\":\"hi\"}\n",
+            "data: {\"type\":\"response.reasoning_summary_text.delta\",\"delta\":\"think\"}\n",
+            "data: {\"type\":\"response.output_item.done\",\"item\":{\"type\":\"function_call\",\"call_id\":\"call_1\",\"name\":\"shell\",\"arguments\":\"{\\\"cmd\\\":\\\"pwd\\\"}\"}}\n",
+            "data: {\"type\":\"response.completed\",\"response\":{\"usage\":{\"total_tokens\":7}}}\n",
+        )
+        .to_string();
+        let mut content = String::new();
+        let mut reasoning = String::new();
+        let mut tool_calls = Vec::new();
+        let mut finish_reason = None;
+        let mut usage = None;
+
+        drain_sse_buffer(
+            &mut buf,
+            &mut content,
+            &mut reasoning,
+            &mut tool_calls,
+            &mut finish_reason,
+            &mut usage,
+            None,
+        )
+        .await;
+
+        assert_eq!(content, "hi");
+        assert_eq!(reasoning, "think");
+        assert_eq!(tool_calls[0].id, "call_1");
+        assert_eq!(tool_calls[0].function.name, "shell");
+        assert_eq!(usage.unwrap().total_tokens, 7);
+        assert_eq!(finish_reason.as_deref(), Some("stop"));
+    }
+}

--- a/src/provider/factory.rs
+++ b/src/provider/factory.rs
@@ -8,6 +8,7 @@
 use anyhow::{Context, Result};
 
 use super::LLMProvider;
+use super::codex::ResponsesProvider;
 use super::openai::OpenAIProvider;
 use crate::config::ProviderConfig;
 
@@ -53,8 +54,20 @@ impl ProviderFactory for DefaultProviderFactory {
                 )
                 .context("Failed to initialize LLM provider")?,
             )),
+            "openai-responses" => Ok(Box::new(
+                ResponsesProvider::new(
+                    &cfg.base_url,
+                    api_key,
+                    &cfg.model,
+                    max_context,
+                    cfg.max_retries,
+                    cfg.max_output_tokens,
+                    cfg.debug,
+                )
+                .context("Failed to initialize OpenAI Responses provider")?,
+            )),
             other => Err(anyhow::anyhow!(
-                "Unknown provider type '{other}'. Supported: openai, openai-compat. \
+                "Unknown provider type '{other}'. Supported: openai, openai-compat, openai-responses. \
                  Set [provider].type in ~/.vulcan/config.toml."
             )),
         }
@@ -110,5 +123,13 @@ mod tests {
             msg.contains("openai"),
             "should list supported types: {msg:?}"
         );
+    }
+
+    #[test]
+    fn default_factory_accepts_openai_responses() {
+        let cfg = cfg_with_type("openai-responses");
+        DefaultProviderFactory
+            .build(&cfg, "token", 128_000, false)
+            .expect("'openai-responses' type should build Responses provider");
     }
 }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -1,4 +1,5 @@
 pub mod catalog;
+pub mod codex;
 pub mod factory;
 pub mod openai;
 pub mod redact;


### PR DESCRIPTION
## Summary
- add an `openai-responses` provider backed by the OpenAI Responses/Codex backend path
- allow provider profiles to resolve auth from the local Codex CLI login cache via `auth_source = "codex"`
- add an `openai-codex` provider preset that writes `auth_source`, not a copied token

## Verification
- `rtk cargo test -p vulcan-core cli_provider::tests::add_openai_codex_preset_writes_auth_source_not_token --lib`
- `rtk cargo test -p vulcan-core provider::factory --lib`
- `rtk cargo test -p vulcan-core config::tests --lib`
- pre-commit `cargo check`, `cargo fmt`, `cargo clippy`
- `npx gitnexus analyze`
