### PR TITLE
feat(mcp): add stdio client bridge

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -82,6 +82,18 @@ default = "always"
 policy = "prompt"
 quota_per_session = 5
 
+# MCP servers are stdio-only in the first bridge slice. They are inert unless
+# both `enabled = true` and `expose_as = "auto"` are set. Exposed tools are
+# registered as `mcp_<server>_<tool>`.
+# [[mcp_servers]]
+# name = "filesystem"
+# command = "npx"
+# args = ["-y", "@modelcontextprotocol/server-filesystem", "/path/to/project"]
+# env = {}
+# enabled = false
+# expose_as = "disabled" # auto | manual | disabled
+# timeout_secs = 30
+
 # YYC-42: auto-recall relevant past-session context on the first turn
 # of a fresh session. Off by default — enable after reviewing the
 # privacy tradeoff (recalled snippets land in the system prompt and

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -91,6 +91,7 @@ pub struct Agent {
     pub(in crate::agent) prompt_builder: PromptBuilder,
     pub(in crate::agent) hooks: Arc<HookRegistry>,
     pub(in crate::agent) session_extensions: Vec<crate::extensions::api::SessionExtensionRuntime>,
+    pub(in crate::agent) _mcp_servers: Vec<Arc<crate::mcp::McpServerHandle>>,
     pub(in crate::agent) session_id: String,
     pub(in crate::agent) turns: u32,
     /// Per-turn cancellation token. `cancel_current_turn()` fires it; the
@@ -556,6 +557,15 @@ impl Agent {
             );
         }
 
+        let mcp_servers =
+            crate::mcp::connect_configured_servers(&config.mcp_servers, &mut tools).await;
+        if !mcp_servers.is_empty() {
+            tracing::info!(
+                mcp_servers = mcp_servers.len(),
+                "Agent: connected configured MCP servers"
+            );
+        }
+
         // YYC-264: embedded cortex-memory-core graph memory. When enabled,
         // registers two hooks:
         //   1. CortexRecallHook — BeforePrompt: semantically searches the graph
@@ -691,6 +701,7 @@ impl Agent {
             prompt_builder: PromptBuilder,
             hooks: Arc::new(hooks),
             session_extensions,
+            _mcp_servers: mcp_servers,
             session_id,
             turns: 0,
             turn_cancel: CancellationToken::new(),
@@ -900,6 +911,7 @@ impl Agent {
             prompt_builder: PromptBuilder,
             hooks: Arc::new(hooks),
             session_extensions: Vec::new(),
+            _mcp_servers: Vec::new(),
             session_id: Uuid::new_v4().to_string(),
             turns: 0,
             turn_cancel: CancellationToken::new(),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -162,6 +162,11 @@ pub struct Config {
     #[serde(default)]
     pub tools: ToolsConfig,
 
+    /// Configured Model Context Protocol servers. Servers are inert unless
+    /// explicitly enabled and exposed.
+    #[serde(default)]
+    pub mcp_servers: Vec<crate::mcp::McpServerConfig>,
+
     #[serde(default = "default_skills_dir")]
     pub skills_dir: PathBuf,
 
@@ -1284,6 +1289,7 @@ impl Default for Config {
             provider: ProviderConfig::default(),
             providers: HashMap::new(),
             tools: ToolsConfig::default(),
+            mcp_servers: Vec::new(),
             skills_dir: default_skills_dir(),
             auto_create_skills: false,
             compaction: CompactionConfig::default(),
@@ -1377,6 +1383,7 @@ impl Config {
             "provider",
             "providers",
             "tools",
+            "mcp_servers",
             "skills_dir",
             "auto_create_skills",
             "compaction",

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -66,6 +66,51 @@ auth_source = "codex"
 }
 
 #[test]
+fn mcp_servers_parse_disabled_by_default() {
+    let cfg: Config = toml::from_str(
+        r#"
+[[mcp_servers]]
+name = "local"
+command = "mcp-server"
+args = ["--stdio"]
+env = { "TOKEN" = "secret" }
+"#,
+    )
+    .expect("parses");
+
+    assert_eq!(cfg.mcp_servers.len(), 1);
+    let server = &cfg.mcp_servers[0];
+    assert_eq!(server.name, "local");
+    assert_eq!(server.command, "mcp-server");
+    assert_eq!(server.args, vec!["--stdio"]);
+    assert_eq!(server.env.get("TOKEN").map(String::as_str), Some("secret"));
+    assert!(!server.enabled);
+    assert_eq!(server.expose_as, crate::mcp::McpExposeMode::Disabled);
+    assert!(!server.should_expose_tools());
+}
+
+#[test]
+fn mcp_servers_expose_only_when_enabled_and_auto() {
+    let cfg: Config = toml::from_str(
+        r#"
+[[mcp_servers]]
+name = "local"
+command = "mcp-server"
+enabled = true
+expose_as = "auto"
+timeout_secs = 3
+"#,
+    )
+    .expect("parses");
+
+    let server = &cfg.mcp_servers[0];
+    assert!(server.enabled);
+    assert_eq!(server.expose_as, crate::mcp::McpExposeMode::Auto);
+    assert_eq!(server.timeout(), std::time::Duration::from_secs(3));
+    assert!(server.should_expose_tools());
+}
+
+#[test]
 fn codex_auth_token_from_file_prefers_api_key_then_access_token() {
     let dir = tempfile::tempdir().unwrap();
     let auth = dir.path().join("auth.json");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ pub mod gateway;
 pub mod hooks;
 pub mod impact;
 pub mod knowledge;
+pub mod mcp;
 pub mod memory;
 pub mod observability;
 pub mod orchestration;

--- a/src/mcp/client.rs
+++ b/src/mcp/client.rs
@@ -1,0 +1,294 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct McpTool {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default, rename = "inputSchema")]
+    pub input_schema: Value,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct McpContent {
+    #[serde(rename = "type")]
+    pub content_type: String,
+    #[serde(default)]
+    pub text: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct McpToolCallResult {
+    #[serde(default)]
+    pub content: Vec<McpContent>,
+    #[serde(default, rename = "isError")]
+    pub is_error: bool,
+}
+
+pub struct McpClient<R, W> {
+    reader: R,
+    writer: W,
+    next_id: AtomicU64,
+}
+
+impl<R, W> McpClient<R, W>
+where
+    R: AsyncBufRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    pub fn new(reader: R, writer: W) -> Self {
+        Self {
+            reader,
+            writer,
+            next_id: AtomicU64::new(1),
+        }
+    }
+
+    pub async fn initialize(&mut self) -> Result<()> {
+        let _: Value = self
+            .request(
+                "initialize",
+                json!({
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {
+                        "name": "vulcan",
+                        "version": env!("CARGO_PKG_VERSION"),
+                    }
+                }),
+            )
+            .await?;
+        self.notify("notifications/initialized", json!({})).await?;
+        Ok(())
+    }
+
+    pub async fn list_tools(&mut self) -> Result<Vec<McpTool>> {
+        #[derive(Deserialize)]
+        struct ToolsResult {
+            #[serde(default)]
+            tools: Vec<McpTool>,
+        }
+
+        let result: ToolsResult = self.request("tools/list", json!({})).await?;
+        Ok(result.tools)
+    }
+
+    pub async fn call_tool(&mut self, name: &str, arguments: Value) -> Result<McpToolCallResult> {
+        self.request(
+            "tools/call",
+            json!({
+                "name": name,
+                "arguments": arguments,
+            }),
+        )
+        .await
+    }
+
+    async fn request<T>(&mut self, method: &str, params: Value) -> Result<T>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        write_frame(
+            &mut self.writer,
+            &json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "method": method,
+                "params": params,
+            }),
+        )
+        .await?;
+
+        loop {
+            let frame = read_frame(&mut self.reader).await?;
+            if frame.get("id").and_then(Value::as_u64) != Some(id) {
+                continue;
+            }
+            if let Some(error) = frame.get("error") {
+                anyhow::bail!("MCP `{method}` failed: {error}");
+            }
+            let result = frame
+                .get("result")
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("MCP `{method}` response missing result"))?;
+            return serde_json::from_value(result)
+                .with_context(|| format!("MCP `{method}` response had unexpected shape"));
+        }
+    }
+
+    async fn notify(&mut self, method: &str, params: Value) -> Result<()> {
+        write_frame(
+            &mut self.writer,
+            &json!({
+                "jsonrpc": "2.0",
+                "method": method,
+                "params": params,
+            }),
+        )
+        .await
+    }
+}
+
+pub async fn write_frame<W>(writer: &mut W, value: &Value) -> Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    let body = serde_json::to_vec(value)?;
+    writer
+        .write_all(format!("Content-Length: {}\r\n\r\n", body.len()).as_bytes())
+        .await?;
+    writer.write_all(&body).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+pub async fn read_frame<R>(reader: &mut R) -> Result<Value>
+where
+    R: AsyncBufRead + Unpin,
+{
+    let mut content_length = None;
+    loop {
+        let mut line = String::new();
+        let n = reader.read_line(&mut line).await?;
+        if n == 0 {
+            anyhow::bail!("MCP server closed stdout");
+        }
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if trimmed.is_empty() {
+            break;
+        }
+        if let Some(raw) = trimmed.strip_prefix("Content-Length:") {
+            content_length = Some(raw.trim().parse::<usize>()?);
+        }
+    }
+
+    let len = content_length.ok_or_else(|| anyhow::anyhow!("MCP frame missing Content-Length"))?;
+    let mut body = vec![0u8; len];
+    reader.read_exact(&mut body).await?;
+    Ok(serde_json::from_slice(&body)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use tokio::io::{BufReader, duplex};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn writes_and_reads_content_length_frames() {
+        let (client, server) = duplex(4096);
+        let (client_read, mut client_write) = tokio::io::split(client);
+        let (server_read, server_write) = tokio::io::split(server);
+        let mut server_reader = BufReader::new(server_read);
+
+        write_frame(&mut client_write, &json!({"jsonrpc": "2.0", "id": 1}))
+            .await
+            .unwrap();
+
+        let sent = read_frame(&mut server_reader).await.unwrap();
+        assert_eq!(sent["id"], 1);
+
+        let mut reader = BufReader::new(client_read);
+        let mut writer = server_write;
+        write_frame(
+            &mut writer,
+            &json!({"jsonrpc": "2.0", "id": 2, "result": {"ok": true}}),
+        )
+        .await
+        .unwrap();
+        let got = read_frame(&mut reader).await.unwrap();
+        assert_eq!(got["id"], 2);
+        assert_eq!(got["result"]["ok"], true);
+    }
+
+    #[tokio::test]
+    async fn client_initializes_lists_and_calls_tools() {
+        let (client_side, server_side) = duplex(8192);
+        let (client_read, client_write) = tokio::io::split(client_side);
+        let (server_read, mut server_write) = tokio::io::split(server_side);
+        let mut server_reader = BufReader::new(server_read);
+
+        let server = tokio::spawn(async move {
+            let initialize = read_frame(&mut server_reader).await.unwrap();
+            assert_eq!(initialize["method"], "initialize");
+            write_frame(
+                &mut server_write,
+                &json!({
+                    "jsonrpc": "2.0",
+                    "id": initialize["id"],
+                    "result": {
+                        "protocolVersion": "2024-11-05",
+                        "capabilities": {},
+                        "serverInfo": {"name": "fake", "version": "0.1.0"}
+                    }
+                }),
+            )
+            .await
+            .unwrap();
+
+            let initialized = read_frame(&mut server_reader).await.unwrap();
+            assert_eq!(initialized["method"], "notifications/initialized");
+
+            let list = read_frame(&mut server_reader).await.unwrap();
+            assert_eq!(list["method"], "tools/list");
+            write_frame(
+                &mut server_write,
+                &json!({
+                    "jsonrpc": "2.0",
+                    "id": list["id"],
+                    "result": {
+                        "tools": [{
+                            "name": "echo",
+                            "description": "Echo input",
+                            "inputSchema": {
+                                "type": "object",
+                                "properties": {"text": {"type": "string"}},
+                                "required": ["text"]
+                            }
+                        }]
+                    }
+                }),
+            )
+            .await
+            .unwrap();
+
+            let call = read_frame(&mut server_reader).await.unwrap();
+            assert_eq!(call["method"], "tools/call");
+            assert_eq!(call["params"]["name"], "echo");
+            assert_eq!(call["params"]["arguments"]["text"], "hello");
+            write_frame(
+                &mut server_write,
+                &json!({
+                    "jsonrpc": "2.0",
+                    "id": call["id"],
+                    "result": {
+                        "content": [{"type": "text", "text": "hello"}],
+                        "isError": false
+                    }
+                }),
+            )
+            .await
+            .unwrap();
+        });
+
+        let mut client = McpClient::new(BufReader::new(client_read), client_write);
+        client.initialize().await.unwrap();
+        let tools = client.list_tools().await.unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0].name, "echo");
+        let result = client
+            .call_tool("echo", json!({"text": "hello"}))
+            .await
+            .unwrap();
+        assert!(!result.is_error);
+        assert_eq!(result.content[0].text.as_deref(), Some("hello"));
+        server.await.unwrap();
+    }
+}

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1,0 +1,125 @@
+//! Model Context Protocol bridge.
+//!
+//! The first slice is stdio-only and opt-in: configured servers do not start
+//! unless `enabled = true` and `expose_as = "auto"` are both set.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+pub mod client;
+pub mod process;
+pub mod tool_adapter;
+
+pub use client::{McpClient, McpContent, McpTool, McpToolCallResult};
+pub use process::{McpServerHandle, connect_configured_servers};
+pub use tool_adapter::McpToolAdapter;
+
+fn default_timeout_secs() -> u64 {
+    30
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum McpExposeMode {
+    Auto,
+    Manual,
+    #[default]
+    Disabled,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct McpServerConfig {
+    pub name: String,
+    pub command: String,
+    pub args: Vec<String>,
+    pub env: HashMap<String, String>,
+    pub enabled: bool,
+    pub expose_as: McpExposeMode,
+    pub timeout_secs: u64,
+}
+
+impl Default for McpServerConfig {
+    fn default() -> Self {
+        Self {
+            name: String::new(),
+            command: String::new(),
+            args: Vec::new(),
+            env: HashMap::new(),
+            enabled: false,
+            expose_as: McpExposeMode::Disabled,
+            timeout_secs: default_timeout_secs(),
+        }
+    }
+}
+
+impl McpServerConfig {
+    pub fn timeout(&self) -> Duration {
+        Duration::from_secs(self.timeout_secs.max(1))
+    }
+
+    pub fn should_expose_tools(&self) -> bool {
+        self.enabled && self.expose_as == McpExposeMode::Auto
+    }
+
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if self.name.trim().is_empty() {
+            anyhow::bail!("MCP server name cannot be empty");
+        }
+        if !is_safe_identifier(&self.name) {
+            anyhow::bail!(
+                "MCP server `{}` has invalid name; use ASCII letters, numbers, `_`, or `-`",
+                self.name
+            );
+        }
+        if self.command.trim().is_empty() {
+            anyhow::bail!("MCP server `{}` command cannot be empty", self.name);
+        }
+        Ok(())
+    }
+}
+
+pub(crate) fn namespaced_tool_name(server: &str, tool: &str) -> String {
+    format!(
+        "mcp_{}_{}",
+        sanitize_identifier(server),
+        sanitize_identifier(tool)
+    )
+}
+
+fn sanitize_identifier(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for ch in value.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '_' {
+            out.push(ch);
+        } else {
+            out.push('_');
+        }
+    }
+    while out.contains("__") {
+        out = out.replace("__", "_");
+    }
+    out.trim_matches('_').to_string()
+}
+
+fn is_safe_identifier(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn namespaced_tool_names_are_stable_and_safe() {
+        assert_eq!(
+            namespaced_tool_name("local-db", "query.table"),
+            "mcp_local_db_query_table"
+        );
+    }
+}

--- a/src/mcp/process.rs
+++ b/src/mcp/process.rs
@@ -1,0 +1,148 @@
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use tokio::io::BufReader;
+use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+use tokio::sync::Mutex;
+
+use crate::tools::{Tool, ToolRegistry};
+
+use super::client::McpClient;
+use super::tool_adapter::McpToolAdapter;
+use super::{McpServerConfig, McpTool};
+
+type StdioClient = McpClient<BufReader<ChildStdout>, ChildStdin>;
+
+pub struct McpServerHandle {
+    name: String,
+    client: Mutex<StdioClient>,
+    tools: Vec<McpTool>,
+    _child: Child,
+    timeout: std::time::Duration,
+}
+
+impl McpServerHandle {
+    pub async fn spawn(config: &McpServerConfig) -> Result<Self> {
+        config.validate()?;
+        let mut command = Command::new(&config.command);
+        command
+            .args(&config.args)
+            .envs(&config.env)
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true);
+
+        let mut child = command
+            .spawn()
+            .with_context(|| format!("failed to start MCP server `{}`", config.name))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("MCP server `{}` stdout unavailable", config.name))?;
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("MCP server `{}` stdin unavailable", config.name))?;
+        let mut client = McpClient::new(BufReader::new(stdout), stdin);
+
+        tokio::time::timeout(config.timeout(), client.initialize())
+            .await
+            .with_context(|| format!("MCP server `{}` initialize timed out", config.name))??;
+        let tools = tokio::time::timeout(config.timeout(), client.list_tools())
+            .await
+            .with_context(|| format!("MCP server `{}` tools/list timed out", config.name))??;
+
+        Ok(Self {
+            name: config.name.clone(),
+            client: Mutex::new(client),
+            tools,
+            _child: child,
+            timeout: config.timeout(),
+        })
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn tools(&self) -> &[McpTool] {
+        &self.tools
+    }
+
+    pub async fn call_tool(
+        &self,
+        tool_name: &str,
+        arguments: serde_json::Value,
+    ) -> Result<super::McpToolCallResult> {
+        let mut client = self.client.lock().await;
+        tokio::time::timeout(self.timeout, client.call_tool(tool_name, arguments))
+            .await
+            .with_context(|| format!("MCP tool `{}`.`{tool_name}` timed out", self.name))?
+    }
+}
+
+pub async fn connect_configured_servers(
+    configs: &[McpServerConfig],
+    registry: &mut ToolRegistry,
+) -> Vec<Arc<McpServerHandle>> {
+    let mut handles = Vec::new();
+    for config in configs {
+        if !config.should_expose_tools() {
+            continue;
+        }
+        match McpServerHandle::spawn(config).await {
+            Ok(handle) => {
+                let handle = Arc::new(handle);
+                for tool in handle.tools() {
+                    let adapter = Arc::new(McpToolAdapter::new(Arc::clone(&handle), tool.clone()));
+                    if registry.contains(adapter.name()) {
+                        tracing::warn!(
+                            server = handle.name(),
+                            tool = adapter.name(),
+                            "MCP tool conflicts with existing registry tool; skipping"
+                        );
+                        continue;
+                    }
+                    registry.register(adapter);
+                }
+                handles.push(handle);
+            }
+            Err(err) => {
+                tracing::warn!(
+                    server = config.name.as_str(),
+                    %err,
+                    "MCP server unavailable; skipping tool exposure"
+                );
+            }
+        }
+    }
+    handles
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mcp::McpExposeMode;
+    use std::collections::HashMap;
+
+    #[tokio::test]
+    async fn failed_server_startup_has_actionable_error() {
+        let config = McpServerConfig {
+            name: "missing".to_string(),
+            command: "vulcan-missing-mcp-server-command-for-test".to_string(),
+            args: Vec::new(),
+            env: HashMap::new(),
+            enabled: true,
+            expose_as: McpExposeMode::Auto,
+            timeout_secs: 1,
+        };
+
+        let err = match McpServerHandle::spawn(&config).await {
+            Ok(_) => panic!("expected missing command to fail"),
+            Err(err) => err,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("failed to start MCP server `missing`"));
+    }
+}

--- a/src/mcp/tool_adapter.rs
+++ b/src/mcp/tool_adapter.rs
@@ -1,0 +1,101 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use tokio_util::sync::CancellationToken;
+
+use crate::tools::{ProgressSink, ReplaySafety, Tool, ToolResult};
+
+use super::{McpServerHandle, McpTool, namespaced_tool_name};
+
+pub struct McpToolAdapter {
+    name: String,
+    server_tool_name: String,
+    description: String,
+    schema: Value,
+    server: Arc<McpServerHandle>,
+}
+
+impl McpToolAdapter {
+    pub fn new(server: Arc<McpServerHandle>, tool: McpTool) -> Self {
+        let name = namespaced_tool_name(server.name(), &tool.name);
+        let description = tool.description.unwrap_or_else(|| {
+            format!(
+                "Call MCP tool `{}` from configured MCP server `{}`.",
+                tool.name,
+                server.name()
+            )
+        });
+        let schema = if tool.input_schema.is_null() {
+            json!({"type": "object", "properties": {}})
+        } else {
+            tool.input_schema
+        };
+        Self {
+            name,
+            server_tool_name: tool.name,
+            description,
+            schema,
+            server,
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for McpToolAdapter {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn description(&self) -> &str {
+        &self.description
+    }
+
+    fn schema(&self) -> Value {
+        self.schema.clone()
+    }
+
+    fn replay_safety(&self) -> ReplaySafety {
+        ReplaySafety::External
+    }
+
+    async fn call(
+        &self,
+        params: Value,
+        cancel: CancellationToken,
+        _progress: Option<ProgressSink>,
+    ) -> Result<ToolResult> {
+        let result = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => return Ok(ToolResult::err("Cancelled")),
+            result = self.server.call_tool(&self.server_tool_name, params) => result?,
+        };
+
+        let output = result
+            .content
+            .iter()
+            .filter_map(|part| {
+                if part.content_type == "text" {
+                    part.text.clone()
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let output = if output.is_empty() {
+            serde_json::to_string_pretty(&result)?
+        } else {
+            output
+        };
+
+        let details = serde_json::to_value(&result)?;
+        let tool_result = if result.is_error {
+            ToolResult::err(output)
+        } else {
+            ToolResult::ok(output)
+        };
+        Ok(tool_result.with_details(details))
+    }
+}

--- a/tests/mcp_bridge.rs
+++ b/tests/mcp_bridge.rs
@@ -1,0 +1,156 @@
+use std::collections::HashMap;
+
+use serde_json::json;
+use tokio_util::sync::CancellationToken;
+use vulcan::mcp::{McpExposeMode, McpServerConfig, connect_configured_servers};
+use vulcan::tools::ToolRegistry;
+
+const FAKE_MCP_SERVER: &str = r#"
+import json
+import sys
+
+def read_frame():
+    length = None
+    while True:
+        line = sys.stdin.buffer.readline()
+        if not line:
+            sys.exit(0)
+        line = line.decode().strip()
+        if not line:
+            break
+        if line.lower().startswith("content-length:"):
+            length = int(line.split(":", 1)[1].strip())
+    body = sys.stdin.buffer.read(length)
+    return json.loads(body.decode())
+
+def write_frame(value):
+    body = json.dumps(value).encode()
+    sys.stdout.buffer.write(f"Content-Length: {len(body)}\r\n\r\n".encode())
+    sys.stdout.buffer.write(body)
+    sys.stdout.buffer.flush()
+
+while True:
+    frame = read_frame()
+    method = frame.get("method")
+    if method == "initialize":
+        write_frame({
+            "jsonrpc": "2.0",
+            "id": frame["id"],
+            "result": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "serverInfo": {"name": "fake", "version": "0.1.0"},
+            },
+        })
+    elif method == "notifications/initialized":
+        continue
+    elif method == "tools/list":
+        write_frame({
+            "jsonrpc": "2.0",
+            "id": frame["id"],
+            "result": {
+                "tools": [{
+                    "name": "echo",
+                    "description": "Echo text through a fake MCP server",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {"text": {"type": "string"}},
+                        "required": ["text"],
+                    },
+                }]
+            },
+        })
+    elif method == "tools/call":
+        text = frame.get("params", {}).get("arguments", {}).get("text", "")
+        write_frame({
+            "jsonrpc": "2.0",
+            "id": frame["id"],
+            "result": {
+                "content": [{"type": "text", "text": "echo:" + text}],
+                "isError": False,
+            },
+        })
+    else:
+        write_frame({
+            "jsonrpc": "2.0",
+            "id": frame.get("id"),
+            "error": {"code": -32601, "message": "unknown method"},
+        })
+"#;
+
+fn python3_available() -> bool {
+    std::process::Command::new("python3")
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+fn fake_server_config(enabled: bool, expose_as: McpExposeMode) -> McpServerConfig {
+    McpServerConfig {
+        name: "fake".to_string(),
+        command: "python3".to_string(),
+        args: vec![
+            "-u".to_string(),
+            "-c".to_string(),
+            FAKE_MCP_SERVER.to_string(),
+        ],
+        env: HashMap::new(),
+        enabled,
+        expose_as,
+        timeout_secs: 5,
+    }
+}
+
+#[tokio::test]
+async fn disabled_mcp_server_does_not_expose_tools() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut registry = ToolRegistry::new_with_diff_and_lsp(None, None, dir.path().to_path_buf());
+    let handles = connect_configured_servers(
+        &[fake_server_config(false, McpExposeMode::Auto)],
+        &mut registry,
+    )
+    .await;
+
+    assert!(handles.is_empty());
+    assert!(!registry.contains("mcp_fake_echo"));
+}
+
+#[tokio::test]
+async fn configured_stdio_mcp_tool_registers_and_dispatches() {
+    if !python3_available() {
+        eprintln!("skipping MCP stdio integration test: python3 unavailable");
+        return;
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    let mut registry = ToolRegistry::new_with_diff_and_lsp(None, None, dir.path().to_path_buf());
+    let handles = connect_configured_servers(
+        &[fake_server_config(true, McpExposeMode::Auto)],
+        &mut registry,
+    )
+    .await;
+
+    assert_eq!(handles.len(), 1);
+    assert!(registry.contains("mcp_fake_echo"));
+    let tool = registry
+        .definitions()
+        .into_iter()
+        .find(|tool| tool.function.name == "mcp_fake_echo")
+        .expect("MCP tool definition exposed");
+    assert!(tool.function.description.contains("fake MCP server"));
+
+    let result = registry
+        .execute(
+            "mcp_fake_echo",
+            &json!({"text": "hello"}).to_string(),
+            CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+    assert!(!result.is_error);
+    assert_eq!(result.output, "echo:hello");
+    assert!(result.details.is_some());
+}


### PR DESCRIPTION
## Summary
- add a stdio-first MCP JSON-RPC client with initialize, tools/list, and tools/call support
- add disabled-by-default `[[mcp_servers]]` config and expose enabled auto servers as native namespaced tools
- keep MCP server handles alive for the agent lifetime with startup/call timeouts and child process cleanup
- add fake stdio MCP server integration coverage with no npm/uvx dependency

Fixes #268

## Verification
- `cargo test mcp_servers`
- `cargo test mcp::`
- `cargo test --test mcp_bridge`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p vulcan-core`
- `cargo check -p vulcan --bin vulcan`
- pre-commit hook passed, including clippy with existing baseline warnings

## Notes
Graphite submit was not used because the local `main` branch is checked out in the primary dirty worktree and is 8 commits behind `origin/main`; tracking this branch against local `main` made Graphite see the already-merged renderer stack as part of this branch. This PR is still based directly on GitHub `main`/`origin/main` and contains only the MCP commit.