### PR TITLE
Agentic extension hook orchestration

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -570,6 +570,12 @@ impl Agent {
             }
             ext.activate().await;
         }
+        let orchestration_hooks = crate::orchestration::OrchestrationHookSet::new(
+            session_extensions
+                .iter()
+                .flat_map(|ext| ext.orchestration_hooks())
+                .collect(),
+        );
         if !session_extensions.is_empty() {
             tracing::info!(
                 daemon_extensions = session_extensions.len(),
@@ -709,7 +715,8 @@ impl Agent {
         )
         .with_artifact_store(Arc::clone(&artifact_store))
         .with_parent_session_id(session_id.clone())
-        .with_parent_run_handle(Arc::clone(&current_run_id));
+        .with_parent_run_handle(Arc::clone(&current_run_id))
+        .with_orchestration_hooks(orchestration_hooks);
         tools.register(Arc::new(spawn_tool));
 
         Ok(Self {

--- a/src/extensions/api.rs
+++ b/src/extensions/api.rs
@@ -23,6 +23,7 @@ use super::state::{ExtensionStateScope, ExtensionStateStore};
 use crate::config::DangerousCommandsConfig;
 use crate::hooks::{HookHandler, HookOutcome};
 use crate::memory::SessionStore;
+use crate::orchestration::OrchestrationHook;
 use crate::pause::PauseSender;
 use crate::provider::factory::ProviderFactory;
 use crate::provider::{ChatResponse, LLMProvider, Message, StreamEvent, ToolCall};
@@ -228,6 +229,13 @@ pub trait SessionExtension: Send + Sync {
         Vec::new()
     }
 
+    /// Typed orchestration hooks this session extension contributes.
+    /// GH issue #271 only emits delegation events today because typed
+    /// plan/step runtime objects do not exist yet.
+    fn orchestration_hooks(&self) -> Vec<Arc<dyn OrchestrationHook>> {
+        Vec::new()
+    }
+
     /// Commands this session extension contributes.
     fn commands(&self) -> Vec<Arc<dyn ExtensionCommand>> {
         Vec::new()
@@ -310,6 +318,10 @@ impl SessionExtensionRuntime {
                 }) as Arc<dyn Tool>
             })
             .collect()
+    }
+
+    pub fn orchestration_hooks(&self) -> Vec<Arc<dyn OrchestrationHook>> {
+        self.extension.orchestration_hooks()
     }
 }
 

--- a/src/orchestration/events.rs
+++ b/src/orchestration/events.rs
@@ -1,0 +1,268 @@
+//! Typed orchestration extension events.
+//!
+//! GH issue #271 is deliberately scoped to the typed runtime surfaces
+//! that exist today. Vulcan does not yet own a typed plan/step runtime,
+//! so this module adds delegation events around `spawn_subagent` and
+//! leaves planning hooks to the future planner.
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use tokio_util::sync::CancellationToken;
+
+use super::ChildAgentId;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DelegationBudget {
+    pub max_iterations: u32,
+    pub token_budget: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DelegationRequest {
+    pub child_id: ChildAgentId,
+    pub parent_session_id: Option<String>,
+    pub task: String,
+    pub allowed_tools: Vec<String>,
+    pub profile_name: Option<String>,
+    pub budget: DelegationBudget,
+}
+
+impl DelegationRequest {
+    pub fn tool_count(&self) -> usize {
+        self.allowed_tools.len()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DelegationStage {
+    Requested,
+    Started,
+    Completed,
+    Failed,
+    Cancelled,
+    Blocked,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DelegationEvent {
+    pub request: DelegationRequest,
+    pub stage: DelegationStage,
+    pub iterations_used: u32,
+    pub tokens_consumed: u64,
+    pub summary: Option<String>,
+    pub reason: Option<String>,
+}
+
+impl DelegationEvent {
+    pub fn requested(request: DelegationRequest) -> Self {
+        Self {
+            request,
+            stage: DelegationStage::Requested,
+            iterations_used: 0,
+            tokens_consumed: 0,
+            summary: None,
+            reason: None,
+        }
+    }
+
+    pub fn started(request: DelegationRequest) -> Self {
+        Self {
+            request,
+            stage: DelegationStage::Started,
+            iterations_used: 0,
+            tokens_consumed: 0,
+            summary: None,
+            reason: None,
+        }
+    }
+
+    pub fn blocked(request: DelegationRequest, reason: impl Into<String>) -> Self {
+        Self {
+            request,
+            stage: DelegationStage::Blocked,
+            iterations_used: 0,
+            tokens_consumed: 0,
+            summary: None,
+            reason: Some(reason.into()),
+        }
+    }
+
+    pub fn terminal(
+        request: DelegationRequest,
+        stage: DelegationStage,
+        iterations_used: u32,
+        tokens_consumed: u64,
+        summary: Option<String>,
+        reason: Option<String>,
+    ) -> Self {
+        Self {
+            request,
+            stage,
+            iterations_used,
+            tokens_consumed,
+            summary,
+            reason,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DelegationDecision {
+    Continue,
+    Block { reason: String },
+}
+
+#[async_trait]
+pub trait OrchestrationHook: Send + Sync {
+    fn name(&self) -> &str;
+
+    fn priority(&self) -> i32 {
+        100
+    }
+
+    async fn before_delegation(
+        &self,
+        _request: &DelegationRequest,
+        _cancel: CancellationToken,
+    ) -> Result<DelegationDecision> {
+        Ok(DelegationDecision::Continue)
+    }
+
+    async fn on_delegation_event(
+        &self,
+        _event: &DelegationEvent,
+        _cancel: CancellationToken,
+    ) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct OrchestrationHookSet {
+    hooks: Vec<Arc<dyn OrchestrationHook>>,
+}
+
+impl OrchestrationHookSet {
+    pub fn new(mut hooks: Vec<Arc<dyn OrchestrationHook>>) -> Self {
+        hooks.sort_by(|a, b| {
+            a.priority()
+                .cmp(&b.priority())
+                .then_with(|| a.name().cmp(b.name()))
+        });
+        Self { hooks }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.hooks.is_empty()
+    }
+
+    pub async fn before_delegation(
+        &self,
+        request: &DelegationRequest,
+        cancel: CancellationToken,
+    ) -> Result<DelegationDecision> {
+        for hook in &self.hooks {
+            match hook.before_delegation(request, cancel.clone()).await? {
+                DelegationDecision::Continue => {}
+                block @ DelegationDecision::Block { .. } => return Ok(block),
+            }
+        }
+        Ok(DelegationDecision::Continue)
+    }
+
+    pub async fn emit_delegation(&self, event: &DelegationEvent, cancel: CancellationToken) {
+        for hook in &self.hooks {
+            if let Err(err) = hook.on_delegation_event(event, cancel.clone()).await {
+                tracing::warn!(
+                    hook = hook.name(),
+                    error = %err,
+                    "orchestration extension hook failed while observing delegation"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    struct TestHook {
+        name: &'static str,
+        priority: i32,
+        decision: DelegationDecision,
+    }
+
+    #[async_trait]
+    impl OrchestrationHook for TestHook {
+        fn name(&self) -> &str {
+            self.name
+        }
+
+        fn priority(&self) -> i32 {
+            self.priority
+        }
+
+        async fn before_delegation(
+            &self,
+            _request: &DelegationRequest,
+            _cancel: CancellationToken,
+        ) -> Result<DelegationDecision> {
+            Ok(self.decision.clone())
+        }
+    }
+
+    fn request() -> DelegationRequest {
+        DelegationRequest {
+            child_id: ChildAgentId::new(),
+            parent_session_id: Some("parent".into()),
+            task: "inspect".into(),
+            allowed_tools: vec!["read_file".into()],
+            profile_name: None,
+            budget: DelegationBudget {
+                max_iterations: 3,
+                token_budget: Some(100),
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn blocking_hooks_are_priority_ordered_first_wins() {
+        let hooks = OrchestrationHookSet::new(vec![
+            Arc::new(TestHook {
+                name: "later",
+                priority: 20,
+                decision: DelegationDecision::Block {
+                    reason: "later block".into(),
+                },
+            }),
+            Arc::new(TestHook {
+                name: "continue",
+                priority: 0,
+                decision: DelegationDecision::Continue,
+            }),
+            Arc::new(TestHook {
+                name: "earlier",
+                priority: 10,
+                decision: DelegationDecision::Block {
+                    reason: "earlier block".into(),
+                },
+            }),
+        ]);
+
+        let decision = hooks
+            .before_delegation(&request(), CancellationToken::new())
+            .await
+            .expect("hook dispatch ok");
+
+        assert_eq!(
+            decision,
+            DelegationDecision::Block {
+                reason: "earlier block".into()
+            }
+        );
+    }
+}

--- a/src/orchestration/mod.rs
+++ b/src/orchestration/mod.rs
@@ -26,6 +26,12 @@ use parking_lot::Mutex;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
+pub mod events;
+pub use events::{
+    DelegationBudget, DelegationDecision, DelegationEvent, DelegationRequest, DelegationStage,
+    OrchestrationHook, OrchestrationHookSet,
+};
+
 /// Cap on the number of records kept in the store. Old records
 /// fall off the front of the ring once the cap is exceeded — the
 /// TUI only wants recent activity. Tunable per-store via
@@ -73,9 +79,14 @@ pub enum ChildStatus {
 
 impl ChildStatus {
     /// Terminal statuses — once a record reaches one of these, no
-    /// further transitions are allowed.
+    /// further transitions are allowed. `Blocked` is terminal for
+    /// extension-denied delegations; future approval-wait states should
+    /// use a distinct status instead of reusing it.
     pub fn is_terminal(self) -> bool {
-        matches!(self, Self::Completed | Self::Failed | Self::Cancelled)
+        matches!(
+            self,
+            Self::Blocked | Self::Completed | Self::Failed | Self::Cancelled
+        )
     }
 }
 
@@ -282,6 +293,18 @@ impl OrchestrationStore {
             r.status = ChildStatus::Failed;
             r.error = Some(error);
             r.iterations_used = iterations;
+            r.ended_at = Some(Utc::now());
+        });
+    }
+
+    pub fn mark_blocked(&self, id: ChildAgentId, reason: impl Into<String>) {
+        let reason = reason.into();
+        self.with_mut(id, |r| {
+            if r.status.is_terminal() {
+                return;
+            }
+            r.status = ChildStatus::Blocked;
+            r.error = Some(reason);
             r.ended_at = Some(Utc::now());
         });
     }

--- a/src/tools/spawn.rs
+++ b/src/tools/spawn.rs
@@ -35,7 +35,10 @@ use serde_json::{Value, json};
 use tokio_util::sync::CancellationToken;
 
 use crate::config::Config;
-use crate::orchestration::{ChildAgentId, OrchestrationStore};
+use crate::orchestration::{
+    ChildAgentId, DelegationBudget, DelegationDecision, DelegationEvent, DelegationRequest,
+    DelegationStage, OrchestrationHookSet, OrchestrationStore,
+};
 use crate::tools::{Tool, ToolResult, parse_tool_params};
 
 #[derive(Deserialize)]
@@ -142,6 +145,10 @@ pub struct SpawnSubagentTool {
     /// Slice 7: when present, delegate child execution to a daemon
     /// child-session runner instead of building a direct child Agent.
     subagent_runner: Option<Arc<dyn SubagentRunner>>,
+    /// GH issue #271: observer/blocking hooks contributed by active
+    /// session extensions. Planning hooks wait for the typed planner;
+    /// delegation can use today's typed subagent runtime objects.
+    orchestration_hooks: OrchestrationHookSet,
 }
 
 impl SpawnSubagentTool {
@@ -160,6 +167,7 @@ impl SpawnSubagentTool {
             parent_session_id: None,
             parent_run_handle: None,
             subagent_runner: None,
+            orchestration_hooks: OrchestrationHookSet::default(),
         }
     }
 
@@ -192,6 +200,11 @@ impl SpawnSubagentTool {
 
     pub fn with_subagent_runner(mut self, runner: Arc<dyn SubagentRunner>) -> Self {
         self.subagent_runner = Some(runner);
+        self
+    }
+
+    pub fn with_orchestration_hooks(mut self, hooks: OrchestrationHookSet) -> Self {
+        self.orchestration_hooks = hooks;
         self
     }
 }
@@ -306,6 +319,51 @@ impl Tool for SpawnSubagentTool {
         self.orchestration
             .update_status(child_id, crate::orchestration::ChildStatus::Running);
 
+        let delegation = DelegationRequest {
+            child_id,
+            parent_session_id: self.parent_session_id.clone(),
+            task: task.clone(),
+            allowed_tools: allowed.clone(),
+            profile_name: profile_name.clone(),
+            budget: DelegationBudget {
+                max_iterations: max_iter,
+                token_budget: None,
+            },
+        };
+        self.orchestration_hooks
+            .emit_delegation(
+                &DelegationEvent::requested(delegation.clone()),
+                cancel.clone(),
+            )
+            .await;
+        match self
+            .orchestration_hooks
+            .before_delegation(&delegation, cancel.clone())
+            .await?
+        {
+            DelegationDecision::Continue => {}
+            DelegationDecision::Block { reason } => {
+                self.orchestration.mark_blocked(child_id, reason.clone());
+                self.orchestration_hooks
+                    .emit_delegation(
+                        &DelegationEvent::blocked(delegation, reason.clone()),
+                        cancel.clone(),
+                    )
+                    .await;
+                let payload = json!({
+                    "status": "blocked",
+                    "child_id": child_id.to_string(),
+                    "summary": reason,
+                    "budget_used": {
+                        "iterations": 0,
+                        "max_iterations": max_iter,
+                    },
+                    "tools_granted": allowed.len(),
+                });
+                return Ok(ToolResult::ok(serde_json::to_string_pretty(&payload)?));
+            }
+        }
+
         // YYC-208: fork a child cancellation token from the parent's
         // so cancelling the parent turn aborts the child's loop.
         // `child_token` cancels when the parent's token cancels and
@@ -317,6 +375,12 @@ impl Tool for SpawnSubagentTool {
             .register_cancel_handle(child_id, child_cancel.clone());
         let parent_run_id = self.parent_run_handle.as_ref().and_then(|h| *h.lock());
         if let Some(runner) = &self.subagent_runner {
+            self.orchestration_hooks
+                .emit_delegation(
+                    &DelegationEvent::started(delegation.clone()),
+                    cancel.clone(),
+                )
+                .await;
             let request = SubagentRunRequest {
                 child_id,
                 parent_session_id: self.parent_session_id.clone(),
@@ -329,7 +393,7 @@ impl Tool for SpawnSubagentTool {
             let run_result = runner.run_subagent(request, child_cancel.clone()).await;
             self.orchestration.forget_cancel_handle(child_id);
             return self
-                .finish_child_result(child_id, task, allowed.len(), max_iter, run_result, cancel)
+                .finish_child_result(delegation, run_result, cancel)
                 .await;
         }
 
@@ -343,13 +407,14 @@ impl Tool for SpawnSubagentTool {
 impl SpawnSubagentTool {
     async fn finish_child_result(
         &self,
-        child_id: ChildAgentId,
-        task: String,
-        tools_granted: usize,
-        max_iter: u32,
+        delegation: DelegationRequest,
         run_result: Result<SubagentRunOutput>,
         cancel: CancellationToken,
     ) -> Result<ToolResult> {
+        let child_id = delegation.child_id;
+        let task = delegation.task.clone();
+        let tools_granted = delegation.tool_count();
+        let max_iter = delegation.budget.max_iterations;
         let (iterations, tokens_consumed) = match &run_result {
             Ok(out) => (out.iterations, out.tokens_consumed),
             Err(_) => (0, 0),
@@ -357,6 +422,19 @@ impl SpawnSubagentTool {
         self.orchestration.update_tokens(child_id, tokens_consumed);
         if cancel.is_cancelled() {
             self.orchestration.mark_cancelled(child_id);
+            self.orchestration_hooks
+                .emit_delegation(
+                    &DelegationEvent::terminal(
+                        delegation,
+                        DelegationStage::Cancelled,
+                        iterations,
+                        tokens_consumed,
+                        Some("child cancelled by parent".into()),
+                        None,
+                    ),
+                    cancel.clone(),
+                )
+                .await;
             let payload = json!({
                 "status": "cancelled",
                 "child_id": child_id.to_string(),
@@ -374,6 +452,19 @@ impl SpawnSubagentTool {
                 let final_text = out.final_text;
                 self.orchestration
                     .mark_completed(child_id, final_text.clone(), iterations);
+                self.orchestration_hooks
+                    .emit_delegation(
+                        &DelegationEvent::terminal(
+                            delegation,
+                            DelegationStage::Completed,
+                            iterations,
+                            tokens_consumed,
+                            Some(final_text.clone()),
+                            None,
+                        ),
+                        cancel.clone(),
+                    )
+                    .await;
                 // YYC-180: persist the child's final summary as a
                 // typed artifact when the parent shared its store.
                 // The artifact's `source` carries the child's id so
@@ -411,6 +502,19 @@ impl SpawnSubagentTool {
                 let err_msg = format!("child agent failed: {e}");
                 self.orchestration
                     .mark_failed(child_id, err_msg.clone(), iterations);
+                self.orchestration_hooks
+                    .emit_delegation(
+                        &DelegationEvent::terminal(
+                            delegation,
+                            DelegationStage::Failed,
+                            iterations,
+                            tokens_consumed,
+                            None,
+                            Some(err_msg.clone()),
+                        ),
+                        cancel.clone(),
+                    )
+                    .await;
                 let payload = json!({
                     "status": "error",
                     "child_id": child_id.to_string(),
@@ -431,6 +535,7 @@ impl SpawnSubagentTool {
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::sync::Mutex as AsyncMutex;
 
     #[test]
     fn default_allowed_tools_contains_read_only_set() {
@@ -495,10 +600,7 @@ mod tests {
         assert!(recent[0].ended_at.is_some());
     }
 
-    #[test]
-    fn iteration_cap_clamps_to_ceiling() {
-        assert!(SUBAGENT_MAX_ITERATIONS_CAP >= SUBAGENT_DEFAULT_ITERATIONS);
-    }
+    const _: () = assert!(SUBAGENT_MAX_ITERATIONS_CAP >= SUBAGENT_DEFAULT_ITERATIONS);
 
     // ── YYC-181: named profile narrowing for subagents ───────────────
 
@@ -609,5 +711,129 @@ mod tests {
         );
         assert_eq!(recent[0].iterations_used, 2);
         assert_eq!(recent[0].tokens_consumed, 11);
+    }
+
+    struct RecordingHook {
+        events: Arc<AsyncMutex<Vec<DelegationStage>>>,
+    }
+
+    #[async_trait]
+    impl crate::orchestration::OrchestrationHook for RecordingHook {
+        fn name(&self) -> &str {
+            "recording"
+        }
+
+        async fn on_delegation_event(
+            &self,
+            event: &DelegationEvent,
+            _cancel: CancellationToken,
+        ) -> Result<()> {
+            self.events.lock().await.push(event.stage.clone());
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn delegation_hooks_observe_typed_event_order() {
+        let cfg = Arc::new(Config::default());
+        let store = Arc::new(OrchestrationStore::new());
+        let calls = Arc::new(AtomicUsize::new(0));
+        let runner = Arc::new(FakeRunner {
+            calls: Arc::clone(&calls),
+        });
+        let events = Arc::new(AsyncMutex::new(Vec::new()));
+        let hook = Arc::new(RecordingHook {
+            events: Arc::clone(&events),
+        });
+        let tool = SpawnSubagentTool::with_store(cfg, store)
+            .with_parent_session_id("parent-session")
+            .with_subagent_runner(runner)
+            .with_orchestration_hooks(OrchestrationHookSet::new(vec![hook]));
+
+        let result = tool
+            .call(
+                json!({
+                    "task": "inspect daemon",
+                    "allowed_tools": ["read_file"],
+                    "max_iterations": 3
+                }),
+                CancellationToken::new(),
+                None,
+            )
+            .await
+            .expect("call ok");
+
+        assert!(!result.is_error);
+        assert_eq!(
+            *events.lock().await,
+            vec![
+                DelegationStage::Requested,
+                DelegationStage::Started,
+                DelegationStage::Completed
+            ]
+        );
+    }
+
+    struct BlockingHook;
+
+    #[async_trait]
+    impl crate::orchestration::OrchestrationHook for BlockingHook {
+        fn name(&self) -> &str {
+            "blocking"
+        }
+
+        fn priority(&self) -> i32 {
+            0
+        }
+
+        async fn before_delegation(
+            &self,
+            request: &DelegationRequest,
+            _cancel: CancellationToken,
+        ) -> Result<DelegationDecision> {
+            assert_eq!(request.parent_session_id.as_deref(), Some("parent-session"));
+            assert_eq!(request.budget.max_iterations, 3);
+            assert_eq!(request.budget.token_budget, None);
+            Ok(DelegationDecision::Block {
+                reason: "delegation disabled by extension".into(),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn delegation_hook_can_block_before_runner_starts() {
+        let cfg = Arc::new(Config::default());
+        let store = Arc::new(OrchestrationStore::new());
+        let calls = Arc::new(AtomicUsize::new(0));
+        let runner = Arc::new(FakeRunner {
+            calls: Arc::clone(&calls),
+        });
+        let tool = SpawnSubagentTool::with_store(cfg, Arc::clone(&store))
+            .with_parent_session_id("parent-session")
+            .with_subagent_runner(runner)
+            .with_orchestration_hooks(OrchestrationHookSet::new(vec![Arc::new(BlockingHook)]));
+
+        let result = tool
+            .call(
+                json!({
+                    "task": "inspect daemon",
+                    "allowed_tools": ["read_file"],
+                    "max_iterations": 3
+                }),
+                CancellationToken::new(),
+                None,
+            )
+            .await
+            .expect("call ok");
+
+        assert!(!result.is_error);
+        assert!(result.output.contains("\"status\": \"blocked\""));
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+        let recent = store.recent(1);
+        assert_eq!(recent[0].status, crate::orchestration::ChildStatus::Blocked);
+        assert_eq!(
+            recent[0].error.as_deref(),
+            Some("delegation disabled by extension")
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Adds extension delegation orchestration hooks on top of scoped state.
- Wires extension hook events into the foundation for agentic extension flows.

Fixes #271