### PR TITLE
WASM extension runtime foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,16 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
- "gimli",
+ "gimli 0.32.3",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
+dependencies = [
+ "gimli 0.33.0",
 ]
 
 [[package]]
@@ -176,7 +185,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
 dependencies = [
- "object",
+ "object 0.37.3",
 ]
 
 [[package]]
@@ -393,11 +402,11 @@ version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
- "addr2line",
+ "addr2line 0.25.1",
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.37.3",
  "rustc-demangle",
  "windows-link",
 ]
@@ -551,6 +560,9 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "bytemuck"
@@ -741,6 +753,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,6 +896,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpp_demangle"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -891,6 +921,148 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "cranelift-assembler-x64"
+version = "0.131.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8628cc4ba7f88a9205a7ee42327697abc61195a1e3d92cfae172d6a946e722e"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.131.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d582754487e6c9a065a91c42ccf1bdd8d5977af33468dac5ae9bec0ce88acb3e"
+dependencies = [
+ "cranelift-srcgen",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.131.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb59c81ace12ee7c33074db7903d4d75d1f40b28cd3e8e6f491de57b29129eb9"
+dependencies = [
+ "cranelift-entity",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-bitset"
+version = "0.131.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f25c06993a681be9cf3140798a3d4ac5bec955e7444416a2fdc87fda8567285d"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.131.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b61f95c5a211918f5d336254a61a488b36a5818de47a868e8c4658dce9cccc"
+dependencies = [
+ "bumpalo",
+ "cranelift-assembler-x64",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
+ "gimli 0.33.0",
+ "hashbrown 0.16.1",
+ "libm",
+ "log",
+ "pulley-interpreter",
+ "regalloc2",
+ "rustc-hash 2.1.2",
+ "serde",
+ "smallvec",
+ "target-lexicon",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.131.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b85aa822fce72080d041d7c2cf7c3f5c6ecdea7afae68379ba4ef85269c4fa5"
+dependencies = [
+ "cranelift-assembler-x64-meta",
+ "cranelift-codegen-shared",
+ "cranelift-srcgen",
+ "heck",
+ "pulley-interpreter",
+]
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.131.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833eb9fc89326cd072cc19e96892f09b5692c0dfe17cd4da2858ba30c2cd85c0"
+
+[[package]]
+name = "cranelift-control"
+version = "0.131.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d005320f487e6e8a3edcc7f2fd4f43fcc9946d1013bf206ea649789ac1617fc"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.131.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e62ef34c6e720f347a79ece043e8584e242d168911da640bac654a33a6aaaf5"
+dependencies = [
+ "cranelift-bitset",
+ "serde",
+ "serde_derive",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.131.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa2ad00399dd47e7e7e33cb1dc23b0e39ed9dcd01e8f026fc37af91655031b8"
+dependencies = [
+ "cranelift-codegen",
+ "log",
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.131.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02c51975ed217b4e8e5a7fd11e9ec83a96104bdff311dddcb505d1d8a9fd7fc6"
+
+[[package]]
+name = "cranelift-native"
+version = "0.131.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9b1889e00da9729d8f8525f3c12998ded86ea709058ff844ebe00b97548de0e"
+dependencies = [
+ "cranelift-codegen",
+ "libc",
+ "target-lexicon",
+]
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.131.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5a8f82fd5124f009f72167e60139245cd3b56cfd4b53050f22110c48c5f4da1"
 
 [[package]]
 name = "crc32fast"
@@ -1150,6 +1322,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "uuid",
+]
+
+[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1297,6 +1478,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1313,8 +1504,19 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -1406,6 +1608,18 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "encode_unicode"
@@ -1811,6 +2025,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxprof-processed-profile"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25234f20a3ec0a962a61770cfe39ecf03cb529a6e474ad8cff025ed497eda557"
+dependencies = [
+ "bitflags 2.11.1",
+ "debugid",
+ "rustc-hash 2.1.2",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1895,6 +2123,18 @@ name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "gimli"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
+dependencies = [
+ "fnv",
+ "hashbrown 0.16.1",
+ "indexmap 2.14.0",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "gix"
@@ -2899,6 +3139,8 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2906,6 +3148,9 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -3524,6 +3769,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "ittapi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b996fe614c41395cdaedf3cf408a9534851090959d90d54a535f675550b64b1"
+dependencies = [
+ "anyhow",
+ "ittapi-sys",
+ "log",
+]
+
+[[package]]
+name = "ittapi-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5385394064fa2c886205dba02598013ce83d3e92d33dbdc0c52fe0e7bf4fc"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "jiff"
 version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3716,6 +3981,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3828,6 +4099,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "macro_rules_attribute"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3905,6 +4185,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memfd"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+dependencies = [
+ "rustix",
+]
 
 [[package]]
 name = "memmap2"
@@ -4303,6 +4592,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.17.0",
+ "indexmap 2.14.0",
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4596,6 +4897,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.14.0",
+]
+
+[[package]]
 name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4818,6 +5129,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4977,6 +5300,29 @@ name = "pulldown-cmark-escape"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
+name = "pulley-interpreter"
+version = "44.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9326e3a0093d170582cf64ed9e4cf253b8aac155ec4a294ff62330450bbf094"
+dependencies = [
+ "cranelift-bitset",
+ "log",
+ "pulley-macros",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "pulley-macros"
+version = "44.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00c6433917e3789605b1f4cd2a589f637ff17212344e7fa5ba99544625ba52c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "pxfm"
@@ -5384,6 +5730,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -5411,6 +5768,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.17.0",
+ "log",
+ "rustc-hash 2.1.2",
+ "smallvec",
 ]
 
 [[package]]
@@ -5880,6 +6251,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -6238,6 +6613,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -6488,6 +6866,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
 name = "teloxide-core"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6540,6 +6924,15 @@ checksum = "c4790fc369d5a530f4b544b094e31388b9b3a37c0f4652ade4505945f5660d24"
 dependencies = [
  "new_debug_unreachable",
  "utf-8",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -7585,6 +7978,8 @@ dependencies = [
  "url",
  "uuid",
  "vulcan-frontend-api",
+ "wasmtime",
+ "wat",
 ]
 
 [[package]]
@@ -7821,13 +8216,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-compose"
+version = "0.246.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05a2b3bad87cc1ce45b63425ec09a854cc4cb369231c9fed1fee31538103efb"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.14.0",
+ "log",
+ "petgraph",
+ "smallvec",
+ "wasm-encoder 0.246.2",
+ "wasmparser 0.246.2",
+ "wat",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
 dependencies = [
  "leb128fmt",
- "wasmparser",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.246.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61fb705ce81adde29d2a8e99d87995e39a6e927358c91398f374474746070ef7"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.246.2",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac92cf547bc18d27ecc521015c08c353b4f18b84ab388bb6d1b6b682c620d9b6"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.248.0",
 ]
 
 [[package]]
@@ -7838,8 +8270,8 @@ checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
- "wasm-encoder",
- "wasmparser",
+ "wasm-encoder 0.244.0",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -7878,6 +8310,320 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.246.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.16.1",
+ "indexmap 2.14.0",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
+dependencies = [
+ "bitflags 2.11.1",
+ "indexmap 2.14.0",
+ "semver",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.246.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e41f7493ba994b8a779430a4c25ff550fd5a40d291693af43a6ef48688f00e3"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser 0.246.2",
+]
+
+[[package]]
+name = "wasmtime"
+version = "44.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "372db8bbad8ec962038101f75ab2c3ffcd18797d7d3ae877a58ab9873cd0c4bd"
+dependencies = [
+ "addr2line 0.26.1",
+ "async-trait",
+ "bitflags 2.11.1",
+ "bumpalo",
+ "cc",
+ "cfg-if",
+ "encoding_rs",
+ "futures",
+ "fxprof-processed-profile",
+ "gimli 0.33.0",
+ "ittapi",
+ "libc",
+ "log",
+ "mach2",
+ "memfd",
+ "object 0.39.1",
+ "once_cell",
+ "postcard",
+ "pulley-interpreter",
+ "rayon",
+ "rustix",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "smallvec",
+ "target-lexicon",
+ "tempfile",
+ "wasm-compose",
+ "wasm-encoder 0.246.2",
+ "wasmparser 0.246.2",
+ "wasmtime-environ",
+ "wasmtime-internal-cache",
+ "wasmtime-internal-component-macro",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-core",
+ "wasmtime-internal-cranelift",
+ "wasmtime-internal-fiber",
+ "wasmtime-internal-jit-debug",
+ "wasmtime-internal-jit-icache-coherence",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+ "wasmtime-internal-winch",
+ "wat",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "44.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e15aa0d1545e48d9b25ca604e9e27b4cd6d5886d30ac5787b57b3a2daf85b57"
+dependencies = [
+ "anyhow",
+ "cpp_demangle",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-entity",
+ "gimli 0.33.0",
+ "hashbrown 0.16.1",
+ "indexmap 2.14.0",
+ "log",
+ "object 0.39.1",
+ "postcard",
+ "rustc-demangle",
+ "semver",
+ "serde",
+ "serde_derive",
+ "sha2 0.10.9",
+ "smallvec",
+ "target-lexicon",
+ "wasm-encoder 0.246.2",
+ "wasmparser 0.246.2",
+ "wasmprinter",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-core",
+]
+
+[[package]]
+name = "wasmtime-internal-cache"
+version = "44.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5441170843ac2ab28a1d7646b04a93a46d63bd4083274fd246c6a80189b37767"
+dependencies = [
+ "base64 0.22.1",
+ "directories-next",
+ "log",
+ "postcard",
+ "rustix",
+ "serde",
+ "serde_derive",
+ "sha2 0.10.9",
+ "toml 0.9.12+spec-1.1.0",
+ "wasmtime-environ",
+ "windows-sys 0.61.2",
+ "zstd",
+]
+
+[[package]]
+name = "wasmtime-internal-component-macro"
+version = "44.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c136cb0d2d47850d6d04a58157130ac98b0df4c17626cd30b083d26b607b7027"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wasmtime-internal-component-util",
+ "wasmtime-internal-wit-bindgen",
+ "wit-parser 0.246.2",
+]
+
+[[package]]
+name = "wasmtime-internal-component-util"
+version = "44.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49df3d3b4fa2119c6fd161e475b4e21aaefb51d082353b922b433bea37facc65"
+
+[[package]]
+name = "wasmtime-internal-core"
+version = "44.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f2c7fa6523647262bfb4095dbdf4087accefe525813e783f81a0c682f418ce4"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.16.1",
+ "libm",
+ "serde",
+]
+
+[[package]]
+name = "wasmtime-internal-cranelift"
+version = "44.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98c032f422e39061dfc43f32190c0a3526b04161ec4867f362958f3fe9d1fe29"
+dependencies = [
+ "cfg-if",
+ "cranelift-codegen",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-frontend",
+ "cranelift-native",
+ "gimli 0.33.0",
+ "itertools",
+ "log",
+ "object 0.39.1",
+ "pulley-interpreter",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 2.0.18",
+ "wasmparser 0.246.2",
+ "wasmtime-environ",
+ "wasmtime-internal-core",
+ "wasmtime-internal-unwinder",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-fiber"
+version = "44.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8dd76d80adf450cc260ba58f23c28030401930b19149695b1d121f7d621e791"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "rustix",
+ "wasmtime-environ",
+ "wasmtime-internal-versioned-export-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-debug"
+version = "44.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab453cc600b28ee5d3f9495aa6d4cb2c81eda40903e9287296b548fba8b2391d"
+dependencies = [
+ "cc",
+ "object 0.39.1",
+ "rustix",
+ "wasmtime-internal-versioned-export-macros",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-icache-coherence"
+version = "44.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1859e920871515d324fb9757c3e448d6ed1512ca6ccdff14b6e016505d6ada"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasmtime-internal-core",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "wasmtime-internal-unwinder"
+version = "44.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dfe405bd6adb1386d935a30f16a236bd4ef0d3c383e7cbbab98d063c9d9b73"
+dependencies = [
+ "cfg-if",
+ "cranelift-codegen",
+ "log",
+ "object 0.39.1",
+ "wasmtime-environ",
+]
+
+[[package]]
+name = "wasmtime-internal-versioned-export-macros"
+version = "44.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a9b9165fc45d42c81edfe3e9cb458e58720594ad5db6553c4079ea041a4a581"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "wasmtime-internal-winch"
+version = "44.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95f439b70ba3855a8c808d2cd798eef79bcd389f78aa48a8a694ea8e2904410c"
+dependencies = [
+ "cranelift-codegen",
+ "gimli 0.33.0",
+ "log",
+ "object 0.39.1",
+ "target-lexicon",
+ "wasmparser 0.246.2",
+ "wasmtime-environ",
+ "wasmtime-internal-cranelift",
+ "winch-codegen",
+]
+
+[[package]]
+name = "wasmtime-internal-wit-bindgen"
+version = "44.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17c7ced16dc16d2027f9f8d3a503e191dcce0f53fe9218e7990135b31f8f6fdb"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.1",
+ "heck",
+ "indexmap 2.14.0",
+ "wit-parser 0.246.2",
+]
+
+[[package]]
+name = "wast"
+version = "248.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acc54622ed5a5cddafcdf152043f9d4aed54d4a653d686b7dfe874809fca99d7"
+dependencies = [
+ "bumpalo",
+ "leb128fmt",
+ "memchr",
+ "unicode-width",
+ "wasm-encoder 0.248.0",
+]
+
+[[package]]
+name = "wat"
+version = "1.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d75cd9e510603909748e6ebab89f27cd04472c1d9d85a3c88a7a6fc51a1a7934"
+dependencies = [
+ "wast",
 ]
 
 [[package]]
@@ -8047,6 +8793,25 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winch-codegen"
+version = "44.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6da7c536f3cfe5ff63537f795902fed56b8b5adcc7a87843a86dd8d4e57a7946"
+dependencies = [
+ "cranelift-assembler-x64",
+ "cranelift-codegen",
+ "gimli 0.33.0",
+ "regalloc2",
+ "smallvec",
+ "target-lexicon",
+ "thiserror 2.0.18",
+ "wasmparser 0.246.2",
+ "wasmtime-environ",
+ "wasmtime-internal-core",
+ "wasmtime-internal-cranelift",
+]
 
 [[package]]
 name = "windows"
@@ -8384,7 +9149,7 @@ checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
  "heck",
- "wit-parser",
+ "wit-parser 0.244.0",
 ]
 
 [[package]]
@@ -8431,10 +9196,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder",
+ "wasm-encoder 0.244.0",
  "wasm-metadata",
- "wasmparser",
- "wit-parser",
+ "wasmparser 0.244.0",
+ "wit-parser 0.244.0",
 ]
 
 [[package]]
@@ -8452,7 +9217,26 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser",
+ "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.246.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd979042b5ff288607ccf3b314145435453f20fc67173195f91062d2289b204d"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.16.1",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.246.2",
 ]
 
 [[package]]
@@ -8603,6 +9387,34 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,9 @@ render-typst = []
 render-images = []
 render-typst-preview = ["render-typst"]
 render-typst-image-preview = ["render-typst-preview", "render-images"]
+# GH issue #273: sandboxed extension runtime. Optional because Wasmtime
+# materially increases compile/link cost and only WASM extension hosts need it.
+extension-wasm = ["dep:wasmtime"]
 
 [dependencies]
 # Async runtime
@@ -264,6 +267,7 @@ notify = { version = "8.2.0", optional = true }
 nix = { version = "0.31.2", optional = true, features = ["fs", "process", "signal"] }
 throbber-widgets-tui = "0.11.0"
 tachyonfx = "0.25.0"
+wasmtime = { version = "44.0.1", optional = true }
 
 # Workspace lint baseline (YYC-121). Conservative defaults that bias
 # toward forward-leaning warnings without forcing a sprawling cleanup
@@ -316,6 +320,7 @@ insta = "1.47.2"
 # E2E binary test harness for daemon subcommand (YYC-266).
 assert_cmd = "2.2.1"
 predicates = "3.1.4"
+wat = "1.248.0"
 
 [[bench]]
 name = "tui_render"

--- a/src/extensions/install_state.rs
+++ b/src/extensions/install_state.rs
@@ -12,6 +12,8 @@ use rusqlite::{Connection, OptionalExtension, params};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
+use super::policy::{ExtensionPermission, PolicyDecision};
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct InstallState {
     pub id: String,
@@ -29,6 +31,16 @@ pub struct TrustMarker {
     pub trusted_at: chrono::DateTime<chrono::Utc>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeAuditRecord {
+    pub extension_id: String,
+    pub requested_permission: Option<ExtensionPermission>,
+    pub decision: PolicyDecision,
+    pub allowed: bool,
+    pub failure_reason: Option<String>,
+    pub occurred_at: chrono::DateTime<chrono::Utc>,
+}
+
 pub trait InstallStateStore: Send + Sync {
     fn upsert(&self, state: &InstallState) -> Result<()>;
     fn get(&self, id: &str) -> Result<Option<InstallState>>;
@@ -36,6 +48,8 @@ pub trait InstallStateStore: Send + Sync {
     fn set_enabled(&self, id: &str, enabled: bool) -> Result<bool>;
     fn record_load_error(&self, id: &str, error: &str) -> Result<bool>;
     fn clear_load_error(&self, id: &str) -> Result<bool>;
+    fn record_runtime_audit(&self, record: &RuntimeAuditRecord) -> Result<()>;
+    fn list_runtime_audit(&self, id: &str, limit: usize) -> Result<Vec<RuntimeAuditRecord>>;
     fn remove(&self, id: &str) -> Result<bool>;
 }
 
@@ -104,6 +118,19 @@ impl SqliteInstallStateStore {
                 trusted_at        TEXT NOT NULL,
                 PRIMARY KEY (workspace_hash, extension_id)
             );
+
+            CREATE TABLE IF NOT EXISTS extension_runtime_audit (
+                id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+                extension_id         TEXT NOT NULL,
+                requested_permission TEXT,
+                decision_json        TEXT NOT NULL,
+                allowed              INTEGER NOT NULL,
+                failure_reason       TEXT,
+                occurred_at          TEXT NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_extension_runtime_audit_ext_time
+                ON extension_runtime_audit(extension_id, occurred_at DESC);
             "#,
         )?;
         Ok(())
@@ -306,6 +333,71 @@ impl InstallStateStore for SqliteInstallStateStore {
         Ok(n > 0)
     }
 
+    fn record_runtime_audit(&self, record: &RuntimeAuditRecord) -> Result<()> {
+        let conn = self.conn.lock();
+        conn.execute(
+            "INSERT INTO extension_runtime_audit
+                (extension_id, requested_permission, decision_json, allowed, failure_reason, occurred_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                record.extension_id,
+                record.requested_permission.map(|p| p.as_str().to_string()),
+                serde_json::to_string(&record.decision)?,
+                record.allowed as i64,
+                record.failure_reason,
+                record.occurred_at.to_rfc3339(),
+            ],
+        )?;
+        Ok(())
+    }
+
+    fn list_runtime_audit(&self, id: &str, limit: usize) -> Result<Vec<RuntimeAuditRecord>> {
+        let conn = self.conn.lock();
+        let mut stmt = conn.prepare(
+            "SELECT extension_id, requested_permission, decision_json, allowed, failure_reason, occurred_at
+             FROM extension_runtime_audit
+             WHERE extension_id = ?1
+             ORDER BY occurred_at DESC, rowid DESC
+             LIMIT ?2",
+        )?;
+        let rows: Vec<_> = stmt
+            .query_map(params![id, limit as i64], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Option<String>>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, Option<String>>(4)?,
+                    row.get::<_, String>(5)?,
+                ))
+            })?
+            .collect::<Result<_, _>>()?;
+        rows.into_iter()
+            .map(
+                |(
+                    extension_id,
+                    permission,
+                    decision_json,
+                    allowed,
+                    failure_reason,
+                    occurred_at,
+                )| {
+                    let requested_permission =
+                        permission.as_deref().and_then(ExtensionPermission::parse);
+                    Ok(RuntimeAuditRecord {
+                        extension_id,
+                        requested_permission,
+                        decision: serde_json::from_str(&decision_json)?,
+                        allowed: allowed != 0,
+                        failure_reason,
+                        occurred_at: chrono::DateTime::parse_from_rfc3339(&occurred_at)?
+                            .with_timezone(&chrono::Utc),
+                    })
+                },
+            )
+            .collect()
+    }
+
     fn remove(&self, id: &str) -> Result<bool> {
         let conn = self.conn.lock();
         let n = conn.execute("DELETE FROM install_state WHERE id = ?1", params![id])?;
@@ -367,7 +459,7 @@ mod tests {
         let s = fixture();
         store.upsert(&s).unwrap();
         assert!(store.set_enabled(&s.id, false).unwrap());
-        assert_eq!(store.get(&s.id).unwrap().unwrap().enabled, false);
+        assert!(!store.get(&s.id).unwrap().unwrap().enabled);
     }
 
     #[test]
@@ -387,6 +479,30 @@ mod tests {
         );
         assert!(store.clear_load_error(&s.id).unwrap());
         assert!(store.get(&s.id).unwrap().unwrap().last_load_error.is_none());
+    }
+
+    #[test]
+    fn runtime_audit_records_policy_decisions() {
+        let store = SqliteInstallStateStore::try_open_in_memory().unwrap();
+        let record = RuntimeAuditRecord {
+            extension_id: "tooler".into(),
+            requested_permission: Some(ExtensionPermission::ToolRegistration),
+            decision: PolicyDecision::Deny {
+                reason: "missing declaration".into(),
+            },
+            allowed: false,
+            failure_reason: Some("missing declaration".into()),
+            occurred_at: chrono::Utc::now(),
+        };
+        store.record_runtime_audit(&record).unwrap();
+        let listed = store.list_runtime_audit("tooler", 10).unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(
+            listed[0].requested_permission,
+            Some(ExtensionPermission::ToolRegistration)
+        );
+        assert!(!listed[0].allowed);
+        assert!(matches!(listed[0].decision, PolicyDecision::Deny { .. }));
     }
 
     #[test]

--- a/src/extensions/manifest.rs
+++ b/src/extensions/manifest.rs
@@ -31,6 +31,10 @@ pub enum EntryKind {
     /// parser doesn't fail on a manifest pointing at one, but
     /// loading is explicitly out of scope for the YYC-166 epic.
     NativeLibrary { path: String },
+    /// Sandboxed WebAssembly extension module. Loading is handled by
+    /// the optional `extension-wasm` feature; manifest parsing remains
+    /// available in all builds so stores can render status consistently.
+    Wasm { path: String },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -115,7 +119,9 @@ impl ExtensionManifest {
             return Err(ManifestError::EmptyField { field: "version" });
         }
         match &self.entry {
-            EntryKind::LocalScript { path } | EntryKind::NativeLibrary { path } => {
+            EntryKind::LocalScript { path }
+            | EntryKind::NativeLibrary { path }
+            | EntryKind::Wasm { path } => {
                 if path.trim().is_empty() {
                     return Err(ManifestError::EmptyField {
                         field: "entry.path",
@@ -180,6 +186,24 @@ path = "./run.sh"
         match &m.entry {
             EntryKind::LocalScript { path } => assert_eq!(path, "./run.sh"),
             other => panic!("expected LocalScript, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parses_wasm_entry_kind() {
+        let raw = r#"
+id = "wasm-helper"
+name = "WASM Helper"
+version = "0.1.0"
+
+[entry]
+kind = "wasm"
+path = "./helper.wasm"
+"#;
+        let manifest = ExtensionManifest::from_toml_str(raw).unwrap();
+        match manifest.entry {
+            EntryKind::Wasm { path } => assert_eq!(path, "./helper.wasm"),
+            other => panic!("expected Wasm, got {other:?}"),
         }
     }
 

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -25,9 +25,12 @@ pub mod install_state;
 pub mod manifest;
 pub mod policy;
 pub mod registry;
+pub mod runtime;
 pub mod state;
 pub mod store;
 pub mod verify;
+#[cfg(feature = "extension-wasm")]
+pub mod wasm;
 
 pub use audit::{
     CompactionAuditAction, CompactionAuditEvent, ExtensionAuditEvent, ExtensionAuditLog,
@@ -35,10 +38,16 @@ pub use audit::{
 };
 pub use config_field::{ExtensionConfigField, ExtensionFieldKind};
 pub use draft::parse_skill_extension;
-pub use install_state::{InstallState, InstallStateStore, SqliteInstallStateStore};
+pub use install_state::{
+    InstallState, InstallStateStore, RuntimeAuditRecord, SqliteInstallStateStore,
+};
 pub use manifest::{EntryKind, ExtensionManifest, ManifestError};
 pub use policy::{ExtensionPermission, ExtensionPolicyEngine, PolicyDecision};
 pub use registry::{CodeExtension, ExtensionInventoryRow, ExtensionRegistry};
+pub use runtime::{
+    ExtensionRuntime, ExtensionRuntimeCapability, ExtensionRuntimeCtx, ExtensionRuntimeDecision,
+    ExtensionRuntimeError, ExtensionRuntimeInit, ExtensionRuntimeKind, ExtensionRuntimeLimits,
+};
 pub use state::{
     CheckpointInfo, CheckpointRecord, ExtensionStateScope, ExtensionStateStore,
     SqliteExtensionStateStore,

--- a/src/extensions/policy.rs
+++ b/src/extensions/policy.rs
@@ -23,6 +23,7 @@ pub enum ExtensionPermission {
     SecretAccess,
     McpLaunch,
     PersistentState,
+    ToolRegistration,
 }
 
 impl ExtensionPermission {
@@ -36,6 +37,7 @@ impl ExtensionPermission {
             ExtensionPermission::SecretAccess => "secret_access",
             ExtensionPermission::McpLaunch => "mcp_launch",
             ExtensionPermission::PersistentState => "persistent_state",
+            ExtensionPermission::ToolRegistration => "tool_registration",
         }
     }
 
@@ -49,6 +51,7 @@ impl ExtensionPermission {
             "secret_access" => Some(ExtensionPermission::SecretAccess),
             "mcp_launch" => Some(ExtensionPermission::McpLaunch),
             "persistent_state" => Some(ExtensionPermission::PersistentState),
+            "tool_registration" => Some(ExtensionPermission::ToolRegistration),
             _ => None,
         }
     }
@@ -66,6 +69,7 @@ impl ExtensionPermission {
                 | ExtensionPermission::ProcessSpawn
                 | ExtensionPermission::SecretAccess
                 | ExtensionPermission::McpLaunch
+                | ExtensionPermission::ToolRegistration
         )
     }
 }
@@ -261,6 +265,7 @@ mod tests {
             ExtensionPermission::SecretAccess,
             ExtensionPermission::McpLaunch,
             ExtensionPermission::PersistentState,
+            ExtensionPermission::ToolRegistration,
         ] {
             let s = p.as_str();
             assert_eq!(ExtensionPermission::parse(s), Some(p));

--- a/src/extensions/registry.rs
+++ b/src/extensions/registry.rs
@@ -197,6 +197,21 @@ impl ExtensionRegistry {
         }
     }
 
+    /// GH issue #273: sandbox runtime failures should disable only the
+    /// extension, record a visible load error, and keep the Vulcan
+    /// process alive.
+    pub fn record_runtime_failure(
+        &self,
+        id: &str,
+        reason: impl Into<String>,
+        install_state: &dyn super::install_state::InstallStateStore,
+    ) -> bool {
+        let reason = reason.into();
+        let marked = self.mark_broken(id, reason.clone());
+        let _ = install_state.record_load_error(id, &reason);
+        marked
+    }
+
     fn sort_in_place(items: &mut [ExtensionMetadata]) {
         items.sort_by(|a, b| {
             b.core
@@ -1137,6 +1152,41 @@ kind = "builtin"
             .unwrap()
             .unwrap();
         assert!(state.last_load_error.is_some());
+    }
+
+    #[test]
+    fn runtime_failure_marks_extension_broken_and_records_error() {
+        let install =
+            crate::extensions::install_state::SqliteInstallStateStore::try_open_in_memory()
+                .unwrap();
+        crate::extensions::install_state::InstallStateStore::upsert(
+            &install,
+            &crate::extensions::install_state::InstallState {
+                id: "wasm-helper".into(),
+                version: "0.1.0".into(),
+                enabled: true,
+                installed_at: chrono::Utc::now(),
+                last_load_error: None,
+            },
+        )
+        .unwrap();
+        let reg = ExtensionRegistry::new();
+        let mut metadata = meta("wasm-helper", 10);
+        metadata.status = ExtensionStatus::Active;
+        reg.upsert(metadata);
+
+        assert!(reg.record_runtime_failure("wasm-helper", "missing _vulcan_init", &install));
+        let got = reg.get("wasm-helper").unwrap();
+        assert_eq!(got.status, ExtensionStatus::Broken);
+        assert_eq!(got.broken_reason.as_deref(), Some("missing _vulcan_init"));
+        let state =
+            crate::extensions::install_state::InstallStateStore::get(&install, "wasm-helper")
+                .unwrap()
+                .unwrap();
+        assert_eq!(
+            state.last_load_error.as_deref(),
+            Some("missing _vulcan_init")
+        );
     }
 
     #[test]

--- a/src/extensions/runtime.rs
+++ b/src/extensions/runtime.rs
@@ -1,0 +1,222 @@
+//! GH issue #273: extension runtime abstraction.
+//!
+//! This module is intentionally independent from manifest parsing and
+//! from any concrete VM. It defines the host-visible lifecycle contract,
+//! resource limits, capability audit records, and error taxonomy used by
+//! sandboxed runtimes.
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use super::policy::{ExtensionPermission, ExtensionPolicyEngine, PolicyDecision};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExtensionRuntimeKind {
+    Wasm,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExtensionRuntimeCapability {
+    Log,
+    RegisterTool,
+    PersistentState,
+    McpLaunch,
+}
+
+impl ExtensionRuntimeCapability {
+    pub fn requested_permission(self) -> Option<ExtensionPermission> {
+        match self {
+            Self::Log => None,
+            Self::RegisterTool => Some(ExtensionPermission::ToolRegistration),
+            Self::PersistentState => Some(ExtensionPermission::PersistentState),
+            Self::McpLaunch => Some(ExtensionPermission::McpLaunch),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ExtensionRuntimeLimits {
+    pub max_memory_bytes: usize,
+    pub fuel: u64,
+    pub call_timeout: Duration,
+    pub max_host_call_depth: u32,
+}
+
+impl Default for ExtensionRuntimeLimits {
+    fn default() -> Self {
+        Self {
+            max_memory_bytes: 16 * 1024 * 1024,
+            fuel: 10_000_000,
+            call_timeout: Duration::from_secs(2),
+            max_host_call_depth: 8,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ExtensionRuntimeCtx {
+    pub extension_id: String,
+    pub declared_permissions: BTreeSet<ExtensionPermission>,
+    pub policy: Arc<ExtensionPolicyEngine>,
+}
+
+impl ExtensionRuntimeCtx {
+    pub fn new(
+        extension_id: impl Into<String>,
+        declared_permissions: BTreeSet<ExtensionPermission>,
+        policy: Arc<ExtensionPolicyEngine>,
+    ) -> Self {
+        Self {
+            extension_id: extension_id.into(),
+            declared_permissions,
+            policy,
+        }
+    }
+
+    pub fn decide(&self, capability: ExtensionRuntimeCapability) -> ExtensionRuntimeDecision {
+        let Some(requested_permission) = capability.requested_permission() else {
+            return ExtensionRuntimeDecision {
+                extension_id: self.extension_id.clone(),
+                capability,
+                requested_permission: None,
+                decision: PolicyDecision::Allow,
+                allowed: true,
+                failure_reason: None,
+            };
+        };
+        let decision = self.policy.decide(
+            &self.extension_id,
+            &self.declared_permissions,
+            requested_permission,
+        );
+        let allowed = decision.is_allow();
+        let failure_reason = if allowed {
+            None
+        } else {
+            Some(match &decision {
+                PolicyDecision::Deny { reason }
+                | PolicyDecision::RequireApproval { reason }
+                | PolicyDecision::AllowWithRedaction { reason }
+                | PolicyDecision::AllowWithQuota { reason, .. } => reason.clone(),
+                PolicyDecision::Allow => String::new(),
+            })
+        };
+        ExtensionRuntimeDecision {
+            extension_id: self.extension_id.clone(),
+            capability,
+            requested_permission: Some(requested_permission),
+            decision,
+            allowed,
+            failure_reason,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExtensionRuntimeDecision {
+    pub extension_id: String,
+    pub capability: ExtensionRuntimeCapability,
+    pub requested_permission: Option<ExtensionPermission>,
+    pub decision: PolicyDecision,
+    pub allowed: bool,
+    pub failure_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExtensionRuntimeInit {
+    pub extension_id: String,
+    pub registered_tools: Vec<String>,
+    pub decisions: Vec<ExtensionRuntimeDecision>,
+}
+
+#[derive(Debug, Error)]
+pub enum ExtensionRuntimeError {
+    #[error("runtime load failed for `{extension_id}`: {reason}")]
+    LoadFailed {
+        extension_id: String,
+        reason: String,
+    },
+    #[error("runtime export missing for `{extension_id}`: {export}")]
+    MissingExport {
+        extension_id: String,
+        export: &'static str,
+    },
+    #[error("runtime limit exceeded for `{extension_id}`: {limit}")]
+    LimitExceeded { extension_id: String, limit: String },
+    #[error("runtime capability denied for `{extension_id}`: {capability:?}: {reason}")]
+    CapabilityDenied {
+        extension_id: String,
+        capability: ExtensionRuntimeCapability,
+        reason: String,
+    },
+    #[error("runtime trapped for `{extension_id}`: {reason}")]
+    Trap {
+        extension_id: String,
+        reason: String,
+    },
+}
+
+impl ExtensionRuntimeError {
+    pub fn extension_id(&self) -> &str {
+        match self {
+            Self::LoadFailed { extension_id, .. }
+            | Self::MissingExport { extension_id, .. }
+            | Self::LimitExceeded { extension_id, .. }
+            | Self::CapabilityDenied { extension_id, .. }
+            | Self::Trap { extension_id, .. } => extension_id,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+pub trait ExtensionRuntime: Send + Sync {
+    fn kind(&self) -> ExtensionRuntimeKind;
+    fn limits(&self) -> &ExtensionRuntimeLimits;
+    async fn initialize(
+        &self,
+        ctx: ExtensionRuntimeCtx,
+    ) -> Result<ExtensionRuntimeInit, ExtensionRuntimeError>;
+    async fn shutdown(&self, _extension_id: &str) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn log_host_call_is_allowed_without_manifest_permission() {
+        let ctx = ExtensionRuntimeCtx::new(
+            "logger",
+            BTreeSet::new(),
+            Arc::new(ExtensionPolicyEngine::new()),
+        );
+        let decision = ctx.decide(ExtensionRuntimeCapability::Log);
+        assert!(decision.allowed);
+        assert!(decision.requested_permission.is_none());
+    }
+
+    #[test]
+    fn tool_registration_requires_declared_permission() {
+        let ctx = ExtensionRuntimeCtx::new(
+            "tooler",
+            BTreeSet::new(),
+            Arc::new(ExtensionPolicyEngine::new()),
+        );
+        let decision = ctx.decide(ExtensionRuntimeCapability::RegisterTool);
+        assert!(!decision.allowed);
+        assert_eq!(
+            decision.requested_permission,
+            Some(ExtensionPermission::ToolRegistration)
+        );
+        assert!(matches!(decision.decision, PolicyDecision::Deny { .. }));
+    }
+}

--- a/src/extensions/wasm.rs
+++ b/src/extensions/wasm.rs
@@ -1,0 +1,421 @@
+//! GH issue #273: optional Wasmtime-backed extension runtime.
+//!
+//! The host ABI is deliberately tiny for v1:
+//!
+//! - `vulcan_host.log(ptr, len)`
+//! - `vulcan_host.register_tool(ptr, len)`
+//!
+//! Both read UTF-8 from the module's exported `memory`. Tool
+//! registration is policy-gated before the host records it.
+
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use wasmtime::{
+    Caller, Config, Engine, Error as WasmtimeError, Linker, Module, Result as WasmtimeResult,
+    Store, StoreLimits, StoreLimitsBuilder, TypedFunc,
+};
+
+use super::runtime::{
+    ExtensionRuntime, ExtensionRuntimeCapability, ExtensionRuntimeCtx, ExtensionRuntimeDecision,
+    ExtensionRuntimeError, ExtensionRuntimeInit, ExtensionRuntimeKind, ExtensionRuntimeLimits,
+};
+
+pub struct WasmExtensionRuntime {
+    module_bytes: Arc<[u8]>,
+    limits: ExtensionRuntimeLimits,
+}
+
+impl WasmExtensionRuntime {
+    pub fn from_bytes(bytes: impl Into<Vec<u8>>, limits: ExtensionRuntimeLimits) -> Self {
+        Self {
+            module_bytes: Arc::<[u8]>::from(bytes.into()),
+            limits,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ExtensionRuntime for WasmExtensionRuntime {
+    fn kind(&self) -> ExtensionRuntimeKind {
+        ExtensionRuntimeKind::Wasm
+    }
+
+    fn limits(&self) -> &ExtensionRuntimeLimits {
+        &self.limits
+    }
+
+    async fn initialize(
+        &self,
+        ctx: ExtensionRuntimeCtx,
+    ) -> Result<ExtensionRuntimeInit, ExtensionRuntimeError> {
+        initialize_sync(self.module_bytes.clone(), self.limits.clone(), ctx)
+    }
+}
+
+fn initialize_sync(
+    module_bytes: Arc<[u8]>,
+    limits: ExtensionRuntimeLimits,
+    ctx: ExtensionRuntimeCtx,
+) -> Result<ExtensionRuntimeInit, ExtensionRuntimeError> {
+    let extension_id = ctx.extension_id.clone();
+    let mut config = Config::new();
+    config.consume_fuel(true);
+    config.epoch_interruption(true);
+    let engine = Engine::new(&config).map_err(|err| ExtensionRuntimeError::LoadFailed {
+        extension_id: extension_id.clone(),
+        reason: err.to_string(),
+    })?;
+    let module =
+        Module::new(&engine, &module_bytes).map_err(|err| ExtensionRuntimeError::LoadFailed {
+            extension_id: extension_id.clone(),
+            reason: err.to_string(),
+        })?;
+
+    let mut store = Store::new(
+        &engine,
+        WasmHostState::new(
+            ctx,
+            limits.clone(),
+            StoreLimitsBuilder::new()
+                .memory_size(limits.max_memory_bytes)
+                .build(),
+        ),
+    );
+    store
+        .set_fuel(limits.fuel)
+        .map_err(|err| ExtensionRuntimeError::LimitExceeded {
+            extension_id: extension_id.clone(),
+            limit: format!("fuel unavailable: {err}"),
+        })?;
+    store.set_epoch_deadline(1);
+    store.limiter(|state| &mut state.store_limits);
+
+    let mut linker = Linker::new(&engine);
+    linker
+        .func_wrap(
+            "vulcan_host",
+            "log",
+            |mut caller: Caller<'_, WasmHostState>, ptr: i32, len: i32| -> WasmtimeResult<()> {
+                let _message = read_guest_string(&mut caller, ptr, len)?;
+                caller
+                    .data_mut()
+                    .record_host_call(ExtensionRuntimeCapability::Log)
+            },
+        )
+        .map_err(|err| ExtensionRuntimeError::LoadFailed {
+            extension_id: extension_id.clone(),
+            reason: err.to_string(),
+        })?;
+    linker
+        .func_wrap(
+            "vulcan_host",
+            "register_tool",
+            |mut caller: Caller<'_, WasmHostState>, ptr: i32, len: i32| -> WasmtimeResult<()> {
+                let tool_name = read_guest_string(&mut caller, ptr, len)?;
+                caller
+                    .data_mut()
+                    .record_host_call(ExtensionRuntimeCapability::RegisterTool)?;
+                caller.data_mut().registered_tools.push(tool_name);
+                Ok(())
+            },
+        )
+        .map_err(|err| ExtensionRuntimeError::LoadFailed {
+            extension_id: extension_id.clone(),
+            reason: err.to_string(),
+        })?;
+
+    let instance = linker.instantiate(&mut store, &module).map_err(|err| {
+        ExtensionRuntimeError::LoadFailed {
+            extension_id: extension_id.clone(),
+            reason: err.to_string(),
+        }
+    })?;
+    let init: TypedFunc<(), ()> = instance
+        .get_typed_func(&mut store, "_vulcan_init")
+        .map_err(|_| ExtensionRuntimeError::MissingExport {
+            extension_id: extension_id.clone(),
+            export: "_vulcan_init",
+        })?;
+
+    let engine_for_timeout = engine.clone();
+    let timeout = limits.call_timeout;
+    std::thread::spawn(move || {
+        std::thread::sleep(timeout);
+        engine_for_timeout.increment_epoch();
+    });
+
+    init.call(&mut store, ()).map_err(|err| {
+        let err_display = err.to_string();
+        let err_debug = format!("{err:?}");
+        if err_display.contains("all fuel consumed") || err_debug.contains("all fuel consumed") {
+            ExtensionRuntimeError::LimitExceeded {
+                extension_id: extension_id.clone(),
+                limit: "fuel".into(),
+            }
+        } else if err_display.contains("interrupt")
+            || err_display.contains("epoch deadline")
+            || err_debug.contains("interrupt")
+            || err_debug.contains("epoch deadline")
+        {
+            ExtensionRuntimeError::LimitExceeded {
+                extension_id: extension_id.clone(),
+                limit: "timeout".into(),
+            }
+        } else if let Some(decision) = store.data().last_denied_decision() {
+            ExtensionRuntimeError::CapabilityDenied {
+                extension_id: extension_id.clone(),
+                capability: decision.capability,
+                reason: decision
+                    .failure_reason
+                    .clone()
+                    .unwrap_or_else(|| err.to_string()),
+            }
+        } else {
+            ExtensionRuntimeError::Trap {
+                extension_id: extension_id.clone(),
+                reason: err_display,
+            }
+        }
+    })?;
+
+    let data = store.into_data();
+    Ok(ExtensionRuntimeInit {
+        extension_id,
+        registered_tools: data.registered_tools,
+        decisions: data.decisions.into_inner(),
+    })
+}
+
+struct WasmHostState {
+    ctx: ExtensionRuntimeCtx,
+    limits: ExtensionRuntimeLimits,
+    store_limits: StoreLimits,
+    host_call_depth: u32,
+    registered_tools: Vec<String>,
+    decisions: Mutex<Vec<ExtensionRuntimeDecision>>,
+}
+
+impl WasmHostState {
+    fn new(
+        ctx: ExtensionRuntimeCtx,
+        limits: ExtensionRuntimeLimits,
+        store_limits: StoreLimits,
+    ) -> Self {
+        Self {
+            ctx,
+            limits,
+            store_limits,
+            host_call_depth: 0,
+            registered_tools: Vec::new(),
+            decisions: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn record_host_call(&mut self, capability: ExtensionRuntimeCapability) -> WasmtimeResult<()> {
+        if self.host_call_depth >= self.limits.max_host_call_depth {
+            return Err(WasmtimeError::msg("max host-call depth exceeded"));
+        }
+        self.host_call_depth += 1;
+        let decision = self.ctx.decide(capability);
+        self.decisions.lock().push(decision.clone());
+        self.host_call_depth -= 1;
+        if decision.allowed {
+            Ok(())
+        } else {
+            Err(WasmtimeError::msg(
+                decision
+                    .failure_reason
+                    .unwrap_or_else(|| "capability denied".into()),
+            ))
+        }
+    }
+
+    fn last_denied_decision(&self) -> Option<ExtensionRuntimeDecision> {
+        self.decisions
+            .lock()
+            .iter()
+            .rev()
+            .find(|decision| !decision.allowed)
+            .cloned()
+    }
+}
+
+fn read_guest_string(
+    caller: &mut Caller<'_, WasmHostState>,
+    ptr: i32,
+    len: i32,
+) -> WasmtimeResult<String> {
+    if ptr < 0 || len < 0 {
+        return Err(WasmtimeError::msg(
+            "negative guest string pointer or length",
+        ));
+    }
+    let memory = caller
+        .get_export("memory")
+        .and_then(|export| export.into_memory())
+        .ok_or_else(|| WasmtimeError::msg("missing exported memory"))?;
+    let ptr = ptr as usize;
+    let len = len as usize;
+    let end = ptr
+        .checked_add(len)
+        .ok_or_else(|| WasmtimeError::msg("guest string range overflow"))?;
+    let data = memory.data(&*caller);
+    let bytes = data
+        .get(ptr..end)
+        .ok_or_else(|| WasmtimeError::msg("guest string range out of bounds"))?;
+    std::str::from_utf8(bytes)
+        .map(|value| value.to_string())
+        .map_err(|err| WasmtimeError::msg(err.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use super::*;
+    use crate::extensions::policy::{ExtensionPermission, ExtensionPolicyEngine, PolicyDecision};
+
+    fn ctx(declared: &[ExtensionPermission]) -> ExtensionRuntimeCtx {
+        let mut engine = ExtensionPolicyEngine::new();
+        engine.set_override(
+            "wasm-helper",
+            ExtensionPermission::ToolRegistration,
+            PolicyDecision::Allow,
+        );
+        ExtensionRuntimeCtx::new(
+            "wasm-helper",
+            declared.iter().copied().collect::<BTreeSet<_>>(),
+            Arc::new(engine),
+        )
+    }
+
+    fn limits() -> ExtensionRuntimeLimits {
+        ExtensionRuntimeLimits {
+            max_memory_bytes: 64 * 1024,
+            fuel: 100_000,
+            call_timeout: Duration::from_millis(50),
+            max_host_call_depth: 4,
+        }
+    }
+
+    #[tokio::test]
+    async fn wasm_extension_initializes_and_registers_tool() {
+        let bytes = wat::parse_str(
+            r#"
+            (module
+              (import "vulcan_host" "log" (func $log (param i32 i32)))
+              (import "vulcan_host" "register_tool" (func $register_tool (param i32 i32)))
+              (memory (export "memory") 1)
+              (data (i32.const 0) "ping")
+              (func (export "_vulcan_init")
+                i32.const 0
+                i32.const 4
+                call $log
+                i32.const 0
+                i32.const 4
+                call $register_tool))
+            "#,
+        )
+        .unwrap();
+        let runtime = WasmExtensionRuntime::from_bytes(bytes, limits());
+        let init = runtime
+            .initialize(ctx(&[ExtensionPermission::ToolRegistration]))
+            .await
+            .unwrap();
+        assert_eq!(init.registered_tools, vec!["ping"]);
+        assert_eq!(init.decisions.len(), 2);
+        assert!(init.decisions.iter().all(|decision| decision.allowed));
+    }
+
+    #[tokio::test]
+    async fn denied_host_call_fails_extension_operation() {
+        let bytes = wat::parse_str(
+            r#"
+            (module
+              (import "vulcan_host" "register_tool" (func $register_tool (param i32 i32)))
+              (memory (export "memory") 1)
+              (data (i32.const 0) "ping")
+              (func (export "_vulcan_init")
+                i32.const 0
+                i32.const 4
+                call $register_tool))
+            "#,
+        )
+        .unwrap();
+        let runtime = WasmExtensionRuntime::from_bytes(bytes, limits());
+        let err = runtime.initialize(ctx(&[])).await.unwrap_err();
+        assert!(matches!(
+            err,
+            ExtensionRuntimeError::CapabilityDenied {
+                capability: ExtensionRuntimeCapability::RegisterTool,
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn missing_init_export_is_load_error() {
+        let bytes = wat::parse_str(r#"(module (memory (export "memory") 1))"#).unwrap();
+        let runtime = WasmExtensionRuntime::from_bytes(bytes, limits());
+        let err = runtime
+            .initialize(ctx(&[ExtensionPermission::ToolRegistration]))
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            ExtensionRuntimeError::MissingExport {
+                export: "_vulcan_init",
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn fuel_limit_stops_runaway_module() {
+        let bytes = wat::parse_str(
+            r#"
+            (module
+              (func (export "_vulcan_init")
+                (loop $again
+                  br $again)))
+            "#,
+        )
+        .unwrap();
+        let runtime = WasmExtensionRuntime::from_bytes(
+            bytes,
+            ExtensionRuntimeLimits {
+                fuel: 10,
+                ..limits()
+            },
+        );
+        let err = runtime.initialize(ctx(&[])).await.unwrap_err();
+        assert!(matches!(
+            err,
+            ExtensionRuntimeError::LimitExceeded { limit, .. } if limit == "fuel"
+        ));
+    }
+
+    #[tokio::test]
+    async fn memory_limit_blocks_large_initial_memory() {
+        let bytes = wat::parse_str(
+            r#"
+            (module
+              (memory (export "memory") 2)
+              (func (export "_vulcan_init")))
+            "#,
+        )
+        .unwrap();
+        let runtime = WasmExtensionRuntime::from_bytes(
+            bytes,
+            ExtensionRuntimeLimits {
+                max_memory_bytes: 64 * 1024,
+                ..limits()
+            },
+        );
+        let err = runtime.initialize(ctx(&[])).await.unwrap_err();
+        assert!(matches!(err, ExtensionRuntimeError::LoadFailed { .. }));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds the optional WASM extension runtime foundation.
- Covers runtime loading, audit behavior, and failure paths behind the feature gate.

Verification
- cargo test extensions::wasm --lib --features extension-wasm
- cargo test extensions::runtime --lib
- cargo check -p vulcan-core --features extension-wasm

Fixes #273