### PR TITLE
Managed MCP server policy foundation

### DIFF
--- a/src/mcp/client.rs
+++ b/src/mcp/client.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
+use super::resources::McpResourceTemplate;
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct McpTool {
     pub name: String,
@@ -76,6 +78,18 @@ where
 
         let result: ToolsResult = self.request("tools/list", json!({})).await?;
         Ok(result.tools)
+    }
+
+    pub async fn list_resource_templates(&mut self) -> Result<Vec<McpResourceTemplate>> {
+        #[derive(Deserialize)]
+        struct ResourceTemplatesResult {
+            #[serde(default, rename = "resourceTemplates")]
+            resource_templates: Vec<McpResourceTemplate>,
+        }
+
+        let result: ResourceTemplatesResult =
+            self.request("resources/templates/list", json!({})).await?;
+        Ok(result.resource_templates)
     }
 
     pub async fn call_tool(&mut self, name: &str, arguments: Value) -> Result<McpToolCallResult> {
@@ -289,6 +303,41 @@ mod tests {
             .unwrap();
         assert!(!result.is_error);
         assert_eq!(result.content[0].text.as_deref(), Some("hello"));
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn client_lists_resource_templates() {
+        let (client_side, server_side) = duplex(4096);
+        let (client_read, client_write) = tokio::io::split(client_side);
+        let (server_read, mut server_write) = tokio::io::split(server_side);
+        let mut server_reader = BufReader::new(server_read);
+
+        let server = tokio::spawn(async move {
+            let list = read_frame(&mut server_reader).await.unwrap();
+            assert_eq!(list["method"], "resources/templates/list");
+            write_frame(
+                &mut server_write,
+                &json!({
+                    "jsonrpc": "2.0",
+                    "id": list["id"],
+                    "result": {
+                        "resourceTemplates": [{
+                            "uriTemplate": "file:///{path}",
+                            "name": "Files",
+                            "mimeType": "text/plain"
+                        }]
+                    }
+                }),
+            )
+            .await
+            .unwrap();
+        });
+
+        let mut client = McpClient::new(BufReader::new(client_read), client_write);
+        let templates = client.list_resource_templates().await.unwrap();
+        assert_eq!(templates.len(), 1);
+        assert_eq!(templates[0].uri_template, "file:///{path}");
         server.await.unwrap();
     }
 }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -10,10 +10,20 @@ use serde::{Deserialize, Serialize};
 
 pub mod client;
 pub mod process;
+pub mod resources;
+pub mod sampling;
+pub mod supervisor;
 pub mod tool_adapter;
 
 pub use client::{McpClient, McpContent, McpTool, McpToolCallResult};
 pub use process::{McpServerHandle, connect_configured_servers};
+pub use resources::{McpResourceTemplate, SafeMcpResourceTemplate};
+pub use sampling::{
+    McpPolicyAuditRecord, McpSamplingDecision, McpSamplingPolicy, McpSamplingRequest,
+};
+pub use supervisor::{
+    McpRestartPolicy, McpServerHealth, McpSupervisorSnapshot, McpSupervisorState,
+};
 pub use tool_adapter::McpToolAdapter;
 
 fn default_timeout_secs() -> u64 {
@@ -36,9 +46,12 @@ pub struct McpServerConfig {
     pub command: String,
     pub args: Vec<String>,
     pub env: HashMap<String, String>,
+    pub managed: bool,
     pub enabled: bool,
     pub expose_as: McpExposeMode,
     pub timeout_secs: u64,
+    pub restart: McpRestartPolicy,
+    pub sampling: McpSamplingPolicy,
 }
 
 impl Default for McpServerConfig {
@@ -48,9 +61,12 @@ impl Default for McpServerConfig {
             command: String::new(),
             args: Vec::new(),
             env: HashMap::new(),
+            managed: false,
             enabled: false,
             expose_as: McpExposeMode::Disabled,
             timeout_secs: default_timeout_secs(),
+            restart: McpRestartPolicy::default(),
+            sampling: McpSamplingPolicy::default(),
         }
     }
 }
@@ -62,6 +78,10 @@ impl McpServerConfig {
 
     pub fn should_expose_tools(&self) -> bool {
         self.enabled && self.expose_as == McpExposeMode::Auto
+    }
+
+    pub fn should_supervise(&self) -> bool {
+        self.enabled && self.managed
     }
 
     pub fn validate(&self) -> anyhow::Result<()> {
@@ -121,5 +141,13 @@ mod tests {
             namespaced_tool_name("local-db", "query.table"),
             "mcp_local_db_query_table"
         );
+    }
+
+    #[test]
+    fn managed_server_defaults_are_inert() {
+        let config = McpServerConfig::default();
+        assert!(!config.should_supervise());
+        assert!(!config.sampling.enabled);
+        assert_eq!(config.restart.max_restarts, 3);
     }
 }

--- a/src/mcp/process.rs
+++ b/src/mcp/process.rs
@@ -9,7 +9,9 @@ use crate::tools::{Tool, ToolRegistry};
 
 use super::client::McpClient;
 use super::tool_adapter::McpToolAdapter;
-use super::{McpServerConfig, McpTool};
+use super::{
+    McpResourceTemplate, McpServerConfig, McpSupervisorSnapshot, McpSupervisorState, McpTool,
+};
 
 type StdioClient = McpClient<BufReader<ChildStdout>, ChildStdin>;
 
@@ -17,6 +19,8 @@ pub struct McpServerHandle {
     name: String,
     client: Mutex<StdioClient>,
     tools: Vec<McpTool>,
+    resource_templates: Vec<McpResourceTemplate>,
+    supervisor: Mutex<McpSupervisorState>,
     _child: Child,
     timeout: std::time::Duration,
 }
@@ -24,6 +28,12 @@ pub struct McpServerHandle {
 impl McpServerHandle {
     pub async fn spawn(config: &McpServerConfig) -> Result<Self> {
         config.validate()?;
+        let mut supervisor = if config.should_supervise() {
+            McpSupervisorState::new(config.name.clone(), config.restart.clone())
+        } else {
+            McpSupervisorState::disabled(config.name.clone(), config.restart.clone())
+        };
+        supervisor.mark_starting();
         let mut command = Command::new(&config.command);
         command
             .args(&config.args)
@@ -52,11 +62,33 @@ impl McpServerHandle {
         let tools = tokio::time::timeout(config.timeout(), client.list_tools())
             .await
             .with_context(|| format!("MCP server `{}` tools/list timed out", config.name))??;
+        let resource_templates =
+            match tokio::time::timeout(config.timeout(), client.list_resource_templates()).await {
+                Ok(Ok(templates)) => templates,
+                Ok(Err(err)) => {
+                    tracing::debug!(
+                        server = config.name.as_str(),
+                        %err,
+                        "MCP server did not provide resource templates"
+                    );
+                    Vec::new()
+                }
+                Err(_) => {
+                    tracing::debug!(
+                        server = config.name.as_str(),
+                        "MCP server resource template discovery timed out"
+                    );
+                    Vec::new()
+                }
+            };
+        supervisor.mark_healthy();
 
         Ok(Self {
             name: config.name.clone(),
             client: Mutex::new(client),
             tools,
+            resource_templates,
+            supervisor: Mutex::new(supervisor),
             _child: child,
             timeout: config.timeout(),
         })
@@ -70,6 +102,14 @@ impl McpServerHandle {
         &self.tools
     }
 
+    pub fn resource_templates(&self) -> &[McpResourceTemplate] {
+        &self.resource_templates
+    }
+
+    pub async fn health(&self) -> McpSupervisorSnapshot {
+        self.supervisor.lock().await.snapshot()
+    }
+
     pub async fn call_tool(
         &self,
         tool_name: &str,
@@ -80,6 +120,10 @@ impl McpServerHandle {
             .await
             .with_context(|| format!("MCP tool `{}`.`{tool_name}` timed out", self.name))?
     }
+}
+
+pub fn disabled_supervisor_snapshot(config: &McpServerConfig) -> McpSupervisorSnapshot {
+    McpSupervisorState::disabled(config.name.clone(), config.restart.clone()).snapshot()
 }
 
 pub async fn connect_configured_servers(
@@ -123,7 +167,7 @@ pub async fn connect_configured_servers(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mcp::McpExposeMode;
+    use crate::mcp::{McpExposeMode, McpRestartPolicy, McpSamplingPolicy, McpServerHealth};
     use std::collections::HashMap;
 
     #[tokio::test]
@@ -133,9 +177,12 @@ mod tests {
             command: "vulcan-missing-mcp-server-command-for-test".to_string(),
             args: Vec::new(),
             env: HashMap::new(),
+            managed: true,
             enabled: true,
             expose_as: McpExposeMode::Auto,
             timeout_secs: 1,
+            restart: McpRestartPolicy::default(),
+            sampling: McpSamplingPolicy::default(),
         };
 
         let err = match McpServerHandle::spawn(&config).await {
@@ -144,5 +191,24 @@ mod tests {
         };
         let msg = err.to_string();
         assert!(msg.contains("failed to start MCP server `missing`"));
+    }
+
+    #[test]
+    fn disabled_server_has_status_snapshot() {
+        let config = McpServerConfig {
+            name: "disabled".to_string(),
+            command: "mcp-server".to_string(),
+            args: Vec::new(),
+            env: HashMap::new(),
+            managed: true,
+            enabled: false,
+            expose_as: McpExposeMode::Disabled,
+            timeout_secs: 1,
+            restart: McpRestartPolicy::default(),
+            sampling: McpSamplingPolicy::default(),
+        };
+        let snapshot = disabled_supervisor_snapshot(&config);
+        assert_eq!(snapshot.health, McpServerHealth::Disabled);
+        assert_eq!(snapshot.server_id, "disabled");
     }
 }

--- a/src/mcp/resources.rs
+++ b/src/mcp/resources.rs
@@ -1,0 +1,81 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct McpResourceTemplate {
+    #[serde(rename = "uriTemplate")]
+    pub uri_template: String,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default, rename = "mimeType")]
+    pub mime_type: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SafeMcpResourceTemplate {
+    pub uri_template: String,
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub mime_type: Option<String>,
+    pub variable_count: usize,
+}
+
+impl McpResourceTemplate {
+    pub fn to_safe_template(&self) -> SafeMcpResourceTemplate {
+        SafeMcpResourceTemplate {
+            uri_template: self.uri_template.clone(),
+            name: self.name.as_ref().map(|value| sanitize_text(value)),
+            description: self.description.as_ref().map(|value| sanitize_text(value)),
+            mime_type: self.mime_type.as_ref().map(|value| sanitize_text(value)),
+            variable_count: count_template_variables(&self.uri_template),
+        }
+    }
+}
+
+fn sanitize_text(value: &str) -> String {
+    value
+        .chars()
+        .filter(|ch| !ch.is_control() || *ch == '\n' || *ch == '\t')
+        .collect::<String>()
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn count_template_variables(value: &str) -> usize {
+    let mut count = 0usize;
+    let mut in_var = false;
+    for ch in value.chars() {
+        match (in_var, ch) {
+            (false, '{') => in_var = true,
+            (true, '}') => {
+                count += 1;
+                in_var = false;
+            }
+            _ => {}
+        }
+    }
+    count
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resource_template_safe_view_keeps_metadata_inert() {
+        let template = McpResourceTemplate {
+            uri_template: "file:///{workspace}/{path}".into(),
+            name: Some(" Repo\nFiles ".into()),
+            description: Some("Read-only\nresource list".into()),
+            mime_type: Some("text/plain".into()),
+        };
+        let safe = template.to_safe_template();
+        assert_eq!(safe.name.as_deref(), Some("Repo Files"));
+        assert_eq!(safe.description.as_deref(), Some("Read-only resource list"));
+        assert_eq!(safe.variable_count, 2);
+    }
+}

--- a/src/mcp/sampling.rs
+++ b/src/mcp/sampling.rs
@@ -1,0 +1,129 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct McpSamplingPolicy {
+    pub enabled: bool,
+    pub max_depth: u32,
+    pub max_tokens: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct McpSamplingRequest {
+    pub server_id: String,
+    pub depth: u32,
+    pub requested_tokens: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum McpSamplingDecision {
+    Allow { max_tokens: u32 },
+    Deny { reason: String },
+}
+
+impl McpSamplingDecision {
+    pub fn allowed(&self) -> bool {
+        matches!(self, Self::Allow { .. })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct McpPolicyAuditRecord {
+    pub server_id: String,
+    pub request_kind: String,
+    pub decision: McpSamplingDecision,
+}
+
+impl McpSamplingPolicy {
+    pub fn decide(
+        &self,
+        request: &McpSamplingRequest,
+    ) -> (McpSamplingDecision, McpPolicyAuditRecord) {
+        let decision = if !self.enabled {
+            McpSamplingDecision::Deny {
+                reason: "MCP sampling is disabled by default".into(),
+            }
+        } else if request.depth > self.max_depth {
+            McpSamplingDecision::Deny {
+                reason: format!(
+                    "MCP sampling depth {} exceeds configured max {}",
+                    request.depth, self.max_depth
+                ),
+            }
+        } else if request.requested_tokens > self.max_tokens {
+            McpSamplingDecision::Deny {
+                reason: format!(
+                    "MCP sampling token request {} exceeds configured max {}",
+                    request.requested_tokens, self.max_tokens
+                ),
+            }
+        } else {
+            McpSamplingDecision::Allow {
+                max_tokens: request.requested_tokens,
+            }
+        };
+        let audit = McpPolicyAuditRecord {
+            server_id: request.server_id.clone(),
+            request_kind: "sampling/createMessage".into(),
+            decision: decision.clone(),
+        };
+        (decision, audit)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sampling_is_denied_by_default() {
+        let request = McpSamplingRequest {
+            server_id: "fake".into(),
+            depth: 0,
+            requested_tokens: 1,
+        };
+        let (decision, audit) = McpSamplingPolicy::default().decide(&request);
+        assert!(!decision.allowed());
+        assert_eq!(audit.server_id, "fake");
+        assert_eq!(audit.request_kind, "sampling/createMessage");
+    }
+
+    #[test]
+    fn enabled_sampling_enforces_depth_and_token_budget() {
+        let policy = McpSamplingPolicy {
+            enabled: true,
+            max_depth: 1,
+            max_tokens: 128,
+        };
+        let too_deep = McpSamplingRequest {
+            server_id: "fake".into(),
+            depth: 2,
+            requested_tokens: 64,
+        };
+        assert!(matches!(
+            policy.decide(&too_deep).0,
+            McpSamplingDecision::Deny { .. }
+        ));
+
+        let too_many_tokens = McpSamplingRequest {
+            server_id: "fake".into(),
+            depth: 1,
+            requested_tokens: 256,
+        };
+        assert!(matches!(
+            policy.decide(&too_many_tokens).0,
+            McpSamplingDecision::Deny { .. }
+        ));
+
+        let allowed = McpSamplingRequest {
+            server_id: "fake".into(),
+            depth: 1,
+            requested_tokens: 64,
+        };
+        assert_eq!(
+            policy.decide(&allowed).0,
+            McpSamplingDecision::Allow { max_tokens: 64 }
+        );
+    }
+}

--- a/src/mcp/supervisor.rs
+++ b/src/mcp/supervisor.rs
@@ -1,0 +1,158 @@
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum McpServerHealth {
+    #[default]
+    Stopped,
+    Starting,
+    Healthy,
+    Unhealthy,
+    Restarting,
+    Disabled,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(default)]
+pub struct McpRestartPolicy {
+    pub max_restarts: u32,
+    pub backoff_secs: u64,
+}
+
+impl Default for McpRestartPolicy {
+    fn default() -> Self {
+        Self {
+            max_restarts: 3,
+            backoff_secs: 2,
+        }
+    }
+}
+
+impl McpRestartPolicy {
+    pub fn backoff(&self) -> Duration {
+        Duration::from_secs(self.backoff_secs.max(1))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct McpSupervisorSnapshot {
+    pub server_id: String,
+    pub health: McpServerHealth,
+    pub restart_attempts: u32,
+    pub last_error: Option<String>,
+    pub next_restart_after: Option<Duration>,
+}
+
+#[derive(Debug, Clone)]
+pub struct McpSupervisorState {
+    server_id: String,
+    policy: McpRestartPolicy,
+    health: McpServerHealth,
+    restart_attempts: u32,
+    last_error: Option<String>,
+    next_restart_after: Option<Duration>,
+}
+
+impl McpSupervisorState {
+    pub fn new(server_id: impl Into<String>, policy: McpRestartPolicy) -> Self {
+        Self {
+            server_id: server_id.into(),
+            policy,
+            health: McpServerHealth::Stopped,
+            restart_attempts: 0,
+            last_error: None,
+            next_restart_after: None,
+        }
+    }
+
+    pub fn disabled(server_id: impl Into<String>, policy: McpRestartPolicy) -> Self {
+        let mut state = Self::new(server_id, policy);
+        state.health = McpServerHealth::Disabled;
+        state
+    }
+
+    pub fn mark_starting(&mut self) {
+        self.health = McpServerHealth::Starting;
+        self.next_restart_after = None;
+    }
+
+    pub fn mark_healthy(&mut self) {
+        self.health = McpServerHealth::Healthy;
+        self.restart_attempts = 0;
+        self.last_error = None;
+        self.next_restart_after = None;
+    }
+
+    pub fn mark_stopped(&mut self) {
+        self.health = McpServerHealth::Stopped;
+        self.next_restart_after = None;
+    }
+
+    pub fn record_crash(&mut self, error: impl Into<String>) -> bool {
+        self.last_error = Some(error.into());
+        if self.restart_attempts >= self.policy.max_restarts {
+            self.health = McpServerHealth::Unhealthy;
+            self.next_restart_after = None;
+            return false;
+        }
+        self.restart_attempts += 1;
+        self.health = McpServerHealth::Restarting;
+        self.next_restart_after = Some(self.policy.backoff() * self.restart_attempts);
+        true
+    }
+
+    pub fn snapshot(&self) -> McpSupervisorSnapshot {
+        McpSupervisorSnapshot {
+            server_id: self.server_id.clone(),
+            health: self.health,
+            restart_attempts: self.restart_attempts,
+            last_error: self.last_error.clone(),
+            next_restart_after: self.next_restart_after,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn crash_restart_is_bounded_with_backoff() {
+        let mut state = McpSupervisorState::new(
+            "fake",
+            McpRestartPolicy {
+                max_restarts: 2,
+                backoff_secs: 3,
+            },
+        );
+        assert!(state.record_crash("boom 1"));
+        assert_eq!(state.snapshot().health, McpServerHealth::Restarting);
+        assert_eq!(
+            state.snapshot().next_restart_after,
+            Some(Duration::from_secs(3))
+        );
+
+        assert!(state.record_crash("boom 2"));
+        assert_eq!(
+            state.snapshot().next_restart_after,
+            Some(Duration::from_secs(6))
+        );
+
+        assert!(!state.record_crash("boom 3"));
+        assert_eq!(state.snapshot().health, McpServerHealth::Unhealthy);
+        assert_eq!(state.snapshot().restart_attempts, 2);
+    }
+
+    #[test]
+    fn healthy_reset_clears_restart_budget() {
+        let mut state = McpSupervisorState::new("fake", McpRestartPolicy::default());
+        assert!(state.record_crash("boom"));
+        state.mark_healthy();
+        let snapshot = state.snapshot();
+        assert_eq!(snapshot.health, McpServerHealth::Healthy);
+        assert_eq!(snapshot.restart_attempts, 0);
+        assert!(snapshot.last_error.is_none());
+    }
+}

--- a/tests/mcp_bridge.rs
+++ b/tests/mcp_bridge.rs
@@ -101,6 +101,7 @@ fn fake_server_config(enabled: bool, expose_as: McpExposeMode) -> McpServerConfi
         enabled,
         expose_as,
         timeout_secs: 5,
+        ..Default::default()
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds the managed MCP server policy foundation.
- Extends MCP server config and bridge tests for managed server behavior.

Verification
- cargo test mcp:: --lib
- cargo test mcp_servers --lib
- cargo test --test mcp_bridge
- cargo check -p vulcan-core
- cargo check -p vulcan --bin vulcan

Fixes #274