### PR TITLE
feat(hooks): add subprocess hook handlers

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -94,6 +94,21 @@ quota_per_session = 5
 # expose_as = "disabled" # auto | manual | disabled
 # timeout_secs = 30
 
+# Subprocess hooks receive a single JSON event on stdin and may return a JSON
+# HookOutcome on stdout. They are inert unless enabled and policy-allowed.
+# If `command` contains a path separator it must be an absolute file path.
+# [[hooks]]
+# id = "audit-bash"
+# event = "before_tool_call" # before_tool_call | after_tool_call
+# match = { tool = "bash" }
+# command = "/home/user/scripts/audit-hook"
+# args = []
+# env = {}
+# enabled = false
+# policy = "deny" # allow | deny | require_approval
+# priority = 60
+# timeout_secs = 10
+
 # YYC-42: auto-recall relevant past-session context on the first turn
 # of a fresh session. Off by default — enable after reviewing the
 # privacy tradeoff (recalled snippets land in the system prompt and

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -583,6 +583,18 @@ impl Agent {
             );
         }
 
+        let external_hooks =
+            crate::hooks::external::configured_handlers(&config.hooks, hooks.audit_log());
+        for hook in &external_hooks {
+            hooks.register(hook.clone());
+        }
+        if !external_hooks.is_empty() {
+            tracing::info!(
+                external_hooks = external_hooks.len(),
+                "Agent: wired configured subprocess hooks"
+            );
+        }
+
         let mcp_servers =
             crate::mcp::connect_configured_servers(&config.mcp_servers, &mut tools).await;
         if !mcp_servers.is_empty() {

--- a/src/agent/tests.rs
+++ b/src/agent/tests.rs
@@ -235,6 +235,41 @@ async fn builder_accepts_hooks_pause_channel_and_max_iterations() {
 }
 
 #[tokio::test]
+async fn builder_wires_enabled_external_hooks_from_config() {
+    let mut config = Config::default();
+    config.provider.disable_catalog = true;
+    config
+        .hooks
+        .push(crate::hooks::external::ExternalHookConfig {
+            id: "config-blocker".to_string(),
+            event: crate::hooks::external::ExternalHookEvent::BeforeToolCall,
+            match_rule: crate::hooks::external::ExternalHookMatch {
+                tool: Some("bash".to_string()),
+            },
+            command: "sh".to_string(),
+            args: vec![
+                "-c".to_string(),
+                "cat >/dev/null; printf '%s' '{\"Block\":{\"reason\":\"blocked by config\"}}'"
+                    .to_string(),
+            ],
+            enabled: true,
+            policy: crate::hooks::external::ExternalHookPolicy::Allow,
+            ..Default::default()
+        });
+
+    let agent = Agent::builder(&config).build().await.unwrap();
+    let decision = agent
+        .hooks
+        .before_tool_call("bash", &serde_json::json!({}), CancellationToken::new())
+        .await;
+
+    assert!(matches!(
+        decision,
+        crate::hooks::ToolCallDecision::Block(reason) if reason == "blocked by config"
+    ));
+}
+
+#[tokio::test]
 async fn single_turn_text_response() {
     let (mut agent, mock) = agent_with_mock();
     mock.enqueue_text("Hello there");

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -167,6 +167,11 @@ pub struct Config {
     #[serde(default)]
     pub mcp_servers: Vec<crate::mcp::McpServerConfig>,
 
+    /// User-configured subprocess hook handlers. Hooks are inert unless each
+    /// entry is explicitly enabled and policy-allowed.
+    #[serde(default)]
+    pub hooks: Vec<crate::hooks::external::ExternalHookConfig>,
+
     #[serde(default = "default_skills_dir")]
     pub skills_dir: PathBuf,
 
@@ -1290,6 +1295,7 @@ impl Default for Config {
             providers: HashMap::new(),
             tools: ToolsConfig::default(),
             mcp_servers: Vec::new(),
+            hooks: Vec::new(),
             skills_dir: default_skills_dir(),
             auto_create_skills: false,
             compaction: CompactionConfig::default(),
@@ -1384,6 +1390,7 @@ impl Config {
             "providers",
             "tools",
             "mcp_servers",
+            "hooks",
             "skills_dir",
             "auto_create_skills",
             "compaction",

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -111,6 +111,70 @@ timeout_secs = 3
 }
 
 #[test]
+fn external_hooks_parse_disabled_and_denied_by_default() {
+    let cfg: Config = toml::from_str(
+        r#"
+[[hooks]]
+id = "audit-bash"
+event = "before_tool_call"
+match = { tool = "bash" }
+command = "audit-hook"
+priority = 60
+"#,
+    )
+    .expect("parses");
+
+    assert_eq!(cfg.hooks.len(), 1);
+    let hook = &cfg.hooks[0];
+    assert_eq!(hook.id, "audit-bash");
+    assert_eq!(
+        hook.event,
+        crate::hooks::external::ExternalHookEvent::BeforeToolCall
+    );
+    assert_eq!(hook.match_rule.tool.as_deref(), Some("bash"));
+    assert_eq!(hook.command, "audit-hook");
+    assert_eq!(hook.priority, 60);
+    assert!(!hook.enabled);
+    assert_eq!(
+        hook.policy,
+        crate::hooks::external::ExternalHookPolicy::Deny
+    );
+}
+
+#[test]
+fn external_hook_validation_rejects_unsafe_command_path() {
+    let hook = crate::hooks::external::ExternalHookConfig {
+        id: "bad-path".to_string(),
+        event: crate::hooks::external::ExternalHookEvent::BeforeToolCall,
+        match_rule: crate::hooks::external::ExternalHookMatch {
+            tool: Some("bash".to_string()),
+        },
+        command: "relative/script.sh".to_string(),
+        enabled: true,
+        policy: crate::hooks::external::ExternalHookPolicy::Allow,
+        ..Default::default()
+    };
+
+    let err = hook.validate().expect_err("relative path is rejected");
+    assert!(err.to_string().contains("path"));
+}
+
+#[test]
+fn external_hook_config_rejects_unknown_event_names() {
+    let err = toml::from_str::<Config>(
+        r#"
+[[hooks]]
+id = "bad-event"
+event = "before_everything"
+command = "audit-hook"
+"#,
+    )
+    .expect_err("unknown event names should not deserialize");
+
+    assert!(err.to_string().contains("unknown variant"));
+}
+
+#[test]
 fn codex_auth_token_from_file_prefers_api_key_then_access_token() {
     let dir = tempfile::tempdir().unwrap();
     let auth = dir.path().join("auth.json");

--- a/src/extensions/audit.rs
+++ b/src/extensions/audit.rs
@@ -65,6 +65,24 @@ pub struct CompactionAuditEvent {
     pub occurred_at: chrono::DateTime<chrono::Utc>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "action")]
+pub enum ExternalHookAuditAction {
+    Ran { outcome: String },
+    Denied { reason: String },
+    ApprovalRequired { reason: String },
+    Failed { reason: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExternalHookAuditEvent {
+    pub extension_id: String,
+    pub event: String,
+    pub command: String,
+    pub action: ExternalHookAuditAction,
+    pub occurred_at: chrono::DateTime<chrono::Utc>,
+}
+
 /// Polymorphic audit row recorded into [`ExtensionAuditLog`]. Each
 /// variant carries the typed payload for one event class.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -73,6 +91,7 @@ pub enum ExtensionAuditEvent {
     Permission(PermissionAuditEvent),
     InputIntercept(InputInterceptEvent),
     Compaction(CompactionAuditEvent),
+    ExternalHook(ExternalHookAuditEvent),
 }
 
 impl ExtensionAuditEvent {
@@ -83,6 +102,7 @@ impl ExtensionAuditEvent {
             Self::Permission(p) => &p.extension_id,
             Self::InputIntercept(i) => &i.extension_id,
             Self::Compaction(c) => &c.extension_id,
+            Self::ExternalHook(e) => &e.extension_id,
         }
     }
 
@@ -93,6 +113,7 @@ impl ExtensionAuditEvent {
             Self::Permission(p) => p.occurred_at,
             Self::InputIntercept(i) => i.occurred_at,
             Self::Compaction(c) => c.occurred_at,
+            Self::ExternalHook(e) => e.occurred_at,
         }
     }
 }

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -34,7 +34,8 @@ pub mod wasm;
 
 pub use audit::{
     CompactionAuditAction, CompactionAuditEvent, ExtensionAuditEvent, ExtensionAuditLog,
-    InputInterceptAction, InputInterceptEvent, PermissionAuditEvent, QuotaTracker,
+    ExternalHookAuditAction, ExternalHookAuditEvent, InputInterceptAction, InputInterceptEvent,
+    PermissionAuditEvent, QuotaTracker,
 };
 pub use config_field::{ExtensionConfigField, ExtensionFieldKind};
 pub use draft::parse_skill_extension;

--- a/src/hooks/external.rs
+++ b/src/hooks/external.rs
@@ -1,0 +1,601 @@
+//! User-configured subprocess hook handlers.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail};
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+use tokio::time::timeout;
+use tokio_util::sync::CancellationToken;
+
+use crate::extensions::{
+    ExtensionAuditEvent, ExtensionAuditLog, ExternalHookAuditAction, ExternalHookAuditEvent,
+};
+use crate::tools::ToolResult;
+
+use super::{HookHandler, HookOutcome};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExternalHookEvent {
+    BeforeToolCall,
+    AfterToolCall,
+}
+
+impl ExternalHookEvent {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::BeforeToolCall => "before_tool_call",
+            Self::AfterToolCall => "after_tool_call",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ExternalHookMatch {
+    pub tool: Option<String>,
+}
+
+impl ExternalHookMatch {
+    fn matches_tool(&self, tool: &str) -> bool {
+        self.tool.as_deref().is_none_or(|expected| expected == tool)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ExternalHookPolicy {
+    Allow,
+    #[default]
+    Deny,
+    RequireApproval,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ExternalHookConfig {
+    pub id: String,
+    pub event: ExternalHookEvent,
+    #[serde(rename = "match")]
+    pub match_rule: ExternalHookMatch,
+    pub command: String,
+    pub args: Vec<String>,
+    pub env: HashMap<String, String>,
+    pub enabled: bool,
+    pub policy: ExternalHookPolicy,
+    pub priority: i32,
+    pub timeout_secs: u64,
+}
+
+impl Default for ExternalHookConfig {
+    fn default() -> Self {
+        Self {
+            id: String::new(),
+            event: ExternalHookEvent::BeforeToolCall,
+            match_rule: ExternalHookMatch::default(),
+            command: String::new(),
+            args: Vec::new(),
+            env: HashMap::new(),
+            enabled: false,
+            policy: ExternalHookPolicy::Deny,
+            priority: 50,
+            timeout_secs: 10,
+        }
+    }
+}
+
+impl ExternalHookConfig {
+    pub fn timeout(&self) -> Duration {
+        Duration::from_secs(self.timeout_secs.max(1))
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        validate_id(&self.id)?;
+        if self.command.trim().is_empty() {
+            bail!("external hook `{}` command must not be empty", self.id);
+        }
+        if self.command.contains('/') || self.command.contains('\\') {
+            let path = Path::new(&self.command);
+            if !path.is_absolute() {
+                bail!(
+                    "external hook `{}` command path must be absolute: {}",
+                    self.id,
+                    self.command
+                );
+            }
+            if !path.is_file() {
+                bail!(
+                    "external hook `{}` command path does not exist or is not a file: {}",
+                    self.id,
+                    self.command
+                );
+            }
+        }
+        if !(0..=1000).contains(&self.priority) {
+            bail!(
+                "external hook `{}` priority must be between 0 and 1000",
+                self.id
+            );
+        }
+        if self.timeout_secs == 0 || self.timeout_secs > 300 {
+            bail!(
+                "external hook `{}` timeout_secs must be between 1 and 300",
+                self.id
+            );
+        }
+        if matches!(
+            self.event,
+            ExternalHookEvent::BeforeToolCall | ExternalHookEvent::AfterToolCall
+        ) && self.match_rule.tool.as_deref().is_some_and(str::is_empty)
+        {
+            bail!("external hook `{}` match.tool must not be empty", self.id);
+        }
+        Ok(())
+    }
+}
+
+fn validate_id(id: &str) -> Result<()> {
+    if id.is_empty() {
+        bail!("external hook id must not be empty");
+    }
+    if !id
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
+    {
+        bail!("external hook id `{id}` contains unsupported characters");
+    }
+    Ok(())
+}
+
+pub fn configured_handlers(
+    configs: &[ExternalHookConfig],
+    audit_log: Option<Arc<ExtensionAuditLog>>,
+) -> Vec<Arc<dyn HookHandler>> {
+    configs
+        .iter()
+        .filter(|cfg| cfg.enabled)
+        .filter_map(
+            |cfg| match ExternalHookHandler::new(cfg.clone(), audit_log.clone()) {
+                Ok(handler) => Some(Arc::new(handler) as Arc<dyn HookHandler>),
+                Err(err) => {
+                    tracing::warn!(hook_id = %cfg.id, %err, "skipping invalid external hook");
+                    None
+                }
+            },
+        )
+        .collect()
+}
+
+pub struct ExternalHookHandler {
+    config: ExternalHookConfig,
+    audit_log: Option<Arc<ExtensionAuditLog>>,
+}
+
+impl ExternalHookHandler {
+    pub fn new(
+        config: ExternalHookConfig,
+        audit_log: Option<Arc<ExtensionAuditLog>>,
+    ) -> Result<Self> {
+        config.validate()?;
+        Ok(Self { config, audit_log })
+    }
+
+    fn allowed_by_policy(&self) -> bool {
+        match self.config.policy {
+            ExternalHookPolicy::Allow => true,
+            ExternalHookPolicy::Deny => {
+                self.record(ExternalHookAuditAction::Denied {
+                    reason: "external hook policy is deny".to_string(),
+                });
+                false
+            }
+            ExternalHookPolicy::RequireApproval => {
+                self.record(ExternalHookAuditAction::ApprovalRequired {
+                    reason: "external hook requires approval; no approval flow is available for subprocess hooks yet".to_string(),
+                });
+                false
+            }
+        }
+    }
+
+    async fn dispatch(&self, event: ExternalHookEvent, payload: Value) -> Result<HookOutcome> {
+        if !self.allowed_by_policy() {
+            return Ok(HookOutcome::Continue);
+        }
+
+        let input = json!({
+            "vulcan_hook_version": 1,
+            "event": event.as_str(),
+            "hook": {
+                "id": self.config.id,
+                "priority": self.config.priority,
+            },
+            "payload": payload,
+        });
+        let input = serde_json::to_vec(&input)?;
+
+        let mut child = match Command::new(&self.config.command)
+            .args(&self.config.args)
+            .envs(&self.config.env)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+        {
+            Ok(child) => child,
+            Err(err) => {
+                self.record(ExternalHookAuditAction::Failed {
+                    reason: format!("spawn failed: {err}"),
+                });
+                return Err(err).with_context(|| {
+                    format!("failed to spawn external hook `{}`", self.config.id)
+                });
+            }
+        };
+
+        if let Some(stdin) = child.stdin.as_mut() {
+            stdin.write_all(&input).await?;
+            stdin.shutdown().await?;
+        }
+
+        let output = match timeout(self.config.timeout(), child.wait_with_output()).await {
+            Ok(result) => result?,
+            Err(_) => {
+                self.record(ExternalHookAuditAction::Failed {
+                    reason: "timeout".to_string(),
+                });
+                bail!("external hook `{}` timed out", self.config.id);
+            }
+        };
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            self.record(ExternalHookAuditAction::Failed {
+                reason: format!("exit status {}: {stderr}", output.status),
+            });
+            bail!(
+                "external hook `{}` exited with {}",
+                self.config.id,
+                output.status
+            );
+        }
+
+        let outcome: HookOutcome = match serde_json::from_slice(&output.stdout) {
+            Ok(outcome) => outcome,
+            Err(err) => {
+                self.record(ExternalHookAuditAction::Failed {
+                    reason: format!("malformed HookOutcome JSON: {err}"),
+                });
+                return Err(err).with_context(|| {
+                    format!(
+                        "external hook `{}` returned malformed HookOutcome JSON",
+                        self.config.id
+                    )
+                });
+            }
+        };
+        self.record(ExternalHookAuditAction::Ran {
+            outcome: outcome_name(&outcome).to_string(),
+        });
+        Ok(outcome)
+    }
+
+    fn record(&self, action: ExternalHookAuditAction) {
+        let Some(log) = self.audit_log.as_ref() else {
+            return;
+        };
+        log.record(ExtensionAuditEvent::ExternalHook(ExternalHookAuditEvent {
+            extension_id: self.config.id.clone(),
+            event: self.config.event.as_str().to_string(),
+            command: self.config.command.clone(),
+            action,
+            occurred_at: Utc::now(),
+        }));
+    }
+}
+
+fn outcome_name(outcome: &HookOutcome) -> &'static str {
+    match outcome {
+        HookOutcome::Continue => "continue",
+        HookOutcome::Block { .. } => "block",
+        HookOutcome::ReplaceArgs(_) => "replace_args",
+        HookOutcome::ReplaceResult(_) => "replace_result",
+        HookOutcome::InjectMessages { .. } => "inject_messages",
+        HookOutcome::RewriteMessages(_) => "rewrite_messages",
+        HookOutcome::RewriteHistory(_) => "rewrite_history",
+        HookOutcome::ForceContinue { .. } => "force_continue",
+        HookOutcome::BlockInput { .. } => "block_input",
+        HookOutcome::ReplaceInput(_) => "replace_input",
+    }
+}
+
+#[async_trait::async_trait]
+impl HookHandler for ExternalHookHandler {
+    fn name(&self) -> &str {
+        &self.config.id
+    }
+
+    fn priority(&self) -> i32 {
+        self.config.priority
+    }
+
+    async fn before_tool_call(
+        &self,
+        tool: &str,
+        args: &Value,
+        _cancel: CancellationToken,
+    ) -> Result<HookOutcome> {
+        if self.config.event != ExternalHookEvent::BeforeToolCall
+            || !self.config.match_rule.matches_tool(tool)
+        {
+            return Ok(HookOutcome::Continue);
+        }
+        self.dispatch(
+            ExternalHookEvent::BeforeToolCall,
+            json!({ "tool": tool, "args": args }),
+        )
+        .await
+    }
+
+    async fn after_tool_call(
+        &self,
+        tool: &str,
+        result: &ToolResult,
+        _cancel: CancellationToken,
+    ) -> Result<HookOutcome> {
+        if self.config.event != ExternalHookEvent::AfterToolCall
+            || !self.config.match_rule.matches_tool(tool)
+        {
+            return Ok(HookOutcome::Continue);
+        }
+        self.dispatch(
+            ExternalHookEvent::AfterToolCall,
+            json!({ "tool": tool, "result": result }),
+        )
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::hooks::{HookRegistry, ToolCallDecision};
+
+    #[tokio::test]
+    async fn subprocess_hook_can_block_before_tool_call() {
+        let hook = ExternalHookHandler::new(
+            ExternalHookConfig {
+                id: "block-bash".to_string(),
+                event: ExternalHookEvent::BeforeToolCall,
+                match_rule: ExternalHookMatch {
+                    tool: Some("bash".to_string()),
+                },
+                command: "sh".to_string(),
+                args: vec![
+                    "-c".to_string(),
+                    "payload=$(cat); case \"$payload\" in *'\"event\":\"before_tool_call\"'*'\"tool\":\"bash\"'*) printf '%s' '{\"Block\":{\"reason\":\"no shell\"}}';; *) printf '%s' \"$payload\" >&2; exit 9;; esac".to_string(),
+                ],
+                enabled: true,
+                policy: ExternalHookPolicy::Allow,
+                ..Default::default()
+            },
+            None,
+        )
+        .unwrap();
+
+        let outcome = hook
+            .before_tool_call(
+                "bash",
+                &json!({ "command": "rm -rf target" }),
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        assert!(matches!(outcome, HookOutcome::Block { reason } if reason == "no shell"));
+    }
+
+    #[tokio::test]
+    async fn denied_policy_continues_and_records_audit() {
+        let audit = Arc::new(ExtensionAuditLog::new(8));
+        let hook = ExternalHookHandler::new(
+            ExternalHookConfig {
+                id: "denied-hook".to_string(),
+                event: ExternalHookEvent::BeforeToolCall,
+                match_rule: ExternalHookMatch {
+                    tool: Some("bash".to_string()),
+                },
+                command: "sh".to_string(),
+                enabled: true,
+                policy: ExternalHookPolicy::Deny,
+                ..Default::default()
+            },
+            Some(audit.clone()),
+        )
+        .unwrap();
+
+        let outcome = hook
+            .before_tool_call("bash", &json!({}), CancellationToken::new())
+            .await
+            .unwrap();
+        assert!(matches!(outcome, HookOutcome::Continue));
+
+        let recent = audit.recent(1);
+        assert!(matches!(
+            &recent[0],
+            ExtensionAuditEvent::ExternalHook(ExternalHookAuditEvent {
+                extension_id,
+                action: ExternalHookAuditAction::Denied { .. },
+                ..
+            }) if extension_id == "denied-hook"
+        ));
+    }
+
+    #[tokio::test]
+    async fn require_approval_policy_continues_and_records_audit() {
+        let audit = Arc::new(ExtensionAuditLog::new(8));
+        let hook = ExternalHookHandler::new(
+            ExternalHookConfig {
+                id: "approval-hook".to_string(),
+                event: ExternalHookEvent::BeforeToolCall,
+                match_rule: ExternalHookMatch {
+                    tool: Some("bash".to_string()),
+                },
+                command: "sh".to_string(),
+                enabled: true,
+                policy: ExternalHookPolicy::RequireApproval,
+                ..Default::default()
+            },
+            Some(audit.clone()),
+        )
+        .unwrap();
+
+        let outcome = hook
+            .before_tool_call("bash", &json!({}), CancellationToken::new())
+            .await
+            .unwrap();
+        assert!(matches!(outcome, HookOutcome::Continue));
+
+        let recent = audit.recent(1);
+        assert!(matches!(
+            &recent[0],
+            ExtensionAuditEvent::ExternalHook(ExternalHookAuditEvent {
+                extension_id,
+                action: ExternalHookAuditAction::ApprovalRequired { reason },
+                ..
+            }) if extension_id == "approval-hook" && reason.contains("requires approval")
+        ));
+    }
+
+    #[tokio::test]
+    async fn registry_turns_subprocess_failure_into_safe_continue() {
+        let audit = Arc::new(ExtensionAuditLog::new(8));
+        let reg = HookRegistry::new().with_audit_log(audit.clone());
+        for hook in configured_handlers(
+            &[ExternalHookConfig {
+                id: "failing-hook".to_string(),
+                event: ExternalHookEvent::BeforeToolCall,
+                match_rule: ExternalHookMatch {
+                    tool: Some("bash".to_string()),
+                },
+                command: "sh".to_string(),
+                args: vec![
+                    "-c".to_string(),
+                    "printf '%s' 'bad news' >&2; exit 17".to_string(),
+                ],
+                enabled: true,
+                policy: ExternalHookPolicy::Allow,
+                ..Default::default()
+            }],
+            reg.audit_log(),
+        ) {
+            reg.register(hook);
+        }
+
+        let decision = reg
+            .before_tool_call("bash", &json!({}), CancellationToken::new())
+            .await;
+        assert!(matches!(decision, ToolCallDecision::Continue));
+        assert_eq!(reg.failure_metrics().errors, 1);
+
+        let recent = audit.recent(1);
+        assert!(matches!(
+            &recent[0],
+            ExtensionAuditEvent::ExternalHook(ExternalHookAuditEvent {
+                extension_id,
+                action: ExternalHookAuditAction::Failed { reason },
+                ..
+            }) if extension_id == "failing-hook" && reason.contains("bad news")
+        ));
+    }
+
+    #[tokio::test]
+    async fn registry_turns_subprocess_timeout_into_safe_continue() {
+        let audit = Arc::new(ExtensionAuditLog::new(8));
+        let reg = HookRegistry::new().with_audit_log(audit.clone());
+        for hook in configured_handlers(
+            &[ExternalHookConfig {
+                id: "slow-hook".to_string(),
+                event: ExternalHookEvent::BeforeToolCall,
+                match_rule: ExternalHookMatch {
+                    tool: Some("bash".to_string()),
+                },
+                command: "sh".to_string(),
+                args: vec!["-c".to_string(), "sleep 2".to_string()],
+                enabled: true,
+                policy: ExternalHookPolicy::Allow,
+                timeout_secs: 1,
+                ..Default::default()
+            }],
+            reg.audit_log(),
+        ) {
+            reg.register(hook);
+        }
+
+        let decision = reg
+            .before_tool_call("bash", &json!({}), CancellationToken::new())
+            .await;
+        assert!(matches!(decision, ToolCallDecision::Continue));
+        assert_eq!(reg.failure_metrics().errors, 1);
+
+        let recent = audit.recent(1);
+        assert!(matches!(
+            &recent[0],
+            ExtensionAuditEvent::ExternalHook(ExternalHookAuditEvent {
+                extension_id,
+                action: ExternalHookAuditAction::Failed { reason },
+                ..
+            }) if extension_id == "slow-hook" && reason == "timeout"
+        ));
+    }
+
+    #[tokio::test]
+    async fn registry_turns_malformed_subprocess_stdout_into_safe_continue() {
+        let audit = Arc::new(ExtensionAuditLog::new(8));
+        let reg = HookRegistry::new().with_audit_log(audit.clone());
+        for hook in configured_handlers(
+            &[ExternalHookConfig {
+                id: "malformed-hook".to_string(),
+                event: ExternalHookEvent::BeforeToolCall,
+                match_rule: ExternalHookMatch {
+                    tool: Some("bash".to_string()),
+                },
+                command: "sh".to_string(),
+                args: vec!["-c".to_string(), "printf '%s' 'not json'".to_string()],
+                enabled: true,
+                policy: ExternalHookPolicy::Allow,
+                ..Default::default()
+            }],
+            reg.audit_log(),
+        ) {
+            reg.register(hook);
+        }
+
+        let decision = reg
+            .before_tool_call("bash", &json!({}), CancellationToken::new())
+            .await;
+        assert!(matches!(decision, ToolCallDecision::Continue));
+        assert_eq!(reg.failure_metrics().errors, 1);
+
+        let recent = audit.recent(1);
+        assert!(matches!(
+            &recent[0],
+            ExtensionAuditEvent::ExternalHook(ExternalHookAuditEvent {
+                extension_id,
+                action: ExternalHookAuditAction::Failed { reason },
+                ..
+            }) if extension_id == "malformed-hook" && reason.contains("malformed HookOutcome JSON")
+        ));
+    }
+}

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -45,6 +45,7 @@ pub mod approval;
 pub mod cortex_capture;
 pub mod cortex_recall;
 pub mod diagnostics;
+pub mod external;
 pub mod prefer_native;
 pub mod recall;
 pub mod rtk;
@@ -403,6 +404,10 @@ impl HookRegistry {
     pub fn with_audit_log(mut self, log: Arc<crate::extensions::ExtensionAuditLog>) -> Self {
         self.audit_log = Some(log);
         self
+    }
+
+    pub fn audit_log(&self) -> Option<Arc<crate::extensions::ExtensionAuditLog>> {
+        self.audit_log.clone()
     }
 
     pub fn with_input_rewrite_pause_channel(mut self, pause_tx: PauseSender) -> Self {


### PR DESCRIPTION
## Summary
- Adds user-configured subprocess hook handlers from `[[hooks]]` config.
- Sends structured JSON event payloads over stdin and accepts JSON `HookOutcome` responses over stdout.
- Validates hook ids, event names, match rules, command paths, priority, timeout, and default-deny policy.
- Records audit events for runs, denials, approval-required policy, failures, and timeouts.

## Verification
- cargo test hooks::external --lib
- cargo test external_hook --lib
- cargo fmt --all -- --check
- cargo check -p vulcan-core
- cargo check -p vulcan --bin vulcan
- cargo clippy -p vulcan-core --lib --tests
- git diff --check

Fixes #3
