### PR TITLE
docs: sync extension runtime trust ladder

### DIFF
--- a/docs/features/developer-experience.md
+++ b/docs/features/developer-experience.md
@@ -13,7 +13,7 @@ Make building, testing, and distributing extensions as easy as possible.
 
 A unified CLI for the extension lifecycle.
 
-- `vulcan extension new <name>` — Scaffold a new extension (choose language/target: rust/wasm/js/py). Generates manifest, stub trait impl, CI template, README.
+- `vulcan extension new <name>` — Scaffold a new extension (choose runtime class: wasm for third-party managed code, subprocess for local scripts/tools, mcp for protocol bridges, or native_first_party for trusted internal cargo-crate work). Generates manifest, stub runtime entry, CI template, README.
 - `vulcan extension build` — Build for selected target(s); produce `.vpk` packages.
 - `vulcan extension test` — Spin up an isolated sandbox agent and run integration tests against extension hooks.
 - `vulcan extension run` — Run extension in local dev agent with hot reload (watch and reload on changes).
@@ -31,8 +31,8 @@ A test harness that implements `ExtensionContext` for unit and integration testi
 ## Live Debugging & Hot Reload
 
 - **WASM**: Restart Wasmtime instance without restarting the host process; preserve minimal state across reloads.
-- **Native (dev mode)**: Allow loading debug `.so`/`.dylib` from `target/debug/` and auto-reload when file changes (on platforms that support it safely).
-- **Scripting**: Evaluate updated JS/Python modules in place.
+- **Native first-party (dev mode)**: Allow trusted internal cargo-crate extension debugging. Loading debug `.so`/`.dylib` from `target/debug/` remains an internal experiment only, not a marketplace or third-party path.
+- **Scripting**: Reload subprocess adapter commands or WASM components; generalized in-process JS/Python embedding is deferred.
 - **Attach debugger**: Debuginfo for native extensions; console + simple step-through UI for WASM.
 
 ## Templates & Starters

--- a/docs/features/extension-runtime-trust-ladder.md
+++ b/docs/features/extension-runtime-trust-ladder.md
@@ -1,0 +1,88 @@
+---
+title: Extension Runtime Trust Ladder
+type: policy
+created: 2026-05-05
+tags: [extensions, runtime, trust, policy, wasm, mcp]
+tracks: [611, 548, 264, 273, 276, 3, 268, 274]
+---
+
+# Extension Runtime Trust Ladder
+
+Status: canonical repository copy of the policy from `~/wiki/queries/vulcan-extension-runtime-trust-ladder.md`.
+
+Vulcan chooses extension/runtime boundaries by author trust and operational risk:
+
+```text
+trusted first-party/internal code -> native cargo-crate extensions
+third-party policy-limited code    -> WASM / Wasmtime runtime
+external tools and services        -> subprocess hooks or MCP bridge
+heavy inference/deployment stacks  -> external backend endpoints
+```
+
+Native in-process Rust extensions are the first-party/internal path. They are not a sandbox boundary. Third-party extension code should target WASM/Wasmtime when it needs to run inside a Vulcan-managed runtime. External tools and services should cross a process or protocol boundary through subprocess hooks or MCP. Heavy inference and deployment platforms stay outside Vulcan as backend endpoints.
+
+Generalized in-process JS/Python runtimes are deferred. If a JS/Python use case becomes concrete, the default boundary is a subprocess or WASM component model, not embedding a broad interpreter into the daemon.
+
+## Runtime classes
+
+| Runtime class | Intended authors | Trust boundary | Supported use | Deferred or denied |
+|---|---|---|---|---|
+| Native cargo-crate extension | Vulcan core, first-party, internal workspace code | Same process, trusted code | Core hooks, first-party tools, providers, frontend renderers, status widgets, trusted state | Third-party marketplace code; arbitrary native dynamic loading |
+| WASM / Wasmtime extension | Third-party code with policy-limited host access | Memory-isolated runtime with explicit host imports | Third-party tools, hooks, state APIs, policy-limited UI events, controlled network/process/MCP capabilities | Direct host filesystem/network/process access without declared capabilities |
+| Subprocess hook or adapter | User scripts, local tools, language-specific integrations | OS process boundary with stdin/stdout protocol, timeout, env/path policy | External hook handlers, CLI adapters, JS/Python/Ruby scripts, one-off local automation | Silent background daemons; unbounded process trees; unaudited mutation |
+| MCP bridge | External tools and services exposing MCP | Protocol boundary plus server process/remote transport policy | Discover tools/resources/prompts and expose selected capabilities through Vulcan's tool registry | Sampling recursion, remote transport, or managed hosting before core MCP policy exists |
+| External backend endpoint | Inference servers, deployment platforms, heavy service stacks | Network/API boundary | OpenAI-compatible model backends, BentoML/vLLM/Ollama/LiteLLM recipes | Embedding heavy serving stacks into the Vulcan daemon |
+
+## Capability and audit requirements
+
+All runtime classes must declare capabilities before activation. The minimum capability set is:
+
+- `hooks`: which hook/event methods can observe, rewrite, block, or replace data.
+- `tools`: tool names, replay-safety ceiling, mutation class, and approval requirements.
+- `providers`: provider ids, defaults, model/endpoint fields, and whether instances are singleton or per-session.
+- `ui`: frontend capability requirements such as text I/O, dialogs, widgets, canvas, raw keys, or ticks.
+- `state`: extension-owned persistent state, branch policy, checkpointing, and cross-session writes.
+- `filesystem`, `network`, `process`, `mcp`: external access scopes, if any.
+
+Every activation decision must be auditable. The host must be able to answer:
+
+- which extension ran;
+- which runtime class it used;
+- which capabilities it requested;
+- which capabilities were allowed or denied;
+- which resource limits applied;
+- what user approval was required;
+- what load, policy, timeout, or crash failure occurred.
+
+Denied capabilities fail the extension operation and record an audit/status reason. They must not crash Vulcan or silently degrade into broader access.
+
+## Registration surface policy
+
+| Extension capability | Native first-party | WASM third-party | Subprocess | MCP bridge |
+|---|---|---|---|---|
+| Hooks/events | Yes | Yes, after policy wrappers | Yes, JSON event protocol | Bridge-observer only until MCP policy expands |
+| Tools | Yes | Yes, capability-gated | Yes, via adapter | Yes, selected discovered tools |
+| Providers | Yes | Later, only with explicit network/model policy | Prefer external endpoint adapter | No direct provider role initially |
+| Frontend UI surfaces | Yes, via frontend extension API | Limited events/render hints after capability handshake | No direct UI ownership; can emit audited status | No direct UI ownership; can expose tool/resource metadata |
+| Persistent state | Yes, through `ExtensionStateStore` | Yes, scoped and quota-limited | Host-owned state API only | Host-owned state/cache API only |
+| Raw filesystem/network/process | Trusted code only | Deny by default; explicit host imports | Configured command/env/path policy | Server config and transport policy |
+
+Native dynamic library loading through `dlopen`/`libloading` is not the marketplace path. It remains restricted to trusted internal/first-party experiments until signing, source trust, crash isolation, and update policy are mature.
+
+## Existing issue mapping
+
+- `#548` PRD: remains the in-process first-party extension design. Its native cargo-crate model is trusted/internal, not a third-party sandbox.
+- `#264` extension ecosystem epic: treats this trust ladder as the parent policy for child specs.
+- `#273` sandboxed extension runtimes: is the third-party runtime path and starts with WASM/Wasmtime plus explicit host capabilities.
+- `#276` marketplace/discovery: must not install arbitrary native code as the default path. Marketplace records identify runtime class, checksum/signature, publisher trust, and required capabilities.
+- `#3` external hook handlers: maps to subprocess hooks with JSON event payloads, timeout, stderr/log capture, command/env/path policy, and audit entries.
+- `#268` MCP client bridge: maps to external tools/services through a protocol/process boundary. MCP tools are exposed only when explicitly configured and selected.
+- `#274` managed MCP hosting: remains later than the stdio MCP bridge and inherits this policy before adding hosting, remote transport, or sampling.
+
+## Consequences
+
+- Extension docs and issues say "native first-party cargo-crate extension" when code runs in-process.
+- Third-party extension language defaults to "WASM/Wasmtime runtime" unless the topic is specifically subprocess or MCP.
+- Marketplace/store work requires runtime-class metadata and capability/audit metadata before install or activation.
+- JS/Python extension requests start as subprocess hooks or WASM components. In-process interpreter embedding needs a separate accepted policy.
+- Backend-serving technologies such as BentoML, vLLM, Ollama, LiteLLM, and llama.cpp stay as provider endpoints or deployment recipes unless a separate issue proves a native daemon need.

--- a/docs/features/extension-store.md
+++ b/docs/features/extension-store.md
@@ -1,6 +1,6 @@
 # Extension Store / Repository — Design & Implementation Plan
 
-This document describes how to add an extension store and repository system to Vulcan, enabling third-party extensions to be discovered, installed, verified, and loaded safely at runtime.
+This document describes how to add an extension store and repository system to Vulcan, enabling third-party extensions to be discovered, installed, verified, and loaded safely at runtime. Store and marketplace work follows the [Extension Runtime Trust Ladder](./extension-runtime-trust-ladder.md): first-party/internal code may use native cargo-crate extensions, third-party code defaults to WASM/Wasmtime, external tools cross subprocess or MCP boundaries, and inference/deployment stacks remain external backend endpoints.
 
 > **Prerequisite context:** See [`docs/features/extensions.md`](./extensions.md) for the lighter-weight skill→extension promotion path that feeds into this system. This document assumes extensions already exist as a concept and focuses on the packaging, distribution, and dynamic-loading infrastructure.
 
@@ -57,8 +57,8 @@ pub enum Capability {
 ```
 my-extension/
 ├── extension.toml          # Manifest (required)
-├── extension.wasm          # Or .so/.dylib/.dll (compiled)
-├── extension.js            # Or .py (scripted)
+├── extension.wasm          # Preferred third-party managed runtime
+├── adapter.sh              # Optional subprocess adapter for local tools/scripts
 ├── schema.json             # Tool/API schemas
 ├── README.md
 └── LICENSE
@@ -73,12 +73,25 @@ version = "1.0.0"
 description = "Store agent memory in Redis"
 author = "Jane Doe"
 license = "MIT"
-language = "rust"            # or "wasm", "js", "python"
-entry = "libmemory_redis.so" # or "extension.wasm"
+language = "wasm"                  # preferred third-party managed runtime
+runtime_class = "wasm"             # wasm | subprocess | mcp | native_first_party
+entry = "extension.wasm"
 signature = "sha256:abc123..."
+
+[trust]
+publisher = "verified-publisher-id"
+source = "marketplace"
+checksum = "sha256:abc123..."
 
 [capabilities]
 memory_backend = "redis"
+filesystem = "none"
+network = ["redis.internal:6379"]
+process = "none"
+
+[audit]
+record_activation = true
+record_denied_capabilities = true
 
 [dependencies]
 redis = "0.23"
@@ -112,6 +125,10 @@ pub struct ExtensionRecord {
     pub signature: String,            // GPG/ed25519 signature
     pub min_vulcan_version: Option<String>,
     pub max_vulcan_version: Option<String>,
+    pub runtime_class: RuntimeClass,       // wasm | subprocess | mcp | native_first_party
+    pub publisher_trust: PublisherTrust,
+    pub required_capabilities: Vec<Capability>,
+    pub audit_requirements: AuditRequirements,
 }
 ```
 
@@ -165,12 +182,12 @@ impl ExtensionStore {
     pub fn load(&self, id: &str) -> Result<()> {
         let manifest = self.read_manifest(id)?;
 
-        match manifest.language.as_str() {
-            "rust"  => self.load_native(id, &manifest),
-            "wasm"  => self.load_wasm(id, &manifest),
-            "js"    => self.load_javascript(id, &manifest),
-            "python" => self.load_python(id, &manifest),
-            _ => anyhow::bail!("Unsupported language"),
+        match manifest.runtime_class.as_str() {
+            "wasm" => self.load_wasm(id, &manifest),
+            "subprocess" => self.load_subprocess_adapter(id, &manifest),
+            "mcp" => self.configure_mcp_bridge(id, &manifest),
+            "native_first_party" => self.load_native_first_party(id, &manifest),
+            _ => anyhow::bail!("Unsupported runtime class"),
         }
     }
 }
@@ -180,83 +197,38 @@ impl ExtensionStore {
 
 ## 4. Runtime Loading Strategies
 
-### Strategy A: Native (Rust) — Dynamic Libraries
+Runtime loading follows the trust ladder instead of treating every package as eligible for arbitrary native loading.
 
-```rust
-impl ExtensionStore {
-    fn load_native(&self, id: &str, manifest: &Manifest) -> Result<()> {
-        let lib_path = self.install_dir.join(id).join(&manifest.entry);
+### Strategy A: WASM / Wasmtime — Default for Third-Party Managed Code
 
-        // SAFETY: Library signature was already verified.
-        // Loading untrusted code can still compromise the process.
-        // For stronger isolation, use WASM or a child process.
-        let lib = unsafe { libloading::Library::new(lib_path)? };
-
-        let factory: libloading::Symbol<
-            unsafe extern fn() -> *mut dyn Extension,
-        > = unsafe { lib.get(b"create_extension") }?;
-
-        let extension = unsafe { Box::from_raw(factory()) };
-        extension.initialize(&ExtensionContext::new(self.shared_state.clone()))?;
-
-        self.loaded_extensions
-            .write()
-            .insert(id.to_string(), extension);
-        Ok(())
-    }
-}
-```
-
-**Extension Crate** (published separately):
-
-```rust
-use vulcan_extension::{Extension, ExtensionMetadata};
-
-pub struct RedisMemory { client: redis::Client }
-
-impl Extension for RedisMemory {
-    fn metadata(&self) -> &ExtensionMetadata { /* ... */ }
-    fn initialize(&self, ctx: &ExtensionContext) -> Result<()> {
-        ctx.register_memory_backend("redis", Arc::new(self.clone()));
-        Ok(())
-    }
-}
-
-// Required export — dynamic library entry point
-#[no_mangle]
-pub unsafe extern fn create_extension() -> *mut dyn Extension {
-    Box::into_raw(Box::new(RedisMemory::new()))
-}
-```
-
-### Strategy B: WebAssembly — Sandboxed
+Use this for marketplace extensions that need to execute inside a Vulcan-managed runtime. Host imports are explicit, capability-gated, resource-limited, and auditable.
 
 ```rust
 fn load_wasm(&self, id: &str, manifest: &Manifest) -> Result<()> {
     use wasmtime::*;
 
+    self.policy.require_runtime_class(id, "wasm")?;
+    self.policy.check_capabilities(id, &manifest.capabilities)?;
+
     let engine = Engine::default();
     let module = Module::from_file(&engine, &manifest.entry)?;
-
     let mut linker = Linker::new(&engine);
 
-    // Provide safe host functions (capability-gated)
+    // Host functions are capability-gated and audited.
     linker.func_wrap("env", "log", |msg: String| {
         log::info!("[wasm ext {}]: {}", id, msg);
     })?;
     linker.func_wrap("env", "register_tool", ...)?;
 
-    let mut store = Store::new(&engine, ());
-    store.limiter(|_| &mut StoreLimiter {
-        memory_size: 1024 * 1024 * 10, // 10 MB cap
-        ..Default::default()
-    });
+    let mut store = Store::new(&engine, ExtensionHostState::new(id, manifest));
+    store.limiter(|state| &mut state.limits);
 
     let instance = linker.instantiate(&mut store, &module)?;
     let init = instance.get_typed_func::<(), ()>(&mut store, "init")
         .ok_or_else(|| anyhow!("Missing init export"))?;
 
     init.call(&mut store, ())?;
+    self.audit.record_activation(id, "wasm", &manifest.capabilities)?;
     Ok(())
 }
 ```
@@ -268,29 +240,59 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 pub fn init() {
+    // Host import succeeds only when the manifest requested and policy allowed it.
     register_tool("weather", WeatherTool {});
 }
 ```
 
-### Strategy C: Scripting (JavaScript / Python)
+### Strategy B: Subprocess Adapter — Local Scripts and Language-Specific Integrations
+
+Use subprocess adapters for user scripts, JS/Python/Ruby integrations, and local tools. The manifest declares the command, allowed arguments/environment, timeout, and capability scope; Vulcan sends JSON event payloads over stdin/stdout and records timeout, stderr, exit status, and denied capabilities.
 
 ```rust
-fn load_javascript(&self, id: &str, manifest: &Manifest) -> Result<()> {
-    use deno_core::*;
-
-    let mut runtime = JsRuntime::new(RuntimeOptions {
-        extensions: vec![Extension::builder()
-            .ops(vec![op_register_tool::<NotNeeded>])
-            .build()],
-        ..Default::default()
+fn load_subprocess_adapter(&self, id: &str, manifest: &Manifest) -> Result<()> {
+    self.policy.require_runtime_class(id, "subprocess")?;
+    self.policy.check_command_scope(&manifest.command, &manifest.env_allowlist)?;
+    self.subprocess_registry.insert(SubprocessAdapter {
+        id: id.to_string(),
+        command: manifest.command.clone(),
+        timeout: manifest.timeout,
+        capabilities: manifest.capabilities.clone(),
     });
-
-    let script = std::fs::read_to_string(&manifest.entry)?;
-    runtime.execute_script("<extension>", script)?;
+    self.audit.record_activation(id, "subprocess", &manifest.capabilities)?;
     Ok(())
 }
 ```
 
+### Strategy C: MCP Bridge — External Tools and Services
+
+Use MCP for tools/resources/prompts exposed through protocol boundaries. Servers are explicitly configured and selected; remote transport, sampling, and managed hosting stay disabled until their specific policy is accepted.
+
+```rust
+fn configure_mcp_bridge(&self, id: &str, manifest: &Manifest) -> Result<()> {
+    self.policy.require_runtime_class(id, "mcp")?;
+    self.policy.check_mcp_server(&manifest.mcp_server)?;
+    self.mcp_bridge.expose_selected_tools(&manifest.mcp_server, &manifest.allowed_tools)?;
+    self.audit.record_activation(id, "mcp", &manifest.capabilities)?;
+    Ok(())
+}
+```
+
+### Strategy D: Native First-Party Cargo Crates — Trusted/Internal Only
+
+Native in-process Rust code is the first-party/internal path. It is not a sandbox boundary and is not the marketplace default. Dynamic library loading through `dlopen`/`libloading` remains restricted to trusted internal experiments until signing, source trust, crash isolation, and update policy are mature.
+
+```rust
+fn load_native_first_party(&self, id: &str, manifest: &Manifest) -> Result<()> {
+    self.policy.require_runtime_class(id, "native_first_party")?;
+    self.policy.require_first_party_source(id, manifest)?;
+    // Trusted code is linked as a cargo-crate extension; arbitrary marketplace
+    // dylibs are rejected before this path.
+    self.first_party_registry.activate(id, manifest)?;
+    self.audit.record_activation(id, "native_first_party", &manifest.capabilities)?;
+    Ok(())
+}
+```
 ---
 
 ## 5. Security Model
@@ -321,10 +323,11 @@ environment = false        # allow env var access
 memory_limit = "64MB"
 ```
 
-3. **Sandboxing**
-   - **WASM**: Full memory isolation; only imported host functions are available.
-   - **Native**: Run untrusted extensions in a child process with seccomp-bpf (Linux) or sandbox-exec (macOS).
-   - **Scripts**: Restricted globals; deny `fs`, `child_process`, etc.
+3. **Sandboxing and boundaries**
+   - **WASM**: Default third-party runtime; memory isolation, resource limits, and explicit host imports only.
+   - **Subprocess**: OS process boundary for scripts/local tools; command, env, path, timeout, stderr, and process-tree policy are enforced.
+   - **MCP**: Protocol/process boundary for external tools and services; only explicitly configured and selected tools/resources are exposed.
+   - **Native first-party**: Trusted/internal cargo-crate extensions only. Native code is not a sandbox and is not the marketplace default.
 
 4. **Resource Limits** (WASM)
    - Max memory: 10–64 MB
@@ -567,8 +570,10 @@ impl EventHandler for MyLogger {
 
 ```rust
 pub struct ExtensionStore {
-    trusted_extensions: HashSet<String>, // IDs
-    trusted_signers: HashSet<PublicKey>,
+    pub trusted_extensions: HashSet<String>, // IDs plus accepted manifest checksum
+    pub trusted_signers: HashSet<PublicKey>,
+    pub allowed_runtime_classes: HashSet<RuntimeClass>,
+    pub denied_capabilities: Vec<DeniedCapability>,
 }
 ```
 
@@ -669,8 +674,8 @@ Vulcan now uses Redis for memory storage when configured.
 | **Package Format (.vpk)** | Bundled manifest + binary/assets |
 | **Repository Index** | JSON catalog of available extensions |
 | **Signature Verification** | GPG/Ed25519 signing & trust |
-| **Runtime Loaders** | Native (dylib) / WASM / Script (JS/Py) |
-| **Sandboxing** | Capability-based permissions & isolation |
+| **Runtime Loaders** | WASM / Subprocess / MCP bridge / trusted native first-party |
+| **Sandboxing** | Capability-based permissions, isolation boundaries, resource limits, and audit records |
 | **Extension Context** | Safe APIs for integration |
 | **CLI / Agent Commands** | Discover, install, manage extensions |
 

--- a/docs/features/extensions.md
+++ b/docs/features/extensions.md
@@ -64,7 +64,7 @@ Extensions live in `~/.vulcan/extensions/`. The `ExtensionRegistry` mirrors `Ski
 
 ## Future: code-backed extensions
 
-The long-term vision (Phase 3 per the master plan) is for extensions to have compiled Rust hook handlers — either in-tree (built into the binary) or dynamically loaded. This mirrors the OpenClaw plugin architecture referenced in [`~/wiki/queries/rust-hermes-plan.md`](../../wiki/queries/rust-hermes-plan.md).
+The long-term vision (Phase 3 per the master plan) is for extensions to have compiled Rust hook handlers for trusted first-party/internal code. This native cargo-crate path is not a sandbox boundary and is not the default third-party marketplace runtime; see the [Extension Runtime Trust Ladder](./extension-runtime-trust-ladder.md). Third-party code that needs a Vulcan-managed runtime should target WASM/Wasmtime, while local scripts and external services should cross subprocess or MCP boundaries.
 
 ```rust
 // Future Extension trait sketch
@@ -91,6 +91,6 @@ Skills use the hook system indirectly via `SkillsHook`. Extensions use it direct
 
 ## Future: dynamic extension store
 
-The long-term vision for packaged, installable extensions with cryptographic signing, sandboxed runtimes (WASM, native dynamic libraries, scripting), and a remote repository index is documented separately in [`docs/features/extension-store.md`](./extension-store.md).
+The long-term vision for packaged, installable extensions with cryptographic signing, sandboxed WASM runtimes, subprocess/MCP adapters, runtime-class metadata, and a remote repository index is documented separately in [`docs/features/extension-store.md`](./extension-store.md). Native dynamic loading is restricted to trusted first-party/internal experiments and is not the default store path.
 
 The promotion path described here (skill→draft extension→code extension) feeds into that system: a promoted code extension is the same `Extension` trait that the store's dynamic loaders ultimately instantiate.

--- a/docs/features/marketplace-discovery.md
+++ b/docs/features/marketplace-discovery.md
@@ -17,7 +17,7 @@ Make the extension store a living, self-sustaining ecosystem.
 ## Dependency Resolution
 
 - **Versioned deps**: Resolve extension-to-extension and library dependencies, warn on conflicts.
-- **Platform constraints**: Filter incompatible extensions by OS/architecture/runtime.
+- **Runtime-class filtering**: Show whether a package runs as `wasm`, `subprocess`, `mcp`, or `native_first_party`; marketplace listings must not imply arbitrary native third-party code is the default extension model.
 - **Semantic upgrades**: Safe minor/patch upgrades, semver-aware breaking-change warnings.
 
 ## Usage Analytics & Reputation (opt-in)
@@ -36,6 +36,7 @@ Make the extension store a living, self-sustaining ecosystem.
 - **Org/person verification**: Proof of ownership of GitHub repo or domain.
 - **Curated collections**: Official and community-curated lists (e.g., "Security", "Data engineering").
 - **Automated scans**: Display scan status (passed/failed) for each published extension.
+- **Capability and audit summary**: Display requested filesystem/network/process/MCP access, approval requirements, resource limits, and the latest activation/denial audit status before install or enable.
 
 ---
 
@@ -46,6 +47,13 @@ Make the extension store a living, self-sustaining ecosystem.
   "id": "memory@redis",
   "name": "Redis Memory Backend",
   "version": "1.0.2",
+  "runtime_class": "wasm",
+  "capabilities": {
+    "tools": ["memory_redis_query"],
+    "network": ["redis.internal:6379"],
+    "filesystem": "none",
+    "process": "none"
+  },
   "publisher": { "id": "acme", "verified": true },
   "downloads_last_30d": 3124,
   "rating": 4.7,

--- a/docs/features/mcp-as-extension.md
+++ b/docs/features/mcp-as-extension.md
@@ -11,7 +11,7 @@ MCP integration can be promoted from a standalone protocol feature into a first-
 
 There are two complementary promotion paths:
 
-- **MCP Client/Bridge Extension** — the agent embeds a robust MCP client that discovers, connects to, and governs remote MCP servers; translates MCP primitives into native tools/resources; and enforces policy, caching, and retry semantics.
+- **MCP Client/Bridge Extension** — the agent embeds a robust stdio-first MCP client that discovers, connects to, and governs explicitly configured MCP servers; translates selected MCP primitives into native tools/resources; and enforces policy, caching, and retry semantics.
 - **MCP Server Hosting Extension** — the agent (or an extension) starts, stops, and monitors local MCP servers as managed child processes (or WASM hosts) and publishes their capabilities into the tool registry under policy controls.
 
 Both paths naturally follow the skill → draft extension → code extension promotion ladder.
@@ -82,8 +82,8 @@ depends:
 ---
 
 The MCP Bridge extension can:
-- Start MCP servers on demand (stdio) or connect to remote SSE endpoints.
-- Negotiate capabilities and validate them against policy before registering tools.
+- Start MCP servers on demand through stdio. Remote/SSE transport stays deferred until the core MCP policy explicitly expands it.
+- Negotiate capabilities and validate them against policy before registering selected tools.
 - Wrap MCP tools with retry, timeouts, and call logging.
 ```
 
@@ -93,7 +93,7 @@ This draft enables richer UI (server status, per-server enable/disable) and stru
 
 ## 3. Code Extension — Native MCP Bridge
 
-A code-backed `McpBridgeExtension` implements the client, lifecycle, and integration with Vulcan internals.
+A code-backed `McpBridgeExtension` implements the client, lifecycle, and integration with Vulcan internals. It inherits the trust ladder's MCP rung: MCP is an external tools/services protocol boundary, not a path for arbitrary native third-party code or inference-backend hosting.
 
 ### Responsibilities
 
@@ -136,7 +136,7 @@ impl Extension for McpBridgeExtension {
 
 impl McpBridgeExtension {
     fn start_and_register(&self, cfg: &McpServerConfig, ctx: &ExtensionContext) -> Result<()> {
-        // 1. Launch server (stdio) or connect (SSE)
+        // 1. Launch configured stdio server (remote/SSE deferred by policy)
         let server = self.client.spawn_stdio(&cfg.command, &cfg.args, &cfg.env)?;
 
         // 2. Negotiate capabilities

--- a/docs/features/mcp-server-support.md
+++ b/docs/features/mcp-server-support.md
@@ -17,11 +17,11 @@ MCP provides a standardized way for LLM applications to expose and consume tools
 
 ### MCP Client (Built-in)
 
-Vulcan embeds an MCP client that can connect to one or more MCP servers on behalf of extensions or the agent itself.
+Vulcan embeds an MCP client that can connect to explicitly configured MCP servers on behalf of extensions or the agent itself. MCP belongs to the external tools/services rung of the [Extension Runtime Trust Ladder](./extension-runtime-trust-ladder.md): it is a protocol/process boundary, not an in-process extension sandbox.
 
-- **Transport**: stdio (default), SSE (Server-Sent Events), or in-process pipes for local servers
-- **Lifecycle**: Start/stop servers, monitor health, auto-restart on crash
-- **Security**: Per-server permission scopes, filesystem access limits, network allowlists/denylists
+- **Transport**: stdio first; SSE/remote transport is deferred until core MCP policy expands.
+- **Lifecycle**: Start/stop configured stdio servers, monitor health, and clean up child processes. Managed hosting/restart policy belongs to the later hosting slice.
+- **Security**: Per-server permission scopes, filesystem access limits, network allowlists/denylists, selected-tool exposure, and audit records.
 
 ### MCP ↔ Extension Bridge
 
@@ -38,7 +38,7 @@ Extensions can declare dependency on MCP capabilities. The bridge translates bet
 
 #### 1. Transparent Mode (Auto-Expose as Tools)
 
-MCP servers are started alongside the agent; all declared tools are automatically registered in the tool registry and appear to the agent as native capabilities.
+MCP servers are started alongside the agent only when explicitly configured and enabled. Selected declared tools are registered in the tool registry and appear to the agent as namespaced capabilities; nothing is exposed by default from an unconfigured server.
 
 ```toml
 # ~/.vulcan/config.toml
@@ -47,11 +47,11 @@ name = "postgres"
 command = "uvx"
 args = ["mcp-server-postgres", "--db-url", "postgres://localhost/mydb"]
 env = { "PGPASSWORD" = "vault://pg/password" }
-expose_as = "auto"          # register as native tools
+expose_as = "manual"        # expose selected tools after policy approval
 permissions = { network = "localhost:5432", filesystem = "none" }
 ```
 
-Result: `list_tables`, `query`, `describe_schema` appear as agent tools immediately.
+Result: selected tools such as `list_tables`, `query`, and `describe_schema` can be exposed after policy approval and appear as namespaced agent tools with audit logging.
 
 #### 2. Bridged Mode (Extension-Controlled)
 
@@ -173,16 +173,16 @@ impl Tool for SafeSelectTool {
 
 ## Comparison: Extensions vs MCP Servers
 
-| | Native Extensions | MCP Servers |
-|---|---|---|
-| Language | Rust (compiled) / WASM / Script | Any (Python, JS, Go, etc.) — anything that speaks MCP |
-| Performance | High | IPC overhead (stdio) / network (SSE) |
-| Isolation | Process/WASM/container boundary | Process boundary |
-| Integration depth | Full access to Vulcan APIs | Protocol-limited (tools, resources, prompts, sampling) |
-| Development effort | Higher (Rust, compiles) | Lower (rapid scripting) |
-| Security surface | Larger (native code) | Smaller (protocol boundary, easier auditing) |
+| | Native first-party extensions | WASM third-party extensions | MCP Servers |
+|---|---|---|---|
+| Language | Rust cargo crates linked into trusted Vulcan builds | Rust/other languages compiled to WASM components | Any (Python, JS, Go, etc.) — anything that speaks MCP |
+| Performance | Highest | Lower than native, usually acceptable for policy-limited extensions | IPC overhead (stdio) / network when later enabled |
+| Isolation | Same process; trusted code only | WASM memory/resource boundary with explicit host imports | Process/protocol boundary |
+| Integration depth | Full access to approved Vulcan APIs | Capability-gated host imports | Protocol-limited (tools, resources, prompts, sampling) |
+| Development effort | Higher (Rust, rebuild) | Medium (WASM ABI/tooling) | Lower (rapid scripting) |
+| Security surface | Largest; not a sandbox | Smaller; host imports deny by default | Smaller; protocol boundary, easier auditing |
 
-Use MCP for quick integrations and scripting-friendly capabilities; use native extensions for high-performance, deep platform features.
+Use MCP for quick integrations and scripting-friendly external capabilities; use WASM for third-party code that must run inside a Vulcan-managed runtime; use native first-party extensions only for trusted high-performance, deep platform features.
 
 ## Future
 

--- a/docs/features/ux-extensions.md
+++ b/docs/features/ux-extensions.md
@@ -22,7 +22,7 @@ Extensions can render interactive terminal UI panels so users can inspect state 
 
 Optional companion web UI (served locally or remotely) to manage extensions.
 
-- **Inventory**: Installed extensions, versions, publishers, and signatures.
+- **Inventory**: Installed extensions, versions, runtime class, publishers, signatures, requested capabilities, and latest activation/audit status.
 - **Config editor**: Schema-driven forms for extension configuration.
 - **Usage & Logs**: Per-extension logs, token usage, event counts.
 - **Enable/disable & updates**: One-click enable/disable, version pinning, updates.

--- a/src/extensions/CONTEXT.md
+++ b/src/extensions/CONTEXT.md
@@ -1,6 +1,6 @@
 # Extensions — Context
 
-Pi-mono–style extension system. Daemon-side and frontend-side extensions distribute as Cargo crates, register via `inventory`, instantiate per **Session** (daemon side) or per **Frontend** process (frontend side). The current registry (`src/extensions/registry.rs`) is the metadata and code-extension foundation; the daemon/frontend split, wide event bus, and lifecycle policy land via the PRD at GitHub issue #548.
+Pi-mono–style extension system. Daemon-side and frontend-side native extensions distribute as Cargo crates, register via `inventory`, instantiate per **Session** (daemon side) or per **Frontend** process (frontend side). This native cargo-crate model is the trusted first-party/internal rung of the [Extension Runtime Trust Ladder](../../docs/features/extension-runtime-trust-ladder.md), not the third-party sandbox or marketplace default. The current registry (`src/extensions/registry.rs`) is the metadata and code-extension foundation; the daemon/frontend split, wide event bus, and lifecycle policy land via the PRD at GitHub issue #548.
 
 ## Glossary
 
@@ -17,7 +17,7 @@ A per-**Frontend**-process registration that owns rendering, custom canvases, ra
 _Avoid_: TUI hook, daemon renderer
 
 **Extension Manifest**:
-A package-level metadata block (`[package.metadata.vulcan]`) declaring an extension's id, version, capabilities, and optional `daemon_entry` / `frontend_entry` registration symbols. Either entry may be absent for pure-daemon (e.g. auto-commit) or pure-frontend (e.g. DOOM) extensions.
+A package-level metadata block (`[package.metadata.vulcan]`) declaring an extension's id, version, runtime class, capabilities, requested external access, and optional `daemon_entry` / `frontend_entry` registration symbols. Either entry may be absent for pure-daemon (e.g. auto-commit) or pure-frontend (e.g. DOOM) extensions. Marketplace manifests must identify the runtime class (`wasm`, `subprocess`, `mcp`, or `native_first_party`) before install or activation.
 _Avoid_: extension config, package.json
 
 **Frontend Capability**:


### PR DESCRIPTION
## Summary
- add a repository copy of the canonical extension runtime trust ladder from the wiki policy
- align extension/store/marketplace/MCP/DX docs with the native-first-party, WASM-third-party, subprocess/MCP-external, backend-endpoint split
- require runtime-class, capability, and audit metadata in marketplace/store-facing language

## Validation
- git diff --check
- python sanity check that trust-ladder docs and marketplace/store metadata language are present

Tracks #611, #548, #264, #273, #276, #3, #268, #274.