### PR TITLE
Add Symphony observability and manual E2E surface

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -640,10 +640,24 @@ pub enum SymphonySubcommand {
     List,
     /// Validate a workflow spec's front-matter and template
     Validate { workflow: std::path::PathBuf },
+    /// Print the effective Symphony config for a workflow
+    Config { workflow: std::path::PathBuf },
     /// Show the normalized task list a workflow would enqueue
     Tasks { workflow: std::path::PathBuf },
+    /// Show Symphony runtime status from the observability snapshot
+    Status {
+        /// Workflow to load for local manual status. Without this, reports service unavailable.
+        workflow: Option<std::path::PathBuf>,
+    },
     /// Run one dry-run orchestrator poll tick for a workflow
     Tick { workflow: std::path::PathBuf },
+    /// Run one fake-backed Symphony dispatch through the runner
+    RunOnce {
+        workflow: std::path::PathBuf,
+        /// Use the built-in fake app-server worker. Required until real service mode lands.
+        #[arg(long)]
+        fake: bool,
+    },
     /// List recent symphony runs from the run-record store
     Runs {
         /// Maximum number of runs to show

--- a/src/cli_symphony.rs
+++ b/src/cli_symphony.rs
@@ -6,8 +6,10 @@ use anyhow::{Context as _, Result, bail};
 use crate::cli::SymphonySubcommand;
 use crate::run_record::{RunOrigin, RunRecord, RunStatus, RunStore, SqliteRunStore};
 use crate::symphony::config::{EffectiveConfig, TaskSourceKind};
-use crate::symphony::orchestrator::OrchestratorEvent;
-use crate::symphony::runtime::{DryTickResult, SymphonyRuntime};
+use crate::symphony::orchestrator::{
+    OrchestratorEvent, RunResult, SymphonyRuntimeSnapshot, SymphonySnapshotStatus,
+};
+use crate::symphony::runtime::{DryTickResult, RunOnceResult, SymphonyRuntime};
 use crate::symphony::workflow::NormalizedTask;
 
 pub async fn run(cmd: SymphonySubcommand) -> Result<()> {
@@ -30,8 +32,11 @@ pub async fn run(cmd: SymphonySubcommand) -> Result<()> {
         }
         SymphonySubcommand::List => list_to_string()?,
         SymphonySubcommand::Validate { workflow } => validate_to_string(&workflow)?,
+        SymphonySubcommand::Config { workflow } => config_to_string(&workflow)?,
         SymphonySubcommand::Tasks { workflow } => tasks_to_string(&workflow)?,
+        SymphonySubcommand::Status { workflow } => status_to_string(workflow.as_deref())?,
         SymphonySubcommand::Tick { workflow } => tick_to_string(&workflow)?,
+        SymphonySubcommand::RunOnce { workflow, fake } => run_once_to_string(&workflow, fake)?,
         SymphonySubcommand::Runs { limit, all } => runs_to_string(limit, all).await?,
     };
     print!("{output}");
@@ -163,6 +168,10 @@ pub fn validate_to_string(workflow: &Path) -> Result<String> {
     Ok(render_config_summary(&runtime.validate().config))
 }
 
+pub fn config_to_string(workflow: &Path) -> Result<String> {
+    validate_to_string(workflow)
+}
+
 pub fn tasks_to_string(workflow: &Path) -> Result<String> {
     let runtime = SymphonyRuntime::load(workflow)?;
     let result = runtime.list_tasks()?;
@@ -185,6 +194,63 @@ pub fn tick_to_string(workflow: &Path) -> Result<String> {
     let runtime = SymphonyRuntime::load(workflow)?;
     let outcome = runtime.dry_tick(0)?;
     Ok(render_tick_outcome(&outcome))
+}
+
+pub fn status_to_string(workflow: Option<&Path>) -> Result<String> {
+    let snapshot = if let Some(workflow) = workflow {
+        SymphonyRuntime::load(workflow)?.snapshot(0)?
+    } else {
+        SymphonyRuntimeSnapshot::unavailable()
+    };
+    Ok(render_symphony_snapshot(&snapshot))
+}
+
+pub fn run_once_to_string(workflow: &Path, fake: bool) -> Result<String> {
+    if !fake {
+        bail!("`vulcan symphony run-once` currently requires --fake");
+    }
+    let runtime = SymphonyRuntime::load(workflow)?;
+    let result = runtime.fake_run_once(0)?;
+    Ok(render_run_once(&result))
+}
+
+pub fn slash_symphony_to_string(args: &str) -> Result<String> {
+    let mut words = args.split_whitespace();
+    match words.next() {
+        None => Ok(symphony_manual_help()),
+        Some("workflow" | "workflows" | "list") => list_to_string(),
+        Some("validate") => {
+            let workflow = required_slash_path(words.next(), "validate")?;
+            validate_to_string(workflow.as_path())
+        }
+        Some("config") => {
+            let workflow = required_slash_path(words.next(), "config")?;
+            config_to_string(workflow.as_path())
+        }
+        Some("tasks") => {
+            let workflow = required_slash_path(words.next(), "tasks")?;
+            tasks_to_string(workflow.as_path())
+        }
+        Some("status") => {
+            let workflow = words.next().map(PathBuf::from);
+            status_to_string(workflow.as_deref())
+        }
+        Some("run-once") => {
+            let mut workflow = None;
+            let mut fake = false;
+            for word in words {
+                if word == "--fake" {
+                    fake = true;
+                } else if workflow.is_none() {
+                    workflow = Some(PathBuf::from(word));
+                }
+            }
+            let workflow = workflow
+                .ok_or_else(|| anyhow::anyhow!("missing workflow path for /symphony run-once"))?;
+            run_once_to_string(workflow.as_path(), fake)
+        }
+        Some(_) => Ok(symphony_manual_help()),
+    }
 }
 
 pub async fn runs_to_string(limit: usize, all: bool) -> Result<String> {
@@ -463,6 +529,131 @@ fn render_tick_outcome(outcome: &DryTickResult) -> String {
     out
 }
 
+fn render_run_once(result: &RunOnceResult) -> String {
+    let mut out = render_tick_outcome(&result.tick);
+    match &result.report {
+        Some(report) => {
+            out.push_str(&format!(
+                "run_result={} reason={:?}\n",
+                run_result_label(&report.result),
+                report.terminal_reason
+            ));
+            if let RunResult::Succeeded {
+                input_tokens,
+                output_tokens,
+                turn_count,
+                ..
+            } = &report.result
+            {
+                out.push_str(&format!(
+                    "turn_count={turn_count} input_tokens={input_tokens} output_tokens={output_tokens}\n"
+                ));
+            }
+        }
+        None => out.push_str("run_result=not_dispatched\n"),
+    }
+    out.push_str(&render_symphony_snapshot(&result.snapshot));
+    out
+}
+
+fn render_symphony_snapshot(snapshot: &SymphonyRuntimeSnapshot) -> String {
+    let mut out = String::new();
+    out.push_str(&format!(
+        "Symphony status: {}\n",
+        snapshot_status_label(snapshot.status)
+    ));
+    out.push_str(&format!("running: {}\n", snapshot.running.len()));
+    for row in &snapshot.running {
+        out.push_str(&format!(
+            "  {} {} run_id={} state={} runtime_secs={} last_seen_ms={}\n",
+            row.task_identifier,
+            row.task_id,
+            row.run_id,
+            row.state,
+            row.runtime_secs,
+            row.last_seen_ms
+        ));
+    }
+    out.push_str(&format!("retrying: {}\n", snapshot.retrying.len()));
+    for row in &snapshot.retrying {
+        out.push_str(&format!(
+            "  {} next_at_ms={} attempt={}\n",
+            row.task_id, row.next_at_ms, row.attempt
+        ));
+    }
+    out.push_str(&format!("turn_count: {}\n", snapshot.turn_count));
+    out.push_str(&format!(
+        "tokens: input={} output={}\n",
+        snapshot.token_totals.input, snapshot.token_totals.output
+    ));
+    out.push_str(&format!(
+        "live_runtime_secs: {}\n",
+        snapshot.live_runtime_secs
+    ));
+    if snapshot.latest_rate_limits.is_empty() {
+        out.push_str("rate_limits: none\n");
+    } else {
+        out.push_str("rate_limits:\n");
+        for (name, limit) in &snapshot.latest_rate_limits {
+            out.push_str(&format!(
+                "  {name}: {}/{} reset_at_ms={}\n",
+                limit.remaining,
+                limit.limit,
+                limit
+                    .reset_at_ms
+                    .map_or_else(|| "-".to_string(), |value| value.to_string())
+            ));
+        }
+    }
+    if let Some(health) = &snapshot.hook_health {
+        out.push_str(&format!(
+            "hooks: handlers={} errors={} timeouts={}\n",
+            health.handler_count, health.errors, health.timeouts
+        ));
+    } else {
+        out.push_str("hooks: unavailable\n");
+    }
+    out
+}
+
+fn run_result_label(result: &RunResult) -> &'static str {
+    match result {
+        RunResult::Succeeded { .. } => "succeeded",
+        RunResult::NeedsContinuation => "needs_continuation",
+        RunResult::Failed => "failed",
+    }
+}
+
+fn snapshot_status_label(status: SymphonySnapshotStatus) -> &'static str {
+    match status {
+        SymphonySnapshotStatus::Ok => "ok",
+        SymphonySnapshotStatus::Unavailable => "unavailable",
+        SymphonySnapshotStatus::Timeout => "timeout",
+    }
+}
+
+fn required_slash_path(value: Option<&str>, command: &str) -> Result<PathBuf> {
+    value
+        .map(PathBuf::from)
+        .ok_or_else(|| anyhow::anyhow!("missing workflow path for /symphony {command}"))
+}
+
+fn symphony_manual_help() -> String {
+    [
+        "Symphony manual E2E:",
+        "  vulcan symphony validate <workflow>",
+        "  vulcan symphony config <workflow>",
+        "  vulcan symphony status [workflow]",
+        "  vulcan symphony run-once <workflow> --fake",
+        "  /symphony workflow",
+        "  /symphony config <workflow>",
+        "  /symphony status [workflow]",
+        "  /symphony run-once <workflow> --fake",
+        "",
+    ]
+    .join("\n")
+}
+
 fn render_symphony_runs(records: &[RunRecord], all: bool) -> String {
     if records.is_empty() {
         return if all {
@@ -622,6 +813,44 @@ Handle {{ issue.identifier }}: {{ issue.title }}
         assert!(output.contains("dispatched ISSUE-1"));
         assert!(output.contains("run_id=symphony-dry-run-1"));
         assert!(output.contains("status=published"));
+    }
+
+    #[test]
+    fn manual_e2e_status_and_fake_run_once_use_snapshot_renderer() {
+        let dir = fixture_dir("manual-e2e");
+        let workflow = write_workflow(&dir);
+
+        let status = status_to_string(Some(&workflow)).expect("status");
+        assert!(status.contains("Symphony status: ok"));
+        assert!(status.contains("turn_count: 0"));
+        assert!(status.contains("hooks: unavailable"));
+
+        let unavailable = status_to_string(None).expect("unavailable status");
+        assert!(unavailable.contains("Symphony status: unavailable"));
+
+        let output = run_once_to_string(&workflow, true).expect("fake run once");
+        assert!(output.contains("dispatched ISSUE-1"));
+        assert!(output.contains("run_result=succeeded"));
+        assert!(output.contains("turn_count=1 input_tokens=1 output_tokens=1"));
+        assert!(output.contains("Symphony status: ok"));
+        assert!(output.contains("tokens: input=1 output=1"));
+    }
+
+    #[test]
+    fn slash_symphony_commands_share_manual_e2e_renderers() {
+        let dir = fixture_dir("slash-manual-e2e");
+        let workflow = write_workflow(&dir);
+
+        let help = slash_symphony_to_string("").expect("help");
+        assert!(help.contains("vulcan symphony run-once <workflow> --fake"));
+
+        let config =
+            slash_symphony_to_string(&format!("config {}", workflow.display())).expect("config");
+        assert!(config.contains("Symphony workflow OK"));
+
+        let run = slash_symphony_to_string(&format!("run-once {} --fake", workflow.display()))
+            .expect("run once");
+        assert!(run.contains("run_result=succeeded"));
     }
 
     #[tokio::test]

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -25,6 +25,7 @@ use crate::config::ObservabilityConfig;
 use crate::hooks::{HookFailureCounts, HookRegistry};
 
 pub mod attr {
+    pub const ACTION: &str = "action";
     pub const OPERATION: &str = "operation";
     pub const REQUEST_ID: &str = "request_id";
     pub const SESSION_ID: &str = "session_id";
@@ -107,6 +108,7 @@ pub mod metric {
     pub const PROCESS_CPU_PERCENT: &str = "vulcan.process.cpu.percent";
     pub const PROCESS_THREADS: &str = "vulcan.process.threads";
     pub const RUNTIME_SECONDS: &str = "vulcan.runtime.seconds";
+    pub const SYMPHONY_TASK_RUNTIME_MS: &str = "vulcan.symphony.task.runtime_ms";
 
     pub const RUNTIME_PERFORMANCE: &[&str] = &[
         DAEMON_REQUEST_DURATION_MS,
@@ -125,6 +127,7 @@ pub mod metric {
         PROCESS_MEMORY_RSS_BYTES,
         PROCESS_CPU_PERCENT,
         PROCESS_THREADS,
+        SYMPHONY_TASK_RUNTIME_MS,
     ];
 }
 
@@ -147,6 +150,7 @@ struct RuntimeMetricInstruments {
     process_memory_rss_bytes: Gauge<u64>,
     process_cpu_percent: Gauge<f64>,
     process_threads: Gauge<u64>,
+    symphony_task_runtime_ms: Histogram<f64>,
 }
 
 static RUNTIME_METRICS: LazyLock<RuntimeMetricInstruments> = LazyLock::new(|| {
@@ -234,6 +238,11 @@ static RUNTIME_METRICS: LazyLock<RuntimeMetricInstruments> = LazyLock::new(|| {
         process_threads: meter
             .u64_gauge(metric::PROCESS_THREADS)
             .with_description("Current process thread count when available.")
+            .build(),
+        symphony_task_runtime_ms: meter
+            .f64_histogram(metric::SYMPHONY_TASK_RUNTIME_MS)
+            .with_unit("ms")
+            .with_description("Symphony task runtime from dispatch to terminal outcome.")
             .build(),
     }
 });
@@ -330,6 +339,22 @@ pub fn provider_request_span(
         ProviderSpanMode::Compaction => span!(span::PROVIDER_COMPACTION),
         ProviderSpanMode::Streaming => span!(span::PROVIDER_STREAMING),
     }
+}
+
+pub fn symphony_task_span(
+    operation: &'static str,
+    task_id: &str,
+    task_identifier: &str,
+) -> tracing::Span {
+    tracing::info_span!(
+        span::TASK_ORCHESTRATION,
+        surface = "symphony",
+        operation,
+        task_id,
+        task_identifier,
+        outcome = tracing::field::Empty,
+        error_kind = tracing::field::Empty
+    )
 }
 
 fn duration_millis(duration: Duration) -> f64 {
@@ -539,6 +564,30 @@ pub fn record_tui_frame_metrics(
     RUNTIME_METRICS
         .tui_surface_count
         .record(surface_count as u64, &attrs);
+}
+
+pub fn record_symphony_task_runtime_metrics(
+    task_id: &str,
+    task_identifier: &str,
+    duration: Duration,
+    outcome: &str,
+    error_kind: Option<&str>,
+) {
+    if !surface_enabled("symphony") {
+        return;
+    }
+    let mut attrs = vec![
+        KeyValue::new(attr::SURFACE, "symphony"),
+        KeyValue::new(attr::TASK_ID, task_id.to_string()),
+        KeyValue::new(attr::TASK_IDENTIFIER, task_identifier.to_string()),
+    ];
+    push_outcome_attrs(&mut attrs, outcome, error_kind);
+    RUNTIME_METRICS
+        .symphony_task_runtime_ms
+        .record(duration_millis(duration), &attrs);
+    if let Some(kind) = error_kind {
+        record_error_metric("symphony", kind);
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -834,6 +883,7 @@ mod tests {
     #[test]
     fn stable_attribute_and_span_names_cover_runtime_surfaces() {
         let attrs = [
+            attr::ACTION,
             attr::OPERATION,
             attr::REQUEST_ID,
             attr::SESSION_ID,
@@ -894,6 +944,10 @@ mod tests {
         assert_eq!(
             metric::PROCESS_MEMORY_RSS_BYTES,
             "vulcan.process.memory.rss_bytes"
+        );
+        assert_eq!(
+            metric::SYMPHONY_TASK_RUNTIME_MS,
+            "vulcan.symphony.task.runtime_ms"
         );
     }
 

--- a/src/symphony/orchestrator.rs
+++ b/src/symphony/orchestrator.rs
@@ -1,7 +1,11 @@
 //! Core Symphony poll-loop orchestration with fake runner boundaries.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::time::Duration;
 
+use serde::Serialize;
+
+use crate::observability::{self, HookHealthSnapshot};
 use crate::symphony::config::PollingConfig;
 use crate::symphony::task_source::TaskSource;
 use crate::symphony::workflow::NormalizedTask;
@@ -24,6 +28,8 @@ pub struct OrchestratorState {
     pub completed: BTreeSet<String>,
     pub token_totals: TokenTotals,
     pub rate_limits: BTreeMap<String, RateLimitSnapshot>,
+    pub turn_count: u64,
+    pub ended_runtime_ms: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -40,17 +46,54 @@ pub struct RetryPlan {
     pub attempt: u32,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
 pub struct TokenTotals {
     pub input: u64,
     pub output: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct RateLimitSnapshot {
     pub limit: u64,
     pub remaining: u64,
     pub reset_at_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SymphonyRuntimeSnapshot {
+    pub status: SymphonySnapshotStatus,
+    pub running: Vec<SymphonyRunningRow>,
+    pub retrying: Vec<SymphonyRetryRow>,
+    pub turn_count: u64,
+    pub token_totals: TokenTotals,
+    pub live_runtime_secs: u64,
+    pub latest_rate_limits: BTreeMap<String, RateLimitSnapshot>,
+    pub hook_health: Option<HookHealthSnapshot>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SymphonySnapshotStatus {
+    Ok,
+    Unavailable,
+    Timeout,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SymphonyRunningRow {
+    pub task_id: String,
+    pub task_identifier: String,
+    pub run_id: String,
+    pub state: String,
+    pub runtime_secs: u64,
+    pub last_seen_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SymphonyRetryRow {
+    pub task_id: String,
+    pub next_at_ms: u64,
+    pub attempt: u32,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -103,6 +146,7 @@ pub enum RunResult {
     Succeeded {
         input_tokens: u64,
         output_tokens: u64,
+        turn_count: u64,
         rate_limits: Vec<(String, RateLimitSnapshot)>,
     },
     NeedsContinuation,
@@ -142,6 +186,14 @@ where
         &self.state
     }
 
+    pub fn snapshot(
+        &self,
+        now_ms: u64,
+        hook_health: Option<HookHealthSnapshot>,
+    ) -> SymphonyRuntimeSnapshot {
+        self.state.snapshot(now_ms, hook_health)
+    }
+
     pub fn poll_tick(&mut self, now_ms: u64) -> PollOutcome {
         let mut events = self.reconcile(now_ms);
         events.push(OrchestratorEvent::Reconciled);
@@ -165,6 +217,18 @@ where
             let start = self.runner.start(&task, now_ms);
             let id = task.id.clone();
             let RunnerStartResult::Started(start) = start else {
+                let span =
+                    observability::symphony_task_span("task.requeued", &task.id, &task.identifier);
+                span.record(observability::attr::OUTCOME, "retry");
+                span.record(observability::attr::ERROR_KIND, "slot_unavailable");
+                let _guard = span.enter();
+                tracing::warn!(
+                    task_id = %task.id,
+                    task_identifier = %task.identifier,
+                    outcome = "retry",
+                    error_kind = "slot_unavailable",
+                    "symphony task requeued"
+                );
                 let plan = self.schedule_retry(&id, now_ms, RetryReason::SlotUnavailable);
                 events.push(OrchestratorEvent::Requeued {
                     id,
@@ -173,6 +237,17 @@ where
                 });
                 continue;
             };
+            let span =
+                observability::symphony_task_span("task.dispatch", &task.id, &task.identifier);
+            span.record(observability::attr::OUTCOME, "started");
+            let _guard = span.enter();
+            tracing::info!(
+                task_id = %task.id,
+                task_identifier = %task.identifier,
+                run_id = %start.run_id,
+                outcome = "started",
+                "symphony task dispatched"
+            );
             self.state.claimed.insert(task.id.clone());
             self.state.running.insert(
                 task.id.clone(),
@@ -256,25 +331,99 @@ where
             RunResult::Succeeded {
                 input_tokens,
                 output_tokens,
+                turn_count,
                 rate_limits,
             } => {
-                self.state.running.remove(id);
+                let running = self.state.running.remove(id);
                 self.state.claimed.remove(id);
                 self.state.retrying.remove(id);
                 self.state.completed.insert(id.to_string());
                 self.state.token_totals.input += input_tokens;
                 self.state.token_totals.output += output_tokens;
+                self.state.turn_count += turn_count;
+                if let Some(running) = running {
+                    let duration_ms = now_ms.saturating_sub(running.started_at_ms);
+                    self.state.ended_runtime_ms += duration_ms;
+                    let span = observability::symphony_task_span(
+                        "task.completed",
+                        id,
+                        &running.task.identifier,
+                    );
+                    span.record(observability::attr::OUTCOME, "ok");
+                    let _guard = span.enter();
+                    observability::record_symphony_task_runtime_metrics(
+                        id,
+                        &running.task.identifier,
+                        Duration::from_millis(duration_ms),
+                        "ok",
+                        None,
+                    );
+                    tracing::info!(
+                        task_id = %id,
+                        task_identifier = %running.task.identifier,
+                        run_id = %running.run_id,
+                        turn_count,
+                        input_tokens,
+                        output_tokens,
+                        outcome = "ok",
+                        "symphony task completed"
+                    );
+                }
                 for (name, snapshot) in rate_limits {
                     self.state.rate_limits.insert(name, snapshot);
                 }
             }
             RunResult::NeedsContinuation => {
+                self.finish_running_attempt(id, now_ms, "needs_continuation", None);
                 self.schedule_retry(id, now_ms, RetryReason::Continuation);
             }
             RunResult::Failed => {
+                self.finish_running_attempt(id, now_ms, "error", Some("task_failed"));
                 self.schedule_retry(id, now_ms, RetryReason::Failure);
             }
         }
+    }
+
+    fn finish_running_attempt(
+        &mut self,
+        id: &str,
+        now_ms: u64,
+        outcome: &'static str,
+        error_kind: Option<&'static str>,
+    ) {
+        let running = self.state.running.remove(id);
+        self.state.claimed.remove(id);
+        let Some(running) = running else {
+            return;
+        };
+
+        let duration_ms = now_ms.saturating_sub(running.started_at_ms);
+        self.state.ended_runtime_ms += duration_ms;
+        let span = observability::symphony_task_span(
+            "task.attempt_finished",
+            id,
+            &running.task.identifier,
+        );
+        span.record(observability::attr::OUTCOME, outcome);
+        if let Some(kind) = error_kind {
+            span.record(observability::attr::ERROR_KIND, kind);
+        }
+        let _guard = span.enter();
+        observability::record_symphony_task_runtime_metrics(
+            id,
+            &running.task.identifier,
+            Duration::from_millis(duration_ms),
+            outcome,
+            error_kind,
+        );
+        tracing::info!(
+            task_id = %id,
+            task_identifier = %running.task.identifier,
+            run_id = %running.run_id,
+            outcome,
+            error_kind = error_kind.unwrap_or(""),
+            "symphony task attempt finished"
+        );
     }
 
     fn is_eligible(&self, task: &NormalizedTask, now_ms: u64) -> bool {
@@ -330,6 +479,75 @@ where
         };
         self.state.retrying.insert(id.to_string(), plan.clone());
         plan
+    }
+}
+
+impl OrchestratorState {
+    pub fn snapshot(
+        &self,
+        now_ms: u64,
+        hook_health: Option<HookHealthSnapshot>,
+    ) -> SymphonyRuntimeSnapshot {
+        let running = self
+            .running
+            .values()
+            .map(|running| SymphonyRunningRow {
+                task_id: running.task.id.clone(),
+                task_identifier: running.task.identifier.clone(),
+                run_id: running.run_id.clone(),
+                state: running.task.state.clone(),
+                runtime_secs: now_ms.saturating_sub(running.started_at_ms) / 1_000,
+                last_seen_ms: running.last_seen_ms,
+            })
+            .collect::<Vec<_>>();
+        let retrying = self
+            .retrying
+            .iter()
+            .map(|(task_id, plan)| SymphonyRetryRow {
+                task_id: task_id.clone(),
+                next_at_ms: plan.next_at_ms,
+                attempt: plan.attempt,
+            })
+            .collect::<Vec<_>>();
+        let active_runtime_ms = self
+            .running
+            .values()
+            .map(|running| now_ms.saturating_sub(running.started_at_ms))
+            .sum::<u64>();
+
+        SymphonyRuntimeSnapshot {
+            status: SymphonySnapshotStatus::Ok,
+            running,
+            retrying,
+            turn_count: self.turn_count,
+            token_totals: self.token_totals.clone(),
+            live_runtime_secs: (self.ended_runtime_ms + active_runtime_ms) / 1_000,
+            latest_rate_limits: self.rate_limits.clone(),
+            hook_health,
+        }
+    }
+}
+
+impl SymphonyRuntimeSnapshot {
+    pub fn unavailable() -> Self {
+        Self::empty(SymphonySnapshotStatus::Unavailable)
+    }
+
+    pub fn timeout() -> Self {
+        Self::empty(SymphonySnapshotStatus::Timeout)
+    }
+
+    fn empty(status: SymphonySnapshotStatus) -> Self {
+        Self {
+            status,
+            running: Vec::new(),
+            retrying: Vec::new(),
+            turn_count: 0,
+            token_totals: TokenTotals::default(),
+            live_runtime_secs: 0,
+            latest_rate_limits: BTreeMap::new(),
+            hook_health: None,
+        }
     }
 }
 
@@ -440,6 +658,16 @@ mod tests {
             })
         );
 
+        orchestrator.state.running.insert(
+            "1".into(),
+            RunningTask {
+                task: task("1", "TASK-1", "ready-for-agent"),
+                run_id: "run-continuation".into(),
+                started_at_ms: 1_500,
+                last_seen_ms: 1_500,
+            },
+        );
+        orchestrator.state.claimed.insert("1".into());
         orchestrator.record_run_result("1", RunResult::NeedsContinuation, 2_000);
         assert_eq!(
             orchestrator.state().retrying.get("1"),
@@ -448,7 +676,20 @@ mod tests {
                 attempt: 1,
             })
         );
+        assert!(!orchestrator.state().running.contains_key("1"));
+        assert!(!orchestrator.state().claimed.contains("1"));
+        assert_eq!(orchestrator.state().ended_runtime_ms, 500);
 
+        orchestrator.state.running.insert(
+            "1".into(),
+            RunningTask {
+                task: task("1", "TASK-1", "ready-for-agent"),
+                run_id: "run-failed".into(),
+                started_at_ms: 2_500,
+                last_seen_ms: 2_500,
+            },
+        );
+        orchestrator.state.claimed.insert("1".into());
         orchestrator.record_run_result("1", RunResult::Failed, 3_000);
         assert_eq!(
             orchestrator.state().retrying.get("1"),
@@ -457,6 +698,9 @@ mod tests {
                 attempt: 2,
             })
         );
+        assert!(!orchestrator.state().running.contains_key("1"));
+        assert!(!orchestrator.state().claimed.contains("1"));
+        assert_eq!(orchestrator.state().ended_runtime_ms, 1_000);
     }
 
     #[test]
@@ -540,6 +784,7 @@ mod tests {
             RunResult::Succeeded {
                 input_tokens: 42,
                 output_tokens: 7,
+                turn_count: 2,
                 rate_limits: vec![(
                     "requests".into(),
                     RateLimitSnapshot {
@@ -561,6 +806,8 @@ mod tests {
                 output: 7,
             }
         );
+        assert_eq!(orchestrator.state().turn_count, 2);
+        assert_eq!(orchestrator.state().ended_runtime_ms, 1_000);
         assert_eq!(
             orchestrator.state().rate_limits["requests"],
             RateLimitSnapshot {
@@ -568,6 +815,69 @@ mod tests {
                 remaining: 93,
                 reset_at_ms: Some(60_000),
             }
+        );
+    }
+
+    #[test]
+    fn snapshot_reports_runtime_rows_accounting_hook_health_and_error_modes() {
+        let source = FakeSource::new(Vec::new());
+        let mut orchestrator = Orchestrator::new(config(10), source, FakeRunner::default());
+        orchestrator.state.running.insert(
+            "active".into(),
+            RunningTask {
+                task: task("active", "TASK-ACTIVE", "ready-for-agent"),
+                run_id: "run-active".into(),
+                started_at_ms: 5_000,
+                last_seen_ms: 8_000,
+            },
+        );
+        orchestrator.state.retrying.insert(
+            "retry".into(),
+            RetryPlan {
+                next_at_ms: 12_000,
+                attempt: 3,
+            },
+        );
+        orchestrator.state.turn_count = 2;
+        orchestrator.state.ended_runtime_ms = 4_000;
+        orchestrator.state.token_totals = TokenTotals {
+            input: 40,
+            output: 8,
+        };
+        orchestrator.state.rate_limits.insert(
+            "requests".into(),
+            RateLimitSnapshot {
+                limit: 100,
+                remaining: 90,
+                reset_at_ms: Some(60_000),
+            },
+        );
+
+        let snapshot = orchestrator.snapshot(
+            9_000,
+            Some(HookHealthSnapshot {
+                handler_count: 4,
+                errors: 1,
+                timeouts: 2,
+            }),
+        );
+
+        assert_eq!(snapshot.status, SymphonySnapshotStatus::Ok);
+        assert_eq!(snapshot.running[0].task_identifier, "TASK-ACTIVE");
+        assert_eq!(snapshot.running[0].runtime_secs, 4);
+        assert_eq!(snapshot.retrying[0].attempt, 3);
+        assert_eq!(snapshot.turn_count, 2);
+        assert_eq!(snapshot.token_totals.input, 40);
+        assert_eq!(snapshot.live_runtime_secs, 8);
+        assert_eq!(snapshot.latest_rate_limits["requests"].remaining, 90);
+        assert_eq!(snapshot.hook_health.as_ref().unwrap().timeouts, 2);
+        assert_eq!(
+            SymphonyRuntimeSnapshot::unavailable().status,
+            SymphonySnapshotStatus::Unavailable
+        );
+        assert_eq!(
+            SymphonyRuntimeSnapshot::timeout().status,
+            SymphonySnapshotStatus::Timeout
         );
     }
 

--- a/src/symphony/orchestrator.rs
+++ b/src/symphony/orchestrator.rs
@@ -186,6 +186,10 @@ where
         &self.state
     }
 
+    pub fn update_polling_config(&mut self, config: PollingConfig) {
+        self.config = config;
+    }
+
     pub fn snapshot(
         &self,
         now_ms: u64,
@@ -635,6 +639,39 @@ mod tests {
         assert!(!orchestrator.state().claimed.contains("blocked"));
         assert!(!orchestrator.state().claimed.contains("missing-title"));
         assert!(!orchestrator.state().claimed.contains("same-state-over-cap"));
+    }
+
+    #[test]
+    fn poll_time_config_reload_affects_future_dispatch_without_restarting_running_work() {
+        let source = FakeSource::new(vec![
+            task("first", "TASK-FIRST", "ready-for-agent"),
+            task("second", "TASK-SECOND", "ready-for-agent"),
+        ]);
+        let mut orchestrator = Orchestrator::new(config(1), source, FakeRunner::default());
+
+        let first = orchestrator.poll_tick(1_000);
+        assert!(first.events.contains(&OrchestratorEvent::Dispatched {
+            id: "first".into(),
+            run_id: "run-1".into(),
+        }));
+        assert_eq!(orchestrator.state().running.len(), 1);
+
+        orchestrator.update_polling_config(config(2));
+        let second = orchestrator.poll_tick(2_000);
+
+        assert!(second.events.contains(&OrchestratorEvent::Dispatched {
+            id: "second".into(),
+            run_id: "run-2".into(),
+        }));
+        assert_eq!(
+            orchestrator
+                .state()
+                .running
+                .keys()
+                .map(String::as_str)
+                .collect::<Vec<_>>(),
+            ["first", "second"]
+        );
     }
 
     #[test]

--- a/src/symphony/runner.rs
+++ b/src/symphony/runner.rs
@@ -1,5 +1,6 @@
 //! Symphony agent-runner integration over workspace, workflow, and app-server boundaries.
 
+use crate::observability;
 use crate::symphony::app_server::{
     AppServerClient, AppServerError, AppServerOutcome, AppServerRequest,
 };
@@ -170,11 +171,30 @@ where
 
             match outcome {
                 Ok(AppServerOutcome::Completed(telemetry)) => {
+                    let session_id = telemetry.session_id.clone();
+                    let span = tracing::info_span!(
+                        observability::span::AGENT_SESSION,
+                        surface = "symphony",
+                        action = "turn_completed",
+                        session_id = %session_id,
+                        outcome = "ok"
+                    );
+                    let _guard = span.enter();
+                    tracing::info!(
+                        session_id = %session_id,
+                        action = "turn_completed",
+                        outcome = "ok",
+                        turn,
+                        input_tokens = telemetry.input_tokens,
+                        output_tokens = telemetry.output_tokens,
+                        "symphony agent session turn completed"
+                    );
                     events.push(AgentRunnerEvent::TurnCompleted { turn });
                     return terminal_with_cleanup(
                         RunResult::Succeeded {
                             input_tokens: telemetry.input_tokens,
                             output_tokens: telemetry.output_tokens,
+                            turn_count: u64::from(turn),
                             rate_limits: telemetry
                                 .rate_limits
                                 .into_iter()
@@ -379,6 +399,7 @@ mod tests {
             RunResult::Succeeded {
                 input_tokens: 40,
                 output_tokens: 8,
+                turn_count: 1,
                 rate_limits: vec![(
                     "requests".into(),
                     RateLimitSnapshot {

--- a/src/symphony/runner.rs
+++ b/src/symphony/runner.rs
@@ -336,9 +336,18 @@ fn terminal_with_cleanup<W>(
 where
     W: AgentWorker,
 {
+    let remove_success_workspace =
+        terminal_reason == AgentTerminalReason::Succeeded && !workspace.preserve_success();
     worker.cleanup();
     events.push(AgentRunnerEvent::WorkerCleanedUp);
     workspace.after_run(prepared);
+    if remove_success_workspace && let Err(err) = workspace.remove(prepared) {
+        tracing::warn!(
+            workspace = %prepared.path.display(),
+            error = %err,
+            "failed to remove successful Symphony workspace"
+        );
+    }
     AgentRunReport {
         result,
         terminal_reason,
@@ -611,6 +620,39 @@ mod tests {
         assert!(report.events.is_empty());
         assert!(runner.worker().prompts.is_empty());
         assert_eq!(runner.worker().cleanup_calls, 0);
+    }
+
+    #[test]
+    fn successful_workspace_cleanup_follows_preserve_success_policy() {
+        let temp = TempDir::new().unwrap();
+        let workspace_root = temp.path().join("workspaces");
+        let mut runner = AgentRunner::new(
+            Workflow::parse("Prompt").expect("workflow"),
+            WorkspaceManager::new(WorkspaceConfig {
+                root: workspace_root,
+                preserve_success: false,
+            }),
+            AgentConfig {
+                max_attempts: 3,
+                max_turns: 1,
+                stall_timeout_secs: Some(900),
+            },
+            FakeWorker::new(vec![Ok(AppServerOutcome::Completed(AppServerTelemetry {
+                session_id: "GH-601:session".into(),
+                input_tokens: 1,
+                output_tokens: 1,
+                messages: Vec::new(),
+                rate_limits: Vec::new(),
+            }))]),
+        );
+
+        let report = runner.run_attempt(AgentRunRequest {
+            task: task("601", "GH-601"),
+            attempt: 1,
+        });
+
+        assert_eq!(report.terminal_reason, AgentTerminalReason::Succeeded);
+        assert!(!std::path::Path::new(&runner.worker().workspaces[0]).exists());
     }
 
     impl AgentWorker for FakeWorker {

--- a/src/symphony/runtime.rs
+++ b/src/symphony/runtime.rs
@@ -5,15 +5,20 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context as _, Result};
 
+use crate::symphony::app_server::{AppServerOutcome, AppServerRequest, AppServerTelemetry};
 use crate::symphony::config::{ConfigView, EffectiveConfig};
 use crate::symphony::orchestrator::{
-    Orchestrator, OrchestratorEvent, RunnerStart, RunnerStartResult, TaskRunner,
+    Orchestrator, OrchestratorEvent, RunnerStart, RunnerStartResult, SymphonyRuntimeSnapshot,
+    TaskRunner,
 };
+use crate::symphony::runner::{AgentRunReport, AgentRunRequest, AgentRunner, AgentWorker};
 use crate::symphony::task_source::task_source_from_config;
 use crate::symphony::workflow::{NormalizedTask, Workflow};
+use crate::symphony::workspace::WorkspaceManager;
 
 #[derive(Debug, Clone)]
 pub struct SymphonyRuntime {
+    workflow: Workflow,
     config: EffectiveConfig,
 }
 
@@ -33,6 +38,13 @@ pub struct DryTickResult {
     pub identifiers: BTreeMap<String, String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunOnceResult {
+    pub tick: DryTickResult,
+    pub report: Option<AgentRunReport>,
+    pub snapshot: SymphonyRuntimeSnapshot,
+}
+
 impl SymphonyRuntime {
     pub fn load(workflow: impl AsRef<Path>) -> Result<Self> {
         let workflow = workflow.as_ref();
@@ -46,7 +58,10 @@ impl SymphonyRuntime {
         let config = ConfigView::new(&workflow_doc.config, repo_root)
             .startup_validate()
             .context("invalid Symphony workflow config")?;
-        Ok(Self { config })
+        Ok(Self {
+            workflow: workflow_doc,
+            config,
+        })
     }
 
     pub fn validate(&self) -> ValidationResult {
@@ -77,6 +92,66 @@ impl SymphonyRuntime {
             identifiers,
         })
     }
+
+    pub fn snapshot(&self, now_ms: u64) -> Result<SymphonyRuntimeSnapshot> {
+        let source = task_source_from_config(&self.config.task_source)?;
+        let runner = DryRunRunner::default();
+        let orchestrator = Orchestrator::new(self.config.polling.clone(), source, runner);
+        Ok(orchestrator.snapshot(now_ms, None))
+    }
+
+    pub fn fake_run_once(&self, now_ms: u64) -> Result<RunOnceResult> {
+        let source = task_source_from_config(&self.config.task_source)?;
+        let mut tasks = source.fetch_candidates(&self.config.polling.active_states)?;
+        tasks.sort_by(|left, right| left.identifier.cmp(&right.identifier));
+        let identifiers = tasks
+            .iter()
+            .map(|task| (task.id.clone(), task.identifier.clone()))
+            .collect::<BTreeMap<_, _>>();
+        let mut orchestrator =
+            Orchestrator::new(self.config.polling.clone(), source, DryRunRunner::default());
+        let outcome = orchestrator.poll_tick(now_ms);
+        let dispatched = outcome.events.iter().find_map(|event| match event {
+            OrchestratorEvent::Dispatched { id, .. } => Some(id.clone()),
+            _ => None,
+        });
+        let tick = DryTickResult {
+            events: outcome.events,
+            identifiers,
+        };
+
+        let Some(id) = dispatched else {
+            return Ok(RunOnceResult {
+                tick,
+                report: None,
+                snapshot: orchestrator.snapshot(now_ms, None),
+            });
+        };
+        let Some(task) = tasks.into_iter().find(|task| task.id == id) else {
+            return Ok(RunOnceResult {
+                tick,
+                report: None,
+                snapshot: orchestrator.snapshot(now_ms, None),
+            });
+        };
+
+        let workspace =
+            WorkspaceManager::from_config(self.config.workspace.clone(), self.config.hooks.clone());
+        let worker = FakeAppServerWorker;
+        let mut runner = AgentRunner::new(
+            self.workflow.clone(),
+            workspace,
+            self.config.agent.clone(),
+            worker,
+        );
+        let report = runner.run_attempt(AgentRunRequest { task, attempt: 1 });
+        orchestrator.record_run_result(&id, report.result.clone(), now_ms + 1_000);
+        Ok(RunOnceResult {
+            tick,
+            report: Some(report),
+            snapshot: orchestrator.snapshot(now_ms + 1_000, None),
+        })
+    }
 }
 
 #[derive(Debug, Default)]
@@ -91,6 +166,28 @@ impl TaskRunner for DryRunRunner {
             run_id: format!("symphony-dry-run-{}", self.next),
         })
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct FakeAppServerWorker;
+
+impl AgentWorker for FakeAppServerWorker {
+    type Error = std::convert::Infallible;
+
+    fn run_turn(
+        &mut self,
+        request: AppServerRequest,
+    ) -> std::result::Result<AppServerOutcome, Self::Error> {
+        Ok(AppServerOutcome::Completed(AppServerTelemetry {
+            session_id: format!("{}:fake", request.task.identifier),
+            input_tokens: 1,
+            output_tokens: 1,
+            messages: Vec::new(),
+            rate_limits: Vec::new(),
+        }))
+    }
+
+    fn cleanup(&mut self) {}
 }
 
 #[cfg(test)]
@@ -209,5 +306,39 @@ Handle {{ issue.identifier }}: {{ issue.title }}
             run_id: "symphony-dry-run-1".into(),
         }));
         assert_eq!(result.identifiers.get("task-a"), Some(&"ISSUE-A".into()));
+    }
+
+    #[test]
+    fn fake_run_once_dispatches_runner_and_updates_snapshot_accounting() {
+        let dir = fixture_dir("run-once");
+        let workflow = write_workflow(&dir);
+
+        let runtime = SymphonyRuntime::load(&workflow).expect("load runtime");
+        let result = runtime.fake_run_once(1_000).expect("run once");
+
+        assert!(result.tick.events.contains(&OrchestratorEvent::Dispatched {
+            id: "task-a".into(),
+            run_id: "symphony-dry-run-1".into(),
+        }));
+        let report = result.report.expect("agent runner report");
+        assert!(matches!(
+            report.result,
+            crate::symphony::orchestrator::RunResult::Succeeded {
+                input_tokens: 1,
+                output_tokens: 1,
+                turn_count: 1,
+                ..
+            }
+        ));
+        assert_eq!(result.snapshot.turn_count, 1);
+        assert_eq!(result.snapshot.token_totals.input, 1);
+        assert_eq!(result.snapshot.token_totals.output, 1);
+        assert_eq!(result.snapshot.live_runtime_secs, 1);
+        assert!(
+            dir.join(".symphony")
+                .join("workspaces")
+                .join("ISSUE-A")
+                .exists()
+        );
     }
 }

--- a/src/symphony/workspace.rs
+++ b/src/symphony/workspace.rs
@@ -123,6 +123,10 @@ impl WorkspaceManager {
         })
     }
 
+    pub fn preserve_success(&self) -> bool {
+        self.config.preserve_success
+    }
+
     fn run_fatal_hook(
         &self,
         name: &'static str,

--- a/src/tui/backend.rs
+++ b/src/tui/backend.rs
@@ -94,6 +94,9 @@ impl TuiBackend {
                 if let Ok(resp) = client.call("session.create", serde_json::json!({})).await {
                     if let Some(id) = resp.get("session_id").and_then(|v| v.as_str()) {
                         *session_id.lock().await = id.to_string();
+                        if let Err(e) = self.sync_status().await {
+                            tracing::debug!("daemon status sync after session create failed: {e}");
+                        }
                     }
                 }
             }
@@ -716,6 +719,11 @@ fn parse_model_selection(resp: &Value) -> Result<Selection> {
 #[cfg(all(test, feature = "daemon"))]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+    use tokio::net::UnixListener;
+
+    use crate::daemon::protocol::{Request, Response, read_frame_bytes, write_response};
 
     #[test]
     fn prompt_stream_params_use_daemon_text_key() {
@@ -753,5 +761,48 @@ mod tests {
         .unwrap();
         assert_eq!(selection.model.id, "model-a");
         assert_eq!(selection.max_context, 16000);
+    }
+
+    #[tokio::test]
+    async fn daemon_start_session_syncs_model_status() {
+        let tmp = TempDir::new().expect("tempdir");
+        let sock = tmp.path().join("daemon.sock");
+        let listener = UnixListener::bind(&sock).expect("bind fake daemon");
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept");
+            let (mut read, mut write) = stream.into_split();
+            for _ in 0..2 {
+                let body = read_frame_bytes(&mut read).await.expect("read request");
+                let req: Request = serde_json::from_slice(&body).expect("decode request");
+                let result = match req.method.as_str() {
+                    "session.create" => serde_json::json!({ "session_id": "session-1" }),
+                    "agent.status" => serde_json::json!({
+                        "model": "configured-model",
+                        "provider": "local",
+                        "max_context": 4096,
+                    }),
+                    other => panic!("unexpected method {other}"),
+                };
+                write_response(&mut write, &Response::ok(req.id, result))
+                    .await
+                    .expect("write response");
+            }
+        });
+
+        let client = Arc::new(Client::connect_at(&sock).await.expect("connect"));
+        let backend = TuiBackend::Daemon {
+            client,
+            session_id: Mutex::new(String::new()),
+            active_model: Mutex::new(String::new()),
+            active_profile: Mutex::new(None),
+            max_context: Mutex::new(0),
+        };
+
+        backend.start_session().await;
+
+        assert_eq!(backend.session_id().await, "session-1");
+        assert_eq!(backend.active_model().await, "configured-model");
+        assert_eq!(backend.max_context().await, 4096);
+        assert_eq!(backend.active_profile().await.as_deref(), Some("local"));
     }
 }

--- a/src/tui/frontend.rs
+++ b/src/tui/frontend.rs
@@ -105,6 +105,24 @@ impl TuiFrontend {
     pub fn dispatch_slash(&self, input: &str) -> Option<FrontendCommandDispatch> {
         let body = input.strip_prefix('/')?.trim();
         let name = body.split_whitespace().next().unwrap_or("");
+        if name == "symphony" {
+            let args = body.strip_prefix(name).unwrap_or("").trim();
+            let output = crate::cli_symphony::slash_symphony_to_string(args)
+                .unwrap_or_else(|err| format!("Symphony error: {err}\n"));
+            return Some(FrontendCommandDispatch {
+                action: FrontendCommandAction::OpenView {
+                    id: "symphony".into(),
+                    title: "Symphony".into(),
+                    body: output.lines().map(str::to_string).collect(),
+                },
+                canvas_requests: Vec::new(),
+                tick_requests: Vec::new(),
+                surface_requests: Vec::new(),
+                surface_updates: Vec::new(),
+                surface_closes: Vec::new(),
+                widget_updates: Vec::new(),
+            });
+        }
         let command = self.commands.get(name)?;
         let mut ctx = FrontendCtx::default();
         let action = command.run(&mut ctx);
@@ -329,6 +347,25 @@ mod tests {
             dispatch.action,
             FrontendCommandAction::OpenSurface(FrontendSurface { ref id, .. }) if id == "todo"
         ));
+    }
+
+    #[test]
+    fn symphony_slash_command_opens_shared_manual_surface() {
+        let frontend = TuiFrontend::default();
+
+        let dispatch = frontend.dispatch_slash("/symphony").expect("symphony");
+
+        match dispatch.action {
+            FrontendCommandAction::OpenView { id, title, body } => {
+                assert_eq!(id, "symphony");
+                assert_eq!(title, "Symphony");
+                assert!(
+                    body.iter()
+                        .any(|line| line.contains("vulcan symphony run-once"))
+                );
+            }
+            other => panic!("unexpected action: {other:?}"),
+        }
     }
 
     #[test]

--- a/src/tui/keymap.rs
+++ b/src/tui/keymap.rs
@@ -89,6 +89,11 @@ pub(super) const SLASH_COMMANDS: &[SlashCommand] = &[
         mid_turn_safe: true,
     },
     SlashCommand {
+        name: "symphony",
+        description: "Open Symphony workflow/status/manual-run tools",
+        mid_turn_safe: true,
+    },
+    SlashCommand {
         name: "diagnostics",
         description: "Toggle frame/runtime diagnostics overlay",
         mid_turn_safe: true,

--- a/vulcan/src/main.rs
+++ b/vulcan/src/main.rs
@@ -24,6 +24,17 @@ use vulcan::config::Config;
 use vulcan::provider::StreamEvent;
 use vulcan::tui::{ResumeTarget, run_tui};
 
+fn needs_first_run_provider_setup(config: &Config, api_key_missing: bool) -> bool {
+    if !config.providers.is_empty() {
+        return false;
+    }
+
+    let active = config.active_provider_config();
+    api_key_missing
+        && !active.disable_catalog
+        && !vulcan::agent::is_local_base_url(&active.base_url)
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
@@ -107,10 +118,7 @@ async fn main() -> anyhow::Result<()> {
             // into the interactive `vulcan auth` provider setup instead
             // of erroring out, then continues into the TUI with the
             // fresh config. Local/self-hosted endpoints don't need auth.
-            let active = config.active_provider_config();
-            if config.api_key().is_none()
-                && !active.disable_catalog
-                && !vulcan::agent::is_local_base_url(&active.base_url)
+            if needs_first_run_provider_setup(&config, config.api_key().is_none())
                 && std::io::IsTerminal::is_terminal(&std::io::stdin())
             {
                 println!("No model provider configured yet — let's set one up.\n");
@@ -593,6 +601,16 @@ mod tests {
             script.contains("vulcan"),
             "bash completion script missing vulcan binary name"
         );
+    }
+
+    #[test]
+    fn first_run_setup_skips_existing_named_providers() {
+        let mut config = Config::default();
+        config
+            .providers
+            .insert("openrouter".to_string(), config.provider.clone());
+
+        assert!(!needs_first_run_provider_setup(&config, true));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add Symphony runtime observability snapshots and structured runtime reporting
- add the shared manual E2E surface for CLI/TUI Symphony workflows
- fix two dogfood startup regressions: daemon model sync on TUI start and first-run auth setup when providers already exist

## Validation
- cargo test -p vulcan-core symphony
- cargo test -p vulcan-core tui::backend::tests::daemon_start_session_syncs_model_status -- --test-threads=1
- cargo test -p vulcan
- cargo fmt

Closes #602
Closes #603
