### PR TITLE
Finish daemon session resume

### DIFF
--- a/src/daemon/handlers/session.rs
+++ b/src/daemon/handlers/session.rs
@@ -14,8 +14,8 @@ use crate::daemon::state::DaemonState;
 // -- session.create --
 
 /// Create a new session. If `id` is `None`, a UUID v4 is generated.
-/// `resume_from` is accepted but currently ignored (lazy-load of
-/// historical session bodies is deferred to Slice 4).
+/// When `resume_from` is set, the saved transcript is copied into the
+/// new session id and lazy-loaded when the Agent is first built.
 pub async fn create(
     state: &DaemonState,
     id: String,
@@ -24,11 +24,6 @@ pub async fn create(
     parent_session_id: Option<String>,
     lineage_label: Option<String>,
 ) -> Response {
-    // resume_from is reserved for a later slice that re-hydrates a
-    // historical session into the new one. For now we just accept
-    // and ignore the field so callers can start passing it.
-    let _ = resume_from;
-
     let new_id = requested_id.unwrap_or_else(|| Uuid::new_v4().to_string());
 
     if new_id == "main" {
@@ -42,12 +37,77 @@ pub async fn create(
         );
     }
 
+    let resume_seed = if let Some(source_id) = resume_from.as_deref() {
+        let store = match pooled_session_store(state) {
+            Ok(s) => s,
+            Err(e) => return Response::error(id, e),
+        };
+        match store.load_history(source_id).await {
+            Ok(Some(history)) => Some((store, history)),
+            Ok(None) => {
+                return Response::error(
+                    id,
+                    ProtocolError {
+                        code: "SESSION_NOT_FOUND".into(),
+                        message: format!("no saved session '{source_id}'"),
+                        retryable: false,
+                    },
+                );
+            }
+            Err(e) => {
+                return Response::error(
+                    id,
+                    ProtocolError {
+                        code: "SESSION_STORE_UNAVAILABLE".into(),
+                        message: format!("could not read saved session: {e}"),
+                        retryable: true,
+                    },
+                );
+            }
+        }
+    } else {
+        None
+    };
+
     match state.sessions().create_named_with_lineage(
         &new_id,
         parent_session_id.clone(),
         lineage_label.clone(),
     ) {
-        Ok(_) => Response::ok(id, json!({ "session_id": new_id })),
+        Ok(_) => {
+            if let Some((store, history)) = resume_seed {
+                if let Err(e) = store.save_messages(&new_id, &history).await {
+                    state.sessions().destroy(&new_id);
+                    return Response::error(
+                        id,
+                        ProtocolError {
+                            code: "RESUME_FAILED".into(),
+                            message: format!("could not seed resumed session: {e}"),
+                            retryable: false,
+                        },
+                    );
+                }
+                if let Err(e) = store
+                    .save_session_metadata(
+                        &new_id,
+                        parent_session_id.as_deref(),
+                        lineage_label.as_deref(),
+                    )
+                    .await
+                {
+                    state.sessions().destroy(&new_id);
+                    return Response::error(
+                        id,
+                        ProtocolError {
+                            code: "RESUME_FAILED".into(),
+                            message: format!("could not seed resumed session metadata: {e}"),
+                            retryable: false,
+                        },
+                    );
+                }
+            }
+            Response::ok(id, json!({ "session_id": new_id }))
+        }
         Err(_) => Response::error(
             id,
             ProtocolError {
@@ -363,6 +423,45 @@ mod tests {
         let resp = create(&state, "r2".into(), Some("foo".into()), None, None, None).await;
         let err = resp.error.expect("err");
         assert_eq!(err.code, "SESSION_EXISTS");
+    }
+
+    #[tokio::test]
+    async fn create_with_resume_from_seeds_new_session_history() {
+        let pool = Arc::new(RuntimeResourcePool::for_tests().await);
+        let source_id = uuid::Uuid::new_v4().to_string();
+        pool.session_store()
+            .save_messages(
+                &source_id,
+                &[Message::User {
+                    content: "resume-from-history".into(),
+                }],
+            )
+            .await
+            .unwrap();
+        let state = Arc::new(DaemonState::for_tests_minimal().with_pool(pool.clone()));
+
+        let resp = create(
+            &state,
+            "r1".into(),
+            Some("target".into()),
+            Some(source_id),
+            None,
+            None,
+        )
+        .await;
+
+        assert!(resp.error.is_none(), "got {:?}", resp.error);
+        let history = pool
+            .session_store()
+            .load_history("target")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(history.len(), 1);
+        assert!(matches!(
+            &history[0],
+            Message::User { content } if content == "resume-from-history"
+        ));
     }
 
     #[tokio::test]

--- a/src/daemon/session.rs
+++ b/src/daemon/session.rs
@@ -218,7 +218,16 @@ impl SessionState {
             return Ok(handle);
         }
 
-        let agent = assembler.assemble(options.clone()).await?;
+        let mut agent = assembler.assemble(options.clone()).await?;
+        agent
+            .memory()
+            .save_session_metadata(
+                &self.id,
+                self.parent_session_id.as_deref(),
+                self.lineage_label.as_deref(),
+            )
+            .await?;
+        agent.resume_session(&self.id).await?;
         *self.agent_seed.lock() = options.seed();
         self.set_agent(agent);
         Ok(self.agent_arc().expect("just installed"))
@@ -463,6 +472,20 @@ mod tests {
             Arc::ptr_eq(&h, &h2),
             "ensure_agent returns the existing handle"
         );
+    }
+
+    #[tokio::test]
+    async fn ensure_agent_binds_lazy_agent_to_session_id() {
+        let mut config = crate::config::Config::default();
+        config.provider.base_url = "http://127.0.0.1:11434/v1".into();
+        config.provider.disable_catalog = true;
+        let pool = Arc::new(crate::runtime_pool::RuntimeResourcePool::for_tests().await);
+        let assembler = SessionAgentAssembler::new(Arc::new(config), Some(pool));
+        let sess = Arc::new(SessionState::new("foo".into()));
+
+        let agent = sess.ensure_agent(&assembler).await.unwrap();
+
+        assert_eq!(agent.lock().await.session_id(), "foo");
     }
 
     #[test]

--- a/src/daemon/session_agent.rs
+++ b/src/daemon/session_agent.rs
@@ -198,9 +198,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn non_pooled_assembly_applies_session_specific_allowlist() {
+    async fn assembly_applies_session_specific_allowlist() {
         let config = Arc::new(local_config());
-        let assembler = SessionAgentAssembler::new(config, None);
+        let pool = Arc::new(RuntimeResourcePool::for_tests().await);
+        let assembler = SessionAgentAssembler::new(config, Some(pool));
         let agent = assembler
             .assemble(SessionAgentOptions::subagent(
                 2,

--- a/src/gateway/commands.rs
+++ b/src/gateway/commands.rs
@@ -266,7 +266,11 @@ impl CommandDispatcher {
             )
             .await
         {
-            Ok(_) => Ok(format!("Resumed session {session_id}.")),
+            Ok(_) => {
+                ctx.lane_router
+                    .bind_session(ctx.lane, session_id.to_string());
+                Ok(format!("Resumed session {session_id}."))
+            }
             Err(ClientError::Daemon(err)) if err.code == "METHOD_NOT_IMPLEMENTED" => Ok(
                 "/resume is not yet supported with the daemon backend (YYC-266 follow-up).".into(),
             ),
@@ -475,5 +479,62 @@ mod tests {
             body: "",
         };
         assert!(d.dispatch("hello world", ctx).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn resume_command_binds_lane_to_resumed_session() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("vulcan.sock");
+        let pool = std::sync::Arc::new(crate::runtime_pool::RuntimeResourcePool::for_tests().await);
+        let saved_id = uuid::Uuid::new_v4().to_string();
+        pool.session_store()
+            .save_messages(
+                &saved_id,
+                &[crate::provider::Message::User {
+                    content: "gateway resume me".into(),
+                }],
+            )
+            .await
+            .unwrap();
+        let mut config = crate::config::Config::default();
+        config.provider.base_url = "http://127.0.0.1:11434/v1".into();
+        config.provider.disable_catalog = true;
+        let state = std::sync::Arc::new(
+            crate::daemon::state::DaemonState::new(std::sync::Arc::new(config)).with_pool(pool),
+        );
+        let server = crate::daemon::server::Server::bind(&sock, state.clone())
+            .await
+            .unwrap();
+        let server_handle = tokio::spawn(server.run());
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let sock_path = sock.clone();
+        let daemon_client = GatewayDaemonClient::with_client_factory(move || {
+            let path = sock_path.clone();
+            Box::pin(async move { crate::client::Client::connect_at(&path).await })
+        });
+        let d = CommandDispatcher::new(&empty_overrides());
+        let lane = LaneKey {
+            platform: "loopback".into(),
+            chat_id: "c".into(),
+        };
+        let lane_router = DaemonLaneRouter::new();
+        let command = format!("/resume {saved_id}");
+        let ctx = DispatchCtx {
+            lane: &lane,
+            user_id: "u",
+            lane_router: &lane_router,
+            daemon_client: &daemon_client,
+            body: &saved_id,
+        };
+
+        let reply = d.dispatch(&command, ctx).await.unwrap().unwrap();
+        assert_eq!(reply, format!("Resumed session {saved_id}."));
+        let snapshot = lane_router.snapshot_cache();
+        assert_eq!(snapshot.len(), 1);
+        assert_eq!(snapshot[0].session_id, saved_id);
+
+        state.signal_shutdown();
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(2), server_handle).await;
     }
 }

--- a/src/gateway/lane_router.rs
+++ b/src/gateway/lane_router.rs
@@ -165,6 +165,10 @@ impl DaemonLaneRouter {
         );
     }
 
+    pub fn bind_session(&self, lane: &LaneKey, session_id: String) {
+        self.remember_session(lane.clone(), session_id);
+    }
+
     /// Number of cached lanes (surface for /v1/lanes route).
     pub fn cached_lane_count(&self) -> usize {
         self.sessions.lock().entries.len()


### PR DESCRIPTION
## Summary
- bind lazy-built daemon Agents to their SessionState id so daemon sessions read/write the expected saved history
- implement session.create resume_from by seeding the new session id from an existing saved transcript
- make gateway /resume update the lane-session cache after session.resume succeeds
- keep the session-agent allowlist test off the real ~/.vulcan session DB

## Validation
Passed:
- cargo test -p vulcan-core daemon::handlers::session -- --test-threads=1
- cargo test -p vulcan-core daemon::session -- --test-threads=1
- cargo test -p vulcan-core gateway::commands --features gateway -- --test-threads=1
- cargo test -p vulcan-core --features gateway gateway:: -- --test-threads=1
- cargo fmt

Not clean:
- timeout 30s node .gitnexus/run.cjs detect-changes timed out with no output
- cargo test -p vulcan-core --features gateway -- --test-threads=1 still has failures outside the touched #703 path: agent builder tests open the live ~/.vulcan/sessions.turso.db, and daemon reload fixture tests return rejected / watcher timing failures

Closes #703
