### PR TITLE
Enforce trust-aware workspace file containment

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -682,6 +682,7 @@ impl Agent {
         // `tools.profile` is set, so a sensitive workspace falls
         // back to `readonly` instead of unrestricted.
         let trust_profile = config.workspace_trust.resolve_for(&tool_context.cwd);
+        tools.configure_fs_sandbox(&tool_context.cwd, trust_profile.level);
 
         // YYC-181: apply the requested tool capability profile.
         // Precedence: CLI flag > `tools.profile` in config > trust

--- a/src/tools/fs_sandbox.rs
+++ b/src/tools/fs_sandbox.rs
@@ -12,12 +12,11 @@
 //! before the prefix check so a symlink at `cwd/escape -> /etc/passwd`
 //! cannot defeat it.
 //!
-//! Workspace-root sandboxing (only allow paths under `cwd` unless the
-//! trust profile permits otherwise) is deliberately deferred to a
-//! follow-up — too disruptive for ops/dev workflows that legitimately
-//! read outside the project. The deny prefix list catches the worst
-//! exfiltration vectors without requiring a trust-profile rewrite.
+//! A session-local [`FsSandbox`] also roots relative paths in the active
+//! workspace and contains restricted, sensitive, and untrusted workspaces.
+//! Trusted workspaces retain access to non-sensitive paths outside the root.
 
+use crate::trust::TrustLevel;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
@@ -31,85 +30,109 @@ pub enum FsSandboxError {
         #[source]
         source: std::io::Error,
     },
+    #[error("blocked path `{path}`: outside workspace `{workspace_root}` for {trust_level} trust")]
+    OutsideWorkspace {
+        path: String,
+        workspace_root: String,
+        trust_level: &'static str,
+    },
 }
 
-/// Validate a path the tool wants to *read*. Returns the canonicalized
-/// path on success.
-pub fn validate_read(raw: &str) -> Result<PathBuf, FsSandboxError> {
-    let resolved = resolve_for_read(raw)?;
-    check_denylist(&resolved, raw)?;
-    Ok(resolved)
+#[derive(Debug, Clone)]
+pub struct FsSandbox {
+    workspace_root: PathBuf,
+    trust_level: TrustLevel,
 }
 
-/// Validate a path the tool wants to *write* (create or overwrite).
-/// Returns the canonicalized path on success.
-pub fn validate_write(raw: &str) -> Result<PathBuf, FsSandboxError> {
-    let resolved = resolve_for_write(raw)?;
-    check_denylist(&resolved, raw)?;
-    Ok(resolved)
-}
-
-fn resolve_for_read(raw: &str) -> Result<PathBuf, FsSandboxError> {
-    let absolute = absolutize(raw);
-    match std::fs::canonicalize(&absolute) {
-        Ok(p) => Ok(p),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            // Reads of non-existent paths are not the sandbox's
-            // problem — let the file tool surface its own NotFound.
-            // Still return the absolute path so the prefix check fires
-            // first (so a missing file under a blocked prefix doesn't
-            // leak the prefix as a NotFound error).
-            Ok(absolute)
+impl FsSandbox {
+    pub fn new(workspace_root: impl AsRef<Path>, trust_level: TrustLevel) -> Self {
+        let workspace_root = workspace_root.as_ref();
+        let workspace_root =
+            std::fs::canonicalize(workspace_root).unwrap_or_else(|_| workspace_root.to_path_buf());
+        Self {
+            workspace_root,
+            trust_level,
         }
-        Err(source) => Err(FsSandboxError::Resolve {
-            path: raw.to_string(),
-            source,
-        }),
     }
-}
 
-fn resolve_for_write(raw: &str) -> Result<PathBuf, FsSandboxError> {
-    let absolute = absolutize(raw);
-    if let Ok(p) = std::fs::canonicalize(&absolute) {
-        return Ok(p);
+    pub fn validate_read(&self, raw: impl AsRef<Path>) -> Result<PathBuf, FsSandboxError> {
+        self.validate(raw)
     }
-    // Target doesn't exist yet. Canonicalize the parent, then re-attach
-    // the filename. This is the standard symlink-defeating idiom for
-    // "where will my new file actually land?"
-    let parent = absolute.parent().ok_or_else(|| FsSandboxError::Resolve {
-        path: raw.to_string(),
-        source: std::io::Error::other("no parent directory"),
-    })?;
-    let canon_parent = match std::fs::canonicalize(parent) {
-        Ok(p) => p,
-        // Parent doesn't exist either (e.g. /etc/sudoers.d on systems
-        // without it). Fall back to the absolutized parent — same as
-        // the read path — so the denylist prefix check still fires and
-        // reports "blocked" rather than a NotFound resolve error.
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => parent.to_path_buf(),
-        Err(source) => {
-            return Err(FsSandboxError::Resolve {
-                path: raw.to_string(),
-                source,
+
+    pub fn validate_write(&self, raw: impl AsRef<Path>) -> Result<PathBuf, FsSandboxError> {
+        self.validate(raw)
+    }
+
+    fn validate(&self, raw: impl AsRef<Path>) -> Result<PathBuf, FsSandboxError> {
+        let raw = raw.as_ref();
+        let resolved = resolve_path(raw, &self.workspace_root)?;
+        let display = raw.to_string_lossy();
+        check_denylist(&resolved, &display)?;
+        if self.trust_level != TrustLevel::Trusted && !resolved.starts_with(&self.workspace_root) {
+            return Err(FsSandboxError::OutsideWorkspace {
+                path: display.into_owned(),
+                workspace_root: self.workspace_root.display().to_string(),
+                trust_level: self.trust_level.as_str(),
             });
         }
-    };
-    let filename = absolute
-        .file_name()
-        .ok_or_else(|| FsSandboxError::Resolve {
-            path: raw.to_string(),
-            source: std::io::Error::other("path has no filename component"),
-        })?;
-    Ok(canon_parent.join(filename))
+        Ok(resolved)
+    }
 }
 
-fn absolutize(raw: &str) -> PathBuf {
-    let p = PathBuf::from(raw);
-    if p.is_absolute() {
-        return p;
+/// Backward-compatible denylist validation for callers without a session
+/// policy. Agent-built file tools apply their explicit policy first.
+pub fn validate_read(raw: &str) -> Result<PathBuf, FsSandboxError> {
+    FsSandbox::new(current_dir(), TrustLevel::Trusted).validate_read(raw)
+}
+
+pub fn validate_write(raw: &str) -> Result<PathBuf, FsSandboxError> {
+    FsSandbox::new(current_dir(), TrustLevel::Trusted).validate_write(raw)
+}
+
+fn resolve_path(raw: &Path, workspace_root: &Path) -> Result<PathBuf, FsSandboxError> {
+    let absolute = if raw.is_absolute() {
+        raw.to_path_buf()
+    } else {
+        workspace_root.join(raw)
+    };
+    let mut cursor = absolute.as_path();
+    let mut missing = Vec::new();
+    loop {
+        match std::fs::canonicalize(cursor) {
+            Ok(mut resolved) => {
+                for component in missing.iter().rev() {
+                    resolved.push(component);
+                }
+                return Ok(resolved);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                let Some(name) = cursor.file_name() else {
+                    return Err(FsSandboxError::Resolve {
+                        path: raw.display().to_string(),
+                        source: error,
+                    });
+                };
+                missing.push(name.to_os_string());
+                let Some(parent) = cursor.parent() else {
+                    return Err(FsSandboxError::Resolve {
+                        path: raw.display().to_string(),
+                        source: error,
+                    });
+                };
+                cursor = parent;
+            }
+            Err(source) => {
+                return Err(FsSandboxError::Resolve {
+                    path: raw.display().to_string(),
+                    source,
+                });
+            }
+        }
     }
-    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    cwd.join(p)
+}
+
+fn current_dir() -> PathBuf {
+    std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
 }
 
 fn check_denylist(canonical: &Path, raw: &str) -> Result<(), FsSandboxError> {
@@ -202,6 +225,74 @@ fn starts_with_any(s: &str, prefixes: &[&str]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::trust::TrustLevel;
+    use tempfile::tempdir;
+
+    #[test]
+    fn contained_trust_levels_reject_outside_paths_and_symlinks() {
+        let workspace = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        let outside_file = outside.path().join("outside.txt");
+        std::fs::write(&outside_file, "secret").unwrap();
+        let escape = workspace.path().join("escape");
+        std::os::unix::fs::symlink(outside.path(), &escape).unwrap();
+        let traversal = PathBuf::from("..")
+            .join(outside.path().file_name().unwrap())
+            .join("outside.txt");
+
+        for level in [
+            TrustLevel::Restricted,
+            TrustLevel::Sensitive,
+            TrustLevel::Untrusted,
+        ] {
+            let sandbox = FsSandbox::new(workspace.path(), level);
+            for result in [
+                sandbox.validate_read(&outside_file),
+                sandbox.validate_write(outside.path().join("new.txt")),
+                sandbox.validate_read("escape/outside.txt"),
+                sandbox.validate_write("escape/new.txt"),
+                sandbox.validate_read(&traversal),
+            ] {
+                let error = result.unwrap_err();
+                assert!(matches!(error, FsSandboxError::OutsideWorkspace { .. }));
+                assert!(error.to_string().contains("outside workspace"));
+            }
+        }
+    }
+
+    #[test]
+    fn trusted_workspace_allows_non_sensitive_outside_paths() {
+        let workspace = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        let outside_file = outside.path().join("outside.txt");
+        std::fs::write(&outside_file, "allowed").unwrap();
+        let sandbox = FsSandbox::new(workspace.path(), TrustLevel::Trusted);
+
+        assert_eq!(sandbox.validate_read(&outside_file).unwrap(), outside_file);
+        assert!(
+            sandbox
+                .validate_write(outside.path().join("new.txt"))
+                .is_ok()
+        );
+        assert!(matches!(
+            sandbox.validate_read("/etc/shadow").unwrap_err(),
+            FsSandboxError::BlockedPrefix { .. }
+        ));
+    }
+
+    #[test]
+    fn relative_paths_resolve_against_the_explicit_workspace_root() {
+        let workspace = tempdir().unwrap();
+        let inside = workspace.path().join("inside.txt");
+        std::fs::write(&inside, "inside").unwrap();
+        let sandbox = FsSandbox::new(workspace.path(), TrustLevel::Untrusted);
+
+        assert_eq!(sandbox.validate_read("inside.txt").unwrap(), inside);
+        assert_eq!(
+            sandbox.validate_write("nested/new.txt").unwrap(),
+            workspace.path().join("nested/new.txt")
+        );
+    }
 
     #[test]
     fn blocks_read_of_etc_shadow() {

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -484,6 +484,7 @@ impl ToolCatalog {
 pub struct ToolRegistry {
     tools: HashMap<String, Arc<dyn Tool>>,
     order: Vec<String>,
+    fs_sandbox: Arc<parking_lot::RwLock<fs_sandbox::FsSandbox>>,
     /// YYC-181: name of the active capability profile, when one was
     /// applied via [`Self::apply_profile`]. `None` means the registry
     /// is unrestricted (the historical default).
@@ -499,14 +500,35 @@ fn builtin_tools(
     sink: Option<EditDiffSink>,
     lsp: Option<Arc<crate::code::lsp::LspManager>>,
     cwd: std::path::PathBuf,
+    fs_sandbox: Arc<parking_lot::RwLock<fs_sandbox::FsSandbox>>,
 ) -> Vec<Arc<dyn Tool>> {
     let mut tools: Vec<Arc<dyn Tool>> = Vec::new();
-    tools.push(Arc::new(file::ReadFile));
-    tools.push(Arc::new(file::WriteFile::new(sink.clone())));
-    tools.push(Arc::new(file::SearchFiles));
-    tools.push(Arc::new(file::PatchFile::new(sink)));
+    tools.push(SandboxedFileTool::new(
+        Arc::new(file::ReadFile),
+        Arc::clone(&fs_sandbox),
+        FileAccess::ReadRequired,
+    ));
+    tools.push(SandboxedFileTool::new(
+        Arc::new(file::WriteFile::new(sink.clone())),
+        Arc::clone(&fs_sandbox),
+        FileAccess::WriteRequired,
+    ));
+    tools.push(SandboxedFileTool::new(
+        Arc::new(file::SearchFiles),
+        Arc::clone(&fs_sandbox),
+        FileAccess::ReadDefaultRoot,
+    ));
+    tools.push(SandboxedFileTool::new(
+        Arc::new(file::PatchFile::new(sink)),
+        Arc::clone(&fs_sandbox),
+        FileAccess::WriteRequired,
+    ));
     // YYC-79: native tree listing.
-    tools.push(Arc::new(file::ListFiles));
+    tools.push(SandboxedFileTool::new(
+        Arc::new(file::ListFiles),
+        fs_sandbox,
+        FileAccess::ReadDefaultRoot,
+    ));
     // YYC-80: structured Rust compile diagnostics.
     tools.push(Arc::new(cargo::CargoCheckTool));
     tools.push(Arc::new(web::WebSearch));
@@ -622,16 +644,29 @@ impl ToolRegistry {
         lsp: Option<Arc<crate::code::lsp::LspManager>>,
         cwd: std::path::PathBuf,
     ) -> Self {
+        let fs_sandbox = Arc::new(parking_lot::RwLock::new(fs_sandbox::FsSandbox::new(
+            &cwd,
+            crate::trust::TrustLevel::Trusted,
+        )));
         let mut registry = Self {
             tools: HashMap::new(),
             order: Vec::new(),
+            fs_sandbox: Arc::clone(&fs_sandbox),
             active_profile: None,
             active_profile_allowed: None,
         };
-        for tool in builtin_tools(sink, lsp, cwd) {
+        for tool in builtin_tools(sink, lsp, cwd, fs_sandbox) {
             registry.register(tool);
         }
         registry
+    }
+
+    pub fn configure_fs_sandbox(
+        &mut self,
+        workspace_root: impl AsRef<std::path::Path>,
+        trust_level: crate::trust::TrustLevel,
+    ) {
+        *self.fs_sandbox.write() = fs_sandbox::FsSandbox::new(workspace_root, trust_level);
     }
 
     pub fn register(&mut self, tool: Arc<dyn Tool>) {
@@ -745,7 +780,11 @@ impl ToolRegistry {
 
     pub fn default_catalog() -> ToolCatalog {
         let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
-        let definitions = builtin_tools(None, None, cwd)
+        let fs_sandbox = Arc::new(parking_lot::RwLock::new(fs_sandbox::FsSandbox::new(
+            &cwd,
+            crate::trust::TrustLevel::Trusted,
+        )));
+        let definitions = builtin_tools(None, None, cwd, fs_sandbox)
             .into_iter()
             .map(|tool| tool_definition(tool.as_ref(), None))
             .collect();
@@ -789,6 +828,88 @@ impl ToolRegistry {
         validate_tool_params(name, &schema, &params, arguments)?;
 
         tool.call(params, cancel, progress).await
+    }
+}
+
+#[derive(Clone, Copy)]
+enum FileAccess {
+    ReadRequired,
+    ReadDefaultRoot,
+    WriteRequired,
+}
+
+struct SandboxedFileTool {
+    inner: Arc<dyn Tool>,
+    sandbox: Arc<parking_lot::RwLock<fs_sandbox::FsSandbox>>,
+    access: FileAccess,
+}
+
+impl SandboxedFileTool {
+    fn new(
+        inner: Arc<dyn Tool>,
+        sandbox: Arc<parking_lot::RwLock<fs_sandbox::FsSandbox>>,
+        access: FileAccess,
+    ) -> Arc<dyn Tool> {
+        Arc::new(Self {
+            inner,
+            sandbox,
+            access,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl Tool for SandboxedFileTool {
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn description(&self) -> &str {
+        self.inner.description()
+    }
+
+    fn schema(&self) -> Value {
+        self.inner.schema()
+    }
+
+    async fn call(
+        &self,
+        mut params: Value,
+        cancel: CancellationToken,
+        progress: Option<ProgressSink>,
+    ) -> Result<ToolResult> {
+        let raw = match params.get("path") {
+            Some(Value::String(path)) => path.clone(),
+            None if matches!(self.access, FileAccess::ReadDefaultRoot) => ".".to_string(),
+            _ => return self.inner.call(params, cancel, progress).await,
+        };
+        let resolved = {
+            let sandbox = self.sandbox.read();
+            match self.access {
+                FileAccess::ReadRequired | FileAccess::ReadDefaultRoot => {
+                    sandbox.validate_read(&raw)
+                }
+                FileAccess::WriteRequired => sandbox.validate_write(&raw),
+            }
+        };
+        let resolved = match resolved {
+            Ok(path) => path,
+            Err(error) => return Ok(ToolResult::err(error.to_string())),
+        };
+        params["path"] = Value::String(resolved.to_string_lossy().into_owned());
+        self.inner.call(params, cancel, progress).await
+    }
+
+    fn is_relevant(&self, ctx: &ToolContext) -> bool {
+        self.inner.is_relevant(ctx)
+    }
+
+    fn dynamic_description(&self, ctx: &ToolContext) -> Option<String> {
+        self.inner.dynamic_description(ctx)
+    }
+
+    fn replay_safety(&self) -> ReplaySafety {
+        self.inner.replay_safety()
     }
 }
 
@@ -1183,6 +1304,88 @@ path = "src/primary.rs"
         let msg = err.to_string();
         assert!(msg.contains("Failed to parse arguments"), "got {msg:?}");
         assert!(msg.contains("Raw args"), "got {msg:?}");
+    }
+
+    #[tokio::test]
+    async fn workspace_sandbox_applies_to_all_file_tools_independent_of_capability_profile() {
+        let workspace = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+        std::fs::write(workspace.path().join("inside.txt"), "inside").unwrap();
+        let outside_file = outside.path().join("outside.txt");
+        std::fs::write(&outside_file, "outside").unwrap();
+
+        let mut registry =
+            ToolRegistry::new_with_diff_and_lsp(None, None, workspace.path().to_path_buf());
+        registry.configure_fs_sandbox(workspace.path(), crate::trust::TrustLevel::Untrusted);
+        registry.apply_profile(&ToolProfile {
+            name: "test-coding".into(),
+            description: "file tools".into(),
+            allowed: [
+                "read_file",
+                "list_files",
+                "search_files",
+                "write_file",
+                "edit_file",
+            ]
+            .into_iter()
+            .map(Into::into)
+            .collect(),
+        });
+
+        let inside = registry
+            .execute(
+                "read_file",
+                &json!({ "path": "inside.txt" }).to_string(),
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+        assert!(!inside.is_error, "{}", inside.output);
+
+        for (tool, args) in [
+            ("read_file", json!({ "path": outside_file })),
+            ("list_files", json!({ "path": outside.path() })),
+            (
+                "search_files",
+                json!({ "pattern": "outside", "path": outside.path() }),
+            ),
+            (
+                "write_file",
+                json!({ "path": outside.path().join("new.txt"), "content": "new" }),
+            ),
+            (
+                "edit_file",
+                json!({
+                    "path": outside_file,
+                    "old_string": "outside",
+                    "new_string": "changed",
+                }),
+            ),
+        ] {
+            let result = registry
+                .execute(tool, &args.to_string(), CancellationToken::new())
+                .await
+                .unwrap();
+            assert!(result.is_error, "{tool} unexpectedly succeeded");
+            assert!(
+                result.output.contains("outside workspace"),
+                "{tool}: {}",
+                result.output
+            );
+        }
+        assert_eq!(std::fs::read_to_string(&outside_file).unwrap(), "outside");
+        assert!(!outside.path().join("new.txt").exists());
+
+        registry.configure_fs_sandbox(workspace.path(), crate::trust::TrustLevel::Trusted);
+        let trusted = registry
+            .execute(
+                "read_file",
+                &json!({ "path": outside_file }).to_string(),
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+        assert!(!trusted.is_error, "{}", trusted.output);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add an explicit filesystem sandbox policy keyed by canonical workspace root and resolved trust level
- apply the same policy to read, list, search, write, and edit tools
- reject absolute, `../`, and symlink escapes for restricted, sensitive, and untrusted workspaces while preserving trusted non-sensitive access

## Why

The existing sandbox denied sensitive prefixes but otherwise resolved relative paths from the process working directory and allowed non-sensitive paths outside the active workspace. Capability-profile overrides could therefore expose file tools without enforcing the workspace trust boundary.

The tool registry now shares one session-local sandbox policy across every built-in file tool. Denied paths return structured tool errors before filesystem I/O or mutation.

## Validation

- `cargo test fs_sandbox` — 16 passed
- all-five-file-tools/profile regression test — passed
- `cargo check --all-targets` — passed
- `cargo test --all-features` — 1,425 passed, 3 ignored
- standards review — clean
- issue-spec review — clean

Closes #683